### PR TITLE
Fixed issue with Terminator Command Squad for Praetor

### DIFF
--- a/(HH) Legiones Astartes - Age of Darkness Army List.cat
+++ b/(HH) Legiones Astartes - Age of Darkness Army List.cat
@@ -16399,7 +16399,7 @@ When rolling on the Thunderblitz and/or Catastrophic Damage tables for the Malca
               <modifiers>
                 <modifier type="hide" field="maxSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
                   <conditions>
-                    <condition parentId="51f64bbe-2968-91a9-051f-51d166caf36a" childId="2103949b-7a93-bec8-0d94-ac8b28e9482a" field="selections" type="equal to" value="0.0"/>
+                    <condition parentId="51f64bbe-2968-91a9-051f-51d166caf36a" childId="2103949b-7a93-bec8-0d94-ac8b28e9482a" field="selections" type="equal to" value="1.0"/>
                   </conditions>
                   <conditionGroups/>
                 </modifier>
@@ -16409,7 +16409,7 @@ When rolling on the Thunderblitz and/or Catastrophic Damage tables for the Malca
               <modifiers>
                 <modifier type="hide" field="maxSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
                   <conditions>
-                    <condition parentId="51f64bbe-2968-91a9-051f-51d166caf36a" childId="2103949b-7a93-bec8-0d94-ac8b28e9482a" field="selections" type="equal to" value="0.0"/>
+                    <condition parentId="51f64bbe-2968-91a9-051f-51d166caf36a" childId="2103949b-7a93-bec8-0d94-ac8b28e9482a" field="selections" type="equal to" value="1.0"/>
                   </conditions>
                   <conditionGroups/>
                 </modifier>
@@ -16429,7 +16429,7 @@ When rolling on the Thunderblitz and/or Catastrophic Damage tables for the Malca
               <modifiers>
                 <modifier type="hide" field="maxSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
                   <conditions>
-                    <condition parentId="51f64bbe-2968-91a9-051f-51d166caf36a" childId="2103949b-7a93-bec8-0d94-ac8b28e9482a" field="selections" type="equal to" value="0.0"/>
+                    <condition parentId="51f64bbe-2968-91a9-051f-51d166caf36a" childId="2103949b-7a93-bec8-0d94-ac8b28e9482a" field="selections" type="equal to" value="1.0"/>
                   </conditions>
                   <conditionGroups/>
                 </modifier>

--- a/(HH) Legiones Astartes - Age of Darkness Army List.cat
+++ b/(HH) Legiones Astartes - Age of Darkness Army List.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="839b6f2a-4041-398b-fc2d-dc6a31d5f75e" revision="167" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="20" battleScribeVersion="1.15" name="Legiones Astartes: Age of Darkness Army List" books="HH Series" authorName="Millicant, capitaladot" authorContact="Please submit any bugs to the website below" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="839b6f2a-4041-398b-fc2d-dc6a31d5f75e" revision="168" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="20" battleScribeVersion="1.15" name="Legiones Astartes: Age of Darkness Army List" books="HH Series" authorName="Millicant, capitaladot" authorContact="Please submit any bugs to the website below" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entries>
     <entry id="a8cf84f2-0e14-b402-f2b0-3c5d36a8f2e5" name="Achilles-Alpha Pattern Land Raider" points="300.0" categoryId="486561767920537570706f727423232344415441232323" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="AODAL" page="67">
       <entries>
@@ -16419,7 +16419,7 @@ When rolling on the Thunderblitz and/or Catastrophic Damage tables for the Malca
               <modifiers>
                 <modifier type="hide" field="maxSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
                   <conditions>
-                    <condition parentId="51f64bbe-2968-91a9-051f-51d166caf36a" childId="2103949b-7a93-bec8-0d94-ac8b28e9482a" field="selections" type="equal to" value="0.0"/>
+                    <condition parentId="51f64bbe-2968-91a9-051f-51d166caf36a" childId="2103949b-7a93-bec8-0d94-ac8b28e9482a" field="selections" type="equal to" value="1.0"/>
                   </conditions>
                   <conditionGroups/>
                 </modifier>


### PR DESCRIPTION
Issue found that Terminator Command Squads had been flagged as a "Hide if equal to 0 choices of Artificer Armour" rather than "Hide if equal to 0 choices of Artificer Armour". Meaning upgrading the Praetor to any Termy armour made Termy command squads hidden, rather than shown.
Had to also fix Deathshroud and others for same update.