### PR TITLE
Fix caestus

### DIFF
--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="839b6f2a-4041-398b-fc2d-dc6a31d5f75e" revision="60" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="20" battleScribeVersion="1.15" name="Legiones Astartes: Crusade Army List" books="HH:LACAL - 2014" authorName="Millicant" authorContact="Please submit any bugs to the website below" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="839b6f2a-4041-398b-fc2d-dc6a31d5f75e" revision="61" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="20" battleScribeVersion="1.15" name="Legiones Astartes: Crusade Army List" books="HH:LACAL - 2014" authorName="Millicant" authorContact="Please submit any bugs to the website below" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entries>
     <entry id="a8cf84f2-0e14-b402-f2b0-3c5d36a8f2e5" name="Achilles-Alpha Pattern Land Raider" points="300.0" categoryId="486561767920537570706f727423232344415441232323" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="HH:LACAL" page="55">
       <entries/>
@@ -6346,6 +6346,9 @@ D6    Result		S	AP
       </profiles>
       <links>
         <link id="e9f3334e-9bf1-c107-6a77-90d323183014" targetId="b3ea1d32-ba66-0585-d7f7-0dc56e707736" linkType="profile">
+          <modifiers/>
+        </link>
+        <link id="d937-4ce6-0bfb-e7f7" targetId="1ea8-a8a3-3a8c-ba32" linkType="profile">
           <modifiers/>
         </link>
       </links>
@@ -13513,23 +13516,17 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
                     </link>
                   </links>
                 </entry>
-                <entry id="06556a30-c351-f5b1-4d64-2403a68f9424" name="Magna-Melta Cannon" points="45.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+                <entry id="1386-6278-f0f2-57e8" name="Magna-Melta Cannon" points="45.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
                   <entries/>
                   <entryGroups/>
                   <modifiers/>
                   <rules/>
-                  <profiles>
-                    <profile id="a4e5b102-7f4e-eaaf-4e70-a11112d965d0" profileTypeId="576561706f6e23232344415441232323" name="Magna-Melta Cannon" hidden="false" book="HH:LACAL" page="92">
-                      <characteristics>
-                        <characteristic characteristicId="52616e676523232344415441232323" name="Range" value="18&quot;"/>
-                        <characteristic characteristicId="537472656e67746823232344415441232323" name="Strength" value="8"/>
-                        <characteristic characteristicId="415023232344415441232323" name="AP" value="1"/>
-                        <characteristic characteristicId="5479706523232344415441232323" name="Type" value="Heavy 1, Large Blast, Melta"/>
-                      </characteristics>
+                  <profiles/>
+                  <links>
+                    <link id="2351-c39c-83c6-3204" targetId="1ea8-a8a3-3a8c-ba32" linkType="profile">
                       <modifiers/>
-                    </profile>
-                  </profiles>
-                  <links/>
+                    </link>
+                  </links>
                 </entry>
               </entries>
               <entryGroups/>
@@ -35615,6 +35612,15 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
         <characteristic characteristicId="537472656e67746823232344415441232323" name="Strength" value="5"/>
         <characteristic characteristicId="415023232344415441232323" name="AP" value="5"/>
         <characteristic characteristicId="5479706523232344415441232323" name="Type" value="Pistol, Deflagrate"/>
+      </characteristics>
+      <modifiers/>
+    </profile>
+    <profile id="1ea8-a8a3-3a8c-ba32" profileTypeId="576561706f6e23232344415441232323" name="Magna-Melta Cannon" hidden="false" book="HH:LACAL" page="92">
+      <characteristics>
+        <characteristic characteristicId="52616e676523232344415441232323" name="Range" value="18&quot;"/>
+        <characteristic characteristicId="537472656e67746823232344415441232323" name="Strength" value="8"/>
+        <characteristic characteristicId="415023232344415441232323" name="AP" value="1"/>
+        <characteristic characteristicId="5479706523232344415441232323" name="Type" value="Heavy 1, Large Blast, Melta"/>
       </characteristics>
       <modifiers/>
     </profile>


### PR DESCRIPTION
Makes weapon profile from Predator with Magna-Melta shared between Caestus Assault Ram and Predator (was missing from Caestus).