### PR TITLE
Vehicle upgrades/standard

### DIFF
--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -39635,16 +39635,15 @@ Token representing the Cyber-hawk plays no other role in the game and may not be
           </characteristics>
         </profile>
       </profiles>
-      <rules>
-        <rule id="60da-07bf-6ffe-8c12" name="Extra Armour" hidden="false">
+      <rules/>
+      <infoLinks>
+        <infoLink id="fa3c-741a-2443-6189" hidden="false" targetId="e0898f15-4b47-28f4-313e-0b321f0a3dca" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-        </rule>
-      </rules>
-      <infoLinks>
-        <infoLink id="fa3c-741a-2443-6189" hidden="false" targetId="e0898f15-4b47-28f4-313e-0b321f0a3dca" type="profile">
+        </infoLink>
+        <infoLink id="a40d-c349-bdc7-6149" name="New InfoLink" hidden="false" targetId="5283-9b50-3dcd-78e4" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -50627,84 +50626,38 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
           <infoLinks/>
           <modifiers/>
           <constraints/>
-          <selectionEntries>
-            <selectionEntry id="823c-7186-b8ec-3d82" name="Hunter-killer Missile" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="10.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="d275-2b64-f39f-c54f" name="Dozer Blade" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="8723-e842-6a9e-4f67" name="Armoured Ceramite" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="367a-455b-26c3-88e4" hidden="false" targetId="2e87b8ca-7cd1-78b9-2116-246015e7935e" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="20.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="02f8-5d63-8a89-5fe8" name="Auxiliary Drive" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="930d-d589-f8a8-caea" hidden="false" targetId="d963a2dd-d9a3-8974-aac6-61ffcc78a99a" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="10.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
+          <selectionEntries/>
           <selectionEntryGroups/>
-          <entryLinks/>
+          <entryLinks>
+            <entryLink id="c619-7066-588e-4388" name="New EntryLink" hidden="false" targetId="c531-2497-7d93-f4e2" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="63dd-597d-6819-586e" name="New EntryLink" hidden="false" targetId="2cf6-8c8c-3a00-2fd1" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="3481-28ac-79d4-95e7" name="New EntryLink" hidden="false" targetId="94ca-8824-d7f4-1456" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="7fd9-3fe4-410b-4a6c" name="New EntryLink" hidden="false" targetId="8283-5931-b96a-4827" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="d4fc-4a93-9155-0357" name="May take one set of two sponson weapons:" hidden="false" collective="false">
           <profiles/>
@@ -50748,7 +50701,14 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
             <selectionEntry id="b574-5e14-089d-a167" name="Heavy Flamers" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
               <profiles/>
               <rules/>
-              <infoLinks/>
+              <infoLinks>
+                <infoLink id="9de5-b4d3-3c7d-e83f" name="New InfoLink" hidden="false" targetId="c554-a05e-607c-5831" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <repeats/>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -49748,31 +49748,17 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
                 <cost name="pts" costTypeId="points" value="10.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="febb-c20a-df37-10a3" name="Machine Spirit" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="0978-d251-e698-eff2" hidden="false" targetId="3a93202e-ac23-5508-2dda-248efcc8ff3d" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="25.0"/>
-              </costs>
-            </selectionEntry>
           </selectionEntries>
           <selectionEntryGroups/>
-          <entryLinks/>
+          <entryLinks>
+            <entryLink id="490e-b5b3-0ebd-385c" name="New EntryLink" hidden="false" targetId="bd68-bcee-b6d0-dff6" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="78ce-7f19-5cd4-5991" name="May take a Pintle-Mounted Weapon:" hidden="false" collective="false">
           <profiles/>
@@ -67011,6 +66997,65 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
       <modifiers/>
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d5b2-35d5-560f-fb2a" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="5.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2cf6-8c8c-3a00-2fd1" name="Auxiliary Drive" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="ce1b-aece-1cc3-5e21" hidden="false" targetId="d963a2dd-d9a3-8974-aac6-61ffcc78a99a" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8470-1353-fe6b-7ec2" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="bd68-bcee-b6d0-dff6" name="Machine Spirit" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="4703-7163-576b-ce53" hidden="false" targetId="3a93202e-ac23-5508-2dda-248efcc8ff3d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="80e4-69a3-104c-3307" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="25.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="94ca-8824-d7f4-1456" name="Hunter-killer Missile" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3754-60d1-9aaf-8809" type="max"/>
       </constraints>
       <selectionEntries/>
       <selectionEntryGroups/>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -55110,7 +55110,25 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="c631-d625-05d3-d2c5" hidden="false" targetId="a993-0e91-2841-9326" type="rule">
+        <infoLink id="c631-d625-05d3-d2c5" name="" hidden="false" targetId="a993-0e91-2841-9326" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="f4f8-3484-d17c-9f1a" name="New InfoLink" hidden="false" targetId="5283-9b50-3dcd-78e4" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="1ca1-905c-3c90-a4e6" name="New InfoLink" hidden="false" targetId="23cd-84ee-5616-7655" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="395d-0a5c-521f-ec6b" name="New InfoLink" hidden="false" targetId="184d-7e20-864a-01a1" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -66997,6 +66997,28 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
         <cost name="pts" costTypeId="points" value="20.0"/>
       </costs>
     </selectionEntry>
+    <selectionEntry id="8283-5931-b96a-4827" name="Dozer Blade" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="48f4-fa28-4948-230c" name="New InfoLink" hidden="false" targetId="22ec-5eec-82ee-ce65" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d5b2-35d5-560f-fb2a" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="5.0"/>
+      </costs>
+    </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup id="fc8ed347-6cd6-c24e-942f-bda78004e894" name="Bodyguard" hidden="false" collective="false">
@@ -71154,6 +71176,15 @@ Legion Reconnaissance Squad - Legion Recon Company (+1)</description>
         <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="5"/>
         <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="5"/>
         <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Pistol, Deflagrate"/>
+      </characteristics>
+    </profile>
+    <profile id="22ec-5eec-82ee-ce65" name="Dozer Blades" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323" profileTypeName="Wargear Item">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Description" characteristicTypeId="4465736372697074696f6e23232344415441232323"/>
       </characteristics>
     </profile>
   </sharedProfiles>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -17975,7 +17975,7 @@
               <selectionEntryGroups/>
               <entryLinks/>
               <costs>
-                <cost name="pts" costTypeId="points" value="25.0"/>
+                <cost name="pts" costTypeId="points" value="35.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -50671,7 +50671,14 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
             <selectionEntry id="0f74-e095-c69a-ec5b" name="Heavy Bolters" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
               <profiles/>
               <rules/>
-              <infoLinks/>
+              <infoLinks>
+                <infoLink id="5a0a-534b-519d-d0eb" name="New InfoLink" hidden="false" targetId="271e-6286-86cc-06dd" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
               <modifiers/>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -66955,6 +66955,26 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
+    <selectionEntry id="8121-d9ab-4026-7a1d" name="Extra Armour" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="95f6-f561-b3dd-ac68" hidden="false" targetId="79c7-90f6-b453-e799" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="5.0"/>
+      </costs>
+    </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup id="fc8ed347-6cd6-c24e-942f-bda78004e894" name="Bodyguard" hidden="false" collective="false">

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -39726,32 +39726,17 @@ Token representing the Cyber-hawk plays no other role in the game and may not be
           <infoLinks/>
           <modifiers/>
           <constraints/>
-          <selectionEntries>
-            <selectionEntry id="f86d-b5ce-c0d3-41d1" name="Armoured Ceramite" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="a370-3105-628a-d172" name="New EntryLink" hidden="false" targetId="c531-2497-7d93-f4e2" type="selectionEntry">
               <profiles/>
               <rules/>
-              <infoLinks>
-                <infoLink id="1454-0771-08c3-f852" hidden="false" targetId="2e87b8ca-7cd1-78b9-2116-246015e7935e" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
+              <infoLinks/>
               <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="20.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups/>
-          <entryLinks/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="ede0-544c-21d8-fe1a" name="May be fitted with the following carapace-mounted systems:" hidden="false" collective="false">
           <profiles/>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -49627,7 +49627,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
               <selectionEntryGroups/>
               <entryLinks/>
               <costs>
-                <cost name="pts" costTypeId="points" value="40.0"/>
+                <cost name="pts" costTypeId="points" value="35.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="af68-1f4a-4ebf-b5f1" name="Magna-Melta Cannon" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -66590,6 +66590,12 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
           <infoLinks/>
           <modifiers/>
         </infoLink>
+        <infoLink id="ece9-0637-3e3a-1b8b" name="New InfoLink" hidden="false" targetId="0ac1-dfc1-295b-50a6" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
       </infoLinks>
       <modifiers/>
       <constraints>
@@ -69383,7 +69389,7 @@ Available to Traitor faction Apothecaries and Primus Medicae models with the Leg
       <modifiers/>
       <description>When a blast weapon is used with this rule, leave the blast marker in play for the rest of the game.  This area is now treated as dangerous terrain for all models with a Toughness value and open-topped vehicles.  </description>
     </rule>
-    <rule id="3a93202e-ac23-5508-2dda-248efcc8ff3d" name="Machine Spirit" book="HH:LACAL" page="239" hidden="false">
+    <rule id="3a93202e-ac23-5508-2dda-248efcc8ff3d" name="Machine Spirit" book="LA:AODAL" page="132" hidden="false">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -69608,7 +69614,7 @@ Legion Reconnaissance Squad - Legion Recon Company (+1)</description>
         <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Pistol, Master-crafted"/>
       </characteristics>
     </profile>
-    <profile id="2e87b8ca-7cd1-78b9-2116-246015e7935e" name="Armoured Ceramite" book="HH:LACAL" page="88" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323">
+    <profile id="2e87b8ca-7cd1-78b9-2116-246015e7935e" name="Armoured Ceramite" book="LA:AODAL" page="131" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -69662,7 +69668,7 @@ Legion Reconnaissance Squad - Legion Recon Company (+1)</description>
         <characteristic name="Description" characteristicTypeId="4465736372697074696f6e23232344415441232323" value="Models cannot be deployed using the Infiltrate special rule within 18&quot; of an Augury Scanner.  A unit carrying an Augury Scanner gains the Interceptor rule against enemy units deploying via Deep Strike within 18&quot;"/>
       </characteristics>
     </profile>
-    <profile id="d963a2dd-d9a3-8974-aac6-61ffcc78a99a" name="Auxiliary Drive" book="HH:LACAL" page="88" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323">
+    <profile id="d963a2dd-d9a3-8974-aac6-61ffcc78a99a" name="Auxiliary Drive" book="LA:AODAL" page="131" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323">
       <profiles/>
       <rules/>
       <infoLinks/>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -66605,7 +66605,14 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
     <selectionEntry id="94ca-8824-d7f4-1456" name="Hunter-killer Missile" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
       <rules/>
-      <infoLinks/>
+      <infoLinks>
+        <infoLink id="411c-4d90-385d-42c2" name="New InfoLink" hidden="false" targetId="0c8a-0516-cf13-1b05" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3754-60d1-9aaf-8809" type="max"/>
@@ -70783,6 +70790,18 @@ Legion Reconnaissance Squad - Legion Recon Company (+1)</description>
       <modifiers/>
       <characteristics>
         <characteristic name="Description" characteristicTypeId="4465736372697074696f6e23232344415441232323"/>
+      </characteristics>
+    </profile>
+    <profile id="0c8a-0516-cf13-1b05" name="Hunter-Killer Missile" book="C:SM" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="Infinite"/>
+        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="8"/>
+        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="3"/>
+        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 1, One Use Only"/>
       </characteristics>
     </profile>
   </sharedProfiles>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -49259,7 +49259,20 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
         </profile>
       </profiles>
       <rules/>
-      <infoLinks/>
+      <infoLinks>
+        <infoLink id="985c-8303-0d0b-f50d" name="New InfoLink" hidden="false" targetId="23cd-84ee-5616-7655" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="dfb6-6fe3-1530-a8d3" name="New InfoLink" hidden="false" targetId="184d-7e20-864a-01a1" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
@@ -69535,14 +69548,6 @@ Veteran tactical OR Terminator - Primarch&apos;s Chosen **Not implemented**
 Legion Dreadnought or Legion Contemptor Dreadnoughts - Fury of the Ancients (Dreadnought Talon shared entry)
 Legion Assault Squad - Drop Assault Vanguard
 Legion Reconnaissance Squad - Legion Recon Company (+1)</description>
-    </rule>
-    <rule id="ecb1-74d4-65b0-2203" name="Smoke Launcher" book="BRB 7th" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Once per game, instead of shooting or moving Flat Out (or Running in the case of Walkers), a vehicle with smoke launchers can trigger them. The vehicle may not fire any of its weapons in the same turn as it used smoke launchers, but counts as obscured in the next enemy Shooting phase, receiving a 5+ cover save.
-After the enemy’s Shooting phase, the smoke disperses with no further effect. A vehicle may still use smoke launchers even if has suffered a Crew Shaken or Stunned result or it does not have any shooting weapons.</description>
     </rule>
   </sharedRules>
   <sharedProfiles>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -17690,7 +17690,7 @@
                   <infoLinks/>
                   <modifiers/>
                 </infoLink>
-                <infoLink id="35fb32ee-71c2-e3e7-847d-4bc8a4c4628d" hidden="false" targetId="2e87b8ca-7cd1-78b9-2116-246015e7935e" type="profile">
+                <infoLink id="35fb32ee-71c2-e3e7-847d-4bc8a4c4628d" name="" hidden="false" targetId="2e87b8ca-7cd1-78b9-2116-246015e7935e" type="profile">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -26207,113 +26207,6 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
-            <selectionEntryGroup id="6d45-1930-f3fb-9501" name="May take any of the following:" hidden="false" collective="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <selectionEntries>
-                <selectionEntry id="a7ee-eb7d-5187-f9c7" name="Auxiliary Drive" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="4cd7-1b08-6499-fc36" hidden="false" targetId="d963a2dd-d9a3-8974-aac6-61ffcc78a99a" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="10.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="9d8a-b172-efef-11c7" name="Hunter-killer Missile" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="10.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="6a0d-081e-1dcb-169f" name="Armoured Ceramite" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="6b8e-b034-a639-62df" hidden="false" targetId="2e87b8ca-7cd1-78b9-2116-246015e7935e" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="20.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="eaf0-068c-941a-05ce" name="Extra Armour" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="10.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="4f7e-e4a7-ac20-a65b" name="Machine Spirit" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="6100-ca9d-5811-b4bc" hidden="false" targetId="3a93202e-ac23-5508-2dda-248efcc8ff3d" type="rule">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="25.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups/>
-              <entryLinks/>
-            </selectionEntryGroup>
             <selectionEntryGroup id="4150-a928-1187-5919" name="May take one of the following:" hidden="false" collective="false">
               <profiles/>
               <rules/>
@@ -26342,6 +26235,52 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
               <selectionEntryGroups/>
               <entryLinks>
                 <entryLink id="2578-8d99-4edf-920f" name="New EntryLink" hidden="false" targetId="8283-5931-b96a-4827" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="e2f1-4c15-6246-f82e" name="May take any of the following:" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="b0f9-f5b8-b5a6-1061" name="New EntryLink" hidden="false" targetId="2cf6-8c8c-3a00-2fd1" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="6d80-d6ef-8faf-21d3" name="New EntryLink" hidden="false" targetId="8121-d9ab-4026-7a1d" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="25f3-e6c7-7280-f9a2" name="New EntryLink" hidden="false" targetId="94ca-8824-d7f4-1456" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="4daa-e0a0-8463-4ce2" name="New EntryLink" hidden="false" targetId="bd68-bcee-b6d0-dff6" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="74e8-e8e7-553e-a5f8" name="New EntryLink" hidden="false" targetId="c531-2497-7d93-f4e2" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -9776,7 +9776,7 @@
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="6f2c-eff4-e969-2d30" hidden="false" targetId="c49a-4a6c-913f-9c09" type="profile">
+        <infoLink id="6f2c-eff4-e969-2d30" name="" hidden="false" targetId="c49a-4a6c-913f-9c09" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -9907,6 +9907,20 @@
       </selectionEntryGroups>
       <entryLinks>
         <entryLink id="8a76-a815-eaf0-ab26" hidden="false" targetId="c487-be13-ea53-917e" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="b327-f502-c1fe-6194" name="New EntryLink" hidden="false" targetId="c531-2497-7d93-f4e2" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="59df-c63c-32f6-c667" name="New EntryLink" hidden="false" targetId="8121-d9ab-4026-7a1d" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -29440,84 +29454,38 @@ Ignores Cover special rule.</description>
           <infoLinks/>
           <modifiers/>
           <constraints/>
-          <selectionEntries>
-            <selectionEntry id="141900c7-3f0d-76d5-93c4-bd2e44024800" name="Hunter-killer Missile" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="10.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="d1ebb668-6bd0-65a1-dd79-46fefe8abea4" name="Dozer Blade" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="425af40c-4887-bbae-c376-14725ccf4a49" name="Armoured Ceramite" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="5a9a5f87-e3a4-201c-7ebf-f10e2200d2e5" hidden="false" targetId="2e87b8ca-7cd1-78b9-2116-246015e7935e" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="20.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="e61f40e9-d09c-2086-a141-afd423f1ae27" name="Auxiliary Drive" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="9d463a3b-173a-79ff-315c-636389e7e3f3" hidden="false" targetId="d963a2dd-d9a3-8974-aac6-61ffcc78a99a" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="10.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
+          <selectionEntries/>
           <selectionEntryGroups/>
-          <entryLinks/>
+          <entryLinks>
+            <entryLink id="a25b-3b26-fb3f-c50c" name="New EntryLink" hidden="false" targetId="c531-2497-7d93-f4e2" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="4522-2ad7-350b-7532" name="New EntryLink" hidden="false" targetId="94ca-8824-d7f4-1456" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="66c7-b187-e2f0-5488" name="New EntryLink" hidden="false" targetId="8283-5931-b96a-4827" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="53df-af5f-00f6-921c" name="New EntryLink" hidden="false" targetId="2cf6-8c8c-3a00-2fd1" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="d5da8eaa-d381-8403-d080-0bad275e1f50" name="May take one set of two sponson weapons:" hidden="false" collective="false">
           <profiles/>
@@ -29614,6 +29582,13 @@ Ignores Cover special rule.</description>
       </selectionEntryGroups>
       <entryLinks>
         <entryLink id="11f4-8fdd-6461-85db" hidden="false" targetId="c487-be13-ea53-917e" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="9646-6aca-f946-c77a" name="New EntryLink" hidden="false" targetId="8121-d9ab-4026-7a1d" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -66975,6 +66975,28 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
         <cost name="pts" costTypeId="points" value="5.0"/>
       </costs>
     </selectionEntry>
+    <selectionEntry id="c531-2497-7d93-f4e2" name="Armoured Ceramite" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="ef7e-5d02-a38f-3ba8" hidden="false" targetId="2e87b8ca-7cd1-78b9-2116-246015e7935e" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c4a7-8790-92d5-eab5" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="20.0"/>
+      </costs>
+    </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup id="fc8ed347-6cd6-c24e-942f-bda78004e894" name="Bodyguard" hidden="false" collective="false">

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -49658,100 +49658,45 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
           <infoLinks/>
           <modifiers/>
           <constraints/>
-          <selectionEntries>
-            <selectionEntry id="993a-6f8a-540c-11c8" name="Dozer Blade" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="8f73-2523-693c-d6d7" name="Auxiliary Drive" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="e7ab-e509-ab12-8b9e" hidden="false" targetId="d963a2dd-d9a3-8974-aac6-61ffcc78a99a" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="10.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="235b-ed7e-6ac9-99a7" name="Hunter-killer Missile" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="10.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="c9aa-3829-619c-6eea" name="Armoured Ceramite" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="a564-663c-5e80-3033" hidden="false" targetId="2e87b8ca-7cd1-78b9-2116-246015e7935e" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="20.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="87e3-7273-70be-8dcc" name="Extra Armour" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="10.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
+          <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
             <entryLink id="490e-b5b3-0ebd-385c" name="New EntryLink" hidden="false" targetId="bd68-bcee-b6d0-dff6" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="134d-c9b5-d8e0-36a3" name="New EntryLink" hidden="false" targetId="c531-2497-7d93-f4e2" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="81d4-07b0-17dc-ccce" name="New EntryLink" hidden="false" targetId="2cf6-8c8c-3a00-2fd1" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="3c4b-bf54-d4a8-f689" name="New EntryLink" hidden="false" targetId="8283-5931-b96a-4827" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="ba65-b196-7758-2dcf" name="New EntryLink" hidden="false" targetId="8121-d9ab-4026-7a1d" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="a5dc-2359-dbd2-84ee" name="New EntryLink" hidden="false" targetId="94ca-8824-d7f4-1456" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -55441,28 +55441,6 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
               <modifiers/>
               <constraints/>
               <selectionEntries>
-                <selectionEntry id="888d-f93e-b42a-656d" name="Armoured Ceramite" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="67dd-f0a8-0b1c-627f" hidden="false" targetId="2e87b8ca-7cd1-78b9-2116-246015e7935e" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="20.0"/>
-                  </costs>
-                </selectionEntry>
                 <selectionEntry id="c84d-1033-2b37-b9c1" name="Phosphex Discharger" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
                   <profiles>
                     <profile id="bae4-80e1-ca17-2920" name="Phosphex Discharger" hidden="false" profileTypeId="576561706f6e23232344415441232323">
@@ -55506,7 +55484,15 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
                 </selectionEntry>
               </selectionEntries>
               <selectionEntryGroups/>
-              <entryLinks/>
+              <entryLinks>
+                <entryLink id="dcb0-01dd-988b-6996" name="New EntryLink" hidden="false" targetId="c531-2497-7d93-f4e2" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="ccc7-2d73-fda1-1f62" name="Legion-specific upgrade" hidden="false" collective="false">
               <profiles/>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -17833,84 +17833,6 @@
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
-                <selectionEntryGroup id="668718b2-5e8f-f318-8459-ce52864c4abf" name="May take any of the following:" hidden="false" collective="false">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <selectionEntries>
-                    <selectionEntry id="e19657dc-24cd-0abe-8a18-5b2e1cf05fc3" name="Extra Armour" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="10.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="08ca09ad-f319-84af-fe87-753b844c158d" name="Dozer Blade" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="5.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="fcea802c-ba91-4f58-428e-6f302e3dfe48" name="Auxiliary Drive" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="fcb79fac-f931-27f2-d897-cc6680c9d646" hidden="false" targetId="d963a2dd-d9a3-8974-aac6-61ffcc78a99a" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="10.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="e35f2f91-6d5e-f55b-7f38-27e3a9f09922" name="Hunter-killer Missile" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="10.0"/>
-                      </costs>
-                    </selectionEntry>
-                  </selectionEntries>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                </selectionEntryGroup>
                 <selectionEntryGroup id="8c142f5e-8023-7a71-55dc-bc8f968e4638" name="Legion-specific upgrade" hidden="false" collective="false">
                   <profiles/>
                   <rules/>
@@ -17935,6 +17857,45 @@
                       <constraints/>
                     </entryLink>
                     <entryLink id="0fc8a5c2-6ac8-cfa5-32a3-d6b91e9a0322" hidden="false" targetId="f785888f-6dfa-08f4-054f-29b1a0e4f20c" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="bc2b-3af4-ba31-f489" name="May take any of the following:" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="4316-40a1-b33e-5084" name="New EntryLink" hidden="false" targetId="2cf6-8c8c-3a00-2fd1" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </entryLink>
+                    <entryLink id="80aa-83e7-8070-012c" name="New EntryLink" hidden="false" targetId="8283-5931-b96a-4827" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </entryLink>
+                    <entryLink id="0de7-c377-024c-4e79" name="New EntryLink" hidden="false" targetId="8121-d9ab-4026-7a1d" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </entryLink>
+                    <entryLink id="9cf3-b5e5-b275-84b7" name="New EntryLink" hidden="false" targetId="94ca-8824-d7f4-1456" type="selectionEntry">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -26362,21 +26323,6 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <selectionEntries>
-                <selectionEntry id="1d52-8a03-2d61-2f3f" name="Dozer Blade" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="5.0"/>
-                  </costs>
-                </selectionEntry>
                 <selectionEntry id="a13e-9a59-42ff-cdd3" name="Mine Plough" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
                   <profiles/>
                   <rules/>
@@ -26394,7 +26340,15 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                 </selectionEntry>
               </selectionEntries>
               <selectionEntryGroups/>
-              <entryLinks/>
+              <entryLinks>
+                <entryLink id="2578-8d99-4edf-920f" name="New EntryLink" hidden="false" targetId="8283-5931-b96a-4827" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks/>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -50720,7 +50720,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
     </selectionEntry>
     <selectionEntry id="a331-2e97-bd94-4103" name="Legion Sicaran Battle Tank" book="HH:LACAL" page="61" hidden="false" collective="false" categoryEntryId="486561767920537570706f727423232344415441232323" type="unit">
       <profiles>
-        <profile id="6f43-e31f-8e59-2e63" name="Legion Sicaran Battle Tank" book="HH:LACAL" page="60" hidden="false" profileTypeId="56656869636c6523232344415441232323">
+        <profile id="6f43-e31f-8e59-2e63" name="Legion Sicaran Battle Tank" book="LA:AODAL" page="73" hidden="false" profileTypeId="56656869636c6523232344415441232323">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -50756,7 +50756,26 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
           <description>Targets may not take a Jink save against damage from this weapon.  </description>
         </rule>
       </rules>
-      <infoLinks/>
+      <infoLinks>
+        <infoLink id="36ce-26d7-98fc-a100" name="New InfoLink" hidden="false" targetId="184d-7e20-864a-01a1" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="2a62-c719-a905-bd33" name="New InfoLink" hidden="false" targetId="23cd-84ee-5616-7655" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="1989-aa9b-6c2c-9d36" name="New InfoLink" page="" hidden="false" targetId="5283-9b50-3dcd-78e4" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
       <constraints>
         <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -4144,21 +4144,6 @@
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="1bfcf7ec-06a4-0b30-d4d6-038897af0859" name="Extra Armour" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="10.0"/>
-              </costs>
-            </selectionEntry>
             <selectionEntry id="7e3d8eca-d9e8-cab2-462b-23901e1543b1" name="Havoc Launcher" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
               <profiles/>
               <rules/>
@@ -4176,7 +4161,15 @@
             </selectionEntry>
           </selectionEntries>
           <selectionEntryGroups/>
-          <entryLinks/>
+          <entryLinks>
+            <entryLink id="f7a6-6ebe-4ddb-7b6b" name="New EntryLink" hidden="false" targetId="8121-d9ab-4026-7a1d" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="a863d60d-f120-eae8-d1a1-b420f5206116" name="Legion-specific upgrade" hidden="false" collective="false">
           <profiles/>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -45659,106 +45659,6 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="400f56b8-88b3-f170-4d09-f74fa399f24c" name="May take any of the following:" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <selectionEntries>
-            <selectionEntry id="37039c17-304e-a1ce-091f-a288227910dc" name="Extra Armour" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="10.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="3bf74ca2-f0d2-a2ac-20ec-8aa4a3474d24" name="Dozer Blade" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="ab80c902-c1dc-2a1b-9598-38e37257a033" name="Auxiliary Drive" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="9fa401bc-9341-e241-3881-1123409e17d9" hidden="false" targetId="d963a2dd-d9a3-8974-aac6-61ffcc78a99a" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="10.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="05c29825-9796-dfee-d45d-d81c757e4680" name="Hunter-killer Missile" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="10.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="f17c0461-9bbc-ee3b-336b-de9a2d8ea807" name="Armoured Ceramite" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="aca3405a-eb68-af1e-8299-51b666637b9b" hidden="false" targetId="2e87b8ca-7cd1-78b9-2116-246015e7935e" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="20.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups/>
-          <entryLinks/>
-        </selectionEntryGroup>
         <selectionEntryGroup id="042077ba-42af-1108-91b1-300fd75e9291" name="May take one hull-mounted weapon" hidden="false" collective="false">
           <profiles/>
           <rules/>
@@ -45841,6 +45741,52 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
               <constraints/>
             </entryLink>
             <entryLink id="7c71ca69-eeca-9e65-51bc-219418bd4f53" hidden="false" targetId="f785888f-6dfa-08f4-054f-29b1a0e4f20c" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="e838-7e28-e916-cb4a" name="May take any of the following:" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="05ab-598d-1ac7-32a4" name="New EntryLink" hidden="false" targetId="c531-2497-7d93-f4e2" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="15c9-01f9-ac4b-413e" name="New EntryLink" hidden="false" targetId="2cf6-8c8c-3a00-2fd1" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="7fa6-8e94-4d0a-2867" name="New EntryLink" hidden="false" targetId="8283-5931-b96a-4827" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="3ebf-ac3f-e716-84ca" name="New EntryLink" hidden="false" targetId="8121-d9ab-4026-7a1d" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="488b-24d1-5a99-4369" name="New EntryLink" hidden="false" targetId="94ca-8824-d7f4-1456" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -39509,7 +39509,7 @@ Token representing the Cyber-hawk plays no other role in the game and may not be
             <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="48&quot;"/>
             <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="5"/>
             <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="4"/>
-            <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 1, Blast, Pinning"/>
+            <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 2, Blast, Pinning"/>
           </characteristics>
         </profile>
       </profiles>
@@ -39625,7 +39625,7 @@ Token representing the Cyber-hawk plays no other role in the game and may not be
                     <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="48&quot;"/>
                     <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="8"/>
                     <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="3"/>
-                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 2"/>
+                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 3"/>
                   </characteristics>
                 </profile>
               </profiles>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -18680,47 +18680,24 @@
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
-          <selectionEntries>
-            <selectionEntry id="c4fe62b1-445d-6f92-d00a-86259061bf4d" name="Extra Armour" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="4c36-d202-98e9-f913" name="New EntryLink" hidden="false" targetId="8121-d9ab-4026-7a1d" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="10.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="71b7ffc5-b0ac-c578-1bc5-859a0880cb26" name="Armoured Ceramite" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <constraints/>
+            </entryLink>
+            <entryLink id="8cb9-fa85-3add-cb25" name="New EntryLink" hidden="false" targetId="c531-2497-7d93-f4e2" type="selectionEntry">
               <profiles/>
               <rules/>
-              <infoLinks>
-                <infoLink id="0d85a937-6c4c-960a-7610-251739fd64e4" hidden="false" targetId="2e87b8ca-7cd1-78b9-2116-246015e7935e" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
+              <infoLinks/>
               <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="20.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups/>
-          <entryLinks/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="ec7e911b-a55c-b944-8a2a-cdc6b6cda36e" name="May take one of the following:" hidden="false" collective="false">
           <profiles/>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -45357,106 +45357,6 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="53ca72a9-050a-6e70-13c7-42961f7192af" name="May take any of the following:" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <selectionEntries>
-            <selectionEntry id="e96b8241-8ca2-4b48-47de-8a26955b07f1" name="Extra Armour" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="10.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="94dcf6af-3af5-ec92-b218-0d40c8c36fb7" name="Dozer Blade" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="869b1ecb-88c4-10c6-bfca-105804359e47" name="Auxiliary Drive" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="e111b7b1-0509-8d0e-bbd6-141df7eebe81" hidden="false" targetId="d963a2dd-d9a3-8974-aac6-61ffcc78a99a" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="10.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="8b52db12-789c-da19-fdbe-7febad95bb08" name="Hunter-killer Missile" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="10.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="48626a66-438d-9e7b-d1b6-ac4a16131d9e" name="Armoured Ceramite" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="8be6cdfe-a77c-e060-a6d3-582c3f124181" hidden="false" targetId="2e87b8ca-7cd1-78b9-2116-246015e7935e" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="20.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups/>
-          <entryLinks/>
-        </selectionEntryGroup>
         <selectionEntryGroup id="63258b06-0048-f9b3-9760-e1d32fd2cd5f" name="Legion-specific upgrade" hidden="false" collective="false">
           <profiles/>
           <rules/>
@@ -45510,6 +45410,52 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
               <constraints/>
             </entryLink>
             <entryLink id="e9072124-166e-e650-4111-de25c48de041" hidden="false" targetId="f785888f-6dfa-08f4-054f-29b1a0e4f20c" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="6a0b-3706-ddb3-c758" name="May take any of the following:" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="d724-093a-6c9a-f574" name="New EntryLink" hidden="false" targetId="c531-2497-7d93-f4e2" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="d1d4-4cf7-2a40-126b" name="New EntryLink" hidden="false" targetId="2cf6-8c8c-3a00-2fd1" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="4d60-80a8-d06e-f51b" name="New EntryLink" hidden="false" targetId="8283-5931-b96a-4827" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="ab93-e2ba-019e-22fc" name="New EntryLink" hidden="false" targetId="8121-d9ab-4026-7a1d" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="92d3-08e3-7d31-3d13" name="New EntryLink" hidden="false" targetId="94ca-8824-d7f4-1456" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -17710,9 +17710,21 @@
                   <infoLinks/>
                   <modifiers/>
                 </infoLink>
+                <infoLink id="5b91-5007-c2c1-749e" name="New InfoLink" hidden="false" targetId="23cd-84ee-5616-7655" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="935e-7450-de53-4a33" name="New InfoLink" hidden="false" targetId="184d-7e20-864a-01a1" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
               </infoLinks>
               <modifiers>
-                <modifier type="set" field="maxSelections" value="1.0">
+                <modifier type="set" field="maxSelections" value="1">
                   <repeats/>
                   <conditions/>
                   <conditionGroups/>
@@ -44933,6 +44945,18 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
           <infoLinks/>
           <modifiers/>
         </infoLink>
+        <infoLink id="f054-661f-b71a-e801" name="New InfoLink" hidden="false" targetId="23cd-84ee-5616-7655" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="95e4-933d-dd71-f0e8" name="New InfoLink" hidden="false" targetId="184d-7e20-864a-01a1" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
       </infoLinks>
       <modifiers/>
       <constraints>
@@ -45213,6 +45237,18 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
       <rules/>
       <infoLinks>
         <infoLink id="26ddbaa2-d2e4-7473-3269-423b26031912" hidden="false" targetId="3a93202e-ac23-5508-2dda-248efcc8ff3d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="f753-2805-2419-64cd" name="New InfoLink" hidden="false" targetId="184d-7e20-864a-01a1" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="e3e3-a30b-ef3d-e85e" name="23cd-84ee-5616-7655" hidden="false" targetId="23cd-84ee-5616-7655" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -26331,7 +26331,7 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="e302-400f-f316-014d" hidden="false" targetId="c487-be13-ea53-917e" type="selectionEntryGroup">
+        <entryLink id="e302-400f-f316-014d" name="" hidden="false" targetId="c487-be13-ea53-917e" type="selectionEntryGroup">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -49443,7 +49443,14 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
             <selectionEntry id="85b6-2e08-678b-6dfd" name="Heavy Bolters" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
               <profiles/>
               <rules/>
-              <infoLinks/>
+              <infoLinks>
+                <infoLink id="a671-71a4-7079-1e63" name="New InfoLink" hidden="false" targetId="271e-6286-86cc-06dd" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
               <modifiers/>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
@@ -49458,7 +49465,14 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
             <selectionEntry id="d655-dc18-bd78-c6e3" name="Heavy Flamers" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
               <profiles/>
               <rules/>
-              <infoLinks/>
+              <infoLinks>
+                <infoLink id="48e6-13d4-0445-02fb" name="New InfoLink" hidden="false" targetId="c554-a05e-607c-5831" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
               <modifiers/>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
@@ -69521,6 +69535,14 @@ Veteran tactical OR Terminator - Primarch&apos;s Chosen **Not implemented**
 Legion Dreadnought or Legion Contemptor Dreadnoughts - Fury of the Ancients (Dreadnought Talon shared entry)
 Legion Assault Squad - Drop Assault Vanguard
 Legion Reconnaissance Squad - Legion Recon Company (+1)</description>
+    </rule>
+    <rule id="ecb1-74d4-65b0-2203" name="Smoke Launcher" book="BRB 7th" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>Once per game, instead of shooting or moving Flat Out (or Running in the case of Walkers), a vehicle with smoke launchers can trigger them. The vehicle may not fire any of its weapons in the same turn as it used smoke launchers, but counts as obscured in the next enemy Shooting phase, receiving a 5+ cover save.
+After the enemy’s Shooting phase, the smoke disperses with no further effect. A vehicle may still use smoke launchers even if has suffered a Crew Shaken or Stunned result or it does not have any shooting weapons.</description>
     </rule>
   </sharedRules>
   <sharedProfiles>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -50258,77 +50258,38 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
           <infoLinks/>
           <modifiers/>
           <constraints/>
-          <selectionEntries>
-            <selectionEntry id="42e89b36-5945-ac23-573b-1bb1f03c3a6c" name="Auxiliary Drive" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="e8432c41-7449-f4b2-6b5d-c8b57ed684ab" hidden="false" targetId="d963a2dd-d9a3-8974-aac6-61ffcc78a99a" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="10.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="50cf58d3-20c4-ea62-b5c1-0427f6dc9b9e" name="Dozer Blade" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="28caa2ec-6cf4-545f-8dac-4db200e9f313" name="Extra Armour" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="99153cec-bcd5-f04b-6bc7-bc0b8b818592" name="Hunter-Killer Missile" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
+          <selectionEntries/>
           <selectionEntryGroups/>
-          <entryLinks/>
+          <entryLinks>
+            <entryLink id="b82f-81e0-fab8-3441" name="New EntryLink" hidden="false" targetId="2cf6-8c8c-3a00-2fd1" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="8107-35f9-4a74-5243" name="New EntryLink" hidden="false" targetId="94ca-8824-d7f4-1456" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="7b5f-9940-5707-424c" name="New EntryLink" hidden="false" targetId="8121-d9ab-4026-7a1d" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="8bc5-0656-a135-4a96" name="New EntryLink" hidden="false" targetId="8283-5931-b96a-4827" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="a8e82035-24ce-482d-b62f-9510c2b1cfe2" name="Legion-specific upgrade" hidden="false" collective="false">
           <profiles/>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -66635,7 +66635,9 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
         </infoLink>
       </infoLinks>
       <modifiers/>
-      <constraints/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b242-a875-4e02-ab65" type="max"/>
+      </constraints>
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks/>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -7272,7 +7272,20 @@
                 </profile>
               </profiles>
               <rules/>
-              <infoLinks/>
+              <infoLinks>
+                <infoLink id="36dd-9b9b-ef51-4750" name="New InfoLink" hidden="false" targetId="184d-7e20-864a-01a1" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="611a-4988-9337-9a39" name="New InfoLink" hidden="false" targetId="23cd-84ee-5616-7655" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
               <modifiers/>
               <constraints>
                 <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
@@ -7436,7 +7449,20 @@
                 </profile>
               </profiles>
               <rules/>
-              <infoLinks/>
+              <infoLinks>
+                <infoLink id="859c-7f66-1a12-14cd" name="New InfoLink" hidden="false" targetId="184d-7e20-864a-01a1" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="dc80-47cc-5eff-a76f" name="New InfoLink" hidden="false" targetId="23cd-84ee-5616-7655" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
               <modifiers/>
               <constraints>
                 <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
@@ -7664,7 +7690,20 @@
                 </profile>
               </profiles>
               <rules/>
-              <infoLinks/>
+              <infoLinks>
+                <infoLink id="653d-a887-adc8-afdf" name="New InfoLink" hidden="false" targetId="184d-7e20-864a-01a1" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="c4b6-3322-fb75-2561" name="New InfoLink" hidden="false" targetId="23cd-84ee-5616-7655" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
               <modifiers/>
               <constraints>
                 <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
@@ -7839,7 +7878,7 @@
               <selectionEntryGroups/>
               <entryLinks/>
               <costs>
-                <cost name="pts" costTypeId="points" value="25.0"/>
+                <cost name="pts" costTypeId="points" value="35.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -70783,16 +70783,16 @@ Legion Reconnaissance Squad - Legion Recon Company (+1)</description>
         <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Pistol, Deflagrate"/>
       </characteristics>
     </profile>
-    <profile id="22ec-5eec-82ee-ce65" name="Dozer Blades" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323" profileTypeName="Wargear Item">
+    <profile id="22ec-5eec-82ee-ce65" name="Dozer Blades" book="BRB 7th" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323" profileTypeName="Wargear Item">
       <profiles/>
       <rules/>
       <infoLinks/>
       <modifiers/>
       <characteristics>
-        <characteristic name="Description" characteristicTypeId="4465736372697074696f6e23232344415441232323"/>
+        <characteristic name="Description" characteristicTypeId="4465736372697074696f6e23232344415441232323" value="Front armour is treated as one higher than normal when ramming. The vehicle can also re-roll failed Dangerous Terrain tests."/>
       </characteristics>
     </profile>
-    <profile id="0c8a-0516-cf13-1b05" name="Hunter-Killer Missile" book="C:SM" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
+    <profile id="0c8a-0516-cf13-1b05" name="Hunter-Killer Missile" book="BRB 7th" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
       <profiles/>
       <rules/>
       <infoLinks/>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -7279,84 +7279,6 @@
               </constraints>
               <selectionEntries/>
               <selectionEntryGroups>
-                <selectionEntryGroup id="9c78cc68-790d-14d5-709f-2fd47a3bb70f" name="May take any of the following:" hidden="false" collective="false">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <selectionEntries>
-                    <selectionEntry id="2d2ac244-e8aa-c261-a21e-786e9033ac12" name="Dozer Blade" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="5.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="90b7f6e6-7b8f-c14e-a3e9-93a8dcbf8bd7" name="Auxiliary Drive" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="f5da6df1-bef2-6908-5727-6437686ae56f" hidden="false" targetId="d963a2dd-d9a3-8974-aac6-61ffcc78a99a" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="10.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="c8d8643d-1396-d2c7-7e51-de99dad60355" name="Hunter-killer Missile" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="10.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="f63d68b5-0cde-f3a8-1462-1f8a05b2a2b1" name="Extra Armour" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="10.0"/>
-                      </costs>
-                    </selectionEntry>
-                  </selectionEntries>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                </selectionEntryGroup>
                 <selectionEntryGroup id="32c5bd56-8c3f-9010-53a4-13196141736b" name="May take a Pintle-Mounted Weapon:" hidden="false" collective="false">
                   <profiles/>
                   <rules/>
@@ -7439,6 +7361,45 @@
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
+                <selectionEntryGroup id="8595-8b9f-ff3a-f89e" name="May take any of the following:" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="54a2-2033-75c7-081f" name="New EntryLink" hidden="false" targetId="2cf6-8c8c-3a00-2fd1" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </entryLink>
+                    <entryLink id="d740-c87e-1c5c-6152" name="New EntryLink" hidden="false" targetId="94ca-8824-d7f4-1456" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </entryLink>
+                    <entryLink id="4057-c341-7e5e-12b8" name="New EntryLink" hidden="false" targetId="8121-d9ab-4026-7a1d" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </entryLink>
+                    <entryLink id="6093-dfd6-71fe-4b08" name="New EntryLink" hidden="false" targetId="8283-5931-b96a-4827" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
               </selectionEntryGroups>
               <entryLinks/>
               <costs>
@@ -7482,84 +7443,6 @@
               </constraints>
               <selectionEntries/>
               <selectionEntryGroups>
-                <selectionEntryGroup id="074fbb7d-ac7e-af42-5e08-4bebdb606bbc" name="May take any of the following:" hidden="false" collective="false">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <selectionEntries>
-                    <selectionEntry id="9b82c994-74e7-57b2-3168-76512a7620dc" name="Dozer Blade" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="5.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="f94a00e2-0bcf-6bf4-b4fc-e89c1f7ab542" name="Auxiliary Drive" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="22cda241-6397-c1e8-616d-feb8e0c237e1" hidden="false" targetId="d963a2dd-d9a3-8974-aac6-61ffcc78a99a" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="10.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="3723a555-d4c3-cd82-d979-9c5665b26dc0" name="Hunter-killer Missile" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="10.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="8f410bd1-d807-a62e-f325-e66ca10b619d" name="Extra Armour" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="10.0"/>
-                      </costs>
-                    </selectionEntry>
-                  </selectionEntries>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                </selectionEntryGroup>
                 <selectionEntryGroup id="3bf3fdb6-315b-6532-41ea-e5b63c3f6c92" name="May take a Pintle-Mounted Weapon:" hidden="false" collective="false">
                   <profiles/>
                   <rules/>
@@ -7678,6 +7561,45 @@
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
+                <selectionEntryGroup id="6e57-43af-b2f2-7034" name="May take any of the following:" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="cc84-6da5-4e5d-d8ee" name="New EntryLink" hidden="false" targetId="2cf6-8c8c-3a00-2fd1" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </entryLink>
+                    <entryLink id="4048-41a7-5e9d-7e21" name="New EntryLink" hidden="false" targetId="94ca-8824-d7f4-1456" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </entryLink>
+                    <entryLink id="5f0b-3a12-3d06-1bc6" name="New EntryLink" hidden="false" targetId="8121-d9ab-4026-7a1d" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </entryLink>
+                    <entryLink id="646e-8795-a992-f8d9" name="New EntryLink" hidden="false" targetId="8283-5931-b96a-4827" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
               </selectionEntryGroups>
               <entryLinks/>
               <costs>
@@ -7749,84 +7671,6 @@
               </constraints>
               <selectionEntries/>
               <selectionEntryGroups>
-                <selectionEntryGroup id="7c391074-2423-d31d-3a3c-056975a8c65b" name="May take any of the following:" hidden="false" collective="false">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <selectionEntries>
-                    <selectionEntry id="dbce0d7e-7926-433b-75e5-4f2094736ad0" name="Dozer Blade" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="5.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="ec6c71d6-74e1-213e-6707-80fd8403df43" name="Auxiliary Drive" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="354433d7-5118-104f-5ace-ecd839bb55ab" hidden="false" targetId="d963a2dd-d9a3-8974-aac6-61ffcc78a99a" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="10.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="ea41fdbf-4d4d-eb12-a4e6-17029247371d" name="Hunter-killer Missile" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="10.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="f381af6b-7b4e-5f86-632d-ee445e6e99e8" name="Extra Armour" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="10.0"/>
-                      </costs>
-                    </selectionEntry>
-                  </selectionEntries>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                </selectionEntryGroup>
                 <selectionEntryGroup id="95bee91d-3cca-23e9-0267-2ce740e670bb" name="May take a Pintle-Mounted Weapon:" hidden="false" collective="false">
                   <profiles/>
                   <rules/>
@@ -7904,6 +7748,45 @@
                   <selectionEntryGroups/>
                   <entryLinks>
                     <entryLink id="23b1b879-68fa-b58c-ebd4-f70b12cbf247" hidden="false" targetId="a15bdf56-4ffe-fe04-ff77-3d533ab99dfa" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="e880-ccc3-0467-fe09" name="May take any of the following:" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="f0e1-d252-c41a-c769" name="New EntryLink" hidden="false" targetId="2cf6-8c8c-3a00-2fd1" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </entryLink>
+                    <entryLink id="b00a-93db-ecec-f054" name="New EntryLink" hidden="false" targetId="94ca-8824-d7f4-1456" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </entryLink>
+                    <entryLink id="9555-160c-aa73-46a3" name="New EntryLink" hidden="false" targetId="8121-d9ab-4026-7a1d" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </entryLink>
+                    <entryLink id="7a1c-c59a-ecce-bd30" name="New EntryLink" hidden="false" targetId="8283-5931-b96a-4827" type="selectionEntry">
                       <profiles/>
                       <rules/>
                       <infoLinks/>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -39742,6 +39742,18 @@ Token representing the Cyber-hawk plays no other role in the game and may not be
           <infoLinks/>
           <modifiers/>
         </infoLink>
+        <infoLink id="3cba-d896-9cad-e1aa" name="New InfoLink" hidden="false" targetId="184d-7e20-864a-01a1" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="3534-34cc-2214-5adf" name="New InfoLink" hidden="false" targetId="23cd-84ee-5616-7655" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
       </infoLinks>
       <modifiers/>
       <constraints/>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -26064,7 +26064,20 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
             </profile>
           </profiles>
           <rules/>
-          <infoLinks/>
+          <infoLinks>
+            <infoLink id="c820-bc34-8c2d-f116" name="New InfoLink" hidden="false" targetId="23cd-84ee-5616-7655" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="1119-6a35-8dcb-65a0" name="New InfoLink" hidden="false" targetId="184d-7e20-864a-01a1" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
           <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
@@ -50916,12 +50929,6 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
         </profile>
       </profiles>
       <rules>
-        <rule id="56e58a7c-884a-db74-96b3-fb0e7f3abedf" name="Extra Armour" page="0" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </rule>
         <rule id="d47d12be-9bf6-065e-bd42-4d0cccb0c01f" name="Assault Vehicle" page="0" hidden="false">
           <profiles/>
           <rules/>
@@ -50931,6 +50938,30 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
       </rules>
       <infoLinks>
         <infoLink id="ce9cdf6c-ef85-fc72-4166-d427312fe70b" hidden="false" targetId="3a93202e-ac23-5508-2dda-248efcc8ff3d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="0b68-154f-cb0a-2191" name="New InfoLink" hidden="false" targetId="5283-9b50-3dcd-78e4" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="c4f4-1f1d-f541-173a" name="New InfoLink" hidden="false" targetId="9298-04e9-9b11-795b" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="fcbe-a6f3-c322-2343" name="New InfoLink" hidden="false" targetId="184d-7e20-864a-01a1" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="5e02-7ce2-e34d-f7ca" name="New InfoLink" hidden="false" targetId="23cd-84ee-5616-7655" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -69102,11 +69133,12 @@ Phalanx Warders</description>
       <modifiers/>
       <description>May be included as a HQ choice in a Legion army whose Legiones Astartes rule he does not share.  Where this is the case, he does not gain any benefits from the different Legiones Astartes rules nor does he negate those rules.  When his Leadership value is used to make tests for the unit, his special rules rather than any for the unit are used.  In the case of a Legion Command Squad, these must use the Legiones Astartes special rules from the detachment he is a part of, rather than his own.  </description>
     </rule>
-    <rule id="9298-04e9-9b11-795b" name="Assault Vehicle" hidden="false">
+    <rule id="9298-04e9-9b11-795b" name="Assault Vehicle" book="BRB 7th" hidden="false">
       <profiles/>
       <rules/>
       <infoLinks/>
       <modifiers/>
+      <description>Passengers disembarking from Access Points on a vehicle with this special rule can charge on the turn they do so (even in a turn that the vehicle was destroyed, or in the following turn) unless the vehicle arrived from Reserve that turn.</description>
     </rule>
     <rule id="beb478f9-bf5e-772f-e627-8ea394beaa5c" name="Banestrike" book="HH:LAICL" page="9" hidden="false">
       <profiles/>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -26445,7 +26445,20 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
           <description>In a turn in which the vehicle has not moved, increase rate of fire to Heavy 1+D3.  </description>
         </rule>
       </rules>
-      <infoLinks/>
+      <infoLinks>
+        <infoLink id="5117-9d01-958a-3023" name="New InfoLink" hidden="false" targetId="23cd-84ee-5616-7655" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="36da-42dd-ef1a-cece" name="New InfoLink" hidden="false" targetId="184d-7e20-864a-01a1" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
       <constraints/>
       <selectionEntries/>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -26359,55 +26359,31 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
           <infoLinks/>
           <modifiers/>
           <constraints/>
-          <selectionEntries>
-            <selectionEntry id="ecea02c6-8d29-f15e-be0e-aa65333cbac1" name="Hunter-killer Missile" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="10.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="83384113-aed2-acf6-e7cf-ab9f3502ec1b" name="Dozer Blade" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="a0d7f5c3-0b2c-ad47-8580-0762142dbb17" name="Extra Armour" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="10.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
+          <selectionEntries/>
           <selectionEntryGroups/>
-          <entryLinks/>
+          <entryLinks>
+            <entryLink id="b288-cb82-3393-58d3" name="New EntryLink" hidden="false" targetId="8283-5931-b96a-4827" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="277c-598a-7b0f-8a6d" name="New EntryLink" hidden="false" targetId="94ca-8824-d7f4-1456" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="4425-e08a-a19c-4dcf" name="New EntryLink" hidden="false" targetId="8121-d9ab-4026-7a1d" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="d8cef9f2-21e2-d5fc-1aa1-95b76334b218" name="Legion-specific upgrade" hidden="false" collective="false">
           <profiles/>
@@ -66590,7 +66566,7 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="ece9-0637-3e3a-1b8b" name="New InfoLink" hidden="false" targetId="0ac1-dfc1-295b-50a6" type="rule">
+        <infoLink id="ece9-0637-3e3a-1b8b" name="" hidden="false" targetId="0ac1-dfc1-295b-50a6" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -26287,7 +26287,49 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
           </costs>
         </selectionEntry>
       </selectionEntries>
-      <selectionEntryGroups/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="8325-9330-60c1-927c" name="In squadrons of three, one Vindicator may be upgraded to:" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries>
+            <selectionEntry id="aefb-4313-ecf5-eb2a" name="Command Tank" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="0e99-c413-5dc2-5868" hidden="false" targetId="eb87c0fc-8658-25c4-b594-2a9fbc752328" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="be067474-b6d7-4ac3-5f36-71c86fcf5f79" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a909-9659-925d-cf82" type="lessThan"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d4d5-f85e-46af-cc8c" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="35.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
       <entryLinks>
         <entryLink id="e302-400f-f316-014d" hidden="false" targetId="c487-be13-ea53-917e" type="selectionEntryGroup">
           <profiles/>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -29534,12 +29534,12 @@ Ignores Cover special rule.</description>
         </profile>
       </profiles>
       <rules>
-        <rule id="f9a009f0-a997-0c78-42b5-9cd8c9516fd6" name="Dangerous Reactor Core" book="HH:LACAL" page="60" hidden="false">
+        <rule id="f9a009f0-a997-0c78-42b5-9cd8c9516fd6" name="Dangerous Reactor Core" book="LA:AODAL" page="72" hidden="false">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <description>An enemy may re-roll a result of a 1 on the Vehicle Damage table against the Sicarian Venator.  Explodes results add D3&quot; to radius.  </description>
+          <description>If an enemy unit inflicts a Penetrating hit they may re-roll a result of a 1 on the Vehicle Damage table against the Sicarian Venator.  Explodes results add D3&quot; to radius.  </description>
         </rule>
         <rule id="f2400536-8a39-8961-18d4-97698fba78cf" name="Shock Pulse" book="HH:LACAL" page="60" hidden="false">
           <profiles/>
@@ -29549,7 +29549,26 @@ Ignores Cover special rule.</description>
           <description>Any vehicle, including super-heavies, that suffers a penetrating hit may only fire snap shots on the following game turn.  </description>
         </rule>
       </rules>
-      <infoLinks/>
+      <infoLinks>
+        <infoLink id="5aa5-d2f4-2884-3115" name="New InfoLink" hidden="false" targetId="5283-9b50-3dcd-78e4" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="62c7-a072-b8dd-a277" name="New InfoLink" hidden="false" targetId="23cd-84ee-5616-7655" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="84af-968c-bbfc-a7e2" name="New InfoLink" hidden="false" targetId="184d-7e20-864a-01a1" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
       <constraints/>
       <selectionEntries/>
@@ -29687,14 +29706,7 @@ Ignores Cover special rule.</description>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="11f4-8fdd-6461-85db" hidden="false" targetId="c487-be13-ea53-917e" type="selectionEntryGroup">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </entryLink>
-        <entryLink id="9646-6aca-f946-c77a" name="New EntryLink" hidden="false" targetId="8121-d9ab-4026-7a1d" type="selectionEntry">
+        <entryLink id="11f4-8fdd-6461-85db" name="" hidden="false" targetId="c487-be13-ea53-917e" type="selectionEntryGroup">
           <profiles/>
           <rules/>
           <infoLinks/>

--- a/The Horus Heresy.gst
+++ b/The Horus Heresy.gst
@@ -5906,7 +5906,9 @@ D6    Result		S	AP
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
@@ -11386,7 +11388,9 @@ Command Benefits:
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="f000-ebfb-3bc8-e612" name="Sentinel Warblade" hidden="false" collective="false" type="upgrade">
           <profiles/>
@@ -11413,7 +11417,9 @@ Command Benefits:
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="0aff-3787-aba5-fae7" name="Guardian Spear" hidden="false" collective="false" type="upgrade">
           <profiles/>
@@ -11440,7 +11446,9 @@ Command Benefits:
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="a14e-970f-8fe3-8797" name="Praesidium Shield" hidden="false" collective="false" type="upgrade">
           <profiles/>
@@ -11461,7 +11469,9 @@ Command Benefits:
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="1488-81b8-f0ad-3703" name="Plasma Grenades" hidden="false" collective="false" type="upgrade">
           <profiles/>
@@ -11488,7 +11498,9 @@ Command Benefits:
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="9ab7-4eee-d3f0-25a1" name="Krak Grenades" hidden="false" collective="false" type="upgrade">
           <profiles/>
@@ -11509,7 +11521,9 @@ Command Benefits:
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="3060-5ce0-cb9d-3bbd" name="Close Combat Weapon" hidden="false" collective="false" type="upgrade">
           <profiles/>
@@ -11530,7 +11544,9 @@ Command Benefits:
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups/>
@@ -11806,7 +11822,9 @@ Command Benefits:
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="f30a-210c-0677-1c83" name="Machine Spirit" hidden="false" collective="false" type="upgrade">
           <profiles/>
@@ -11833,7 +11851,9 @@ Command Benefits:
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups/>
@@ -11865,7 +11885,9 @@ Command Benefits:
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="7b19-0e33-9c8d-e56a" name="Searchlight" hidden="false" collective="false" type="upgrade">
           <profiles/>
@@ -11886,7 +11908,9 @@ Command Benefits:
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="4167-42c8-42d8-1ce0" name="Extra Armour" hidden="false" collective="false" type="upgrade">
           <profiles/>
@@ -11907,7 +11931,9 @@ Command Benefits:
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="da74-5542-17da-8a49" name="Machine Spirit" hidden="false" collective="false" type="upgrade">
           <profiles/>
@@ -11934,7 +11960,9 @@ Command Benefits:
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="5627-96b7-0b67-5274" name="Flare Shield" hidden="false" collective="false" type="upgrade">
           <profiles/>
@@ -11955,7 +11983,9 @@ Command Benefits:
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups/>
@@ -12767,6 +12797,25 @@ D6 - Result
       <infoLinks/>
       <modifiers/>
       <description>Targets may not take Jink saves against damage from this weapon.  </description>
+    </rule>
+    <rule id="184d-7e20-864a-01a1" name="Smoke Launcher" book="BRB 7th" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>Once per game, instead of shooting or moving Flat Out (or Running in the case of Walkers), a vehicle with smoke launchers can trigger them. The vehicle may not fire any of its weapons in the same turn as it used smoke launchers, but counts as obscured in the next enemy Shooting phase, receiving a 5+ cover save.
+After the enemy’s Shooting phase, the smoke disperses with no further effect. A vehicle may still use smoke launchers even if has suffered a Crew Shaken or Stunned result or it does not have any shooting weapons.</description>
+    </rule>
+    <rule id="23cd-84ee-5616-7655" name="Searchlight" book="BRB 7th" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>Searchlights are used when the Night Fighting rules are in effect. If a vehicle has a searchlight, it can, after firing all of its weapons, choose to illuminate its target with the searchlight. If it does so, it also illuminates itself.
+
+Illumination lasts until the end of the following turn. Illuminated units gain no benefit from the Night Fighting rule.
+
+</description>
     </rule>
   </sharedRules>
   <sharedProfiles>


### PR DESCRIPTION
This updates some of the shared vehicle wargear options, changing them over to a shared profile and updating the points value for them.

Extra Armour
Armour Ceramite
Dozer Blade
Hunter-Killer Missile
Smoke Launcher (GST)
Searchlights (GST)

The first four could probably be moved to the GST file in future updates but I'm not yet familar with their use in other armies.

Also updated weapon profiles on some of the Heavy Support units. If this request is suitable, along with the pintle-mount update and get's merged, I'll finish off the fixes for the Heavy Support slot I have listed in #568 

Ran some test merges on my fork and with the pintle-mount update request and didn't see any conflicts/issues so submitting this for QA/Review. If there's anything I missed or have any suggestions please let me know.