### PR TITLE
Adding Leviathan Pattern Siege Dreadnought Talon

### DIFF
--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="839b6f2a-4041-398b-fc2d-dc6a31d5f75e" revision="61" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="20" battleScribeVersion="1.15" name="Legiones Astartes: Crusade Army List" books="HH:LACAL - 2014" authorName="Millicant" authorContact="Please submit any bugs to the website below" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="839b6f2a-4041-398b-fc2d-dc6a31d5f75e" revision="62" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="20" battleScribeVersion="1.15" name="Legiones Astartes: Crusade Army List" books="HH:LACAL - 2014" authorName="Millicant" authorContact="Please submit any bugs to the website below" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entries>
     <entry id="a8cf84f2-0e14-b402-f2b0-3c5d36a8f2e5" name="Achilles-Alpha Pattern Land Raider" points="300.0" categoryId="486561767920537570706f727423232344415441232323" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="HH:LACAL" page="55">
       <entries/>
@@ -21349,6 +21349,9 @@ Phalanx Breacher squads and Legion Terminator squads may be taken as troops in a
         </modifier>
       </modifiers>
     </link>
+    <link id="f29e-97f1-aea9-83c6" targetId="c0b4-7344-371c-dec6" linkType="entry" categoryId="486561767920537570706f727423232344415441232323">
+      <modifiers/>
+    </link>
   </links>
   <sharedEntries>
     <entry id="c05a-83e2-dc93-0bed" name="Anakatis Kul Blade-slaves" points="100.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="HH5: Tempest" page="253">
@@ -22636,6 +22639,14 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
       </profiles>
       <links/>
     </entry>
+    <entry id="a59e-d65e-f998-88f3" name="Extra Armour" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles/>
+      <links/>
+    </entry>
     <entry id="b14a9d49-fb08-e3f5-8e39-6dedfc0a69c1" name="Firedrake Terminator Squad" points="115.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
       <entries>
         <entry id="c7553117-133b-e169-22bf-fe775a0927da" name="Firedrakes" points="40.0" categoryId="(No Category)" type="upgrade" minSelections="4" maxSelections="9" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
@@ -22921,6 +22932,14 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
       </links>
     </entry>
     <entry id="c92a3180-03bc-a10e-e3ef-0583fb1b7ae1" name="Frag and Krak Grenades" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles/>
+      <links/>
+    </entry>
+    <entry id="0a9d-7b2f-a459-e5a4" name="Frag grenades" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
       <entries/>
       <entryGroups/>
       <modifiers/>
@@ -25907,14 +25926,6 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
             </entryGroup>
             <entryGroup id="a5391437-7379-6d5d-db24-a0cb3e0f6a34" name="May be equipped with:" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
               <entries>
-                <entry id="7b24513e-57c2-9e68-bcf0-c16167a2e513" name="Extra Armour" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links/>
-                </entry>
                 <entry id="dd42e229-49f6-4528-80f5-6884b7a267fc" name="Armoured Ceramite" points="20.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
                   <entries/>
                   <entryGroups/>
@@ -25938,7 +25949,11 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
               </entries>
               <entryGroups/>
               <modifiers/>
-              <links/>
+              <links>
+                <link id="5412-b5a6-b983-03a6" targetId="a59e-d65e-f998-88f3" linkType="entry">
+                  <modifiers/>
+                </link>
+              </links>
             </entryGroup>
             <entryGroup id="74d5cd23-bbec-3821-7264-2258c98d3890" name="May take one of the following:" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
               <entries>
@@ -26110,17 +26125,16 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
               <modifiers/>
             </profile>
           </profiles>
-          <links/>
+          <links>
+            <link id="2286-554f-bb94-b475" targetId="84db-886b-78af-56ff" linkType="rule">
+              <modifiers/>
+            </link>
+          </links>
         </entry>
       </entries>
       <entryGroups/>
       <modifiers/>
-      <rules>
-        <rule id="234feb78-aa82-a1a8-14f0-767fb0260609" name="Dreadnought Talon" hidden="false" book="HH:LACAL" page="25">
-          <description>Dreadnoughts taken as a part of a Talon must deploy with 6&quot; of each other but afterwards are treated as independent units.  </description>
-          <modifiers/>
-        </rule>
-      </rules>
+      <rules/>
       <profiles/>
       <links/>
     </entry>
@@ -28904,6 +28918,93 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
           <modifiers/>
         </link>
       </links>
+    </entry>
+    <entry id="c0b4-7344-371c-dec6" name="Leviathan Pattern Siege Dreadnought Talon" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Forgeworld Datasheet">
+      <entries>
+        <entry id="468f-8d8a-5c10-af3f" name="Leviathan Siege Dreadnought" points="270.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="3" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Forgeworld Datasheet">
+          <entries/>
+          <entryGroups>
+            <entryGroup id="90f6-327a-49ff-5cda" name="Dedicated Transport" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <links>
+                <link id="e411-9a2a-5325-de5d" targetId="df4ceff0-6bd4-1cb9-b101-bef9ec61394e" linkType="entry">
+                  <modifiers/>
+                </link>
+              </links>
+            </entryGroup>
+            <entryGroup id="fd7b-e700-20cc-eb80" name="Two torso-mounted heavy flamers" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries>
+                <entry id="3e16-b13e-1cca-635f" name="Heavy Flamer" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="2" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                  <entries/>
+                  <entryGroups/>
+                  <modifiers/>
+                  <rules/>
+                  <profiles/>
+                  <links/>
+                </entry>
+              </entries>
+              <entryGroups/>
+              <modifiers/>
+              <links/>
+            </entryGroup>
+          </entryGroups>
+          <modifiers/>
+          <rules>
+            <rule id="d0c0-ece3-2b52-8e74" name="Reinforced Atomantic Shielding" hidden="false">
+              <description>A Leviathan Dreadnought has a 4+ invulnerable save. In addition, if the Leviathan suffers a Vehicle Explodes damage result, add +D3 Str and +D3&quot; to the radius of the blast.</description>
+              <modifiers/>
+            </rule>
+            <rule id="f924-0aa2-b038-f2b5" name="Crushing Charge" hidden="false">
+              <description>When charging, the model inflicts 2 Hammer of Wrath attacks and gains +1 Initiative in the Assault phase of any turn in which it has charged</description>
+              <modifiers/>
+            </rule>
+          </rules>
+          <profiles>
+            <profile id="83c9-725c-1cef-b099" profileTypeId="57616c6b657223232344415441232323" name="Leviathan Siege Dreadnought" hidden="false">
+              <characteristics>
+                <characteristic characteristicId="575323232344415441232323" name="WS" value="5"/>
+                <characteristic characteristicId="425323232344415441232323" name="BS" value="5"/>
+                <characteristic characteristicId="5323232344415441232323" name="S" value="8"/>
+                <characteristic characteristicId="46726f6e7423232344415441232323" name="Front" value="13"/>
+                <characteristic characteristicId="5369646523232344415441232323" name="Side" value="13"/>
+                <characteristic characteristicId="5265617223232344415441232323" name="Rear" value="12"/>
+                <characteristic characteristicId="4923232344415441232323" name="I" value="4"/>
+                <characteristic characteristicId="4123232344415441232323" name="A" value="4"/>
+                <characteristic characteristicId="485023232344415441232323" name="HP" value="4"/>
+                <characteristic characteristicId="5479706523232344415441232323" name="Type" value="Vehicle (Walker)"/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+          </profiles>
+          <links>
+            <link id="a6ab-17a0-c2f2-a38e" targetId="64b566b4-cb21-5f4c-6e76-1dd302e152f8" linkType="rule">
+              <modifiers/>
+            </link>
+            <link id="e286-4c4b-9733-51b1" targetId="84db-886b-78af-56ff" linkType="rule">
+              <modifiers/>
+            </link>
+            <link id="eba9-a3d0-c23d-3847" targetId="b572273e-2b93-4961-75c8-d9022c31a47d" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="bf46-1eab-840e-8579" targetId="1e27e511-cf75-d55a-6807-b67be6f7474f" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="83fc-4c62-a402-0278" targetId="0a9d-7b2f-a459-e5a4" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="a7df-e247-e105-a630" targetId="a59e-d65e-f998-88f3" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entry>
+      </entries>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles/>
+      <links/>
     </entry>
     <entry id="b7c9-010a-fcab-2fe5" name="Locutarus Storm Squad" points="105.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="HH5: Tempest" page="234">
       <entries>
@@ -34727,6 +34828,10 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
       <description>Reduces enemy benefit from cover by -2.  Additionally infiltrators may not be deployed within 24&quot;.  </description>
       <modifiers/>
     </rule>
+    <rule id="84db-886b-78af-56ff" name="Dreadnought Talon" hidden="false" book="HH:LACAL" page="25">
+      <description>Dreadnoughts taken as a part of a Talon must deploy with 6&quot; of each other but afterwards are treated as independent units.  </description>
+      <modifiers/>
+    </rule>
     <rule id="ecfa2ca1-a0dc-98c5-cf90-3d110382112f" name="Duellist&apos;s Edge" hidden="false" book="HH:LACAL" page="86">
       <description>When fighting a challenge, the user of this weapon gains +1 to their initiative value.  </description>
       <modifiers/>
@@ -35312,6 +35417,15 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
       </characteristics>
       <modifiers/>
     </profile>
+    <profile id="1ea8-a8a3-3a8c-ba32" profileTypeId="576561706f6e23232344415441232323" name="Magna-Melta Cannon" hidden="false" book="HH:LACAL" page="92">
+      <characteristics>
+        <characteristic characteristicId="52616e676523232344415441232323" name="Range" value="18&quot;"/>
+        <characteristic characteristicId="537472656e67746823232344415441232323" name="Strength" value="8"/>
+        <characteristic characteristicId="415023232344415441232323" name="AP" value="1"/>
+        <characteristic characteristicId="5479706523232344415441232323" name="Type" value="Heavy 1, Large Blast, Melta"/>
+      </characteristics>
+      <modifiers/>
+    </profile>
     <profile id="959ff616-ce22-b9ee-1ee6-2496b305e880" profileTypeId="57617267656172204974656d23232344415441232323" name="Mantle of the Elder Drake" hidden="false" book="HH:LAICL" page="65">
       <characteristics>
         <characteristic characteristicId="4465736372697074696f6e23232344415441232323" name="Description" value="Confers Eternal Warrior"/>
@@ -35612,15 +35726,6 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
         <characteristic characteristicId="537472656e67746823232344415441232323" name="Strength" value="5"/>
         <characteristic characteristicId="415023232344415441232323" name="AP" value="5"/>
         <characteristic characteristicId="5479706523232344415441232323" name="Type" value="Pistol, Deflagrate"/>
-      </characteristics>
-      <modifiers/>
-    </profile>
-    <profile id="1ea8-a8a3-3a8c-ba32" profileTypeId="576561706f6e23232344415441232323" name="Magna-Melta Cannon" hidden="false" book="HH:LACAL" page="92">
-      <characteristics>
-        <characteristic characteristicId="52616e676523232344415441232323" name="Range" value="18&quot;"/>
-        <characteristic characteristicId="537472656e67746823232344415441232323" name="Strength" value="8"/>
-        <characteristic characteristicId="415023232344415441232323" name="AP" value="1"/>
-        <characteristic characteristicId="5479706523232344415441232323" name="Type" value="Heavy 1, Large Blast, Melta"/>
       </characteristics>
       <modifiers/>
     </profile>


### PR DESCRIPTION
Adding Leviathan Pattern Siege Dreadnought Talon, and moving (and updating) Kharybdis Assault Klaw so it can be used as a transport for a Leviathan.