### PR TITLE
#164

### DIFF
--- a/(HH) Mechanicum - Taghmata Army List (Complete).cat
+++ b/(HH) Mechanicum - Taghmata Army List (Complete).cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="cf03-f607-41dc-7545" revision="1" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="20" battleScribeVersion="1.15" name="Mechanicum: Taghmata Army List" books="Taghmata Army List" authorName="Millicant" authorContact="Submit &quot;New Issue&quot; on website" authorUrl="https://github.com/BSData/horus-heresy/issues" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="cf03-f607-41dc-7545" revision="2" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="20" battleScribeVersion="1.15" name="Mechanicum: Taghmata Army List" books="Taghmata Army List" authorName="Capitaladot" authorContact="Submit &quot;New Issue&quot; on website" authorUrl="https://github.com/BSData/horus-heresy/issues" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entries>
     <entry id="cb78-d695-f736-f672" name="Adsecularis Covenant" points="5.0" categoryId="54726f6f707323232344415441232323" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Taghmata Army List" page="37">
       <entries>
@@ -416,10 +416,6 @@
         <rule id="b493-977b-43db-5547" name="Stubborn" hidden="false" page="0">
           <modifiers/>
         </rule>
-        <rule id="6f9e-e126-6f17-0fec" name="Patris Cybernetica" hidden="false" book="75" page="Taghmata Army List">
-          <description>A character with this special rule may join a unit of Monstrous creatures so long as they have the Cybernetica Cortex special rule, even thought this would not normally be allowed. while it is part of a unit of Monstrous Creatures, a model with this special rule may not Go To Ground, voluntarily or otherwise, and enemy shooting at the unit may opt to ignore the fact that the character is the closest model in the unit for the purposes of shooting attacks if they wish and instead target the closest Monstrous Creature in the unit, if they have attacks in range.</description>
-          <modifiers/>
-        </rule>
       </rules>
       <profiles>
         <profile id="f292-c3dc-9dc4-c069" profileTypeId="556e697423232344415441232323" name="Archmagos Dominus" hidden="false" book="Taghmata Army List" page="75">
@@ -470,6 +466,9 @@
           <modifiers/>
         </link>
         <link id="be2f-fee2-554b-9450" targetId="df18-c724-2a3d-a6e5" linkType="entry group">
+          <modifiers/>
+        </link>
+        <link id="1950-e393-a7f3-663f" targetId="a41e-00bb-2ace-734f" linkType="rule">
           <modifiers/>
         </link>
       </links>
@@ -3961,11 +3960,7 @@ D6    Result		S	AP
           </entries>
           <entryGroups/>
           <modifiers/>
-          <links>
-            <link id="8c08-fbc7-52fa-1994" targetId="9d9f-63d3-f635-7fd5" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
+          <links/>
         </entryGroup>
         <entryGroup id="861c-37c6-2469-88bd" name="May take any of the following:" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
           <entries>
@@ -4080,6 +4075,84 @@ D6    Result		S	AP
           <modifiers/>
           <links/>
         </entryGroup>
+        <entryGroup id="9b0e-e417-8fe3-e86e" name="May take of the following additional weapons:" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="9ea5-37a1-5118-bbd5" name="Rotor Cannon" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="6b75-58d9-bce7-1e07" targetId="75683330-6490-c0bf-560c-2e58617425a1" linkType="profile">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+            <entry id="2018-09ab-b395-200c" name="Meltagun" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+            <entry id="6839-5cf1-ae31-5763" name="Phased Plasma-fusil" points="20.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="91ca-03db-9920-72eb" targetId="71ed050b-073d-852a-e50a-425b96eb71cd" linkType="profile">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+            <entry id="1545-79ec-e0e1-d767" name="Graviton Gun" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="5274-5115-c328-41c3" targetId="48a06170-d952-045d-a033-bd04d1122b59" linkType="profile">
+                  <modifiers/>
+                </link>
+                <link id="0d2e-7f6f-d096-13e5" targetId="53a62286-f01f-a0b5-7003-7cc0c702a11a" linkType="rule">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+            <entry id="3c28-90a1-e165-623b" name="Rad/irad Cleanser" points="20.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="2e45-2ee6-096d-c748" targetId="087e3cad-c849-204a-b83a-29093869a431" linkType="profile">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+            <entry id="48ca-67a0-6871-f292" name="Photon Thruster" points="30.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="f6e3-2ad9-6a28-541b" targetId="43648289-5a0f-99d3-1cfc-55b689750afa" linkType="profile">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+          </entries>
+          <entryGroups/>
+          <modifiers/>
+          <links/>
+        </entryGroup>
       </entryGroups>
       <modifiers/>
       <rules>
@@ -4127,6 +4200,12 @@ D6    Result		S	AP
           <modifiers/>
         </link>
         <link id="33a6-e7bb-8d76-fdac" targetId="df18-c724-2a3d-a6e5" linkType="entry group">
+          <modifiers/>
+        </link>
+        <link id="2d41-a70e-dea2-f6aa" targetId="0be9-1a9f-14a5-ebb8" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="7ef1-581d-ef25-2562" targetId="a41e-00bb-2ace-734f" linkType="rule">
           <modifiers/>
         </link>
       </links>
@@ -4201,7 +4280,7 @@ D6    Result		S	AP
         </entry>
       </entries>
       <entryGroups>
-        <entryGroup id="713c-8d3a-17e7-2974" name="Exchange Power Weapon for:" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+        <entryGroup id="713c-8d3a-17e7-2974" name="Exchange Power Weapon for:" defaultEntryId="320d-470f-f823-baa4" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
           <entries>
             <entry id="8ba7-88cf-221a-9f74" name="Archaeotech Pistol" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
               <entries/>
@@ -4331,7 +4410,7 @@ D6    Result		S	AP
           <modifiers/>
           <links/>
         </entryGroup>
-        <entryGroup id="d12d-4733-79f6-ccc8" name="Exchange Volkite Serpenta for:" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+        <entryGroup id="d12d-4733-79f6-ccc8" name="Exchange Volkite Serpenta for:" defaultEntryId="1555-5f1a-3fc8-e8ea" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
           <entries>
             <entry id="f7c1-5355-4e87-cc64" name="Archaeotech Pistol" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
               <entries/>
@@ -4444,6 +4523,21 @@ D6    Result		S	AP
               </profiles>
               <links/>
             </entry>
+            <entry id="1555-5f1a-3fc8-e8ea" name="Volkite Serpenta" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="b2da-7c71-e442-9ab0" targetId="2c6ee84f-08d4-4e84-2468-6f39375d509b" linkType="profile">
+                  <modifiers/>
+                </link>
+                <link id="03cd-0380-05e0-7ff3" targetId="e31cf870-3fa6-f2a2-8704-9bf05f7efcd8" linkType="rule">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
           </entries>
           <entryGroups/>
           <modifiers/>
@@ -4549,9 +4643,9 @@ D6    Result		S	AP
           <modifiers/>
           <links/>
         </entryGroup>
-        <entryGroup id="1db7-efeb-e0bc-2876" name="May take one additional weapon:" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+        <entryGroup id="1db7-efeb-e0bc-2876" name="May take of the following additional weapons:" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
           <entries>
-            <entry id="a8a7-9f6a-de8d-3bea" name="Rotor Cannon" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+            <entry id="a8a7-9f6a-de8d-3bea" name="Rotor Cannon" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
               <entries/>
               <entryGroups/>
               <modifiers/>
@@ -4563,7 +4657,7 @@ D6    Result		S	AP
                 </link>
               </links>
             </entry>
-            <entry id="447c-cc78-3813-087f" name="Meltagun" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+            <entry id="447c-cc78-3813-087f" name="Meltagun" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
               <entries/>
               <entryGroups/>
               <modifiers/>
@@ -4571,7 +4665,7 @@ D6    Result		S	AP
               <profiles/>
               <links/>
             </entry>
-            <entry id="3e9b-8fa3-7b7d-7830" name="Phased Plasma-fusil" points="20.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+            <entry id="3e9b-8fa3-7b7d-7830" name="Phased Plasma-fusil" points="20.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
               <entries/>
               <entryGroups/>
               <modifiers/>
@@ -4583,7 +4677,7 @@ D6    Result		S	AP
                 </link>
               </links>
             </entry>
-            <entry id="1873-57ea-c90c-8d3f" name="Graviton Gun" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+            <entry id="1873-57ea-c90c-8d3f" name="Graviton Gun" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
               <entries/>
               <entryGroups/>
               <modifiers/>
@@ -4598,9 +4692,52 @@ D6    Result		S	AP
                 </link>
               </links>
             </entry>
+            <entry id="0675-8c59-cd54-0321" name="Rad/irad Cleanser" points="20.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="0d76-3356-894d-9eca" targetId="087e3cad-c849-204a-b83a-29093869a431" linkType="profile">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+            <entry id="6cfa-2d8a-fdb3-6176" name="Rad Furnace" points="30.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="d72b-5282-16fe-0272" targetId="7f32-3376-7246-eeb0" linkType="profile">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+            <entry id="f55d-d23f-474c-d90c" name="Photon Thruster" points="30.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="2a91-6cda-45b5-9e9f" targetId="43648289-5a0f-99d3-1cfc-55b689750afa" linkType="profile">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
           </entries>
           <entryGroups/>
-          <modifiers/>
+          <modifiers>
+            <modifier type="set" field="maxSelections" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="4050-cf79-db98-7110" incrementField="selections" incrementValue="1.0">
+              <conditions>
+                <condition parentId="f2b2-170e-52e7-073d" childId="4050-cf79-db98-7110" field="selections" type="equal to" value="0.0"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
           <links/>
         </entryGroup>
         <entryGroup id="a640-071a-a550-4c8f" name="May take one of the following:" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
@@ -4633,18 +4770,6 @@ D6    Result		S	AP
               <profiles/>
               <links>
                 <link id="f03e-5c93-8763-bfd2" targetId="3ffc1f76-719b-bc95-a3c9-15614a8c94bc" linkType="profile">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="a949-3a72-7261-5dbe" name="Rad/irad Cleanser" points="20.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="0500-7f12-2778-ce54" targetId="087e3cad-c849-204a-b83a-29093869a431" linkType="profile">
                   <modifiers/>
                 </link>
               </links>
@@ -4682,14 +4807,14 @@ D6    Result		S	AP
                 </link>
               </links>
             </entry>
-            <entry id="1475-a017-d161-e985" name="Photon Thruster" points="30.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+            <entry id="4948-473f-e1c8-5ad6" name="Rad Furnace" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
               <entries/>
               <entryGroups/>
               <modifiers/>
               <rules/>
               <profiles/>
               <links>
-                <link id="bccd-1697-a764-afd8" targetId="43648289-5a0f-99d3-1cfc-55b689750afa" linkType="profile">
+                <link id="85a4-cf34-a3ed-2fc6" targetId="7f32-3376-7246-eeb0" linkType="profile">
                   <modifiers/>
                 </link>
               </links>
@@ -4697,71 +4822,6 @@ D6    Result		S	AP
           </entries>
           <entryGroups/>
           <modifiers/>
-          <links>
-            <link id="471b-dc11-2b31-251b" targetId="9d9f-63d3-f635-7fd5" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="a23b-2018-956e-b718" name="May take one second additional weapon:" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries>
-            <entry id="c0f7-91de-8327-3f6a" name="Rotor Cannon" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="85ad-f372-64e3-98d7" targetId="75683330-6490-c0bf-560c-2e58617425a1" linkType="profile">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="cd33-3302-05f9-ad88" name="Meltagun" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links/>
-            </entry>
-            <entry id="06af-7c99-850b-a367" name="Phased Plasma-fusil" points="20.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="26f0-2783-52d7-5219" targetId="71ed050b-073d-852a-e50a-425b96eb71cd" linkType="profile">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="8000-c98f-4473-2afc" name="Graviton Gun" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="2d2c-13b0-edcb-25a6" targetId="48a06170-d952-045d-a033-bd04d1122b59" linkType="profile">
-                  <modifiers/>
-                </link>
-                <link id="b530-41ce-aee8-916c" targetId="53a62286-f01f-a0b5-7003-7cc0c702a11a" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-          </entries>
-          <entryGroups/>
-          <modifiers>
-            <modifier type="hide" field="maxSelections" value="1.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions>
-                <condition parentId="f2b2-170e-52e7-073d" childId="590a-1e0f-e669-9b34" field="selections" type="equal to" value="0.0"/>
-              </conditions>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
           <links/>
         </entryGroup>
         <entryGroup id="590a-1e0f-e669-9b34" name="The Orders of High Techno-Arcana" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
@@ -4827,9 +4887,6 @@ D6    Result		S	AP
               </rules>
               <profiles/>
               <links>
-                <link id="62d9-e566-6d50-844f" targetId="8e53a9a8-1408-23bf-5be8-4601caec5d10" linkType="rule">
-                  <modifiers/>
-                </link>
                 <link id="a184-8ac2-5c6d-03b0" targetId="797e55b1-251e-6606-9cb3-64661b0b18a3" linkType="rule">
                   <modifiers/>
                 </link>
@@ -4965,6 +5022,18 @@ D6    Result		S	AP
           <modifiers/>
         </link>
         <link id="74aa-04ef-1ead-bb90" targetId="df18-c724-2a3d-a6e5" linkType="entry group">
+          <modifiers/>
+        </link>
+        <link id="a1ba-cae5-3c61-af91" targetId="5aad03df-0fd0-5920-0aec-2aefbe5bcf5b" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="519b-b6e2-81f0-79a5" targetId="fa9a-ff67-537f-3be9" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="0f64-b8e7-49a4-818f" targetId="6187-9edf-ea79-4188" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="c209-1a13-4a36-67b6" targetId="8199e922-e844-5d34-b04b-86edadffa2df" linkType="rule">
           <modifiers/>
         </link>
       </links>
@@ -6334,6 +6403,134 @@ Use at the start of the controlling player’s turn. Until the beginning of thei
           <modifiers/>
         </link>
         <link id="9a60bd72-1c24-a6ea-9ac7-33c1e3847005" targetId="4d0a2655-b103-5681-15a0-74973416358a" linkType="profile">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="12e9-130c-c8be-29be" name="Ordinatus Minoris Macro Engine" points="0.0" categoryId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Taghmata Army List" page="62-63">
+      <entries>
+        <entry id="cd13-8d07-aa12-5c39" name="Turret Mounted Volkite Culverins" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="3" maxSelections="3" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles/>
+          <links>
+            <link id="534c-48b2-c251-b000" targetId="c7838603-9e18-8756-26b1-222a294c5c2c" linkType="profile">
+              <modifiers/>
+            </link>
+          </links>
+        </entry>
+      </entries>
+      <entryGroups>
+        <entryGroup id="4b2c-fa3f-11e7-1d9a" name="Ordinatus" defaultEntryId="86d9-ed86-7502-e16a" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="86d9-ed86-7502-e16a" name="Sagittar" points="750.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles>
+                <profile id="d3db-4945-95a2-0076" profileTypeId="56656869636c6523232344415441232323" name="Ordinatus Sagittar" hidden="false">
+                  <characteristics>
+                    <characteristic characteristicId="425323232344415441232323" name="BS" value="4"/>
+                    <characteristic characteristicId="46726f6e7423232344415441232323" name="Front" value="14"/>
+                    <characteristic characteristicId="5369646523232344415441232323" name="Side" value="14"/>
+                    <characteristic characteristicId="5265617223232344415441232323" name="Rear" value="13"/>
+                    <characteristic characteristicId="485023232344415441232323" name="HP" value="14"/>
+                    <characteristic characteristicId="5479706523232344415441232323" name="Type" value="Vehicle (Super-heavy)"/>
+                  </characteristics>
+                  <modifiers/>
+                </profile>
+              </profiles>
+              <links>
+                <link id="93c2-c42e-b7e5-9fee" targetId="1bc5-f4e3-a97e-1da4" linkType="entry">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+            <entry id="9436-382b-b9e4-99d8" name="Ulator" points="1075.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules>
+                <rule id="e6ab-495c-1795-d4b6" name="Ulator Sonic Wave" hidden="false">
+                  <description>When firing the weapon, place the Massive Blast (7&quot;) marker so that its edge is touching some part of the firing model&apos;s forward hull. Then move the template in a direct line away from the model, travelling in any direction within the weapon&apos;s 4 5 degree forward firing arc until its maximum range is reached or the template leaves the table. All models the template passes over at least partially suffer a single automatic hit. In the case of units of multiple models, the unit suffers a number of automatic hits equal to the number of models the template has contacted, casualties being chosen by the controlling player of the affected unit. Flyers and Flying Creatures are also struck if the template passes over their base. 
+
+Note: The weapon may be still fired even if friendly models are caught in its area of effect, and the weapon&apos;s fire may strike units along the path of the blast to which it may not itself have line of sight or be eligible to target. However, the first unit targeted by the weapon must be an enemy model or the weapon may not be fired. 
+
+The strength of the weapon&apos;s hit is determined by the type of the model it strikes, as listed on the following chart: 
+
+Unit Type                                                                    Strength
+Infantry (including jump pack and jet pack infantry)  5
+Bikes, Jetbikes, Beasts, Cavalry                                 5
+Monstrous Creatures, Vehicles                                    8
+Vehicles with the Tank type                                        10
+Super-heavy vehicles (all types)                                 D
+Gargantuan Creatures (all types)                               D
+Buildings and Fortifications                                          D
+ </description>
+                  <modifiers/>
+                </rule>
+              </rules>
+              <profiles>
+                <profile id="7c73-22eb-a60d-d883" profileTypeId="56656869636c6523232344415441232323" name="Ordinatus Ulator" hidden="false">
+                  <characteristics>
+                    <characteristic characteristicId="425323232344415441232323" name="BS" value="4"/>
+                    <characteristic characteristicId="46726f6e7423232344415441232323" name="Front" value="14"/>
+                    <characteristic characteristicId="5369646523232344415441232323" name="Side" value="14"/>
+                    <characteristic characteristicId="5265617223232344415441232323" name="Rear" value="13"/>
+                    <characteristic characteristicId="485023232344415441232323" name="HP" value="14"/>
+                    <characteristic characteristicId="5479706523232344415441232323" name="Type" value="Vehicle (Super-heavy)"/>
+                  </characteristics>
+                  <modifiers/>
+                </profile>
+                <profile id="cc1b-14c0-6338-7200" profileTypeId="576561706f6e23232344415441232323" name="Ulator class sonic destructor" hidden="false">
+                  <characteristics>
+                    <characteristic characteristicId="52616e676523232344415441232323" name="Range" value="72&quot;"/>
+                    <characteristic characteristicId="537472656e67746823232344415441232323" name="Strength" value="X*"/>
+                    <characteristic characteristicId="415023232344415441232323" name="AP" value="2"/>
+                    <characteristic characteristicId="5479706523232344415441232323" name="Type" value="Primary Weapon 1, Ulator Sonic Wave, Pinning, Armourbane, Instant Death, Ignores Cover"/>
+                  </characteristics>
+                  <modifiers/>
+                </profile>
+              </profiles>
+              <links/>
+            </entry>
+          </entries>
+          <entryGroups/>
+          <modifiers/>
+          <links/>
+        </entryGroup>
+      </entryGroups>
+      <modifiers/>
+      <rules>
+        <rule id="09fc-86f4-d2b3-ed80" name="Ordinatus Reactor Meltdown" hidden="false">
+          <description>The potent onboard plasma reactor of the Ordinatus ensures that if this warengine be destroyed, its fiery demise will immolate a sizeable proportion of the battlefield on which it fights. Because of this, instead of using the usual Catastrophic Damage table for Super-heavy vehicles, use the table presented here instead. Note as well, in thh case of the Explosion and Devastating Explosion results, the Orddinatus model remains on the table as impassable terrain after it is destroyed. The radius effect of the Ordinatus&apos; explosion does not use the usual Apocalyptic Blast marker either. Instead, measure distances from the hull of the model as a starting point with the blase ranges respectively. ranges of 6&quot;/12&quot;/24&quot; respectively. 
+
+D6   Result 1-2 Explosion 
+3-5  Devastating Explosion
+6     Titanic Explosion</description>
+          <modifiers/>
+        </rule>
+        <rule id="02b4-6900-0822-b412" name="Reinforced Structure" hidden="false">
+          <description>The Ordinatus has an invulnerable save of 6+.</description>
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles>
+        <profile id="cca2-507c-52e5-8b81" profileTypeId="57617267656172204974656d23232344415441232323" name="Ordinatus Dispersion Shield" hidden="false">
+          <characteristics>
+            <characteristic characteristicId="4465736372697074696f6e23232344415441232323" name="Description" value="An arcane and obscure hybrid of both void shield and flare shield technologies, the powerful dispersion shields mounted on Ordinatus class vehicles are designed to make them all but impervious to counter-battery fire. However, such is the strain the field creates on its generators that its protection degrades over time as its elements begin to burn out.  The protection provided by the dispersion shield affects only shooting attacks originating from its front and side arcs, and against barrage weapons from any arc.  • On the first turn the ordinatus is in play, the strength of shooting attacks and the roll result on the Destroyer table made against it are at -3.  • On the second turn the Ordinatus is in play, the strength of shooting attacks and the roll result on the Dectroyer table made against it are at -2. • On the third and subsequent turns the Ordinatus is in play, the strength of shooting attacks and the roll result on the Destroyer table made against it are at  -1. "/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links>
+        <link id="2894-cea8-337a-4194" targetId="2904feff-37ef-ffc4-89b7-340b250746a3" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="0f21-2274-acd1-27a4" targetId="2db60061-47bc-2922-17b3-88cd261bac40" linkType="profile">
           <modifiers/>
         </link>
       </links>
@@ -7720,138 +7917,6 @@ Units with this augment count as a Heavy Support choice instead of a troops choi
         </link>
       </links>
     </entry>
-    <entry id="12e9-130c-c8be-29be" name="Ordinatus Minoris Macro Engine" points="0.0" categoryId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Taghmata Army List" page="62-63">
-      <entries>
-        <entry id="cd13-8d07-aa12-5c39" name="Turret Mounted Volkite Culverins" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="3" maxSelections="3" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="534c-48b2-c251-b000" targetId="c7838603-9e18-8756-26b1-222a294c5c2c" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="4b2c-fa3f-11e7-1d9a" name="Ordinatus" defaultEntryId="86d9-ed86-7502-e16a" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries>
-            <entry id="86d9-ed86-7502-e16a" name="Sagittar" points="750.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles>
-                <profile id="d3db-4945-95a2-0076" profileTypeId="56656869636c6523232344415441232323" name="Ordinatus Sagittar" hidden="false">
-                  <characteristics>
-                    <characteristic characteristicId="425323232344415441232323" name="BS" value="4"/>
-                    <characteristic characteristicId="46726f6e7423232344415441232323" name="Front" value="14"/>
-                    <characteristic characteristicId="5369646523232344415441232323" name="Side" value="14"/>
-                    <characteristic characteristicId="5265617223232344415441232323" name="Rear" value="13"/>
-                    <characteristic characteristicId="485023232344415441232323" name="HP" value="14"/>
-                    <characteristic characteristicId="5479706523232344415441232323" name="Type" value="Vehicle (Super-heavy)"/>
-                  </characteristics>
-                  <modifiers/>
-                </profile>
-              </profiles>
-              <links>
-                <link id="93c2-c42e-b7e5-9fee" targetId="1bc5-f4e3-a97e-1da4" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="9436-382b-b9e4-99d8" name="Ulator" points="1075.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules>
-                <rule id="e6ab-495c-1795-d4b6" name="Ulator Sonic Wave" hidden="false">
-                  <description>When firing the weapon, place the Massive Blast (7&quot;) marker so that its edge is touching some part of the firing model&apos;s forward hull. Then move the template in a direct line away from the model, travelling in any direction within the weapon&apos;s 4 5 degree forward firing arc until its maximum range is reached or the template leaves the table. All models the template passes over at least partially suffer a single automatic hit. In the case of units of multiple models, the unit suffers a number of automatic hits equal to the number of models the template has contacted, casualties being chosen by the controlling player of the affected unit. Flyers and Flying Creatures are also struck if the template passes over their base. 
-
-Note: The weapon may be still fired even if friendly models are caught in its area of effect, and the weapon&apos;s fire may strike units along the path of the blast to which it may not itself have line of sight or be eligible to target. However, the first unit targeted by the weapon must be an enemy model or the weapon may not be fired. 
-
-The strength of the weapon&apos;s hit is determined by the type of the model it strikes, as listed on the following chart: 
-
-Unit Type                                                                    Strength
-Infantry (including jump pack and jet pack infantry)  5
-Bikes, Jetbikes, Beasts, Cavalry                                 5
-Monstrous Creatures, Vehicles                                    8
-Vehicles with the Tank type                                        10
-Super-heavy vehicles (all types)                                 D
-Gargantuan Creatures (all types)                               D
-Buildings and Fortifications                                          D
- </description>
-                  <modifiers/>
-                </rule>
-              </rules>
-              <profiles>
-                <profile id="7c73-22eb-a60d-d883" profileTypeId="56656869636c6523232344415441232323" name="Ordinatus Ulator" hidden="false">
-                  <characteristics>
-                    <characteristic characteristicId="425323232344415441232323" name="BS" value="4"/>
-                    <characteristic characteristicId="46726f6e7423232344415441232323" name="Front" value="14"/>
-                    <characteristic characteristicId="5369646523232344415441232323" name="Side" value="14"/>
-                    <characteristic characteristicId="5265617223232344415441232323" name="Rear" value="13"/>
-                    <characteristic characteristicId="485023232344415441232323" name="HP" value="14"/>
-                    <characteristic characteristicId="5479706523232344415441232323" name="Type" value="Vehicle (Super-heavy)"/>
-                  </characteristics>
-                  <modifiers/>
-                </profile>
-                <profile id="cc1b-14c0-6338-7200" profileTypeId="576561706f6e23232344415441232323" name="Ulator class sonic destructor" hidden="false">
-                  <characteristics>
-                    <characteristic characteristicId="52616e676523232344415441232323" name="Range" value="72&quot;"/>
-                    <characteristic characteristicId="537472656e67746823232344415441232323" name="Strength" value="X*"/>
-                    <characteristic characteristicId="415023232344415441232323" name="AP" value="2"/>
-                    <characteristic characteristicId="5479706523232344415441232323" name="Type" value="Primary Weapon 1, Ulator Sonic Wave, Pinning, Armourbane, Instant Death, Ignores Cover"/>
-                  </characteristics>
-                  <modifiers/>
-                </profile>
-              </profiles>
-              <links/>
-            </entry>
-          </entries>
-          <entryGroups/>
-          <modifiers/>
-          <links/>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules>
-        <rule id="09fc-86f4-d2b3-ed80" name="Ordinatus Reactor Meltdown" hidden="false">
-          <description>The potent onboard plasma reactor of the Ordinatus ensures that if this warengine be destroyed, its fiery demise will immolate a sizeable proportion of the battlefield on which it fights. Because of this, instead of using the usual Catastrophic Damage table for Super-heavy vehicles, use the table presented here instead. Note as well, in thh case of the Explosion and Devastating Explosion results, the Orddinatus model remains on the table as impassable terrain after it is destroyed. The radius effect of the Ordinatus&apos; explosion does not use the usual Apocalyptic Blast marker either. Instead, measure distances from the hull of the model as a starting point with the blase ranges respectively. ranges of 6&quot;/12&quot;/24&quot; respectively. 
-
-D6   Result 1-2 Explosion 
-3-5  Devastating Explosion
-6     Titanic Explosion</description>
-          <modifiers/>
-        </rule>
-        <rule id="02b4-6900-0822-b412" name="Reinforced Structure" hidden="false">
-          <description>The Ordinatus has an invulnerable save of 6+.</description>
-          <modifiers/>
-        </rule>
-      </rules>
-      <profiles>
-        <profile id="cca2-507c-52e5-8b81" profileTypeId="57617267656172204974656d23232344415441232323" name="Ordinatus Dispersion Shield" hidden="false">
-          <characteristics>
-            <characteristic characteristicId="4465736372697074696f6e23232344415441232323" name="Description" value="An arcane and obscure hybrid of both void shield and flare shield technologies, the powerful dispersion shields mounted on Ordinatus class vehicles are designed to make them all but impervious to counter-battery fire. However, such is the strain the field creates on its generators that its protection degrades over time as its elements begin to burn out. 
-The protection provided by the dispersion shield affects only shooting attacks originating from its front and side arcs, and against barrage weapons from any arc. 
-• On the first turn the ordinatus is in play, the strength of shooting attacks and the roll result on the Destroyer table made against it are at -3. 
-• On the second turn the Ordinatus is in play, the strength of shooting attacks and the roll result on the Dectroyer table made against it are at -2.
-• On the third and subsequent turns the Ordinatus is in play, the strength of shooting attacks and the roll result on the Destroyer table made against it are at  -1. "/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="2894-cea8-337a-4194" targetId="2904feff-37ef-ffc4-89b7-340b250746a3" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="0f21-2274-acd1-27a4" targetId="2db60061-47bc-2922-17b3-88cd261bac40" linkType="profile">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
   </entries>
   <rules/>
   <links>
@@ -7891,6 +7956,29 @@ The protection provided by the dispersion shield affects only shooting attacks o
           <modifiers/>
         </link>
       </links>
+    </entry>
+    <entry id="1bc5-f4e3-a97e-1da4" name="Belicosa Pattern Volcano Cannon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules>
+        <rule id="cf08-0e28-98f1-2f9a" name="Machine Destroyer" hidden="false" book="HH5: Tempest" page="264">
+          <description>When attacking any target with an armour value, rolls of 1 on the Destroyer Damage table may be re-rolled.  </description>
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles>
+        <profile id="bfe4-e2fb-5231-ac7c" profileTypeId="576561706f6e23232344415441232323" name="Belicosa Pattern Volcano Cannon" hidden="false" book="HH5: Tempest" page="264">
+          <characteristics>
+            <characteristic characteristicId="52616e676523232344415441232323" name="Range" value="180&quot;"/>
+            <characteristic characteristicId="537472656e67746823232344415441232323" name="Strength" value="D"/>
+            <characteristic characteristicId="415023232344415441232323" name="AP" value="1"/>
+            <characteristic characteristicId="5479706523232344415441232323" name="Type" value="Primary Weapon 1, Apocalyptic Blast, Machine Destroyer"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links/>
     </entry>
     <entry id="fb66-11c0-3cb4-aac3" name="Blessed Autosimulacra" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Taghmata Army List">
       <entries/>
@@ -9435,29 +9523,6 @@ Reduces transport capacity to 8.  </description>
         </link>
       </links>
     </entry>
-    <entry id="1bc5-f4e3-a97e-1da4" name="Belicosa Pattern Volcano Cannon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules>
-        <rule id="cf08-0e28-98f1-2f9a" name="Machine Destroyer" hidden="false" book="HH5: Tempest" page="264">
-          <description>When attacking any target with an armour value, rolls of 1 on the Destroyer Damage table may be re-rolled.  </description>
-          <modifiers/>
-        </rule>
-      </rules>
-      <profiles>
-        <profile id="bfe4-e2fb-5231-ac7c" profileTypeId="576561706f6e23232344415441232323" name="Belicosa Pattern Volcano Cannon" hidden="false" book="HH5: Tempest" page="264">
-          <characteristics>
-            <characteristic characteristicId="52616e676523232344415441232323" name="Range" value="180&quot;"/>
-            <characteristic characteristicId="537472656e67746823232344415441232323" name="Strength" value="D"/>
-            <characteristic characteristicId="415023232344415441232323" name="AP" value="1"/>
-            <characteristic characteristicId="5479706523232344415441232323" name="Type" value="Primary Weapon 1, Apocalyptic Blast, Machine Destroyer"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links/>
-    </entry>
   </sharedEntries>
   <sharedEntryGroups>
     <entryGroup id="d696-042d-2afa-b026" name="Heavy Bolter or Heavy Flamer" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
@@ -9803,6 +9868,10 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
     <rule id="6187-9edf-ea79-4188" name="Stubborn" hidden="false" page="0">
       <modifiers/>
     </rule>
+    <rule id="c2e6-597c-db69-3685" name="Sunder" hidden="false" book="HH:LAICL" page="47">
+      <description>Attacks with this rule may re-roll failed Armour Penetration rolls. </description>
+      <modifiers/>
+    </rule>
     <rule id="0510-de0c-2bd9-c3c4" name="Tank Hunters" hidden="false">
       <modifiers/>
     </rule>
@@ -9817,8 +9886,14 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
       <description>Attacks with this special rule may re-roll failed armour penetration rolls against fortifications and immobile structures and add +1 to any result rolled on the Building Damage chart.  If this attack damages a bulkhead or wall section of terrain and destroys it, remove that section of terrain from play if possible.  </description>
       <modifiers/>
     </rule>
-    <rule id="c2e6-597c-db69-3685" name="Sunder" hidden="false" book="HH:LAICL" page="47">
-      <description>Attacks with this rule may re-roll failed Armour Penetration rolls. </description>
+    <rule id="fa9a-ff67-537f-3be9" name="Precision Shot" hidden="false">
+      <modifiers/>
+    </rule>
+    <rule id="0be9-1a9f-14a5-ebb8" name="Feel No Pain" hidden="false">
+      <modifiers/>
+    </rule>
+    <rule id="a41e-00bb-2ace-734f" name="Patris Cybernetica" hidden="false" book="75" page="Taghmata Army List">
+      <description>A character with this special rule may join a unit of Monstrous creatures so long as they have the Cybernetica Cortex special rule, even thought this would not normally be allowed. while it is part of a unit of Monstrous Creatures, a model with this special rule may not Go To Ground, voluntarily or otherwise, and enemy shooting at the unit may opt to ignore the fact that the character is the closest model in the unit for the purposes of shooting attacks if they wish and instead target the closest Monstrous Creature in the unit, if they have attacks in range.</description>
       <modifiers/>
     </rule>
   </sharedRules>
@@ -10531,6 +10606,15 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
       </characteristics>
       <modifiers/>
     </profile>
+    <profile id="4d09-af3d-aad0-0729" profileTypeId="576561706f6e23232344415441232323" name="Paragon Blade" hidden="false" book="HH1: Betrayal" page="235">
+      <characteristics>
+        <characteristic characteristicId="52616e676523232344415441232323" name="Range" value="-"/>
+        <characteristic characteristicId="537472656e67746823232344415441232323" name="Strength" value="+1"/>
+        <characteristic characteristicId="415023232344415441232323" name="AP" value="2"/>
+        <characteristic characteristicId="5479706523232344415441232323" name="Type" value="Melee, Murderous Strike, Specialist Weapon"/>
+      </characteristics>
+      <modifiers/>
+    </profile>
     <profile id="71ed050b-073d-852a-e50a-425b96eb71cd" profileTypeId="576561706f6e23232344415441232323" name="Phased-Plasma Fusil" hidden="false" book="HH1:Betrayal" page="232">
       <characteristics>
         <characteristic characteristicId="52616e676523232344415441232323" name="Range" value="24&quot;"/>
@@ -10672,6 +10756,12 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
         <characteristic characteristicId="537472656e67746823232344415441232323" name="Strength" value="2"/>
         <characteristic characteristicId="415023232344415441232323" name="AP" value="5"/>
         <characteristic characteristicId="5479706523232344415441232323" name="Type" value="Assault 1, Fleshbane, Rad-Phage"/>
+      </characteristics>
+      <modifiers/>
+    </profile>
+    <profile id="7f32-3376-7246-eeb0" profileTypeId="57617267656172204974656d23232344415441232323" name="Rad Furnace" hidden="false" book="HH5: Tempest" page="223">
+      <characteristics>
+        <characteristic characteristicId="4465736372697074696f6e23232344415441232323" name="Description" value="All models locked in combat with one or more unit of Scyllax suffer -1  to their Toughness for the duration of the combat.  Scyllax models are immune to this effect as well as to Rad Grenades.  Any weapon with Poison or Rad-phage only woulds a model with a Rad Furnace on a 6.  "/>
       </characteristics>
       <modifiers/>
     </profile>
@@ -10891,7 +10981,7 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
       </characteristics>
       <modifiers/>
     </profile>
-    <profile id="2c6ee84f-08d4-4e84-2468-6f39375d509b" profileTypeId="576561706f6e23232344415441232323" name="Volkite Serpentia" hidden="false" book="HH:LACAL" page="85">
+    <profile id="2c6ee84f-08d4-4e84-2468-6f39375d509b" profileTypeId="576561706f6e23232344415441232323" name="Volkite Serpenta" hidden="false" book="HH:LACAL" page="85">
       <characteristics>
         <characteristic characteristicId="52616e676523232344415441232323" name="Range" value="10&quot;"/>
         <characteristic characteristicId="537472656e67746823232344415441232323" name="Strength" value="5"/>
@@ -10924,21 +11014,6 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
         <characteristic characteristicId="537472656e67746823232344415441232323" name="Strength" value="6"/>
         <characteristic characteristicId="415023232344415441232323" name="AP" value="3"/>
         <characteristic characteristicId="5479706523232344415441232323" name="Type" value="Heavy 15"/>
-      </characteristics>
-      <modifiers/>
-    </profile>
-    <profile id="4d09-af3d-aad0-0729" profileTypeId="576561706f6e23232344415441232323" name="Paragon Blade" hidden="false" book="HH1: Betrayal" page="235">
-      <characteristics>
-        <characteristic characteristicId="52616e676523232344415441232323" name="Range" value="-"/>
-        <characteristic characteristicId="537472656e67746823232344415441232323" name="Strength" value="+1"/>
-        <characteristic characteristicId="415023232344415441232323" name="AP" value="2"/>
-        <characteristic characteristicId="5479706523232344415441232323" name="Type" value="Melee, Murderous Strike, Specialist Weapon"/>
-      </characteristics>
-      <modifiers/>
-    </profile>
-    <profile id="7f32-3376-7246-eeb0" profileTypeId="57617267656172204974656d23232344415441232323" name="Rad Furnace" hidden="false" book="HH5: Tempest" page="223">
-      <characteristics>
-        <characteristic characteristicId="4465736372697074696f6e23232344415441232323" name="Description" value="All models locked in combat with one or more unit of Scyllax suffer -1  to their Toughness for the duration of the combat.  Scyllax models are immune to this effect as well as to Rad Grenades.  Any weapon with Poison or Rad-phage only woulds a model with a Rad Furnace on a 6.  "/>
       </characteristics>
       <modifiers/>
     </profile>


### PR DESCRIPTION
The Magos Prime has the redundant option to exchange their power weapon
for a power weapon. Not redundant per se; included to present the the
item as part of default equipment.

 The "May take one second additional weapon" menu unlocked by selecting
the Myrmidax High Order of Techno-Arcana for a Magos Prime will remain
even if one subsequently changes the selected High Order of
Techno-Arcana.

 No error is reported if these additional weapons are selected by a
character who should not have access to them.

 The Rad/Irad Cleanser and Photon Thruster are listed on the Magos
Prime’s “May take one of the following” menu when they should be on the
“May take one additional weapon” menu so that they can be taken a second
time by a Magos Prime with of the Myrmidax High Order of Techno Arcana
via the “May take one second additional weapon” menu. Currently it is
impossible for a Magos Prime with of the Myrmidax High Order of Techno
Arcana to select these weapons twice in Battlescribe even though they
should have that option.

 The Magos Prime has no option to take a Rad Furnace.

 The Machinator Array is listed twice under the Magos Prime and Magos
Dominus' "May take one of the following" menus.

 None of the Magos Prime’s special rules are listed in its profile.

 The Magos Dominus requires an entirely separate menu to allow access to
one of a Rotator Cannon, Meltagun, Graviton Gun, Phased Plasma-Fusil,
Rad/Irad Cleanser or Photon Thruster. Currently Battlescribe only allows
the Magos Dominus access to the Rad/Irad Cleanser but it is located on
the “May take one of the following” menu and thus disallows, or is
disallowed by, the selection of other items of wargear that the rules
should allow it to be taken alongside. The relevant options are present
for the Legio Cybernetica exclusive (Legion selection) Archmagos
Dominus.

 The Magos Dominus is not listed as possessing the Patris Cybernetica or
Feel No Pain (5+) special rules.