### PR TITLE
[Anon] File update: (HH) Legiones Astartes - Crusade Army List.cat

### DIFF
--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="839b6f2a-4041-398b-fc2d-dc6a31d5f75e" revision="46" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="20" battleScribeVersion="1.15" name="Legiones Astartes: Crusade Army List" books="HH:LACAL - 2014" authorName="Millicant" authorContact="Please submit any bugs to the website below" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="839b6f2a-4041-398b-fc2d-dc6a31d5f75e" revision="47" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="20" battleScribeVersion="1.15" name="Legiones Astartes: Crusade Army List" books="HH:LACAL - 2014" authorName="Millicant" authorContact="Please submit any bugs to the website below" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entries>
     <entry id="a8cf84f2-0e14-b402-f2b0-3c5d36a8f2e5" name="Achilles-Alpha Pattern Land Raider" points="300.0" categoryId="486561767920537570706f727423232344415441232323" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="HH:LACAL" page="55">
       <entries/>
@@ -8413,7 +8413,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
       <entryGroups>
         <entryGroup id="b96eba7f-5c86-d4bd-ddd3-15b3b831992d" name="Squadron Vehicles:" minSelections="1" maxSelections="3" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
           <entries>
-            <entry id="78734d8e-3b34-d003-60b0-f7f3a581483e" name="Land Raider Achilles" points="300.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="" page="0">
+            <entry id="78734d8e-3b34-d003-60b0-f7f3a581483e" name="Land Raider Achilles" points="275.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="" page="0">
               <entries/>
               <entryGroups>
                 <entryGroup id="0df7e07f-c191-3b3f-c4bd-59e8271ac651" name="May take a Pintle-Mounted Weapon:" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
@@ -11970,7 +11970,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
         </link>
       </links>
     </entry>
-    <entry id="330713e9-c17f-6a5a-28dd-60175d944e9f" name="Legion Sicarian Battle Tank" points="135.0" categoryId="486561767920537570706f727423232344415441232323" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="HH:LACAL" page="61">
+    <entry id="330713e9-c17f-6a5a-28dd-60175d944e9f" name="Legion Sicaran Battle Tank" points="135.0" categoryId="486561767920537570706f727423232344415441232323" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="HH:LACAL" page="61">
       <entries/>
       <entryGroups>
         <entryGroup id="d772efff-9395-cfa2-c731-1a81953e7363" name="May take any of the following:" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
@@ -12080,7 +12080,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
         </rule>
       </rules>
       <profiles>
-        <profile id="063395e7-2e69-7eb5-fc36-792d1cf0a625" profileTypeId="56656869636c6523232344415441232323" name="Legion Sicarian Battle Tank" hidden="false" book="HH:LACAL" page="60">
+        <profile id="063395e7-2e69-7eb5-fc36-792d1cf0a625" profileTypeId="56656869636c6523232344415441232323" name="Legion Sicaran Battle Tank" hidden="false" book="HH:LACAL" page="60">
           <characteristics>
             <characteristic characteristicId="425323232344415441232323" name="BS" value="4"/>
             <characteristic characteristicId="46726f6e7423232344415441232323" name="Front" value="13"/>


### PR DESCRIPTION
**File:** (HH) Legiones Astartes - Crusade Army List.cat

**Description:** Achilles points were set at 300 points, but in the Legion Army List book, they're 275.

Corrected the spelling of Sicaran Tanks (was originally the incorrect "Sicarian")