### PR TITLE
#525 Updated Land Raider Proteus

### DIFF
--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -18081,7 +18081,7 @@
               <rules/>
               <infoLinks/>
               <modifiers>
-                <modifier type="set" field="maxSelections" value="3.0">
+                <modifier type="set" field="maxSelections" value="3">
                   <repeats/>
                   <conditions/>
                   <conditionGroups/>
@@ -18094,7 +18094,7 @@
               <rules/>
               <infoLinks/>
               <modifiers>
-                <modifier type="set" field="maxSelections" value="3.0">
+                <modifier type="set" field="maxSelections" value="3">
                   <repeats/>
                   <conditions/>
                   <conditionGroups/>
@@ -45850,6 +45850,21 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
               <entryLinks/>
               <costs>
                 <cost name="pts" costTypeId="points" value="20.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="44af-8ba1-2fd7-82db" name="Twin-linked Lascannon" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3b42-e289-22cc-fdd0" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="30.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>


### PR DESCRIPTION
Extended Additional Options with twin-linked lascannon in hull-mounted
weapon list.