### PR TITLE
Fixes for Astarte Heavy Support - Basic units

### DIFF
--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -61435,7 +61435,7 @@ Phalanx Breacher squads and Legion Terminator squads may be taken as troops in a
       </infoLinks>
       <modifiers/>
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
       </constraints>
       <selectionEntries/>
       <selectionEntryGroups/>
@@ -61450,8 +61450,8 @@ Phalanx Breacher squads and Legion Terminator squads may be taken as troops in a
       <infoLinks/>
       <modifiers/>
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
       </constraints>
       <selectionEntries/>
       <selectionEntryGroups/>
@@ -61540,8 +61540,8 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
       </infoLinks>
       <modifiers/>
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
       </constraints>
       <selectionEntries/>
       <selectionEntryGroups/>
@@ -66595,47 +66595,30 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
           <infoLinks/>
           <modifiers/>
           <constraints/>
-          <selectionEntries>
-            <selectionEntry id="b022-1650-3bec-90bb" name="Searchlight" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="0342-4c7a-50a6-2001" name="New EntryLink" hidden="false" targetId="f888-a294-fcff-8391" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1184-150f-f3e5-a0a3" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="1.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="a7dd-0216-1dbe-8b20" name="Armoured Ceramite" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <constraints/>
+            </entryLink>
+            <entryLink id="4caa-8b1d-1fbf-fbb8" name="New EntryLink" hidden="false" targetId="1e27e511-cf75-d55a-6807-b67be6f7474f" type="selectionEntry">
               <profiles/>
               <rules/>
-              <infoLinks>
-                <infoLink id="fd98-d85f-e49b-e1a6" hidden="false" targetId="2e87b8ca-7cd1-78b9-2116-246015e7935e" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1572-0012-993b-12a3" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="20.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups/>
-          <entryLinks/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="1">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="c0ba-0d78-6db3-cd6c" name="Two Turret Mounted:" hidden="false" collective="false" defaultSelectionEntryId="ce55-b5dc-c18b-fc38">
           <profiles/>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -67151,6 +67151,17 @@ Explodes results add D3&quot; to radius.  </description>
             <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 4, Sunder"/>
           </characteristics>
         </profile>
+        <profile id="ff5a-79dd-62ff-4dfd" name="Achilles-Alpha Pattern Land Raider" book="AL:AoDAL" page="67" hidden="false" profileTypeId="307d-047f-ca13-706b" profileTypeName="Transport">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Capacity" characteristicTypeId="8285-4205-b6cd-8473" value="6"/>
+            <characteristic name="Fire Points" characteristicTypeId="b270-a7f9-22b2-3702" value="None"/>
+            <characteristic name="Access Points" characteristicTypeId="d17b-0342-b1dc-b8e7" value="One access hatch on each side of the hull."/>
+          </characteristics>
+        </profile>
       </profiles>
       <rules>
         <rule id="7b20-ef5b-3986-5a0d" name="Enhanced Ferromantic Rites" book="HH:LACAL" page="55" hidden="false">
@@ -67165,7 +67176,7 @@ Explodes results add D3&quot; to radius.  </description>
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <description>Must re-roll all failed Dangerous Terrain tests.  </description>
+          <description>Must re-roll failed Dangerous Terrain tests.  </description>
         </rule>
       </rules>
       <infoLinks>
@@ -67188,6 +67199,18 @@ Explodes results add D3&quot; to radius.  </description>
           <modifiers/>
         </infoLink>
         <infoLink id="f94a-4c57-596f-87e0" hidden="false" targetId="e31cf870-3fa6-f2a2-8704-9bf05f7efcd8" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="46ce-d5b2-5115-3f94" name="New InfoLink" page="" hidden="false" targetId="79c7-90f6-b453-e799" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="7708-0ba6-d339-650a" name="New InfoLink" hidden="false" targetId="3a93202e-ac23-5508-2dda-248efcc8ff3d" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -67225,10 +67248,191 @@ Explodes results add D3&quot; to radius.  </description>
           <modifiers/>
           <constraints/>
         </entryLink>
+        <entryLink id="60bb-8dc2-231d-2ae6" name="New EntryLink" hidden="false" targetId="b572273e-2b93-4961-75c8-d9022c31a47d" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="cac5-f77d-bfd2-a3bc" name="New EntryLink" hidden="false" targetId="d9c1-46b9-e742-8d83" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="set" field="name" value="Two Sponson-mount Twin-linked Culverin">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="pts" costTypeId="points" value="300.0"/>
       </costs>
+    </selectionEntry>
+    <selectionEntry id="d9c1-46b9-e742-8d83" name="Twin-linked Volkite culverin" book="LA:AoDAL" page="129" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="6ff0-ecc2-244a-28fe" name="New InfoLink" hidden="false" targetId="34d1-b4db-3e75-ccce" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="f619-5f97-7ca3-f8db" name="New InfoLink" hidden="false" targetId="cbcf-5f25-f8ea-7cfd" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs/>
+    </selectionEntry>
+    <selectionEntry id="1914-1ced-69c6-585c" name="Quad Launcher" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="3f1d-2245-7ee6-4bb2" name="Quad Launcher" hidden="false" profileTypeId="556e697423232344415441232323" profileTypeName="Unit">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Unit Type" characteristicTypeId="556e6974205479706523232344415441232323"/>
+            <characteristic name="WS" characteristicTypeId="575323232344415441232323" value="-"/>
+            <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="-"/>
+            <characteristic name="S" characteristicTypeId="5323232344415441232323" value="-"/>
+            <characteristic name="T" characteristicTypeId="5423232344415441232323" value="7"/>
+            <characteristic name="W" characteristicTypeId="5723232344415441232323" value="2"/>
+            <characteristic name="I" characteristicTypeId="4923232344415441232323" value="-"/>
+            <characteristic name="A" characteristicTypeId="4123232344415441232323" value="-"/>
+            <characteristic name="LD" characteristicTypeId="4c4423232344415441232323" value="-"/>
+            <characteristic name="Save" characteristicTypeId="5361766523232344415441232323" value="3+"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="5400-9dc8-7fa2-c1fe" name="New InfoLink" hidden="false" targetId="6d02b74f-b832-0249-9ba0-01ac9c192099" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="00fa-34d6-294f-fb4e" name="May be upgraded with:" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries>
+            <selectionEntry id="3ff1-6220-d027-a086" name="Quad Launcher (Incendiary)" hidden="false" collective="false" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="ddbc-7866-81e6-be2b" name="New InfoLink" hidden="false" targetId="e2e6-c3ad-41be-d14d" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1c07-2267-4399-3f70" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="5175-8fb3-7cf1-967a" name="Quad Launcher (Phosphex Cannister Shot)" hidden="false" collective="false" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="5ca1-2a8f-5114-70e0" name="New InfoLink" hidden="false" targetId="4d8c-ee11-e291-bc32" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e59f-a981-7ffe-7edd" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="20.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="acf4-f8ef-3ea9-c1df" name="Quad Launcher (Splinter)" hidden="false" collective="false" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="b4a7-6fba-4cd5-768a" name="New InfoLink" hidden="false" targetId="9d51-7566-2ac6-1c08" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5529-eded-4a53-a384" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="176a-efd5-c008-daa7" name="Quad Launcher (Shatter)" hidden="false" collective="false" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="d3b8-4d25-f96f-6e76" name="New InfoLink" hidden="false" targetId="5162-7d25-fd22-1b37" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0398-55ba-f601-96bc" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="10.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs/>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
@@ -71306,7 +71510,7 @@ Kharybdis: After it has landed treat as a flyer in Hover mode. LA:AODAL P75</des
         <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 2, Twin-linked"/>
       </characteristics>
     </profile>
-    <profile id="6d02b74f-b832-0249-9ba0-01ac9c192099" name="Quad Mortar" book="HH:LACAL" page="83" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+    <profile id="6d02b74f-b832-0249-9ba0-01ac9c192099" name="Quad Launcher (Frag)" book="AL:AoDAL" page="125" hidden="false" profileTypeId="576561706f6e23232344415441232323">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -71657,6 +71861,54 @@ Kharybdis: After it has landed treat as a flyer in Hover mode. LA:AODAL P75</des
         <characteristic name="Rear" characteristicTypeId="5265617223232344415441232323" value="12"/>
         <characteristic name="HP" characteristicTypeId="485023232344415441232323" value="3"/>
         <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Vehicle (Tank, Fast)"/>
+      </characteristics>
+    </profile>
+    <profile id="5162-7d25-fd22-1b37" name="Quad Launcher (Shatter)" book="AL:AoDAL" page="125" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="36&quot;"/>
+        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="8"/>
+        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="4"/>
+        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 4, Sunder"/>
+      </characteristics>
+    </profile>
+    <profile id="9d51-7566-2ac6-1c08" name="Quad Launcher (Splinter)" book="AL:AoDAL" page="125" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="12&quot; - 26&quot;"/>
+        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="2"/>
+        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="4"/>
+        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 4, Barrage, Blast, Rending"/>
+      </characteristics>
+    </profile>
+    <profile id="e2e6-c3ad-41be-d14d" name="Quad Launcher (Incendiary)" book="AL:AoDAL" page="125" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="12&quot; - 60&quot;"/>
+        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="4"/>
+        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="5"/>
+        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 4, Barrage, Blast, Ignores Cover"/>
+      </characteristics>
+    </profile>
+    <profile id="4d8c-ee11-e291-bc32" name="Quad Launcher (Phosphex Cannister Shot)" book="AL:AoDAL" page="125" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="12&quot; - 36&quot;"/>
+        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="4"/>
+        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="3"/>
+        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 4, Barrage, Poisoned, Crawling Fire, Lingering Death"/>
       </characteristics>
     </profile>
   </sharedProfiles>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -66159,13 +66159,6 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <entryLinks>
-                <entryLink id="93c7-37f1-e9c1-9517" name="New EntryLink" hidden="false" targetId="fe17-5ed2-ca63-9379" type="selectionEntryGroup">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
                 <entryLink id="b4ee-085a-fba1-fe1a" name="New EntryLink" hidden="false" targetId="b572273e-2b93-4961-75c8-d9022c31a47d" type="selectionEntry">
                   <profiles/>
                   <rules/>
@@ -66479,368 +66472,56 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
       <infoLinks/>
       <modifiers/>
       <constraints/>
-      <selectionEntries>
-        <selectionEntry id="d1df-667a-f167-7e62" name="Legion Vindicator Tank" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
-          <profiles>
-            <profile id="2985-3017-61a9-adc1" name="Legion Vindicator" book="HH:LACAL" page="57" hidden="false" profileTypeId="56656869636c6523232344415441232323">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="4"/>
-                <characteristic name="Front" characteristicTypeId="46726f6e7423232344415441232323" value="13"/>
-                <characteristic name="Side" characteristicTypeId="5369646523232344415441232323" value="11"/>
-                <characteristic name="Rear" characteristicTypeId="5265617223232344415441232323" value="10"/>
-                <characteristic name="HP" characteristicTypeId="485023232344415441232323" value="3"/>
-                <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Tank"/>
-              </characteristics>
-            </profile>
-          </profiles>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="403d-cf01-86c8-a116" name="Squadron Vehicles" hidden="false" collective="false">
+          <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b09e-34db-6219-f6e5" type="min"/>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7c47-1831-089e-f4a4" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="14bd-68c3-4bb0-c772" type="min"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1df7-7829-2a43-e828" type="max"/>
           </constraints>
           <selectionEntries/>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="d7ed-f038-273a-b195" name="Exchange Demolisher Cannon for:" hidden="false" collective="false">
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="a5ae-c55c-b6d2-305b" name="New EntryLink" hidden="false" targetId="ddd7-5e93-1110-5a68" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
               <constraints/>
-              <selectionEntries>
-                <selectionEntry id="a847-6304-1563-8960" name="Laser Destroyer Array" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules>
-                    <rule id="9254-006e-01a1-49ce" name="Power Capacitor" book="HH6: Retribution" page="241" hidden="false">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <description>- Capacitor Fire: If the tank has not moved this turn, the Laser Destroyer Array becomes an Ordnance 2 Twin-linked weapon.
-- Overcharged Fire: The owning player may declare an overcharged volley if the vehicle has not moved this turn.  The Laser Destroyer Array becomes Ordnance 3, Twin-linked.  After firing, roll a D6 - on a 1 the Vindicator suffers a single Hull Point of damage. </description>
-                    </rule>
-                  </rules>
-                  <infoLinks>
-                    <infoLink id="204b-a799-2b99-a2be" hidden="false" targetId="c4094da7-8d2e-8d6a-8af8-4cf88f5d7c06" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ba10-69bf-1c2e-0d38" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="10.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups/>
-              <entryLinks/>
-            </selectionEntryGroup>
-            <selectionEntryGroup id="73c5-58d8-cacd-f44a" name="Legion-specific upgrade" hidden="false" collective="false">
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="e952-c5f7-98d1-963c" name="In squadrons of three, one Vehicle may be upgraded to:" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="403d-cf01-86c8-a116" type="lessThan"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="499a-4c6f-0cdd-86b4" name="New EntryLink" hidden="false" targetId="2330-16be-009d-4a66" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
               <constraints/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="6a2a-61dd-1d0d-3094" hidden="false" targetId="a15bdf56-4ffe-fe04-ff77-3d533ab99dfa" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-                <entryLink id="bb91-64e9-94ae-6165" hidden="false" targetId="86e70545-ed1a-7cf4-5a3d-d60662a6b3be" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-                <entryLink id="a3d6-7278-97cb-9ecd" hidden="false" targetId="f785888f-6dfa-08f4-054f-29b1a0e4f20c" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-            <selectionEntryGroup id="fbe5-8215-1436-9ea5" name="May take a Pintle-Mounted Weapon:" hidden="false" collective="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6080-448a-6196-1e26" type="max"/>
-              </constraints>
-              <selectionEntries>
-                <selectionEntry id="ba1a-6019-0a3f-1205" name="Twin-Linked Bolter" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5761-811d-612c-5abe" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="5.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="7722-1a20-a027-09b9" name="Combi-Weapon" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1388-6d45-545b-60d8" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="10.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="39db-d2f4-858b-d0a8" name="Heavy Bolter" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d5ab-0884-ad16-3477" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="15.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="d69b-5a01-ea30-3ed7" name="Heavy Flamer" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2336-7dde-187a-7f5f" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="10.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="2b96-1545-79a4-2358" name="Havoc Launcher" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="d262-a941-7a52-c17d" hidden="false" targetId="b3ea1d32-ba66-0585-d7f7-0dc56e707736" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1c05-3146-fa3c-4c74" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="15.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="d952-4c15-27ea-0b41" hidden="false" targetId="2d56d45d-d276-7830-2b7d-026de64bbae8" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-            <selectionEntryGroup id="ae26-45a5-f561-0234" name="May take any of the following:" hidden="false" collective="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <selectionEntries>
-                <selectionEntry id="2474-4d1a-f548-0c7b" name="Auxiliary Drive" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="5286-31f4-db65-7e76" hidden="false" targetId="d963a2dd-d9a3-8974-aac6-61ffcc78a99a" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3eb3-08d6-3819-2db7" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="10.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="0524-f3d3-6951-4d35" name="Hunter-killer Missile" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a433-4950-3be2-7d39" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="10.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="ab69-9c8c-b34e-86b6" name="Armoured Ceramite" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="2e99-f4cb-c34f-7404" hidden="false" targetId="2e87b8ca-7cd1-78b9-2116-246015e7935e" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="cbf5-59a4-1abc-84b0" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="20.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="2827-e4bd-1aab-fa94" name="Extra Armour" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7fc5-b925-a301-0ab9" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="10.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="392c-9f44-efd4-a040" name="Machine Spirit" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="463c-ef8a-8ca3-d97f" hidden="false" targetId="3a93202e-ac23-5508-2dda-248efcc8ff3d" type="rule">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9181-dec2-9c3e-ab5d" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="25.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups/>
-              <entryLinks/>
-            </selectionEntryGroup>
-            <selectionEntryGroup id="37fb-ea9b-da4e-4b97" name="May take one of the following:" hidden="false" collective="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6625-ec72-cddb-839a" type="max"/>
-              </constraints>
-              <selectionEntries>
-                <selectionEntry id="eead-69a6-67bc-e9ec" name="Dozer Blade" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="192e-d410-83f0-fb37" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="5.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="5a1d-28d0-86b3-dd1b" name="Mine Plough" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2891-5ff6-2532-2708" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="10.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups/>
-              <entryLinks/>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="120.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
       <entryLinks>
         <entryLink id="a548-6a7c-aa84-c044" hidden="false" targetId="c487-be13-ea53-917e" type="selectionEntryGroup">
           <profiles/>
@@ -66853,6 +66534,258 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
       <costs>
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
+    </selectionEntry>
+    <selectionEntry id="ddd7-5e93-1110-5a68" name="Legion Vindicator Tank" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+      <profiles>
+        <profile id="1d03-c363-2eb9-842e" name="Legion Vindicator" book="HH:LACAL" page="57" hidden="false" profileTypeId="56656869636c6523232344415441232323">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="4"/>
+            <characteristic name="Front" characteristicTypeId="46726f6e7423232344415441232323" value="13"/>
+            <characteristic name="Side" characteristicTypeId="5369646523232344415441232323" value="11"/>
+            <characteristic name="Rear" characteristicTypeId="5265617223232344415441232323" value="10"/>
+            <characteristic name="HP" characteristicTypeId="485023232344415441232323" value="3"/>
+            <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Vehicle (Tank)"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="0ee4-0c13-41d9-7979" name="New InfoLink" hidden="false" targetId="21f23fa8-cf11-b9c3-d613-1b711b0897d7" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="6c97-26a8-0921-e79d" name="New InfoLink" hidden="false" targetId="885d-81f6-6ace-3228" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="1279-0cdc-87e2-de22" name="Traverse-mounted:" hidden="false" collective="false" defaultSelectionEntryId="c007-8540-9cab-a4b7">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="04f5-60d7-05b5-5125" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aceb-b764-3c16-2a54" type="min"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="5661-2ffe-9a77-8725" name="New EntryLink" hidden="false" targetId="5708-9bd4-2edc-ddc9" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="c007-8540-9cab-a4b7" name="New EntryLink" hidden="false" targetId="7d9a-8d94-f9b4-aebf" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="8ea1-a5c0-19fd-f171" name="Legion-specific upgrade" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="5c51-23a0-4aa3-34a8" hidden="false" targetId="a15bdf56-4ffe-fe04-ff77-3d533ab99dfa" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="b034-1117-7291-cc6f" hidden="false" targetId="86e70545-ed1a-7cf4-5a3d-d60662a6b3be" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="a60a-903b-b2f5-2603" hidden="false" targetId="f785888f-6dfa-08f4-054f-29b1a0e4f20c" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="bab2-98cd-2b8d-43c0" name="May take one of the following:" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ff2-f4c8-c740-c027" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="63b2-d6c4-f52f-beda" name="New EntryLink" hidden="false" targetId="915f-bdbc-c3cb-9b0b" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="c724-18cc-f33c-ed70" name="New EntryLink" hidden="false" targetId="7c81-4f38-1f4e-ac6b" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="9123-8751-5598-556c" name="May take any of the following:" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="2986-323b-b141-e14a" name="New EntryLink" hidden="false" targetId="a6cd-f04b-711e-c083" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="2734-2969-c4ce-3b38" name="New EntryLink" hidden="false" targetId="a0a4-4e61-7118-fcff" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="2ddd-e0c8-befd-94b2" name="New EntryLink" hidden="false" targetId="f888-a294-fcff-8391" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="1f23-20a8-32e9-4f1a" name="New EntryLink" hidden="false" targetId="00d9-65e8-94b2-2396" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="efaf-e0d7-b1f1-2903" name="New EntryLink" hidden="false" targetId="f30a-210c-0677-1c83" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="6665-b65e-0a91-aff1" name="New EntryLink" hidden="false" targetId="fe17-5ed2-ca63-9379" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="af88-d1f6-cde8-f5fd" name="New EntryLink" hidden="false" targetId="b572273e-2b93-4961-75c8-d9022c31a47d" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="926c-94cd-2ba3-13b6" name="New EntryLink" hidden="false" targetId="10e739aa-3153-9348-3458-738dd5938617" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="120.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7c81-4f38-1f4e-ac6b" name="Mine Plough" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="93df-8954-23ad-b8d4" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5708-9bd4-2edc-ddc9" name="Laser Destroyer Array" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="2fb1-e0fc-20f5-280d" hidden="false" targetId="c4094da7-8d2e-8d6a-8af8-4cf88f5d7c06" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8f32-11dd-7c73-c37d" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7d9a-8d94-f9b4-aebf" name="Demolisher Cannon" book="LA:AoDAL" page="125" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="e5b2-4586-ec0f-9551" name="New InfoLink" hidden="false" targetId="683c-5486-3438-cae9" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs/>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
@@ -70008,6 +69941,14 @@ Kharybdis: After it has landed treat as a flyer in Hover mode. LA:AODAL P75</des
       <modifiers/>
       <description>A weapon with this special rule can re-roll all failed To Hit rolls against Flyers and Fast Skimmers.</description>
     </rule>
+    <rule id="885d-81f6-6ace-3228" name="Power Capacitor" book="LA:AoDAL" page="69" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>- Capacitor Fire: If the tank has not moved this turn, the Laser Destroyer Array becomes an Ordnance 2 Twin-linked weapon.
+- Overcharged Fire: The owning player may declare an overcharged volley if the vehicle has not moved this turn.  The Laser Destroyer Array becomes Ordnance 3, Twin-linked.  After firing, roll a D6 - on a 1 the Vindicator suffers a single Hull Point of damage. </description>
+    </rule>
   </sharedRules>
   <sharedProfiles>
     <profile id="9045e242-71f8-6029-fc57-2b7cbedcc398" name="Archaeotech Pistol" book="HH:LACAL" page="82" hidden="false" profileTypeId="576561706f6e23232344415441232323">
@@ -70193,7 +70134,7 @@ Kharybdis: After it has landed treat as a flyer in Hover mode. LA:AODAL P75</des
         <characteristic name="Description" characteristicTypeId="4465736372697074696f6e23232344415441232323" value="Confers 6++ invulnverable save, increasing to a 5++ in close combat.  User is treated as having defensive grenades, but may never claim the extra attack for being armed with an additional close combat weapon.  "/>
       </characteristics>
     </profile>
-    <profile id="21f23fa8-cf11-b9c3-d613-1b711b0897d7" name="Combi-bolter" book="HH:LACAL" page="82" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+    <profile id="21f23fa8-cf11-b9c3-d613-1b711b0897d7" name="Combi-bolter" book="LA:AoDAL" page="124" hidden="false" profileTypeId="576561706f6e23232344415441232323">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -70592,7 +70533,7 @@ Kharybdis: After it has landed treat as a flyer in Hover mode. LA:AODAL P75</des
         <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Melee, Unwieldy, Cumbersome"/>
       </characteristics>
     </profile>
-    <profile id="c4094da7-8d2e-8d6a-8af8-4cf88f5d7c06" name="Laser Destroyer" book="HH:LACAL" page="84" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+    <profile id="c4094da7-8d2e-8d6a-8af8-4cf88f5d7c06" name="Laser Destroyer" book="LA:AoDAL" page="126" hidden="false" profileTypeId="576561706f6e23232344415441232323">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -71214,6 +71155,18 @@ Kharybdis: After it has landed treat as a flyer in Hover mode. LA:AODAL P75</des
         <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="6"/>
         <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="3"/>
         <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 7"/>
+      </characteristics>
+    </profile>
+    <profile id="683c-5486-3438-cae9" name="Demolisher Cannon" book="LA:AoDAL" page="125" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="24&quot;"/>
+        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="10"/>
+        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="2"/>
+        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Ordnance 1, Large Blast"/>
       </characteristics>
     </profile>
   </sharedProfiles>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -46672,7 +46672,7 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
             <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Vehicle (Flyer, Transport, Hover)"/>
           </characteristics>
         </profile>
-        <profile id="9e3d-ac3b-1e86-9807" name="Kharybdis Storm Launcher" book="HH:LACAL" page="63" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+        <profile id="9e3d-ac3b-1e86-9807" name="Five Kharybdis Storm Launchers" book="AL:AoDAL" page="75" hidden="false" profileTypeId="576561706f6e23232344415441232323">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -46684,15 +46684,20 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
             <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 2, Pinning, Twin-linked"/>
           </characteristics>
         </profile>
-      </profiles>
-      <rules>
-        <rule id="c94c-4616-6444-bb6b" name="Inertial Guidance System" page="0" hidden="false">
+        <profile id="3d8d-10c1-8d08-e3f6" name="Legion Kharybdis Assault Claw (Transport)" book="HH:LACAL" page="62" hidden="false" profileTypeId="307d-047f-ca13-706b" profileTypeName="Transport">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-        </rule>
-        <rule id="86f1-39c0-5841-0b59" name="Heat Blast" book="HH:LACAL" page="63" hidden="false">
+          <characteristics>
+            <characteristic name="Capacity" characteristicTypeId="8285-4205-b6cd-8473" value="20, or a single Dreadnought or a unit of Rapier Carrier Teams"/>
+            <characteristic name="Fire Points" characteristicTypeId="b270-a7f9-22b2-3702" value="None."/>
+            <characteristic name="Access Points" characteristicTypeId="d17b-0342-b1dc-b8e7" value="One access hatch beneath the hull. Passengers can disembark at ground level, measuring their disembarkation from the ground level of the main hull."/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="86f1-39c0-5841-0b59" name="Heat Blast" book="LA:AoDAL" page="75" hidden="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -46703,28 +46708,34 @@ Heat Blast (Deep Strike): Immediately after deploying, measure a radius of 3+D3&
 
 Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit with no cover saves.  Vehicles are struck on their weakest armour value.  This counts as a flamer based attack.  Unit being hit determines wound allocation.  On a D6 of 1, the Drop Pod suffers a penetrating hit.  </description>
         </rule>
-        <rule id="01df-0b7b-2948-524c" name="Melta-ram" book="HH:LACAL" page="63" hidden="false">
+        <rule id="01df-0b7b-2948-524c" name="Melta-ram" book="LA:AoDAL" page="75" hidden="false">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-        </rule>
-        <rule id="895e-7dd1-fabc-cb95" name="Independant Machine Spirits" book="HH:LACAL" page="63" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <description>Each of the weapons may fire at different targets. </description>
-        </rule>
-        <rule id="96d6-b83d-85aa-72b7" name="Assault Vehicle" page="0" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
+          <description>the Kharybdis may conduct Ram attacks as if it were a Tank while using Hover mode. It may not, however, Ram other Flyers or make such an attack on any turn in which it arrives from Reserve. It also may not conduct a Ram on any turn on which it embarks or disembarks models or uses its Heat Blast attack.</description>
         </rule>
       </rules>
       <infoLinks>
         <infoLink id="250a-992f-3375-14f4" name="New InfoLink" hidden="false" targetId="9bc2-f58b-4edd-8673" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="334e-d86a-7989-2337" name="New InfoLink" hidden="false" targetId="502e-1950-cef4-540b" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="4ed8-435c-8672-cf83" name="New InfoLink" hidden="false" targetId="1e1f-97cd-3109-626d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="8a71-cfb1-f253-0f15" name="New InfoLink" hidden="false" targetId="45cf-653a-4ff6-f22d" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -46768,6 +46779,21 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
           <infoLinks/>
           <modifiers/>
           <constraints/>
+        </entryLink>
+        <entryLink id="ebae-fec5-262e-4b7b" name="New EntryLink" page="" hidden="false" targetId="eca0-004a-24f2-e2e9" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="set" field="points" value="0.0">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5e12-1c99-67fc-e8a2" type="min"/>
+          </constraints>
         </entryLink>
       </entryLinks>
       <costs>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -37820,15 +37820,7 @@ Token representing the Cyber-hawk plays no other role in the game and may not be
           <profiles/>
           <rules/>
           <infoLinks/>
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <repeats/>
-              <conditions>
-                <condition field="selections" scope="45fd-559d-32de-5110" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b0a7-73cc-b50e-94d7" type="equalTo"/>
-              </conditions>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
+          <modifiers/>
           <characteristics>
             <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="48&quot;"/>
             <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="8"/>
@@ -37836,26 +37828,16 @@ Token representing the Cyber-hawk plays no other role in the game and may not be
             <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 4, Sunder"/>
           </characteristics>
         </profile>
-        <profile id="0ee7-6cf1-48e4-4feb" name="Helical Targeting Array" book="HH5: Tempest" page="214" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Description" characteristicTypeId="4465736372697074696f6e23232344415441232323" value="If the Deredeo chooses to neither move nor Run in its turn it may, if its controlling player wishes, gain the Skyfire and Interceptor special rules for that entire game turn (ie, both the controlling player’s turn and their opponent’s following player turn) for all of its weapons except its heavy bolters/heavy flamers."/>
-          </characteristics>
-        </profile>
       </profiles>
-      <rules>
-        <rule id="60da-07bf-6ffe-8c12" name="Extra Armour" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </rule>
-      </rules>
+      <rules/>
       <infoLinks>
         <infoLink id="fa3c-741a-2443-6189" hidden="false" targetId="e0898f15-4b47-28f4-313e-0b321f0a3dca" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="116e-720b-52cf-c24a" name="New InfoLink" hidden="false" targetId="5283-9b50-3dcd-78e4" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -37866,70 +37848,39 @@ Token representing the Cyber-hawk plays no other role in the game and may not be
       <constraints/>
       <selectionEntries/>
       <selectionEntryGroups>
-        <selectionEntryGroup id="6421-e8ff-e03a-0696" name="May exchange twin-linked heavy bolter for:" hidden="false" collective="false">
+        <selectionEntryGroup id="6421-e8ff-e03a-0696" name="Torso-mounted:" hidden="false" collective="false" defaultSelectionEntryId="362c-cdff-5b6c-a68d">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
-          <selectionEntries>
-            <selectionEntry id="164e-7939-3f1c-b07b" name="Twin-linked Heavy Flamer" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="f61f-28bb-a530-2939" name="New EntryLink" hidden="false" targetId="2bc5-53e9-b8fd-0b6b" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="949a-6141-fca3-0410" name="Twin-linked Iliastus Assault Cannon" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <constraints/>
+            </entryLink>
+            <entryLink id="eb80-f6b5-77bf-c15f" name="New EntryLink" hidden="false" targetId="5986-c8ef-d448-397b" type="selectionEntry">
               <profiles/>
               <rules/>
-              <infoLinks>
-                <infoLink id="7b68-837b-2fee-d57d" hidden="false" targetId="0d8bdd64-39f0-7759-d8ca-0702ee1f0fd0" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="9c51-fec3-ca04-b458" hidden="false" targetId="0d300426-e90a-4a8d-bff5-9b64949b128d" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers>
-                <modifier type="set" field="hidden" value="true">
-                  <repeats/>
-                  <conditions>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="16a2-56d6-9be5-ede0" type="equalTo"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups/>
-          <entryLinks/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="362c-cdff-5b6c-a68d" name="New EntryLink" hidden="false" targetId="aa78-540d-996f-52ff" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="4e89-c0d1-627b-1c67" name="May be equipped with:" hidden="false" collective="false">
           <profiles/>
@@ -37937,32 +37888,17 @@ Token representing the Cyber-hawk plays no other role in the game and may not be
           <infoLinks/>
           <modifiers/>
           <constraints/>
-          <selectionEntries>
-            <selectionEntry id="f86d-b5ce-c0d3-41d1" name="Armoured Ceramite" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="fc49-3e68-76a6-9ac9" name="New EntryLink" hidden="false" targetId="f888-a294-fcff-8391" type="selectionEntry">
               <profiles/>
               <rules/>
-              <infoLinks>
-                <infoLink id="1454-0771-08c3-f852" hidden="false" targetId="2e87b8ca-7cd1-78b9-2116-246015e7935e" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
+              <infoLinks/>
               <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="20.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups/>
-          <entryLinks/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="ede0-544c-21d8-fe1a" name="May be fitted with the following carapace-mounted systems:" hidden="false" collective="false">
           <profiles/>
@@ -37970,7 +37906,7 @@ Token representing the Cyber-hawk plays no other role in the game and may not be
           <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="3054-0dce-e9e3-bb1a" name="Aiolos Missile Launcher" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
@@ -38000,7 +37936,7 @@ Token representing the Cyber-hawk plays no other role in the game and may not be
               <infoLinks/>
               <modifiers/>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <selectionEntries/>
               <selectionEntryGroups/>
@@ -38025,7 +37961,7 @@ Token representing the Cyber-hawk plays no other role in the game and may not be
               <infoLinks/>
               <modifiers/>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <selectionEntries/>
               <selectionEntryGroups/>
@@ -38036,9 +37972,17 @@ Token representing the Cyber-hawk plays no other role in the game and may not be
             </selectionEntry>
           </selectionEntries>
           <selectionEntryGroups/>
-          <entryLinks/>
+          <entryLinks>
+            <entryLink id="fe12-2e24-0a5d-2b52" name="New EntryLink" hidden="false" targetId="92bd-b77f-2857-28db" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="2670-2695-b491-9d43" name="May exchange Anvilus Pattern Autocannon Battery for:" hidden="false" collective="false">
+        <selectionEntryGroup id="2670-2695-b491-9d43" name="May exchange Anvilus Pattern Autocannon Battery for:" hidden="false" collective="false" defaultSelectionEntryId="18bf-193c-c3b0-408d">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -38076,7 +38020,7 @@ Token representing the Cyber-hawk plays no other role in the game and may not be
               <infoLinks/>
               <modifiers/>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <selectionEntries/>
               <selectionEntryGroups/>
@@ -38087,7 +38031,22 @@ Token representing the Cyber-hawk plays no other role in the game and may not be
             </selectionEntry>
           </selectionEntries>
           <selectionEntryGroups/>
-          <entryLinks/>
+          <entryLinks>
+            <entryLink id="18bf-193c-c3b0-408d" name="New EntryLink" book="" hidden="false" targetId="efb9-6294-ddbf-ee16" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="8677-ca9f-a028-3b66" name="New EntryLink" hidden="false" targetId="92bd-b77f-2857-28db" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="9a00-690a-ee03-41ab" name="Legion-specific upgrade" hidden="false" collective="false">
           <profiles/>
@@ -38124,6 +38083,13 @@ Token representing the Cyber-hawk plays no other role in the game and may not be
       </selectionEntryGroups>
       <entryLinks>
         <entryLink id="b730-62ec-6069-2964" hidden="false" targetId="c487-be13-ea53-917e" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="33d9-fb91-5a57-fd6e" name="New EntryLink" hidden="false" targetId="6633-bb06-ca81-2a22" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -48764,8 +48730,8 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
           <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5c53-ba30-2622-14a0" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ad11-b600-4504-8516" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5c53-ba30-2622-14a0" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ad11-b600-4504-8516" type="min"/>
           </constraints>
           <selectionEntries/>
           <selectionEntryGroups/>
@@ -48799,8 +48765,8 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
           <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="57b1-da06-8e38-8f67" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d300-b3d3-71a1-14de" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="57b1-da06-8e38-8f67" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d300-b3d3-71a1-14de" type="min"/>
           </constraints>
           <selectionEntries/>
           <selectionEntryGroups/>
@@ -48928,6 +48894,13 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
           <constraints/>
         </entryLink>
         <entryLink id="b740-a536-73bc-c194" name="New EntryLink" hidden="false" targetId="fe17-5ed2-ca63-9379" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="ef15-1621-2f77-5006" name="New EntryLink" hidden="false" targetId="b572273e-2b93-4961-75c8-d9022c31a47d" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -66719,6 +66692,84 @@ When conducting a Ram attack, use Strength 10, roll two dice and pick the higher
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
+    <selectionEntry id="efb9-6294-ddbf-ee16" name="Twin-linked Anvilius Pattern Autocannon Battery" book="LA:AoDAL" page="79" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="89d3-3ef0-d4db-7bdf" name="Anvilus Pattern Autocannon Battery" book="HH5: Tempest" page="214" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="48&quot;"/>
+            <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="8"/>
+            <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="4"/>
+            <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 4, Sunder"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="0800-84c7-7b53-e4cb" name="New InfoLink" hidden="false" targetId="b67a5fd8-9dcd-1d03-ef50-8170a6b1e839" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs/>
+    </selectionEntry>
+    <selectionEntry id="92bd-b77f-2857-28db" name="Single Arachnus heavy lascannon battery" book="AL:AoADL" page="79" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="c092-6851-cbfc-3efe" name="New InfoLink" hidden="false" targetId="99df-1868-ca24-eafb" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="1229-5586-d6c9-c694" name="New InfoLink" hidden="false" targetId="328c-2d71-a3d8-20c6" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="50.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6633-bb06-ca81-2a22" name="Helical Targeting Array" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="3186-3053-951f-5fb7" name="New InfoLink" hidden="false" targetId="a654-c4d7-5e67-0a65" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2fcd-3dc2-8aa9-5b22" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="054f-632e-e212-5363" type="min"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs/>
+    </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup id="fc8ed347-6cd6-c24e-942f-bda78004e894" name="Bodyguard" hidden="false" collective="false">
@@ -69888,6 +69939,13 @@ Kharybdis: After it has landed treat as a flyer in Hover mode. LA:AODAL P75</des
       <modifiers/>
       <description>Any unit charging into close combat on the same turn it disembarks from a transport vehicle equipped with frag assault launchers counts as having frag grenades.</description>
     </rule>
+    <rule id="99df-1868-ca24-eafb" name="Exoshock" book="AL:AoDLA" page="79" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>If this weapon successfully scores a penetrating hit on a target, roll a D6. On the roll of a 4,+ a second automatic penetrating hit is in􀁵icted on the same target against which cover saves may not be taken.</description>
+    </rule>
   </sharedRules>
   <sharedProfiles>
     <profile id="9045e242-71f8-6029-fc57-2b7cbedcc398" name="Archaeotech Pistol" book="HH:LACAL" page="82" hidden="false" profileTypeId="576561706f6e23232344415441232323">
@@ -71097,6 +71155,27 @@ Kharybdis: After it has landed treat as a flyer in Hover mode. LA:AODAL P75</des
         <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="10"/>
         <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="2"/>
         <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Ordnance 1, Large Blast"/>
+      </characteristics>
+    </profile>
+    <profile id="328c-2d71-a3d8-20c6" name="Arachnus heavy lascannon battery" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="48&quot;"/>
+        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="10"/>
+        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="2"/>
+        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 2, Exoshock"/>
+      </characteristics>
+    </profile>
+    <profile id="a654-c4d7-5e67-0a65" name="Helica Targeting Array" book="LA:AoDAL" page="79" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323" profileTypeName="Wargear Item">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Description" characteristicTypeId="4465736372697074696f6e23232344415441232323" value="If the Dreadnought chooses to neither move nor Run in its turn it may, if its controlling player wishes, gain the Skyfire and Interceptor special rules for that entire game turn (ie, both the controlling player’s turn and their opponent’s following player turn) for all of its weapons except its heavy bolters/heavy flamers."/>
       </characteristics>
     </profile>
   </sharedProfiles>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -37018,7 +37018,7 @@ Token representing the Cyber-hawk plays no other role in the game and may not be
             <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="-"/>
             <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="+1"/>
             <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="2"/>
-            <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Melee, Unwieldy, Two-handed, Reaping Blow"/>
+            <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Melee, Two-handed, Reaping Blow"/>
           </characteristics>
         </profile>
         <profile id="6e68111c-c765-c98a-2189-b098f577327e" name="Chem-munitions" book="HH:LAICL" page="38" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323">

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -65404,7 +65404,7 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="df03-d269-13b4-94d7" name="In squadrons of three, one Land Raider may be upgraded to:" hidden="false" collective="false">
+        <selectionEntryGroup id="ea28-aaf1-93fb-a0f4" name="In squadrons of three, one Vehicle may be upgraded to:" hidden="false" collective="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -65421,7 +65421,7 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="f5a7-890a-ff02-5d13" name="New EntryLink" hidden="false" targetId="2330-16be-009d-4a66" type="selectionEntry">
+            <entryLink id="8b60-5d5e-e83f-81d1" name="New EntryLink" hidden="false" targetId="2330-16be-009d-4a66" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -66178,7 +66178,7 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="57e7-980d-f042-f566" name="Legion Artillery Tank Squadron" book="HH:LACAL" page="56" hidden="false" collective="false" categoryEntryId="486561767920537570706f727423232344415441232323" type="unit">
+    <selectionEntry id="57e7-980d-f042-f566" name="Legion Artillery Tank Squadron" book="LA:AoDAL" page="68" hidden="false" collective="false" categoryEntryId="486561767920537570706f727423232344415441232323" type="unit">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -66343,6 +66343,22 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
                   <infoLinks/>
                   <modifiers/>
                   <constraints/>
+                </entryLink>
+                <entryLink id="0345-676b-179a-e625" name="New EntryLink" hidden="false" targetId="a161-76b3-9ef1-da7b" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="set" field="name" value="Hull-mounted Heavy Bolter">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b207-ad0c-a8b1-0ea0" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d737-863a-ae42-b39f" type="min"/>
+                  </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
@@ -66531,6 +66547,22 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
                   <modifiers/>
                   <constraints/>
                 </entryLink>
+                <entryLink id="f3e1-923f-4f09-6c2b" name="New EntryLink" hidden="false" targetId="a161-76b3-9ef1-da7b" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="set" field="name" value="Hull-mounted Heavy Bolter">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9393-c17e-9a2e-bc8b" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f405-c1e4-fd54-52d6" type="min"/>
+                  </constraints>
+                </entryLink>
               </entryLinks>
               <costs>
                 <cost name="pts" costTypeId="points" value="155.0"/>
@@ -66552,30 +66584,6 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
                     <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Vehicle (Tank)"/>
                   </characteristics>
                 </profile>
-                <profile id="a08d-6af0-36af-5a2c" name="Whirlwind Launcher: Vengeance Warhead" book="HH:LACAL" page="93" hidden="false" profileTypeId="576561706f6e23232344415441232323">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <characteristics>
-                    <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="12&quot; - 48&quot;"/>
-                    <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="5"/>
-                    <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="4"/>
-                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Ordnance 1, Barrage, Large Blast"/>
-                  </characteristics>
-                </profile>
-                <profile id="d708-d409-5d33-5caf" name="Whirlwind Launcher: Castellan Warhead" book="HH:LACAL" page="93" hidden="false" profileTypeId="576561706f6e23232344415441232323">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <characteristics>
-                    <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="12&quot; - 48&quot;"/>
-                    <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="4"/>
-                    <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="5"/>
-                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Ordnance 1, Barrage, Large Blast, Ignores Cover"/>
-                  </characteristics>
-                </profile>
               </profiles>
               <rules/>
               <infoLinks/>
@@ -66585,7 +66593,7 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
               </constraints>
               <selectionEntries/>
               <selectionEntryGroups>
-                <selectionEntryGroup id="a4ed-55f7-78c9-2ef4" name="Exchange Vengeance and Castellan missiles for:" hidden="false" collective="false">
+                <selectionEntryGroup id="a4ed-55f7-78c9-2ef4" name="Exchange Vengeance and Castellan missiles for:" hidden="false" collective="false" defaultSelectionEntryId="910e-cea0-521f-5b79">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -66619,6 +66627,44 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
                       <costs>
                         <cost name="pts" costTypeId="points" value="0.0"/>
                       </costs>
+                    </selectionEntry>
+                    <selectionEntry id="910e-cea0-521f-5b79" name="Whirlwind Launcher" hidden="false" collective="false" type="upgrade">
+                      <profiles>
+                        <profile id="f533-5a47-47a6-4e8b" name="Whirlwind Launcher: Castellan Warhead" book="HH:LACAL" page="93" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <characteristics>
+                            <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="12&quot; - 48&quot;"/>
+                            <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="4"/>
+                            <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="5"/>
+                            <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Ordnance 1, Barrage, Large Blast, Ignores Cover"/>
+                          </characteristics>
+                        </profile>
+                        <profile id="eee8-e6aa-bfcd-7de2" name="Whirlwind Launcher: Vengeance Warhead" book="HH:LACAL" page="93" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <characteristics>
+                            <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="12&quot; - 48&quot;"/>
+                            <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="5"/>
+                            <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="4"/>
+                            <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Ordnance 1, Barrage, Large Blast"/>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c775-8ae0-99ab-b495" type="max"/>
+                      </constraints>
+                      <selectionEntries/>
+                      <selectionEntryGroups/>
+                      <entryLinks/>
+                      <costs/>
                     </selectionEntry>
                   </selectionEntries>
                   <selectionEntryGroups/>
@@ -66697,6 +66743,16 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
                   <modifiers/>
                   <constraints/>
                 </entryLink>
+                <entryLink id="37e6-f31d-d105-2788" name="New EntryLink" hidden="false" targetId="30c2c848-c1d3-e61f-6632-a91bcee1fdc4" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5837-2e6c-e6fd-a932" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4362-be8c-ac67-1feb" type="min"/>
+                  </constraints>
+                </entryLink>
               </entryLinks>
               <costs>
                 <cost name="pts" costTypeId="points" value="75.0"/>
@@ -66706,16 +66762,24 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
           <selectionEntryGroups/>
           <entryLinks/>
         </selectionEntryGroup>
-        <selectionEntryGroup id="54de-fb9d-794e-b73b" name="In squadrons of three, one model may upgraded to:" hidden="false" collective="false">
+        <selectionEntryGroup id="22c3-c9be-b6b3-5e15" name="In squadrons of three, one Vehicle may be upgraded to:" hidden="false" collective="false">
           <profiles/>
           <rules/>
           <infoLinks/>
-          <modifiers/>
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="511d-594e-09c3-7ee1" type="lessThan"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
           <constraints/>
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="385e-f4c7-27a1-ca73" name="New EntryLink" hidden="false" targetId="2330-16be-009d-4a66" type="selectionEntry">
+            <entryLink id="67ce-13db-7187-cab2" name="New EntryLink" hidden="false" targetId="2330-16be-009d-4a66" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -37855,6 +37855,7 @@ Token representing the Cyber-hawk plays no other role in the game and may not be
           <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9efa-be80-221d-0a79" type="min"/>
           </constraints>
           <selectionEntries/>
           <selectionEntryGroups/>
@@ -37972,22 +37973,17 @@ Token representing the Cyber-hawk plays no other role in the game and may not be
             </selectionEntry>
           </selectionEntries>
           <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="fe12-2e24-0a5d-2b52" name="New EntryLink" hidden="false" targetId="92bd-b77f-2857-28db" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </entryLink>
-          </entryLinks>
+          <entryLinks/>
         </selectionEntryGroup>
         <selectionEntryGroup id="2670-2695-b491-9d43" name="May exchange Anvilus Pattern Autocannon Battery for:" hidden="false" collective="false" defaultSelectionEntryId="18bf-193c-c3b0-408d">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <constraints/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="18f2-3947-6c46-349f" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c041-314c-206a-00fe" type="min"/>
+          </constraints>
           <selectionEntries>
             <selectionEntry id="b0a7-73cc-b50e-94d7" name="Single twin-linked Hellfire Plasma Cannonade" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
               <profiles>
@@ -38090,6 +38086,13 @@ Token representing the Cyber-hawk plays no other role in the game and may not be
           <constraints/>
         </entryLink>
         <entryLink id="33d9-fb91-5a57-fd6e" name="New EntryLink" hidden="false" targetId="6633-bb06-ca81-2a22" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="2150-a9f2-74b9-73da" name="New EntryLink" hidden="false" targetId="b572273e-2b93-4961-75c8-d9022c31a47d" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -67223,7 +67223,7 @@ Explodes results add D3&quot; to radius.  </description>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="cf48-f905-2129-33e2" hidden="false" targetId="c487-be13-ea53-917e" type="selectionEntryGroup">
+        <entryLink id="cf48-f905-2129-33e2" name="" hidden="false" targetId="c487-be13-ea53-917e" type="selectionEntryGroup">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -67248,7 +67248,10 @@ Explodes results add D3&quot; to radius.  </description>
               <conditionGroups/>
             </modifier>
           </modifiers>
-          <constraints/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c816-7bfb-3b6f-6e6b" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a37a-2107-9c3e-c3da" type="min"/>
+          </constraints>
         </entryLink>
         <entryLink id="b5b0-43b4-fddd-c3bb" name="New EntryLink" hidden="false" targetId="1914-1ced-69c6-585c" type="selectionEntry">
           <profiles/>
@@ -67308,20 +67311,41 @@ Explodes results add D3&quot; to radius.  </description>
         </profile>
       </profiles>
       <rules/>
-      <infoLinks>
-        <infoLink id="5400-9dc8-7fa2-c1fe" name="New InfoLink" hidden="false" targetId="6d02b74f-b832-0249-9ba0-01ac9c192099" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
+      <infoLinks/>
       <modifiers/>
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="302f-49b0-89f6-65da" type="max"/>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e526-83b5-8729-1321" type="min"/>
       </constraints>
-      <selectionEntries/>
+      <selectionEntries>
+        <selectionEntry id="1f24-a6c4-bfbf-03cf" name="Quad Launcher (Frag)" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="faea-1613-aee3-aeff" name="New InfoLink" hidden="false" targetId="6d02b74f-b832-0249-9ba0-01ac9c192099" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="b5fb-4322-d459-adfc" name="New InfoLink" hidden="false" targetId="887c2e1c-8eae-d449-e212-7dddb39cf726" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8786-0198-8205-8ceb" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2f06-80be-1bd0-e020" type="min"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs/>
+        </selectionEntry>
+      </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="00fa-34d6-294f-fb4e" name="May be upgraded with:" hidden="false" collective="false">
           <profiles/>
@@ -67335,6 +67359,12 @@ Explodes results add D3&quot; to radius.  </description>
               <rules/>
               <infoLinks>
                 <infoLink id="ddbc-7866-81e6-be2b" name="New InfoLink" hidden="false" targetId="e2e6-c3ad-41be-d14d" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="f286-25ad-66c1-5a11" name="New InfoLink" hidden="false" targetId="acf2-681d-4188-94d7" type="rule">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -67354,9 +67384,29 @@ Explodes results add D3&quot; to radius.  </description>
             </selectionEntry>
             <selectionEntry id="5175-8fb3-7cf1-967a" name="Quad Launcher (Phosphex Cannister Shot)" hidden="false" collective="false" type="upgrade">
               <profiles/>
-              <rules/>
+              <rules>
+                <rule id="82cf-c5c6-6ee4-faa5" name="Poisoned (3+)" hidden="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <description></description>
+                </rule>
+              </rules>
               <infoLinks>
                 <infoLink id="5ca1-2a8f-5114-70e0" name="New InfoLink" hidden="false" targetId="4d8c-ee11-e291-bc32" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="c579-e1d1-f941-6de9" name="New InfoLink" hidden="false" targetId="395c911d-e7ca-b2cc-c4e9-1e5d807187f1" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="627b-f188-98e4-c7d2" name="New InfoLink" hidden="false" targetId="c05245e1-0c49-a3e4-30d9-f6006c256839" type="rule">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -67384,6 +67434,12 @@ Explodes results add D3&quot; to radius.  </description>
                   <infoLinks/>
                   <modifiers/>
                 </infoLink>
+                <infoLink id="cdc2-b783-3e0f-ad0e" name="New InfoLink" hidden="false" targetId="8269-2cd6-9236-16e7" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
               </infoLinks>
               <modifiers/>
               <constraints>
@@ -67400,7 +67456,13 @@ Explodes results add D3&quot; to radius.  </description>
               <profiles/>
               <rules/>
               <infoLinks>
-                <infoLink id="d3b8-4d25-f96f-6e76" name="New InfoLink" hidden="false" targetId="5162-7d25-fd22-1b37" type="profile">
+                <infoLink id="d3b8-4d25-f96f-6e76" name="New InfoLink" book="" hidden="false" targetId="5162-7d25-fd22-1b37" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="bc6f-330d-10f4-015c" name="New InfoLink" hidden="false" targetId="b67a5fd8-9dcd-1d03-ef50-8170a6b1e839" type="rule">
                   <profiles/>
                   <rules/>
                   <infoLinks/>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -50997,6 +50997,21 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
                   </modifiers>
                   <constraints/>
                 </entryLink>
+                <entryLink id="f594-27de-123d-ab79" name="New EntryLink" book="HH:6" page="259" hidden="false" targetId="5eb2-7950-9270-ceb5" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <repeats/>
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="16a2-56d6-9be5-ede0" type="equalTo"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="ef3f-f368-a7ac-cd2a" name="Any Veteran may exchange their bolter:" hidden="false" collective="false">
@@ -68277,6 +68292,26 @@ Explodes results add D3&quot; to radius.  </description>
         <cost name="pts" costTypeId="points" value="30.0"/>
       </costs>
     </selectionEntry>
+    <selectionEntry id="5eb2-7950-9270-ceb5" name="Hand Flamer" book="HH:6" page="259" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="fa9f-25dd-6267-0721" name="Hand Flamer" book="HH:6" page="259" hidden="false" targetId="b7b7-09e6-8101-0834" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="15.0"/>
+      </costs>
+    </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup id="fc8ed347-6cd6-c24e-942f-bda78004e894" name="Bodyguard" hidden="false" collective="false">
@@ -72808,6 +72843,18 @@ Kharybdis: After it has landed treat as a flyer in Hover mode. LA:AODAL P75</des
         <characteristic name="A" characteristicTypeId="4123232344415441232323" value="2"/>
         <characteristic name="LD" characteristicTypeId="4c4423232344415441232323" value="9"/>
         <characteristic name="Save" characteristicTypeId="5361766523232344415441232323" value="2+"/>
+      </characteristics>
+    </profile>
+    <profile id="b7b7-09e6-8101-0834" name="Hand Flamer" book="HH: 6" page="259" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="Template"/>
+        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="3"/>
+        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="6"/>
+        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Pistol"/>
       </characteristics>
     </profile>
   </sharedProfiles>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -56075,33 +56075,8 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
       </costs>
     </selectionEntry>
     <selectionEntry id="5de71262-935f-d357-f3d5-aefd3ac0bfcd" name="Phoenix Terminator Squad" book="HH:LAICL" page="30" hidden="false" collective="false" categoryEntryId="456c6974657323232344415441232323" type="unit">
-      <profiles>
-        <profile id="ea89ee2a-7b0b-932a-ba44-a5ae6a54a54b" name="Phoenix Champion" book="LA:ADL" page="10" hidden="false" profileTypeId="556e697423232344415441232323">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Unit Type" characteristicTypeId="556e6974205479706523232344415441232323" value="Infantry (Character)"/>
-            <characteristic name="WS" characteristicTypeId="575323232344415441232323" value="5"/>
-            <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="4"/>
-            <characteristic name="S" characteristicTypeId="5323232344415441232323" value="4"/>
-            <characteristic name="T" characteristicTypeId="5423232344415441232323" value="4"/>
-            <characteristic name="W" characteristicTypeId="5723232344415441232323" value="1"/>
-            <characteristic name="I" characteristicTypeId="4923232344415441232323" value="4"/>
-            <characteristic name="A" characteristicTypeId="4123232344415441232323" value="3"/>
-            <characteristic name="LD" characteristicTypeId="4c4423232344415441232323" value="9"/>
-            <characteristic name="Save" characteristicTypeId="5361766523232344415441232323" value="2+"/>
-          </characteristics>
-        </profile>
-      </profiles>
+      <profiles/>
       <rules>
-        <rule id="69b88f88-be4b-ee3f-ee89-be987c2515ae" name="Stubborn" page="0" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </rule>
         <rule id="814f99bb-229f-6708-ae75-8cea536bcd47" name="Living Icon" book="HH:LAICL" page="30" hidden="false">
           <profiles/>
           <rules/>
@@ -56136,6 +56111,12 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
           <modifiers/>
         </infoLink>
         <infoLink id="686a-60c2-8f88-b1ec" hidden="false" targetId="48ee-9a7f-07f1-22d0" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="2bbc-0624-e9f3-332d" name="New InfoLink" hidden="false" targetId="7be5-30af-1a02-0a89" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -56188,6 +56169,68 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
             <cost name="pts" costTypeId="points" value="40.0"/>
           </costs>
         </selectionEntry>
+        <selectionEntry id="da68-3384-e4b0-f685" name="Pheonix Champion" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="1c2e-f241-c396-1be0" name="Phoenix Champion" book="LA:ADL" page="10" hidden="false" profileTypeId="556e697423232344415441232323">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Unit Type" characteristicTypeId="556e6974205479706523232344415441232323" value="Infantry (Character)"/>
+                <characteristic name="WS" characteristicTypeId="575323232344415441232323" value="5"/>
+                <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="4"/>
+                <characteristic name="S" characteristicTypeId="5323232344415441232323" value="4"/>
+                <characteristic name="T" characteristicTypeId="5423232344415441232323" value="4"/>
+                <characteristic name="W" characteristicTypeId="5723232344415441232323" value="1"/>
+                <characteristic name="I" characteristicTypeId="4923232344415441232323" value="4"/>
+                <characteristic name="A" characteristicTypeId="4123232344415441232323" value="3"/>
+                <characteristic name="LD" characteristicTypeId="4c4423232344415441232323" value="9"/>
+                <characteristic name="Save" characteristicTypeId="5361766523232344415441232323" value="2+"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8bd3-adf3-3ef9-638d" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="41fc-f5ff-d0c9-968d" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="2713-9c3c-5418-c454" name="Grenade Harness" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="a050-44d6-b38b-591b" hidden="false" targetId="889ea663-40f5-0ecc-7ba9-4b68e2955022" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="ea65-b504-edb2-4d2d" hidden="false" targetId="659ff44e-b4b4-e754-d640-1207926a1f5b" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2229-5d43-b7c4-07d1" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="10.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs/>
+        </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="16aa85f5-edeb-dbe9-cc49-e8999e24b964" name="Entire squad may take:" hidden="false" collective="false">
@@ -56201,7 +56244,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
               <profiles/>
               <rules/>
               <infoLinks>
-                <infoLink id="e71d-84d5-c7da-b616" hidden="false" targetId="580dd5a9-f85d-c9f3-eeff-e72d970ad9e5" type="profile">
+                <infoLink id="e71d-84d5-c7da-b616" name="" hidden="false" targetId="580dd5a9-f85d-c9f3-eeff-e72d970ad9e5" type="profile">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -56229,36 +56272,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
           <infoLinks/>
           <modifiers/>
           <constraints/>
-          <selectionEntries>
-            <selectionEntry id="9409ff8f-7d30-1ef5-20d1-deb6f17e8f33" name="Grenade Harness" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="7e525517-85c3-7603-5162-002b361613bd" hidden="false" targetId="889ea663-40f5-0ecc-7ba9-4b68e2955022" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="3e3d5783-a77b-2f8a-7c71-e802d49dbfa6" hidden="false" targetId="659ff44e-b4b4-e754-d640-1207926a1f5b" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="10.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
+          <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
         </selectionEntryGroup>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -66552,24 +66552,12 @@ When conducting a Ram attack, use Strength 10, roll two dice and pick the higher
             <characteristic name="Side" characteristicTypeId="5369646523232344415441232323" value="12"/>
             <characteristic name="Rear" characteristicTypeId="5265617223232344415441232323" value="12"/>
             <characteristic name="HP" characteristicTypeId="485023232344415441232323" value="3"/>
-            <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Tank, Fast"/>
-          </characteristics>
-        </profile>
-        <profile id="5468-1738-9841-2669" name="Neutron Beam Laser" book="HH:LACAL" page="60" hidden="false" profileTypeId="576561706f6e23232344415441232323">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="36&quot;"/>
-            <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="10"/>
-            <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="1"/>
-            <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Ordnance 2, Concussive, Shock Pulse"/>
+            <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Vehicle (Tank, Fast)"/>
           </characteristics>
         </profile>
       </profiles>
       <rules>
-        <rule id="d2e7-4843-97dc-52e6" name="Dangerous Reactor Core" book="HH:LACAL" page="60" hidden="false">
+        <rule id="d2e7-4843-97dc-52e6" name="Dangerous Reactor Core" book="AL:AoDAL" page="75" hidden="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -66578,7 +66566,13 @@ When conducting a Ram attack, use Strength 10, roll two dice and pick the higher
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="28c5-1a45-944b-ca2a" name="New InfoLink" hidden="false" targetId="b382-3da8-e6c2-48eb" type="rule">
+        <infoLink id="28c5-1a45-944b-ca2a" name="New InfoLink" book="" hidden="false" targetId="b382-3da8-e6c2-48eb" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="da02-ad44-9efe-0d80" name="New InfoLink" hidden="false" targetId="5283-9b50-3dcd-78e4" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -66587,160 +66581,36 @@ When conducting a Ram attack, use Strength 10, roll two dice and pick the higher
       </infoLinks>
       <modifiers/>
       <constraints/>
-      <selectionEntries/>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="e674-219e-efe4-7f68" name="May take any of the following:" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <selectionEntries>
-            <selectionEntry id="183d-d9ed-3a7c-6402" name="Hunter-killer Missile" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <selectionEntries>
+        <selectionEntry id="0672-9d5e-d484-c299" name="Hull Mounted Neutron Beam Laser" book="" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="761a-0848-0786-38e0" name="Neutron Beam Laser" book="AL:AoDAL" page="72" hidden="false" profileTypeId="576561706f6e23232344415441232323">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="30a2-c40d-7e2d-a8d4" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="10.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="75c2-de9b-fe9e-f55a" name="Dozer Blade" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="41a3-e496-f9b1-7908" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="8e1f-36b7-09fb-e3df" name="Armoured Ceramite" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="614b-1150-6770-730a" hidden="false" targetId="2e87b8ca-7cd1-78b9-2116-246015e7935e" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="027c-4cc7-2097-37e3" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="20.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="0632-9c2d-807c-bd4f" name="Auxiliary Drive" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="9a70-8450-7c83-0399" hidden="false" targetId="d963a2dd-d9a3-8974-aac6-61ffcc78a99a" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ca8f-3236-5897-450a" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="10.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups/>
-          <entryLinks/>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="02b4-02c1-8387-86da" name="May take one set of two sponson weapons:" hidden="false" collective="false">
-          <profiles/>
+              <characteristics>
+                <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="36&quot;"/>
+                <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="10"/>
+                <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="1"/>
+                <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Ordnance 2, Concussive, Shock Pulse"/>
+              </characteristics>
+            </profile>
+          </profiles>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="151c-51f4-c74a-f98b" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4a78-0e8f-1c0a-36c2" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c8ce-5977-f19d-3ca7" type="min"/>
           </constraints>
-          <selectionEntries>
-            <selectionEntry id="9f67-e7f4-4544-134c" name="Heavy Bolters" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7968-b7ec-c46f-fce9" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="20.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="f307-4a53-b99a-e059" name="Lascannons" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0865-046e-4087-4d8b" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="40.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="646e-fb0b-4226-c88c" name="Heavy Flamers" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="set" field="hidden" value="true">
-                  <repeats/>
-                  <conditions>
-                    <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a91f-3b51-950d-ba8a" type="equalTo"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="671b-521e-004f-9a39" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5f6d-8ebb-a511-bc40" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="20.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
+          <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-        </selectionEntryGroup>
+          <costs/>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
         <selectionEntryGroup id="86c6-30ee-aa7a-a8c9" name="Legion-specific upgrade" hidden="false" collective="false">
           <profiles/>
           <rules/>
@@ -66766,6 +66636,130 @@ When conducting a Ram attack, use Strength 10, roll two dice and pick the higher
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
+        <selectionEntryGroup id="93e1-ec52-eeaf-b8f8" name="May take one set of sponsons:" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5d0c-b9a6-054c-dc18" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="8000-f3cb-0dd6-c0f3" name="" hidden="false" targetId="2d56d45d-d276-7830-2b7d-026de64bbae8" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="20">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="append" field="name" value="Sponsons">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="8a75-a6e4-ffe6-1adc" name="New EntryLink" hidden="false" targetId="a161-76b3-9ef1-da7b" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="20">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="append" field="name" value="Sponsons">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="d1d0-401d-d342-b75d" name="New EntryLink" hidden="false" targetId="f2d4a6e5-edf4-52b2-fa15-13b163113aa5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="20">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="append" field="name" value="Sponsons">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="be5f-788d-e2d0-257d" name="New EntryLink" hidden="false" targetId="8036-b730-d533-e31f" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="40">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="append" field="name" value="Sponsons">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="57b0-8209-9997-70dd" name="May take any of the following:" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="ef2d-4bc7-a9ca-509d" name="New EntryLink" hidden="false" targetId="a0a4-4e61-7118-fcff" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="c510-6e36-6b8b-829d" name="New EntryLink" hidden="false" targetId="915f-bdbc-c3cb-9b0b" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="6185-73a8-234b-87dc" name="New EntryLink" hidden="false" targetId="f888-a294-fcff-8391" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="c01e-ad06-63f6-0229" name="New EntryLink" hidden="false" targetId="00d9-65e8-94b2-2396" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
         <entryLink id="a07c-85da-c9a2-ad1a" hidden="false" targetId="c487-be13-ea53-917e" type="selectionEntryGroup">
@@ -66781,6 +66775,29 @@ When conducting a Ram attack, use Strength 10, roll two dice and pick the higher
           <infoLinks/>
           <modifiers/>
           <constraints/>
+        </entryLink>
+        <entryLink id="6daf-94ad-7a20-d29f" name="New EntryLink" hidden="false" targetId="b572273e-2b93-4961-75c8-d9022c31a47d" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="874f-5076-9248-4393" name="Hull Mounted Heavy Bolter" hidden="false" targetId="a161-76b3-9ef1-da7b" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="set" field="name" value="Pintle-mounted Heavy Bolter">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="479f-081d-cfa8-a129" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e37a-f3e4-62d7-6904" type="min"/>
+          </constraints>
         </entryLink>
       </entryLinks>
       <costs>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="839b6f2a-4041-398b-fc2d-dc6a31d5f75e" name="Legiones Astartes: Age of Darkness Army List" book="Forgeworld Horus Heresy Series" revision="202" battleScribeVersion="2.00" authorName="Millicant" authorContact="Please submit any bugs to the website below" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="20" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="839b6f2a-4041-398b-fc2d-dc6a31d5f75e" name="Legiones Astartes: Age of Darkness Army List" book="Forgeworld Horus Heresy Series" revision="203" battleScribeVersion="2.00" authorName="Millicant" authorContact="Please submit any bugs to the website below" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="20" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules/>
   <infoLinks/>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -32399,7 +32399,7 @@ Ignores Cover special rule.</description>
       <rules/>
       <infoLinks/>
       <modifiers>
-        <modifier type="set" field="maxInRoster" value="1.0">
+        <modifier type="set" field="6c4d-36ea-5ed5-1f57" value="1">
           <repeats/>
           <conditions/>
           <conditionGroups/>
@@ -44090,7 +44090,7 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
       <infoLinks/>
       <modifiers/>
       <constraints>
-        <constraint field="selections" scope="roster" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
+        <constraint field="selections" scope="roster" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6c4d-36ea-5ed5-1f57" type="max"/>
       </constraints>
       <selectionEntries>
         <selectionEntry id="7bb09ddd-6e04-eb0b-9755-526b119c3870" name="Legion Dreadnought" book="" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
@@ -48205,6 +48205,12 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
           <infoLinks/>
           <modifiers/>
         </infoLink>
+        <infoLink id="f862-004e-a7ad-9129" name="New InfoLink" hidden="false" targetId="5283-9b50-3dcd-78e4" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
       </infoLinks>
       <modifiers/>
       <constraints/>
@@ -48247,7 +48253,9 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -48408,6 +48416,29 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
           <infoLinks/>
           <modifiers/>
           <constraints/>
+        </entryLink>
+        <entryLink id="d033-f495-3cf6-c007" name="New EntryLink" hidden="false" targetId="b572273e-2b93-4961-75c8-d9022c31a47d" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="e061-9df8-26de-4aae" name="Hull Mounted Heavy Bolter" hidden="false" targetId="a161-76b3-9ef1-da7b" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="set" field="name" value="Pintle-mounted Heavy Bolter">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4947-e333-d0d0-1cfe" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ef8b-56b0-c126-dfb6" type="min"/>
+          </constraints>
         </entryLink>
       </entryLinks>
       <costs>
@@ -52350,28 +52381,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
     </selectionEntry>
     <selectionEntry id="cb46-ed69-d353-eb45" name="Leviathan Siege Dreadnought Talon" book="Forgeworld.co.uk" page="Downloads" hidden="false" collective="false" categoryEntryId="(No Category)" type="unit">
       <profiles/>
-      <rules>
-        <rule id="a99f-61e2-f700-ffdc" name="Reinforced Atomantic Shielding" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <description>A Leviathan Dreadnought has a 4+ invulnerable save. In addition, if the Leviathan suffers a Vehicle Explodes damage result, add +D3 Str and +D3&quot; to the radius of the blast.</description>
-        </rule>
-        <rule id="7531-f41e-56a3-cc1a" name="Crushing Charge" book="" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <description>When charging, the model inflicts 2 Hammer of Wrath attacks and gains +1 Initiative in the Assault phase of any turn in which it has charged.</description>
-        </rule>
-        <rule id="e9ab-7457-2e0b-4b41" name="Move Through Cover" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </rule>
-      </rules>
+      <rules/>
       <infoLinks>
         <infoLink id="c631-d625-05d3-d2c5" hidden="false" targetId="a993-0e91-2841-9326" type="rule">
           <profiles/>
@@ -52382,425 +52392,54 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
       </infoLinks>
       <modifiers/>
       <constraints/>
-      <selectionEntries>
-        <selectionEntry id="28ea-8dbb-f25b-d037" name="Leviathan Siege Dreadnought" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
-          <profiles>
-            <profile id="ff58-b60e-5ec7-c9d5" name="Leviathan Siege Dreadnought" book="HH6: Retribution" page="236" hidden="false" profileTypeId="57616c6b657223232344415441232323">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="WS" characteristicTypeId="575323232344415441232323" value="5"/>
-                <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="5"/>
-                <characteristic name="S" characteristicTypeId="5323232344415441232323" value="8"/>
-                <characteristic name="Front" characteristicTypeId="46726f6e7423232344415441232323" value="13"/>
-                <characteristic name="Side" characteristicTypeId="5369646523232344415441232323" value="13"/>
-                <characteristic name="Rear" characteristicTypeId="5265617223232344415441232323" value="12"/>
-                <characteristic name="I" characteristicTypeId="4923232344415441232323" value="4"/>
-                <characteristic name="A" characteristicTypeId="4123232344415441232323" value="4"/>
-                <characteristic name="HP" characteristicTypeId="485023232344415441232323" value="4"/>
-                <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Vehicle (Walker)"/>
-              </characteristics>
-            </profile>
-            <profile id="9b9f-6ac1-d01b-89cf" name="Leviathan Siege Claw" book="HH6: Retribution" page="236" hidden="false" profileTypeId="576561706f6e23232344415441232323">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="set" field="hidden" value="true">
-                  <repeats/>
-                  <conditions>
-                    <condition field="selections" scope="28ea-8dbb-f25b-d037" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="352f-fa04-21c9-6075" type="equalTo"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <characteristics>
-                <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="-"/>
-                <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="X2"/>
-                <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="2"/>
-                <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Melee, Wrecker, Severing Cut"/>
-              </characteristics>
-            </profile>
-          </profiles>
-          <rules>
-            <rule id="6ae3-f593-27f6-ecce" name="Severing Cut" book="HH6: Retribution" page="236" hidden="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="set" field="hidden" value="true">
-                  <repeats/>
-                  <conditions>
-                    <condition field="selections" scope="28ea-8dbb-f25b-d037" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="352f-fa04-21c9-6075" type="equalTo"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <description>Each time a non-vehicle model suffers an unsaved wound from this weapon, roll a D6. On a 4+, the model suffers an extra D3 wounds which must be saved separately using the weapon’s profile (note that these wounds do not themselves generate more additional wounds).</description>
-            </rule>
-          </rules>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="b1e6-9664-903d-6a8a" name="Dedicated Transport" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
           <infoLinks/>
-          <modifiers/>
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="cb46-ed69-d353-eb45" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="54b0-fe0f-1182-c1de" type="greaterThan"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="11b5-4158-5ca6-93c1" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d5da-1daa-70e2-95af" type="min"/>
           </constraints>
           <selectionEntries/>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="5e3c-a1de-6880-87c2" name="Dedicated Transport" hidden="false" collective="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="78e8-ba79-1636-f848" hidden="false" targetId="604c-bdd0-25b9-2bed" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers>
-                    <modifier type="set" field="hidden" value="true">
-                      <repeats/>
-                      <conditions>
-                        <condition field="selections" scope="cb46-ed69-d353-eb45" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="28ea-8dbb-f25b-d037" type="greaterThan"/>
-                      </conditions>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                  <constraints/>
-                </entryLink>
-                <entryLink id="319f-b1c1-a176-894e" hidden="false" targetId="df4ceff0-6bd4-1cb9-b101-bef9ec61394e" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers>
-                    <modifier type="set" field="hidden" value="true">
-                      <repeats/>
-                      <conditions>
-                        <condition field="selections" scope="cb46-ed69-d353-eb45" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="28ea-8dbb-f25b-d037" type="greaterThan"/>
-                      </conditions>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                  <constraints/>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-            <selectionEntryGroup id="cf21-56a8-0ce1-37f8" name="May exchange either Heavy Flamer for" hidden="false" collective="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries>
-                <selectionEntry id="215b-3731-ff61-b78f" name="Twin-linked Volkite Caliver" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="7e10-2b2c-7bfd-d50d" hidden="false" targetId="402babca-fc14-e4b0-c135-a078ce95d036" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                    <infoLink id="545e-8f12-8f20-945a" hidden="false" targetId="e31cf870-3fa6-f2a2-8704-9bf05f7efcd8" type="rule">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="5.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="3efb-2f42-95f1-a88e" name="New EntryLink" hidden="false" targetId="2d56d45d-d276-7830-2b7d-026de64bbae8" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers>
-                    <modifier type="set" field="points" value="5">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                    <modifier type="set" field="maxSelections" value="2">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                  <constraints/>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-            <selectionEntryGroup id="3eb0-f686-0c8d-6e11" name="May take:" hidden="false" collective="false">
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="adc1-8f56-2b3d-4e6c" hidden="false" targetId="df4ceff0-6bd4-1cb9-b101-bef9ec61394e" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
               <constraints/>
-              <selectionEntries>
-                <selectionEntry id="888d-f93e-b42a-656d" name="Armoured Ceramite" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="67dd-f0a8-0b1c-627f" hidden="false" targetId="2e87b8ca-7cd1-78b9-2116-246015e7935e" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="20.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="c84d-1033-2b37-b9c1" name="Phosphex Discharger" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles>
-                    <profile id="bae4-80e1-ca17-2920" name="Phosphex Discharger" hidden="false" profileTypeId="576561706f6e23232344415441232323">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <characteristics>
-                        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="6&quot; - 18&quot;"/>
-                        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="5"/>
-                        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="2"/>
-                        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 3, One Use, Barrage, Blast, Poison (3+), Crawling Fire, Lingering Death"/>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="224b-71e6-5ba4-8e4c" hidden="false" targetId="395c911d-e7ca-b2cc-c4e9-1e5d807187f1" type="rule">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                    <infoLink id="840e-0e1d-a688-874d" hidden="false" targetId="c05245e1-0c49-a3e4-30d9-f6006c256839" type="rule">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="15.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups/>
-              <entryLinks/>
-            </selectionEntryGroup>
-            <selectionEntryGroup id="ccc7-2d73-fda1-1f62" name="Legion-specific upgrade" hidden="false" collective="false">
+            </entryLink>
+            <entryLink id="da06-8ada-27a3-b850" hidden="false" targetId="604c-bdd0-25b9-2bed" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
               <constraints/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="28ec-d7c6-32a2-db02" hidden="false" targetId="a15bdf56-4ffe-fe04-ff77-3d533ab99dfa" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-                <entryLink id="fbf5-dee2-6fc7-0182" hidden="false" targetId="86e70545-ed1a-7cf4-5a3d-d60662a6b3be" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-            <selectionEntryGroup id="352f-fa04-21c9-6075" name="Exchange Leviathan Siege Claw for:" hidden="false" collective="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries>
-                <selectionEntry id="7833-629f-1757-731c" name="Leviathan Siege Drill" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles>
-                    <profile id="afd8-d5cd-135d-758c" name="Leviathan Siege Drill" book="HH6: Retribution" page="236" hidden="false" profileTypeId="576561706f6e23232344415441232323">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <characteristics>
-                        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="-"/>
-                        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="X2"/>
-                        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="2"/>
-                        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Melee, Wrecker, Armourbane"/>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="5.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="6301-8fe5-fd17-3516" name="Leviathan Storm Cannon" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles>
-                    <profile id="7fb1-f71b-ec52-8ee5" name="Leviathan Storm Cannon" book="HH6: Retribution" page="236" hidden="false" profileTypeId="576561706f6e23232344415441232323">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <characteristics>
-                        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="24&quot;"/>
-                        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="7"/>
-                        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="3"/>
-                        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 6, Sunder"/>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="10.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="5fc1-8664-6e4f-89a2" name="Grav-flux Bombard" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles>
-                    <profile id="d0a2-118f-7ad3-c07a" name="Grav-flux Bombard" book="HH6: Retribution" page="236" hidden="false" profileTypeId="576561706f6e23232344415441232323">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <characteristics>
-                        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="18&quot;"/>
-                        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="*"/>
-                        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="2"/>
-                        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 1, Large Blast, Ignores Cover, Pinning, Graviton Collapse, Torsion Crusher"/>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                  <rules>
-                    <rule id="728a-5877-b8cf-2665" name="Graviton Collapse" hidden="false">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <description>Instead of rolling To Wound normally with this weapon, any model caught in its blast must instead roll equal to or under their Strength on 2D6 or suffer a wound. Against targets with an Armour value, roll 3D6 for armour penetration instead. After the graviton pulse weapon has been fired, leave the Blast marker in place. This area now counts as both difficult terrain and dangerous terrain for the next turn thanks to the gravity flux.</description>
-                    </rule>
-                    <rule id="a6a5-d5d0-e102-c1e2" name="Torsion Crusher" hidden="false">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <description>When a target with an Armour value is struck by this weapon, the amount of Hull Point damage caused by the weapon is doubled.</description>
-                    </rule>
-                  </rules>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="20.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="019b-f4ec-01d9-77d8" name="Cyclonic Melta Lance" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles>
-                    <profile id="2eec-c1d3-4b3d-9c77" name="Cyclonic Melta Lance" book="HH6: Retribution" page="236" hidden="false" profileTypeId="576561706f6e23232344415441232323">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <characteristics>
-                        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="18&quot;"/>
-                        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="9"/>
-                        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="1"/>
-                        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 3, Melta"/>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="20.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups/>
-              <entryLinks/>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="270.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
       <entryLinks>
         <entryLink id="2159-17ed-3441-d5b8" hidden="false" targetId="c487-be13-ea53-917e" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="54b0-fe0f-1182-c1de" name="New EntryLink" hidden="false" targetId="62ea-3ce6-cdb4-5705" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -66464,7 +66103,9 @@ When conducting a Ram attack, use Strength 10, roll two dice and pick the higher
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="92bd-b77f-2857-28db" name="Single Arachnus heavy lascannon battery" book="AL:AoADL" page="79" hidden="false" collective="false" type="upgrade">
       <profiles/>
@@ -66511,7 +66152,9 @@ When conducting a Ram attack, use Strength 10, roll two dice and pick the higher
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="1068-ed8b-b7fb-44c9" name="Sicaran Venator Tank Destroyer" book="HH:LACAL" page="60" hidden="false" collective="false" categoryEntryId="486561767920537570706f727423232344415441232323" type="unit">
       <profiles/>
@@ -66580,7 +66223,9 @@ Explodes results add D3&quot; to radius.  </description>
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -66775,6 +66420,807 @@ Explodes results add D3&quot; to radius.  </description>
       </entryLinks>
       <costs>
         <cost name="pts" costTypeId="points" value="190.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="62ea-3ce6-cdb4-5705" name="Leviathan Siege Dreadnought" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+      <profiles>
+        <profile id="d19d-34cc-544b-94d6" name="Leviathan Siege Dreadnought" book="HH6: Retribution" page="236" hidden="false" profileTypeId="57616c6b657223232344415441232323">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="WS" characteristicTypeId="575323232344415441232323" value="5"/>
+            <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="5"/>
+            <characteristic name="S" characteristicTypeId="5323232344415441232323" value="8"/>
+            <characteristic name="Front" characteristicTypeId="46726f6e7423232344415441232323" value="13"/>
+            <characteristic name="Side" characteristicTypeId="5369646523232344415441232323" value="13"/>
+            <characteristic name="Rear" characteristicTypeId="5265617223232344415441232323" value="12"/>
+            <characteristic name="I" characteristicTypeId="4923232344415441232323" value="4"/>
+            <characteristic name="A" characteristicTypeId="4123232344415441232323" value="4"/>
+            <characteristic name="HP" characteristicTypeId="485023232344415441232323" value="4"/>
+            <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Vehicle (Walker)"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="bd88-2d0d-47da-e381" name="Reinforced Atomantic Shielding" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <description>A Leviathan Dreadnought has a 4+ invulnerable save. In addition, if the Leviathan suffers a Vehicle Explodes damage result, add +D3 Str and +D3&quot; to the radius of the blast.</description>
+        </rule>
+        <rule id="57b2-6a8a-402e-bc21" name="Crushing Charge" book="" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <description>When charging, the model inflicts 2 Hammer of Wrath attacks and gains +1 Initiative in the Assault phase of any turn in which it has charged.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="ebac-6d11-056a-43a6" name="New InfoLink" hidden="false" targetId="6d06-5ea0-9a17-ca97" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2e59-7757-c5b4-57ec" type="min"/>
+        <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="27d0-820f-c5db-5b76" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="dc80-3733-1bc8-3596" name="May equip Right Torso Mount with:" hidden="false" collective="false" defaultSelectionEntryId="4999-e6a4-5e3e-0994">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="fbfc-e7f5-4e02-cffc" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="16eb-4e37-e8b8-0b9f" type="min"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="abf0-8f5f-16bb-08a5" name="New EntryLink" hidden="false" targetId="2d56d45d-d276-7830-2b7d-026de64bbae8" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="5">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="4999-e6a4-5e3e-0994" name="New EntryLink" hidden="false" targetId="9fef-d14e-0e9f-1cc8" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="cf10-76ae-d5f2-6de3" name="New EntryLink" hidden="false" targetId="31f8-648a-9fa6-564e" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="2b70-ace6-32af-74ac" name="May take:" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries>
+            <selectionEntry id="403d-6485-d3e4-bd9c" name="Phosphex Discharger" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles>
+                <profile id="0c52-45ce-9462-373d" name="Phosphex Discharger" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="6&quot; - 18&quot;"/>
+                    <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="5"/>
+                    <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="2"/>
+                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 3, One Use, Barrage, Blast, Poison (3+), Crawling Fire, Lingering Death"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks>
+                <infoLink id="0a49-72b7-52aa-2439" hidden="false" targetId="395c911d-e7ca-b2cc-c4e9-1e5d807187f1" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="d757-1453-f6a6-516c" hidden="false" targetId="c05245e1-0c49-a3e4-30d9-f6006c256839" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1280-892b-44cc-2573" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="15.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="9f3c-7f4c-56ec-86dc" name="New EntryLink" hidden="false" targetId="f888-a294-fcff-8391" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="06e2-e1ca-b6e0-0c17" name="Legion-specific upgrade" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="7ce2-3961-bd1a-c7d3" hidden="false" targetId="a15bdf56-4ffe-fe04-ff77-3d533ab99dfa" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="7220-0b64-fb0f-0e9a" hidden="false" targetId="86e70545-ed1a-7cf4-5a3d-d60662a6b3be" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="913f-14da-094a-0514" name="May equip Left Torso Mount with:" hidden="false" collective="false" defaultSelectionEntryId="e550-d372-bac9-0b00">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="aa3a-2343-af46-c65c" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e568-1750-5e53-edf6" type="min"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="82b1-8e7a-6a72-f529" name="New EntryLink" hidden="false" targetId="2d56d45d-d276-7830-2b7d-026de64bbae8" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="5">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="e550-d372-bac9-0b00" name="New EntryLink" hidden="false" targetId="9fef-d14e-0e9f-1cc8" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="7970-456c-7aac-dda1" name="New EntryLink" hidden="false" targetId="31f8-648a-9fa6-564e" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="ddab-d338-8b7e-f12a" name="Exchange Leviathan right Siege Claw for:" hidden="false" collective="false" defaultSelectionEntryId="bd08-1211-db8d-e0b7">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6195-d0bc-66c6-3c5c" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a836-1a42-3426-3c12" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="b1f0-2196-54dd-1bd4" name="Leviathan Siege Drill" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles>
+                <profile id="734a-d6a8-55ff-826a" name="Leviathan Siege Drill" book="HH6: Retribution" page="236" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="-"/>
+                    <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="X2"/>
+                    <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="2"/>
+                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Melee, Wrecker, Armourbane"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks>
+                <infoLink id="b9d7-1ff8-1fa3-4492" name="New InfoLink" hidden="false" targetId="fe2f-3220-3fef-b177" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="33c8-dfc6-555a-ceac" name="New InfoLink" hidden="false" targetId="e182-50cd-0867-9a8d" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="7864-cf17-3135-bac3" name="New EntryLink" hidden="false" targetId="a22d-ceac-5063-54e1" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="set" field="name" value="In-built Meltagun">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                    <modifier type="set" field="points" value="0.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0f0f-01b7-eb50-21e0" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ee6c-9ce8-14be-bb49" type="min"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="f1d7-f1cf-3d1b-c852" name="Leviathan Storm Cannon" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles>
+                <profile id="1354-8cfe-8918-c21b" name="Leviathan Storm Cannon" book="HH6: Retribution" page="236" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="24&quot;"/>
+                    <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="7"/>
+                    <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="3"/>
+                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 6, Sunder"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks>
+                <infoLink id="6732-f217-4559-462b" name="New InfoLink" hidden="false" targetId="b67a5fd8-9dcd-1d03-ef50-8170a6b1e839" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="8f4f-35ae-e737-819d" name="Grav-flux Bombard" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles>
+                <profile id="9a94-cc5e-b3c0-669c" name="Grav-flux Bombard" book="HH6: Retribution" page="236" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="18&quot;"/>
+                    <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="*"/>
+                    <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="2"/>
+                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 1, Large Blast, Ignores Cover, Pinning, Graviton Collapse, Torsion Crusher"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules>
+                <rule id="9bac-0d0f-7f7d-ffc8" name="Graviton Collapse" hidden="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <description>Instead of rolling To Wound normally with this weapon, any model caught in its blast must instead roll equal to or under their Strength on 2D6 or suffer a wound. Against targets with an Armour value, roll 3D6 for armour penetration instead. After the graviton pulse weapon has been fired, leave the Blast marker in place. This area now counts as both difficult terrain and dangerous terrain for the next turn thanks to the gravity flux.</description>
+                </rule>
+                <rule id="1538-a975-af1c-ceaf" name="Torsion Crusher" hidden="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <description>When a target with an Armour value is struck by this weapon, the amount of Hull Point damage caused by the weapon is doubled.</description>
+                </rule>
+              </rules>
+              <infoLinks>
+                <infoLink id="2302-e39a-0c75-0853" name="New InfoLink" hidden="false" targetId="acf2-681d-4188-94d7" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="d441-6da3-d486-d2f9" name="New InfoLink" hidden="false" targetId="f624-f475-e5ec-0dfa" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="20.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="dc5d-9291-fc8c-2529" name="Cyclonic Melta Lance" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles>
+                <profile id="ca63-af67-663c-35a7" name="Cyclonic Melta Lance" book="HH6: Retribution" page="236" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="18&quot;"/>
+                    <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="9"/>
+                    <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="1"/>
+                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 3, Melta"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks>
+                <infoLink id="a5c1-d465-1fbd-58e3" name="New InfoLink" page="" hidden="false" targetId="21c0-62ff-3ed2-17a7" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="20.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="bd08-1211-db8d-e0b7" name="Leviathan Siege Claw" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="d3a0-f5c7-3955-e91e" name="Leviathan Siege Claw" book="HH6: Retribution" page="236" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="-"/>
+                    <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="X2"/>
+                    <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="2"/>
+                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Melee, Wrecker, Severing Cut"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules>
+                <rule id="b22a-c9db-eab3-a656" name="Severing Cut" book="HH6: Retribution" page="236" hidden="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <description>Each time a non-vehicle model suffers an unsaved wound from this weapon, roll a D6. On a 4+, the model suffers an extra D3 wounds which must be saved separately using the weapon’s profile (note that these wounds do not themselves generate more additional wounds).</description>
+                </rule>
+              </rules>
+              <infoLinks>
+                <infoLink id="8415-8e26-1140-a0d1" name="New InfoLink" hidden="false" targetId="fe2f-3220-3fef-b177" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="d15e-536e-b493-8fa3" name="New EntryLink" hidden="false" targetId="a22d-ceac-5063-54e1" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="set" field="name" value="In-built Meltagun">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                    <modifier type="set" field="points" value="0.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="460d-b6ac-e37a-1503" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="afcc-f512-f1c5-4862" type="min"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="8da9-4717-77a3-a082" name="Exchange Leviathan left Siege Claw for:" hidden="false" collective="false" defaultSelectionEntryId="1eac-8d13-c114-4a25">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7c05-73ed-df57-c457" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="807f-77f2-bdcd-fd89" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="63fb-8413-3121-5150" name="Leviathan Siege Drill" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles>
+                <profile id="9d85-ea11-88f6-9e61" name="Leviathan Siege Drill" book="HH6: Retribution" page="236" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="-"/>
+                    <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="X2"/>
+                    <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="2"/>
+                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Melee, Wrecker, Armourbane"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks>
+                <infoLink id="dc95-de48-7eb6-e725" name="New InfoLink" hidden="false" targetId="fe2f-3220-3fef-b177" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="a5d4-7b4b-e2de-2877" name="New InfoLink" hidden="false" targetId="e182-50cd-0867-9a8d" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="278f-92b0-7734-ad22" name="New EntryLink" hidden="false" targetId="a22d-ceac-5063-54e1" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="set" field="name" value="In-built Meltagun">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                    <modifier type="set" field="points" value="0.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f48e-80db-8018-bf74" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="91a6-23e1-a77f-5aad" type="min"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="2580-f7ec-0e85-204a" name="Leviathan Storm Cannon" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles>
+                <profile id="6856-3200-c5b9-4f1d" name="Leviathan Storm Cannon" book="HH6: Retribution" page="236" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="24&quot;"/>
+                    <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="7"/>
+                    <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="3"/>
+                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 6, Sunder"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks>
+                <infoLink id="8368-fd29-73a2-e64e" name="New InfoLink" hidden="false" targetId="b67a5fd8-9dcd-1d03-ef50-8170a6b1e839" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="9384-01e3-43f3-fb0e" name="Grav-flux Bombard" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles>
+                <profile id="37ec-645d-9358-b6c0" name="Grav-flux Bombard" book="HH6: Retribution" page="236" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="18&quot;"/>
+                    <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="*"/>
+                    <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="2"/>
+                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 1, Large Blast, Ignores Cover, Pinning, Graviton Collapse, Torsion Crusher"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules>
+                <rule id="14f8-f868-6371-7bae" name="Graviton Collapse" hidden="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <description>Instead of rolling To Wound normally with this weapon, any model caught in its blast must instead roll equal to or under their Strength on 2D6 or suffer a wound. Against targets with an Armour value, roll 3D6 for armour penetration instead. After the graviton pulse weapon has been fired, leave the Blast marker in place. This area now counts as both difficult terrain and dangerous terrain for the next turn thanks to the gravity flux.</description>
+                </rule>
+                <rule id="a09f-9976-e32f-796c" name="Torsion Crusher" hidden="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <description>When a target with an Armour value is struck by this weapon, the amount of Hull Point damage caused by the weapon is doubled.</description>
+                </rule>
+              </rules>
+              <infoLinks>
+                <infoLink id="6c7a-366d-20fe-16c4" name="New InfoLink" hidden="false" targetId="acf2-681d-4188-94d7" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="7db2-0c89-e118-373e" name="New InfoLink" hidden="false" targetId="f624-f475-e5ec-0dfa" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="20.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="04eb-de27-1a1c-9c7b" name="Cyclonic Melta Lance" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles>
+                <profile id="e82a-4a90-802b-b1ef" name="Cyclonic Melta Lance" book="HH6: Retribution" page="236" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="18&quot;"/>
+                    <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="9"/>
+                    <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="1"/>
+                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 3, Melta"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks>
+                <infoLink id="5bb7-2ebc-fa26-9226" name="New InfoLink" page="" hidden="false" targetId="21c0-62ff-3ed2-17a7" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="20.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="1eac-8d13-c114-4a25" name="Leviathan Siege Claw" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="897c-8f60-159a-6f90" name="Leviathan Siege Claw" book="HH6: Retribution" page="236" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="-"/>
+                    <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="X2"/>
+                    <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="2"/>
+                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Melee, Wrecker, Severing Cut"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules>
+                <rule id="4148-faf0-f70a-53bd" name="Severing Cut" book="HH6: Retribution" page="236" hidden="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <description>Each time a non-vehicle model suffers an unsaved wound from this weapon, roll a D6. On a 4+, the model suffers an extra D3 wounds which must be saved separately using the weapon’s profile (note that these wounds do not themselves generate more additional wounds).</description>
+                </rule>
+              </rules>
+              <infoLinks>
+                <infoLink id="2fbc-d75a-992a-2686" name="New InfoLink" hidden="false" targetId="fe2f-3220-3fef-b177" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="05d1-0ced-ad80-8a01" name="New EntryLink" hidden="false" targetId="a22d-ceac-5063-54e1" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="set" field="name" value="In-built Meltagun">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                    <modifier type="set" field="points" value="0.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="94f0-9cac-1948-a2b1" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="47a2-88d5-bdfb-f009" type="min"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="270.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9fef-d14e-0e9f-1cc8" name="Heavy Flamer, Legion" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="4777-4d1b-57a7-5e04" name="New InfoLink" hidden="false" targetId="c554-a05e-607c-5831" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="537472656e67746823232344415441232323" value="1">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a91f-3b51-950d-ba8a" type="equalTo"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <modifiers>
+        <modifier type="set" field="name" value="Heavy Flamer">
+          <repeats/>
+          <conditions/>
+          <conditionGroups/>
+        </modifier>
+      </modifiers>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="31f8-648a-9fa6-564e" name="Twin-linked Volkite Caliver" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="987c-6459-1c18-419c" hidden="false" targetId="402babca-fc14-e4b0-c135-a078ce95d036" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="c319-3771-c114-f48b" hidden="false" targetId="e31cf870-3fa6-f2a2-8704-9bf05f7efcd8" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="5.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -66534,19 +66534,7 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
             <characteristic name="Side" characteristicTypeId="5369646523232344415441232323" value="12"/>
             <characteristic name="Rear" characteristicTypeId="5265617223232344415441232323" value="12"/>
             <characteristic name="HP" characteristicTypeId="485023232344415441232323" value="4"/>
-            <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Flyer, Hover"/>
-          </characteristics>
-        </profile>
-        <profile id="2294-380b-5d0c-86ff" name="Avenger Bolt Cannon" book="HH:LACAL" page="54" hidden="false" profileTypeId="576561706f6e23232344415441232323">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="36&quot;"/>
-            <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="6"/>
-            <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="3"/>
-            <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 7"/>
+            <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Vehicle (Flyer, Hover)"/>
           </characteristics>
         </profile>
       </profiles>
@@ -66709,6 +66697,27 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
+        <selectionEntryGroup id="bf2c-bb95-7b18-9431" name="Hull Mounted:" hidden="false" collective="false" defaultSelectionEntryId="a59c-512d-d8c8-9171">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ddb-1423-1551-95a9" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="60ff-fecc-e287-32f5" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="a59c-512d-d8c8-9171" name="Twin Linked Avenger Bolt Cannon" hidden="false" targetId="9f7b-ce08-7726-63af" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
         <entryLink id="d510-5924-3592-b464" hidden="false" targetId="f785888f-6dfa-08f4-054f-29b1a0e4f20c" type="selectionEntry">
@@ -66718,7 +66727,7 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
           <modifiers/>
           <constraints/>
         </entryLink>
-        <entryLink id="3541-5cf4-07a7-11b5" hidden="false" targetId="c487-be13-ea53-917e" type="selectionEntryGroup">
+        <entryLink id="3541-5cf4-07a7-11b5" name="" hidden="false" targetId="c487-be13-ea53-917e" type="selectionEntryGroup">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -66855,6 +66864,55 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
       </infoLinks>
       <modifiers/>
       <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs/>
+    </selectionEntry>
+    <selectionEntry id="4210-154f-6cf3-61d8" name="Avenger Bolt Cannon" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="8c37-f83e-7018-a767" name="New InfoLink" hidden="false" targetId="f3f5-75f6-90bd-2224" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs/>
+    </selectionEntry>
+    <selectionEntry id="9f7b-ce08-7726-63af" name="Twin-linked Avenger Bolt Cannon" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="a70e-71fc-944e-e664" name="New InfoLink" hidden="false" targetId="f3f5-75f6-90bd-2224" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="append" field="5479706523232344415441232323" value=", Twin-Linked">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="set" field="name" value="Twin-Linked Avenger Bolt Cannon">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8140-e3b2-d9fb-3b96" type="max"/>
+      </constraints>
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks/>
@@ -71208,6 +71266,18 @@ Kharybdis: After it has landed treat as a flyer in Hover mode. LA:AODAL P75</des
         <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="8"/>
         <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="2"/>
         <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 1, Sunder, One-Shot"/>
+      </characteristics>
+    </profile>
+    <profile id="f3f5-75f6-90bd-2224" name="Avenger Bolt Cannon" book="HH:LACAL" page="54" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="36&quot;"/>
+        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="6"/>
+        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="3"/>
+        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 7"/>
       </characteristics>
     </profile>
   </sharedProfiles>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -7229,761 +7229,6 @@
         <cost name="pts" costTypeId="points" value="195.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="51b23a66-6ec9-7ceb-2d26-9d45a6bccb1d" name="Legion Artillery Tank Squadron" book="HH:LACAL" page="56" hidden="false" collective="false" categoryEntryId="486561767920537570706f727423232344415441232323" type="unit">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
-      </constraints>
-      <selectionEntries/>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="b581889f-f540-8d5a-adb5-cb4d285e9dd4" name="Squadron Vehicles" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="054e4d70-5d63-df33-e79f-e43658f301db" name="Legion Basilisk" book="" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles>
-                <profile id="8ad14e5d-1630-f85c-fe83-099c210a0ab5" name="Legion Basilisk" book="HH:LACAL" page="56" hidden="false" profileTypeId="56656869636c6523232344415441232323">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <characteristics>
-                    <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="4"/>
-                    <characteristic name="Front" characteristicTypeId="46726f6e7423232344415441232323" value="12"/>
-                    <characteristic name="Side" characteristicTypeId="5369646523232344415441232323" value="10"/>
-                    <characteristic name="Rear" characteristicTypeId="5265617223232344415441232323" value="10"/>
-                    <characteristic name="HP" characteristicTypeId="485023232344415441232323" value="3"/>
-                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Tank"/>
-                  </characteristics>
-                </profile>
-                <profile id="6fbd9cb8-0961-8f05-8682-86b91823a76b" name="Earthshaker Cannon" book="HH:LACAL" page="92" hidden="false" profileTypeId="576561706f6e23232344415441232323">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <characteristics>
-                    <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="36&quot; -  240&quot;"/>
-                    <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="9"/>
-                    <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="3"/>
-                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Ordnance 1, Barrage, Large Blast"/>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups>
-                <selectionEntryGroup id="9c78cc68-790d-14d5-709f-2fd47a3bb70f" name="May take any of the following:" hidden="false" collective="false">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <selectionEntries>
-                    <selectionEntry id="2d2ac244-e8aa-c261-a21e-786e9033ac12" name="Dozer Blade" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="5.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="90b7f6e6-7b8f-c14e-a3e9-93a8dcbf8bd7" name="Auxiliary Drive" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="f5da6df1-bef2-6908-5727-6437686ae56f" hidden="false" targetId="d963a2dd-d9a3-8974-aac6-61ffcc78a99a" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="10.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="c8d8643d-1396-d2c7-7e51-de99dad60355" name="Hunter-killer Missile" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="10.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="f63d68b5-0cde-f3a8-1462-1f8a05b2a2b1" name="Extra Armour" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="10.0"/>
-                      </costs>
-                    </selectionEntry>
-                  </selectionEntries>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                </selectionEntryGroup>
-                <selectionEntryGroup id="32c5bd56-8c3f-9010-53a4-13196141736b" name="May take a Pintle-Mounted Weapon:" hidden="false" collective="false">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries>
-                    <selectionEntry id="8520bb89-6500-262b-4170-7f320af90e4e" name="Twin-Linked Bolter" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="5.0"/>
-                      </costs>
-                    </selectionEntry>
-                  </selectionEntries>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                </selectionEntryGroup>
-                <selectionEntryGroup id="77344f6a-d059-d22b-8dc0-cc5863b09c8c" name="Legion-specific upgrade" hidden="false" collective="false">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <selectionEntries/>
-                  <selectionEntryGroups>
-                    <selectionEntryGroup id="e0399baf-72bd-75a9-82d0-0451a2826bb6" name="Exchange Hull-mounted Heavy Bolter for:" hidden="false" collective="false">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers>
-                        <modifier type="set" field="hidden" value="true">
-                          <repeats/>
-                          <conditions>
-                            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a91f-3b51-950d-ba8a" type="equalTo"/>
-                          </conditions>
-                          <conditionGroups/>
-                        </modifier>
-                      </modifiers>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks>
-                        <entryLink id="02ac3ac8-e26d-0eab-5724-19be1c10a71f" hidden="false" targetId="f2d4a6e5-edf4-52b2-fa15-13b163113aa5" type="selectionEntry">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                          <constraints/>
-                        </entryLink>
-                      </entryLinks>
-                    </selectionEntryGroup>
-                  </selectionEntryGroups>
-                  <entryLinks>
-                    <entryLink id="14152f4d-2ad6-7ac8-5d31-26bb9296bcd6" hidden="false" targetId="a15bdf56-4ffe-fe04-ff77-3d533ab99dfa" type="selectionEntry">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints/>
-                    </entryLink>
-                    <entryLink id="6cf15030-2f07-b41f-f629-47a8d8c01f0b" hidden="false" targetId="f785888f-6dfa-08f4-054f-29b1a0e4f20c" type="selectionEntry">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints/>
-                    </entryLink>
-                  </entryLinks>
-                </selectionEntryGroup>
-              </selectionEntryGroups>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="140.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="1b87424a-5d3c-0e78-e414-44bec398a664" name="Legion Medusa" book="" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles>
-                <profile id="9d86e85c-dfc6-689f-559d-b1f77b448b6b" name="Legion Medusa" book="HH:LACAL" page="56" hidden="false" profileTypeId="56656869636c6523232344415441232323">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <characteristics>
-                    <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="4"/>
-                    <characteristic name="Front" characteristicTypeId="46726f6e7423232344415441232323" value="12"/>
-                    <characteristic name="Side" characteristicTypeId="5369646523232344415441232323" value="10"/>
-                    <characteristic name="Rear" characteristicTypeId="5265617223232344415441232323" value="10"/>
-                    <characteristic name="HP" characteristicTypeId="485023232344415441232323" value="3"/>
-                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Tank"/>
-                  </characteristics>
-                </profile>
-                <profile id="7f3b6e64-e06b-ef7a-177f-c9de64ee312b" name="Medusa Siege Gun" book="HH:LACAL" page="92" hidden="false" profileTypeId="576561706f6e23232344415441232323">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <characteristics>
-                    <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="36&quot;"/>
-                    <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="10"/>
-                    <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="2"/>
-                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Ordnance 1, Barrage, Large Blast"/>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups>
-                <selectionEntryGroup id="074fbb7d-ac7e-af42-5e08-4bebdb606bbc" name="May take any of the following:" hidden="false" collective="false">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <selectionEntries>
-                    <selectionEntry id="9b82c994-74e7-57b2-3168-76512a7620dc" name="Dozer Blade" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="5.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="f94a00e2-0bcf-6bf4-b4fc-e89c1f7ab542" name="Auxiliary Drive" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="22cda241-6397-c1e8-616d-feb8e0c237e1" hidden="false" targetId="d963a2dd-d9a3-8974-aac6-61ffcc78a99a" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="10.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="3723a555-d4c3-cd82-d979-9c5665b26dc0" name="Hunter-killer Missile" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="10.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="8f410bd1-d807-a62e-f325-e66ca10b619d" name="Extra Armour" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="10.0"/>
-                      </costs>
-                    </selectionEntry>
-                  </selectionEntries>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                </selectionEntryGroup>
-                <selectionEntryGroup id="3bf3fdb6-315b-6532-41ea-e5b63c3f6c92" name="May take a Pintle-Mounted Weapon:" hidden="false" collective="false">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries>
-                    <selectionEntry id="64c82e94-0c0b-5d0d-a1ee-923a63c137b3" name="Twin-Linked Bolter" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="5.0"/>
-                      </costs>
-                    </selectionEntry>
-                  </selectionEntries>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                </selectionEntryGroup>
-                <selectionEntryGroup id="f0d3ff35-5c70-2e30-1481-66ad38736517" name="Legion-specific upgrade" hidden="false" collective="false">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <selectionEntries/>
-                  <selectionEntryGroups>
-                    <selectionEntryGroup id="38d8ab37-7ba9-e3df-0dc9-2589b0afe22f" name="Exchange Hull-mounted Heavy Bolter for:" hidden="false" collective="false">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers>
-                        <modifier type="set" field="hidden" value="true">
-                          <repeats/>
-                          <conditions>
-                            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a91f-3b51-950d-ba8a" type="equalTo"/>
-                          </conditions>
-                          <conditionGroups/>
-                        </modifier>
-                      </modifiers>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks>
-                        <entryLink id="501bbd85-4c6e-fa2f-1a75-ddbcea30e214" hidden="false" targetId="f2d4a6e5-edf4-52b2-fa15-13b163113aa5" type="selectionEntry">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                          <constraints/>
-                        </entryLink>
-                      </entryLinks>
-                    </selectionEntryGroup>
-                    <selectionEntryGroup id="61a14968-e1fe-858a-9cd8-9a3567e0fb9d" name="May exchange normal shells for:" hidden="false" collective="false">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers>
-                        <modifier type="set" field="hidden" value="true">
-                          <repeats/>
-                          <conditions>
-                            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="66cb4a66-d860-119c-edfc-1749a899f258" type="equalTo"/>
-                          </conditions>
-                          <conditionGroups/>
-                        </modifier>
-                      </modifiers>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                      </constraints>
-                      <selectionEntries>
-                        <selectionEntry id="0bc4d457-92a4-17c6-717d-588e642f4142" name="Phosphex Shells" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                          <constraints>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                          </constraints>
-                          <selectionEntries/>
-                          <selectionEntryGroups/>
-                          <entryLinks/>
-                          <costs>
-                            <cost name="pts" costTypeId="points" value="0.0"/>
-                          </costs>
-                        </selectionEntry>
-                      </selectionEntries>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                    </selectionEntryGroup>
-                  </selectionEntryGroups>
-                  <entryLinks>
-                    <entryLink id="a37a4db6-635f-b7a1-76f0-b1bc6afbf976" hidden="false" targetId="a15bdf56-4ffe-fe04-ff77-3d533ab99dfa" type="selectionEntry">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints/>
-                    </entryLink>
-                    <entryLink id="1a3d199b-ce6d-633e-0505-1357fa866795" hidden="false" targetId="f785888f-6dfa-08f4-054f-29b1a0e4f20c" type="selectionEntry">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints/>
-                    </entryLink>
-                  </entryLinks>
-                </selectionEntryGroup>
-              </selectionEntryGroups>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="155.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="0cc53f7a-a640-e252-eab1-f5755db4b9e4" name="Legion Whirlwind" book="" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles>
-                <profile id="cf14f8ee-cc3d-2a97-cb3e-9df8708a81c7" name="Legion Whirlwind" book="HH:LACAL" page="56" hidden="false" profileTypeId="56656869636c6523232344415441232323">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <characteristics>
-                    <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="4"/>
-                    <characteristic name="Front" characteristicTypeId="46726f6e7423232344415441232323" value="11"/>
-                    <characteristic name="Side" characteristicTypeId="5369646523232344415441232323" value="11"/>
-                    <characteristic name="Rear" characteristicTypeId="5265617223232344415441232323" value="10"/>
-                    <characteristic name="HP" characteristicTypeId="485023232344415441232323" value="3"/>
-                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Tank"/>
-                  </characteristics>
-                </profile>
-                <profile id="8b542d42-3e35-f456-d4ab-70b15559d38c" name="Whirlwind Launcher: Vengeance Warhead" book="HH:LACAL" page="93" hidden="false" profileTypeId="576561706f6e23232344415441232323">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers>
-                    <modifier type="set" field="hidden" value="true">
-                      <repeats/>
-                      <conditions>
-                        <condition field="selections" scope="0cc53f7a-a640-e252-eab1-f5755db4b9e4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="81fec200-22f5-7659-7b69-eec9565cafce" type="equalTo"/>
-                      </conditions>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                  <characteristics>
-                    <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="12&quot; - 48&quot;"/>
-                    <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="5"/>
-                    <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="4"/>
-                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Ordnance 1, Barrage, Large Blast"/>
-                  </characteristics>
-                </profile>
-                <profile id="11f69230-9ffc-b660-284f-a412adf21eaa" name="Whirlwind Launcher: Castellan Warhead" book="HH:LACAL" page="93" hidden="false" profileTypeId="576561706f6e23232344415441232323">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers>
-                    <modifier type="set" field="hidden" value="true">
-                      <repeats/>
-                      <conditions>
-                        <condition field="selections" scope="0cc53f7a-a640-e252-eab1-f5755db4b9e4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="81fec200-22f5-7659-7b69-eec9565cafce" type="equalTo"/>
-                      </conditions>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                  <characteristics>
-                    <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="12&quot; - 48&quot;"/>
-                    <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="4"/>
-                    <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="5"/>
-                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Ordnance 1, Barrage, Large Blast, Ignores Cover"/>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups>
-                <selectionEntryGroup id="7c391074-2423-d31d-3a3c-056975a8c65b" name="May take any of the following:" hidden="false" collective="false">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <selectionEntries>
-                    <selectionEntry id="dbce0d7e-7926-433b-75e5-4f2094736ad0" name="Dozer Blade" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="5.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="ec6c71d6-74e1-213e-6707-80fd8403df43" name="Auxiliary Drive" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="354433d7-5118-104f-5ace-ecd839bb55ab" hidden="false" targetId="d963a2dd-d9a3-8974-aac6-61ffcc78a99a" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="10.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="ea41fdbf-4d4d-eb12-a4e6-17029247371d" name="Hunter-killer Missile" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="10.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="f381af6b-7b4e-5f86-632d-ee445e6e99e8" name="Extra Armour" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="10.0"/>
-                      </costs>
-                    </selectionEntry>
-                  </selectionEntries>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                </selectionEntryGroup>
-                <selectionEntryGroup id="95bee91d-3cca-23e9-0267-2ce740e670bb" name="May take a Pintle-Mounted Weapon:" hidden="false" collective="false">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries>
-                    <selectionEntry id="3bc61f3d-f1e3-4499-03ef-62b0dd20f2c6" name="Twin-Linked Bolter" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="5.0"/>
-                      </costs>
-                    </selectionEntry>
-                  </selectionEntries>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                </selectionEntryGroup>
-                <selectionEntryGroup id="c4473b23-84de-3bef-62de-41af13135f49" name="Exchange Vengeance and Castellan missiles for:" hidden="false" collective="false">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <selectionEntries>
-                    <selectionEntry id="81fec200-22f5-7659-7b69-eec9565cafce" name="Hyperios air-defence Missiles" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles>
-                        <profile id="3f1bb4fb-9297-c860-c911-01717fe87711" name="Whirlwind Launcher: Hyperios Warhead" book="HH:LACAL" page="93" hidden="false" profileTypeId="576561706f6e23232344415441232323">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                          <characteristics>
-                            <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="48&quot;"/>
-                            <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="8"/>
-                            <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="3"/>
-                            <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 1, Skyfire, Interceptor"/>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                  </selectionEntries>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                </selectionEntryGroup>
-                <selectionEntryGroup id="f2c6a37b-5254-b625-4cf1-5ea275ed2b50" name="Legion-specific upgrade" hidden="false" collective="false">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks>
-                    <entryLink id="23b1b879-68fa-b58c-ebd4-f70b12cbf247" hidden="false" targetId="a15bdf56-4ffe-fe04-ff77-3d533ab99dfa" type="selectionEntry">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints/>
-                    </entryLink>
-                  </entryLinks>
-                </selectionEntryGroup>
-              </selectionEntryGroups>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="75.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups/>
-          <entryLinks/>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="156c55a4-656e-c381-9851-08d84179e187" name="In squadrons of three, one model may upgraded to:" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <selectionEntries>
-            <selectionEntry id="04d34a33-f3cb-2aef-b9ba-ca9b98c8d2fa" name="Command Tank" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="b8bb9308-c5c5-dde6-2929-1da656391190" hidden="false" targetId="eb87c0fc-8658-25c4-b594-2a9fbc752328" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers>
-                <modifier type="set" field="hidden" value="true">
-                  <repeats/>
-                  <conditions>
-                    <condition field="selections" scope="51b23a66-6ec9-7ceb-2d26-9d45a6bccb1d" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b581889f-f540-8d5a-adb5-cb4d285e9dd4" type="lessThan"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="25.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups/>
-          <entryLinks/>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="2b61-a965-3a3e-03ae" hidden="false" targetId="c487-be13-ea53-917e" type="selectionEntryGroup">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </entryLink>
-      </entryLinks>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
     <selectionEntry id="e2bbc832-2c59-80ad-5a6f-6c8daeda79e2" name="Legion Assault Squad" book="HH:LACAL" page="31" hidden="false" collective="false" categoryEntryId="54726f6f707323232344415441232323" type="upgrade">
       <profiles/>
       <rules/>
@@ -35532,6 +34777,13 @@ Ignores Cover special rule.</description>
       <constraints/>
     </entryLink>
     <entryLink id="ca37-291f-af06-a390" name="New EntryLink" hidden="false" targetId="eb64-e310-ac49-08e7" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </entryLink>
+    <entryLink id="b22d-6356-a2b3-695f" name="New EntryLink" hidden="false" targetId="57e7-980d-f042-f566" type="selectionEntry">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -66917,6 +66169,662 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
       <selectionEntryGroups/>
       <entryLinks/>
       <costs/>
+    </selectionEntry>
+    <selectionEntry id="57e7-980d-f042-f566" name="Legion Artillery Tank Squadron" book="HH:LACAL" page="56" hidden="false" collective="false" categoryEntryId="486561767920537570706f727423232344415441232323" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d8f2-e6e9-3cc1-42e1" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="511d-594e-09c3-7ee1" name="Squadron Vehicles" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="198e-8d98-398f-b59f" type="min"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fb9e-54b4-e8bb-22d4" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="d9bd-4556-c34c-c5f6" name="Legion Basilisk" book="" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles>
+                <profile id="0cc0-ec1e-0704-1c6d" name="Legion Basilisk" book="HH:LACAL" page="56" hidden="false" profileTypeId="56656869636c6523232344415441232323">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="4"/>
+                    <characteristic name="Front" characteristicTypeId="46726f6e7423232344415441232323" value="12"/>
+                    <characteristic name="Side" characteristicTypeId="5369646523232344415441232323" value="10"/>
+                    <characteristic name="Rear" characteristicTypeId="5265617223232344415441232323" value="10"/>
+                    <characteristic name="HP" characteristicTypeId="485023232344415441232323" value="3"/>
+                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Tank"/>
+                  </characteristics>
+                </profile>
+                <profile id="cb0e-78a5-d63d-cc4c" name="Earthshaker Cannon" book="HH:LACAL" page="92" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="36&quot; -  240&quot;"/>
+                    <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="9"/>
+                    <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="3"/>
+                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Ordnance 1, Barrage, Large Blast"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5923-a24f-f6c2-7786" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="9be6-6bef-3509-ccf6" name="May take any of the following:" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <selectionEntries>
+                    <selectionEntry id="2ce5-d8b8-d633-f1c4" name="Dozer Blade" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="39d5-a217-107f-8744" type="max"/>
+                      </constraints>
+                      <selectionEntries/>
+                      <selectionEntryGroups/>
+                      <entryLinks/>
+                      <costs>
+                        <cost name="pts" costTypeId="points" value="5.0"/>
+                      </costs>
+                    </selectionEntry>
+                    <selectionEntry id="2ad8-8336-c2e5-5f7e" name="Auxiliary Drive" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks>
+                        <infoLink id="618b-d5d7-471a-a95f" hidden="false" targetId="d963a2dd-d9a3-8974-aac6-61ffcc78a99a" type="profile">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                        </infoLink>
+                      </infoLinks>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ecb6-840d-7e56-4572" type="max"/>
+                      </constraints>
+                      <selectionEntries/>
+                      <selectionEntryGroups/>
+                      <entryLinks/>
+                      <costs>
+                        <cost name="pts" costTypeId="points" value="10.0"/>
+                      </costs>
+                    </selectionEntry>
+                    <selectionEntry id="0cfe-dc4f-35fc-9911" name="Hunter-killer Missile" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="159c-a897-df6c-a8a4" type="max"/>
+                      </constraints>
+                      <selectionEntries/>
+                      <selectionEntryGroups/>
+                      <entryLinks/>
+                      <costs>
+                        <cost name="pts" costTypeId="points" value="10.0"/>
+                      </costs>
+                    </selectionEntry>
+                    <selectionEntry id="fbbc-2f70-d262-55f5" name="Extra Armour" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a760-0d77-fd52-2deb" type="max"/>
+                      </constraints>
+                      <selectionEntries/>
+                      <selectionEntryGroups/>
+                      <entryLinks/>
+                      <costs>
+                        <cost name="pts" costTypeId="points" value="10.0"/>
+                      </costs>
+                    </selectionEntry>
+                  </selectionEntries>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="95c0-4993-9123-57d0" name="Legion-specific upgrade" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <selectionEntries/>
+                  <selectionEntryGroups>
+                    <selectionEntryGroup id="a9b4-7797-a144-7b43" name="Exchange Hull-mounted Heavy Bolter for:" hidden="false" collective="false">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers>
+                        <modifier type="set" field="hidden" value="true">
+                          <repeats/>
+                          <conditions>
+                            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a91f-3b51-950d-ba8a" type="equalTo"/>
+                          </conditions>
+                          <conditionGroups/>
+                        </modifier>
+                      </modifiers>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9039-97ea-762c-2098" type="min"/>
+                      </constraints>
+                      <selectionEntries/>
+                      <selectionEntryGroups/>
+                      <entryLinks>
+                        <entryLink id="fbc6-1106-4b6e-e144" hidden="false" targetId="f2d4a6e5-edf4-52b2-fa15-13b163113aa5" type="selectionEntry">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints/>
+                        </entryLink>
+                      </entryLinks>
+                    </selectionEntryGroup>
+                  </selectionEntryGroups>
+                  <entryLinks>
+                    <entryLink id="71c8-5876-6474-3345" hidden="false" targetId="a15bdf56-4ffe-fe04-ff77-3d533ab99dfa" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </entryLink>
+                    <entryLink id="1392-719c-a3bf-66c0" hidden="false" targetId="f785888f-6dfa-08f4-054f-29b1a0e4f20c" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <entryLinks>
+                <entryLink id="d47a-a15c-204e-9bb9" name="New EntryLink" hidden="false" targetId="fe17-5ed2-ca63-9379" type="selectionEntryGroup">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" costTypeId="points" value="140.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="c34e-cd3b-dbb4-55e3" name="Legion Medusa" book="" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles>
+                <profile id="607e-b741-7510-db94" name="Legion Medusa" book="HH:LACAL" page="56" hidden="false" profileTypeId="56656869636c6523232344415441232323">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="4"/>
+                    <characteristic name="Front" characteristicTypeId="46726f6e7423232344415441232323" value="12"/>
+                    <characteristic name="Side" characteristicTypeId="5369646523232344415441232323" value="10"/>
+                    <characteristic name="Rear" characteristicTypeId="5265617223232344415441232323" value="10"/>
+                    <characteristic name="HP" characteristicTypeId="485023232344415441232323" value="3"/>
+                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Tank"/>
+                  </characteristics>
+                </profile>
+                <profile id="bd2f-2698-8b1f-e0bb" name="Medusa Siege Gun" book="HH:LACAL" page="92" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="36&quot;"/>
+                    <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="10"/>
+                    <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="2"/>
+                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Ordnance 1, Barrage, Large Blast"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="94fb-3635-371b-7cea" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="e3ce-390d-2fa0-59bf" name="May take any of the following:" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <selectionEntries>
+                    <selectionEntry id="9be6-0a6d-704f-590a" name="Dozer Blade" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="bba4-63ce-7594-c89e" type="max"/>
+                      </constraints>
+                      <selectionEntries/>
+                      <selectionEntryGroups/>
+                      <entryLinks/>
+                      <costs>
+                        <cost name="pts" costTypeId="points" value="5.0"/>
+                      </costs>
+                    </selectionEntry>
+                    <selectionEntry id="ebd5-f67f-f2b4-1448" name="Auxiliary Drive" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks>
+                        <infoLink id="196b-4536-517e-8a6a" hidden="false" targetId="d963a2dd-d9a3-8974-aac6-61ffcc78a99a" type="profile">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                        </infoLink>
+                      </infoLinks>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5963-9d58-e4ff-131b" type="max"/>
+                      </constraints>
+                      <selectionEntries/>
+                      <selectionEntryGroups/>
+                      <entryLinks/>
+                      <costs>
+                        <cost name="pts" costTypeId="points" value="10.0"/>
+                      </costs>
+                    </selectionEntry>
+                    <selectionEntry id="f5f9-9c87-786b-9814" name="Hunter-killer Missile" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e0bc-ca51-d222-bdb2" type="max"/>
+                      </constraints>
+                      <selectionEntries/>
+                      <selectionEntryGroups/>
+                      <entryLinks/>
+                      <costs>
+                        <cost name="pts" costTypeId="points" value="10.0"/>
+                      </costs>
+                    </selectionEntry>
+                    <selectionEntry id="38bc-8299-3e06-a724" name="Extra Armour" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ddf4-a947-2b0e-0999" type="max"/>
+                      </constraints>
+                      <selectionEntries/>
+                      <selectionEntryGroups/>
+                      <entryLinks/>
+                      <costs>
+                        <cost name="pts" costTypeId="points" value="10.0"/>
+                      </costs>
+                    </selectionEntry>
+                  </selectionEntries>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="3c84-0d2f-0084-01a8" name="Legion-specific upgrade" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <selectionEntries/>
+                  <selectionEntryGroups>
+                    <selectionEntryGroup id="5384-c682-618a-e8de" name="Exchange Hull-mounted Heavy Bolter for:" hidden="false" collective="false">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers>
+                        <modifier type="set" field="hidden" value="true">
+                          <repeats/>
+                          <conditions>
+                            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a91f-3b51-950d-ba8a" type="equalTo"/>
+                          </conditions>
+                          <conditionGroups/>
+                        </modifier>
+                      </modifiers>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2b47-8845-37f3-f70a" type="min"/>
+                      </constraints>
+                      <selectionEntries/>
+                      <selectionEntryGroups/>
+                      <entryLinks>
+                        <entryLink id="5751-49be-6af4-6741" hidden="false" targetId="f2d4a6e5-edf4-52b2-fa15-13b163113aa5" type="selectionEntry">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints/>
+                        </entryLink>
+                      </entryLinks>
+                    </selectionEntryGroup>
+                    <selectionEntryGroup id="78db-8804-a4b5-c2a1" name="May exchange normal shells for:" hidden="false" collective="false">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers>
+                        <modifier type="set" field="hidden" value="true">
+                          <repeats/>
+                          <conditions>
+                            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="66cb4a66-d860-119c-edfc-1749a899f258" type="equalTo"/>
+                          </conditions>
+                          <conditionGroups/>
+                        </modifier>
+                      </modifiers>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0485-b2a9-ec72-f8f4" type="min"/>
+                      </constraints>
+                      <selectionEntries>
+                        <selectionEntry id="05aa-ed09-b359-3b0f" name="Phosphex Shells" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1ba1-a41f-7731-c045" type="max"/>
+                          </constraints>
+                          <selectionEntries/>
+                          <selectionEntryGroups/>
+                          <entryLinks/>
+                          <costs>
+                            <cost name="pts" costTypeId="points" value="0.0"/>
+                          </costs>
+                        </selectionEntry>
+                      </selectionEntries>
+                      <selectionEntryGroups/>
+                      <entryLinks/>
+                    </selectionEntryGroup>
+                  </selectionEntryGroups>
+                  <entryLinks>
+                    <entryLink id="42e0-01a2-44e7-f539" hidden="false" targetId="a15bdf56-4ffe-fe04-ff77-3d533ab99dfa" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </entryLink>
+                    <entryLink id="31ac-60df-ef1e-0e67" hidden="false" targetId="f785888f-6dfa-08f4-054f-29b1a0e4f20c" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <entryLinks>
+                <entryLink id="93c7-37f1-e9c1-9517" name="New EntryLink" hidden="false" targetId="fe17-5ed2-ca63-9379" type="selectionEntryGroup">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" costTypeId="points" value="155.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="b0d7-629c-5780-10f2" name="Legion Whirlwind" book="" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles>
+                <profile id="6457-4193-e54c-9017" name="Legion Whirlwind" book="HH:LACAL" page="56" hidden="false" profileTypeId="56656869636c6523232344415441232323">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="4"/>
+                    <characteristic name="Front" characteristicTypeId="46726f6e7423232344415441232323" value="11"/>
+                    <characteristic name="Side" characteristicTypeId="5369646523232344415441232323" value="11"/>
+                    <characteristic name="Rear" characteristicTypeId="5265617223232344415441232323" value="10"/>
+                    <characteristic name="HP" characteristicTypeId="485023232344415441232323" value="3"/>
+                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Tank"/>
+                  </characteristics>
+                </profile>
+                <profile id="a08d-6af0-36af-5a2c" name="Whirlwind Launcher: Vengeance Warhead" book="HH:LACAL" page="93" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="12&quot; - 48&quot;"/>
+                    <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="5"/>
+                    <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="4"/>
+                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Ordnance 1, Barrage, Large Blast"/>
+                  </characteristics>
+                </profile>
+                <profile id="d708-d409-5d33-5caf" name="Whirlwind Launcher: Castellan Warhead" book="HH:LACAL" page="93" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="12&quot; - 48&quot;"/>
+                    <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="4"/>
+                    <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="5"/>
+                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Ordnance 1, Barrage, Large Blast, Ignores Cover"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b3aa-ea71-f5ec-289b" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="80dd-8bce-2cc7-bec5" name="May take any of the following:" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <selectionEntries>
+                    <selectionEntry id="d9aa-11da-0d0a-f3f3" name="Dozer Blade" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0ae6-f2b9-50d7-9d91" type="max"/>
+                      </constraints>
+                      <selectionEntries/>
+                      <selectionEntryGroups/>
+                      <entryLinks/>
+                      <costs>
+                        <cost name="pts" costTypeId="points" value="5.0"/>
+                      </costs>
+                    </selectionEntry>
+                    <selectionEntry id="f429-a8e1-6b86-674b" name="Auxiliary Drive" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks>
+                        <infoLink id="5d1e-d61c-a045-46c5" hidden="false" targetId="d963a2dd-d9a3-8974-aac6-61ffcc78a99a" type="profile">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                        </infoLink>
+                      </infoLinks>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="df69-d52e-3cfd-da3a" type="max"/>
+                      </constraints>
+                      <selectionEntries/>
+                      <selectionEntryGroups/>
+                      <entryLinks/>
+                      <costs>
+                        <cost name="pts" costTypeId="points" value="10.0"/>
+                      </costs>
+                    </selectionEntry>
+                    <selectionEntry id="fffe-03aa-41e8-f89d" name="Hunter-killer Missile" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5783-f35b-e62d-7ab7" type="max"/>
+                      </constraints>
+                      <selectionEntries/>
+                      <selectionEntryGroups/>
+                      <entryLinks/>
+                      <costs>
+                        <cost name="pts" costTypeId="points" value="10.0"/>
+                      </costs>
+                    </selectionEntry>
+                    <selectionEntry id="a79e-c74c-2a4a-f434" name="Extra Armour" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="15f8-455b-7755-1ee0" type="max"/>
+                      </constraints>
+                      <selectionEntries/>
+                      <selectionEntryGroups/>
+                      <entryLinks/>
+                      <costs>
+                        <cost name="pts" costTypeId="points" value="10.0"/>
+                      </costs>
+                    </selectionEntry>
+                  </selectionEntries>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="a4ed-55f7-78c9-2ef4" name="Exchange Vengeance and Castellan missiles for:" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <selectionEntries>
+                    <selectionEntry id="132d-f357-3e51-6e96" name="Hyperios air-defence Missiles" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                      <profiles>
+                        <profile id="460a-ad43-ca82-d49b" name="Whirlwind Launcher: Hyperios Warhead" book="HH:LACAL" page="93" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <characteristics>
+                            <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="48&quot;"/>
+                            <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="8"/>
+                            <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="3"/>
+                            <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 1, Skyfire, Interceptor"/>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b447-6cd6-af1e-4e59" type="max"/>
+                      </constraints>
+                      <selectionEntries/>
+                      <selectionEntryGroups/>
+                      <entryLinks/>
+                      <costs>
+                        <cost name="pts" costTypeId="points" value="0.0"/>
+                      </costs>
+                    </selectionEntry>
+                  </selectionEntries>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="923e-cff0-623f-c8b8" name="Legion-specific upgrade" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="9d9a-da2a-be7c-9ae5" hidden="false" targetId="a15bdf56-4ffe-fe04-ff77-3d533ab99dfa" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <entryLinks>
+                <entryLink id="3210-f028-22b6-4c47" name="New EntryLink" hidden="false" targetId="fe17-5ed2-ca63-9379" type="selectionEntryGroup">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" costTypeId="points" value="75.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="54de-fb9d-794e-b73b" name="In squadrons of three, one model may upgraded to:" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="385e-f4c7-27a1-ca73" name="New EntryLink" hidden="false" targetId="2330-16be-009d-4a66" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="cee4-965a-4c18-f604" hidden="false" targetId="c487-be13-ea53-917e" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -46669,7 +46669,7 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
             <characteristic name="Side" characteristicTypeId="5369646523232344415441232323" value="12"/>
             <characteristic name="Rear" characteristicTypeId="5265617223232344415441232323" value="12"/>
             <characteristic name="HP" characteristicTypeId="485023232344415441232323" value="5"/>
-            <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Flyer, Hover, Transport"/>
+            <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Vehicle (Flyer, Transport, Hover)"/>
           </characteristics>
         </profile>
         <profile id="9e3d-ac3b-1e86-9807" name="Kharybdis Storm Launcher" book="HH:LACAL" page="63" hidden="false" profileTypeId="576561706f6e23232344415441232323">

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -13470,8 +13470,8 @@
             <modifier type="set" field="hidden" value="true">
               <repeats/>
               <conditions>
-                <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1006-e22e-3aa4-f79a" type="equalTo"/>
-                <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ea6f-0a58-58b0-0d01" type="equalTo"/>
+                <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1006-e22e-3aa4-f79a" type="equalTo"/>
+                <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ea6f-0a58-58b0-0d01" type="equalTo"/>
               </conditions>
               <conditionGroups/>
             </modifier>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -45604,16 +45604,15 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
     </selectionEntry>
     <selectionEntry id="b9f0-57cc-d0da-4ae3" name="Legion Jetbike Sky Hunter Squadron" book="HH:LACAL" page="41" hidden="false" collective="false" categoryEntryId="466173742041747461636b23232344415441232323" type="unit">
       <profiles/>
-      <rules>
-        <rule id="3621-3589-b4fe-f4ed" name="Deep Strike" page="0" hidden="false">
+      <rules/>
+      <infoLinks>
+        <infoLink id="804b-2413-ab90-316b" hidden="false" targetId="d4a1a878-9ad4-6ae0-a864-08f58264c4a5" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-        </rule>
-      </rules>
-      <infoLinks>
-        <infoLink id="804b-2413-ab90-316b" hidden="false" targetId="d4a1a878-9ad4-6ae0-a864-08f58264c4a5" type="rule">
+        </infoLink>
+        <infoLink id="e4f5-23e2-c6c0-2fd2" name="New InfoLink" hidden="false" targetId="d219-2314-4834-c054" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -45682,28 +45681,16 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
           </costs>
         </selectionEntry>
         <selectionEntry id="9740-9beb-39a0-3203" name="Sky Hunter Sergeant" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-          <profiles>
-            <profile id="2aa7-34d8-5263-6276" name="Legion Sky Hunter Sergeant" book="HH:LACAL" page="41" hidden="false" profileTypeId="556e697423232344415441232323">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="ec0c-eda5-c014-debc" name="New InfoLink" hidden="false" targetId="7d40-c47e-9fcc-7cb4" type="profile">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
-              <characteristics>
-                <characteristic name="Unit Type" characteristicTypeId="556e6974205479706523232344415441232323" value="Jetbike (Character)"/>
-                <characteristic name="WS" characteristicTypeId="575323232344415441232323" value="4"/>
-                <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="4"/>
-                <characteristic name="S" characteristicTypeId="5323232344415441232323" value="4"/>
-                <characteristic name="T" characteristicTypeId="5423232344415441232323" value="5"/>
-                <characteristic name="W" characteristicTypeId="5723232344415441232323" value="1"/>
-                <characteristic name="I" characteristicTypeId="4923232344415441232323" value="4"/>
-                <characteristic name="A" characteristicTypeId="4123232344415441232323" value="2"/>
-                <characteristic name="LD" characteristicTypeId="4c4423232344415441232323" value="9"/>
-                <characteristic name="Save" characteristicTypeId="5361766523232344415441232323" value="2+"/>
-              </characteristics>
-            </profile>
-          </profiles>
-          <rules/>
-          <infoLinks/>
+            </infoLink>
+          </infoLinks>
           <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
@@ -67301,7 +67288,9 @@ Explodes results add D3&quot; to radius.  </description>
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="1914-1ced-69c6-585c" name="Quad Launcher" hidden="false" collective="false" type="upgrade">
       <profiles>
@@ -67357,7 +67346,9 @@ Explodes results add D3&quot; to radius.  </description>
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -67404,7 +67395,6 @@ Explodes results add D3&quot; to radius.  </description>
                   <rules/>
                   <infoLinks/>
                   <modifiers/>
-                  <description></description>
                 </rule>
               </rules>
               <infoLinks>
@@ -67500,7 +67490,9 @@ Explodes results add D3&quot; to radius.  </description>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="6683-c57a-0a90-e0f2" name="Legion Malcador Assault Tank" book="AL:AoDAL" page="81" hidden="false" collective="false" type="unit">
       <profiles/>
@@ -67835,7 +67827,9 @@ Explodes results add D3&quot; to radius.  </description>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="0137-bfce-22c9-8f03" name="Autocannon" book="BRB 7th" hidden="false" collective="false" type="upgrade">
       <profiles/>
@@ -67853,7 +67847,9 @@ Explodes results add D3&quot; to radius.  </description>
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="a75b-d337-1f8b-d4af" name="Battle Cannon" hidden="false" collective="false" type="upgrade">
       <profiles/>
@@ -67871,7 +67867,449 @@ Explodes results add D3&quot; to radius.  </description>
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9b0f-fe11-248c-953f" name="Legion Jetbike Sky Slayer Support Squadron" book="HH:LACAL" page="41" hidden="false" collective="false" categoryEntryId="466173742041747461636b23232344415441232323" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="b599-488a-44d0-0cf1" hidden="false" targetId="d4a1a878-9ad4-6ae0-a864-08f58264c4a5" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="bb2a-0f2d-981a-ddfb" name="New InfoLink" hidden="false" targetId="d219-2314-4834-c054" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="6112-73ef-3754-6518" name="Space Marine Sky Slayers" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles>
+            <profile id="6c77-1427-5e74-d1b1" name="Legion Space Marine Sky Hunter" book="HH:LACAL" page="41" hidden="false" profileTypeId="556e697423232344415441232323">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Unit Type" characteristicTypeId="556e6974205479706523232344415441232323" value="Jetbike"/>
+                <characteristic name="WS" characteristicTypeId="575323232344415441232323" value="4"/>
+                <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="4"/>
+                <characteristic name="S" characteristicTypeId="5323232344415441232323" value="4"/>
+                <characteristic name="T" characteristicTypeId="5423232344415441232323" value="5"/>
+                <characteristic name="W" characteristicTypeId="5723232344415441232323" value="1"/>
+                <characteristic name="I" characteristicTypeId="4923232344415441232323" value="4"/>
+                <characteristic name="A" characteristicTypeId="4123232344415441232323" value="1"/>
+                <characteristic name="LD" characteristicTypeId="4c4423232344415441232323" value="8"/>
+                <characteristic name="Save" characteristicTypeId="5361766523232344415441232323" value="2+"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="02f8-fc1d-4e34-8fed" type="min"/>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d7dc-e9ce-0517-a31f" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="35.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="b932-2302-a52f-a269" name="Sky Slayer Sergeant" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="e333-cb7f-3298-43db" name="New InfoLink" hidden="false" targetId="7d40-c47e-9fcc-7cb4" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7032-5d71-ff7e-b264" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="f277-623d-d1b1-78e3" name="Melta Bombs" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats>
+                    <repeat field="selections" scope="9b0f-fe11-248c-953f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c1ee-dbf0-ab40-bad2" repeats="1"/>
+                  </repeats>
+                  <conditions>
+                    <condition field="selections" scope="9b0f-fe11-248c-953f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c1ee-dbf0-ab40-bad2" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4423-30e0-2b24-1c2e" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="f48f-a1f7-a042-aeb5" name="Exchange Bolt Pistol for:" hidden="false" collective="false" defaultSelectionEntryId="cd94-bf4b-6814-4a16">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7478-6ace-0d76-8bd4" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="db54-fadc-a850-88a0" type="min"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="6325-4f82-d8be-26f2" name="Hand Flamer" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="e951-3b8d-e190-8cf6" hidden="false" targetId="21b6-668e-d5ef-a8da" type="profile">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1e4d-6ceb-59a2-311f" type="max"/>
+                    <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a084-0c43-a2dd-a8fb" type="min"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="2dcd-9a62-a033-ed10" name="" hidden="false" targetId="82d4-9768-236a-2ea1" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="ec39-da28-d8be-b117" name="New EntryLink" hidden="false" targetId="f832-f4b2-6aaf-ad83" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="cd94-bf4b-6814-4a16" name="New EntryLink" hidden="false" targetId="6026-d507-935a-7200" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="822b-f167-7c1f-7868" name="Exchange Chainsword/Combat Blade for:" hidden="false" collective="false" defaultSelectionEntryId="4951-c155-d8da-91e0">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="489e-92ce-7532-3403" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8b3c-c021-defa-531b" type="min"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="cba3-c446-505b-b001" hidden="false" targetId="30834ca2-20b0-cb5a-c7db-f76092533a64" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="set" field="points" value="15.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="d3e5-ca6e-d3ab-d4bc" hidden="false" targetId="fa1c768d-9b24-bfbd-8dea-ec7b4ff72bb2" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="6fa1-dd19-8317-eeec" hidden="false" targetId="479f576b-b28d-801e-b928-d82431d554b9" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="set" field="points" value="15.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="5e4d-db81-5512-c28b" hidden="false" targetId="6435afdc-d8b1-09a1-a82a-9d4d7af1c869" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="15.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="340a-be68-1179-2cd7" hidden="false" targetId="c31253d0-d1b9-35ac-6435-f1a06611e356" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="fbd3-810f-6138-a9dd" hidden="false" targetId="2acd15a3-57b3-6c4e-1199-0fa706a5b3d8" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="843b-8687-0329-e627" hidden="false" targetId="2767-2afe-31ac-5cca" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="02ff-6808-477c-8485" hidden="false" targetId="5beb-0cde-90c1-0f88" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="491d-2d89-749c-9bd0" name="New EntryLink" hidden="false" targetId="e890-52eb-3444-c6c7" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="6d9a-21d2-3195-9b9e" name="New EntryLink" hidden="false" targetId="26db-484d-3757-03c8" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="set" field="name" value="Single Lighting Claw">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="19d0-ee3b-3a56-d0b9" name="New EntryLink" hidden="false" targetId="fcef-f5ac-16a3-9401" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="4951-c155-d8da-91e0" name="New EntryLink" hidden="false" targetId="4b1e-680b-1d39-e4f1" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="143c-4d6b-52c1-d739" hidden="false" targetId="8b059b74-0029-efeb-ecc0-98a21dded43a" type="selectionEntryGroup">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="15.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="079a-31e3-90c4-c7c0" name="The entire Squadron may exchange their Jetbike&apos;s Multi-Melta for:" hidden="false" collective="false" defaultSelectionEntryId="6cbe-1141-fb99-0cfa">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="724c-4d3e-b127-eabc" value="1">
+              <repeats>
+                <repeat field="selections" scope="9b0f-fe11-248c-953f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6112-73ef-3754-6518" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="724c-4d3e-b127-eabc" value="1">
+              <repeats>
+                <repeat field="selections" scope="9b0f-fe11-248c-953f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6112-73ef-3754-6518" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="724c-4d3e-b127-eabc" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6f2e-a1e7-987b-3078" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="6cbe-1141-fb99-0cfa" name="Multi-Melta" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2812-139d-6a5d-ccf6" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs/>
+            </selectionEntry>
+            <selectionEntry id="5f2a-eb96-e759-e022" name="Plasma Cannon" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e201-972b-14f9-e6c5" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="15.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="3e19-c26f-0062-828b" name="Volkite Culverin" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="8cdc-2d30-f09d-3d94" hidden="false" targetId="c7838603-9e18-8756-26b1-222a294c5c2c" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="4608-0b56-ae34-8fa0" hidden="false" targetId="e31cf870-3fa6-f2a2-8704-9bf05f7efcd8" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ba58-436d-3b34-778f" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="10.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="8637-c985-1bd4-16eb" name="Legion-specific upgrades:" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="6f14-f4b9-1503-8820" hidden="false" targetId="cea6be0e-460b-ce44-90f4-b1b0159ee33c" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="25.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d3a3-3f65-2193-bc1b" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="ba48-908b-da7f-6d57" hidden="false" targetId="c487-be13-ea53-917e" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="c1ee-dbf0-ab40-bad2" name="New EntryLink" hidden="false" targetId="4c62-8983-4a1b-d1c6" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="5">
+              <repeats>
+                <repeat field="selections" scope="9b0f-fe11-248c-953f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6112-73ef-3754-6518" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="30.0"/>
+      </costs>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
@@ -72386,6 +72824,24 @@ Kharybdis: After it has landed treat as a flyer in Hover mode. LA:AODAL P75</des
         <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="8"/>
         <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="3"/>
         <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Ordnance 1, Large Blast"/>
+      </characteristics>
+    </profile>
+    <profile id="7d40-c47e-9fcc-7cb4" name="Legion Jetbike Sergeant" book="HH:LACAL" page="41" hidden="false" profileTypeId="556e697423232344415441232323">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Unit Type" characteristicTypeId="556e6974205479706523232344415441232323" value="Jetbike (Character)"/>
+        <characteristic name="WS" characteristicTypeId="575323232344415441232323" value="4"/>
+        <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="4"/>
+        <characteristic name="S" characteristicTypeId="5323232344415441232323" value="4"/>
+        <characteristic name="T" characteristicTypeId="5423232344415441232323" value="5"/>
+        <characteristic name="W" characteristicTypeId="5723232344415441232323" value="1"/>
+        <characteristic name="I" characteristicTypeId="4923232344415441232323" value="4"/>
+        <characteristic name="A" characteristicTypeId="4123232344415441232323" value="2"/>
+        <characteristic name="LD" characteristicTypeId="4c4423232344415441232323" value="9"/>
+        <characteristic name="Save" characteristicTypeId="5361766523232344415441232323" value="2+"/>
       </characteristics>
     </profile>
   </sharedProfiles>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -8989,7 +8989,7 @@
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="pts" costTypeId="points" value="65.0"/>
+        <cost name="pts" costTypeId="points" value="55.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="5fab84ab-ab50-ecc0-a170-bb2ebc0059ad" name="Legion Castellax Class Battle-Automata Maniple" book="http://www.forgeworld.co.uk/resources/fw_site/fw_pdfs/Horus_Heresy/Horus_Heresy_7th_Edition.pdf" page="7" hidden="false" collective="false" categoryEntryId="486561767920537570706f727423232344415441232323" type="upgrade">

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -7,113 +7,6 @@
   <profileTypes/>
   <forceEntries/>
   <selectionEntries>
-    <selectionEntry id="a8cf84f2-0e14-b402-f2b0-3c5d36a8f2e5" name="Achilles-Alpha Pattern Land Raider" book="HH:LACAL" page="55" hidden="false" collective="false" categoryEntryId="486561767920537570706f727423232344415441232323" type="unit">
-      <profiles>
-        <profile id="be48b29f-652d-8c25-9627-f211ec0fc86d" name="Achilles-Alpha Pattern Land Raider" book="HH:LACAL" page="55" hidden="false" profileTypeId="56656869636c6523232344415441232323">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="4"/>
-            <characteristic name="Front" characteristicTypeId="46726f6e7423232344415441232323" value="14"/>
-            <characteristic name="Side" characteristicTypeId="5369646523232344415441232323" value="14"/>
-            <characteristic name="Rear" characteristicTypeId="5265617223232344415441232323" value="14"/>
-            <characteristic name="HP" characteristicTypeId="485023232344415441232323" value="4"/>
-            <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Tank, Transport"/>
-          </characteristics>
-        </profile>
-        <profile id="2774dac8-220e-5298-07c1-500540d7f6ac" name="Quad Mortar (Shatter)" book="HH:LACAL" page="55" hidden="false" profileTypeId="576561706f6e23232344415441232323">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="36&quot;"/>
-            <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="8"/>
-            <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="4"/>
-            <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 4, Sunder"/>
-          </characteristics>
-        </profile>
-      </profiles>
-      <rules>
-        <rule id="3fce71a5-1dfc-ec30-bd7f-46752a09f4f4" name="Enhanced Ferromantic Rites" book="HH:LACAL" page="55" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <description>Land Raider Achilles-Alpha is not subject to the effects of the Melta and Lance special rules by attacks made against it.  In addition it reduces the effects of all rolls on the damage chart by -1 (except Destroyer hits).  </description>
-        </rule>
-        <rule id="347803fd-aaac-1d95-83d0-2de6c5d01ec9" name="Galvanic Traction Drive" book="HH:LACAL" page="55" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <description>Must re-roll all failed Dangerous Terrain tests.  </description>
-        </rule>
-      </rules>
-      <infoLinks>
-        <infoLink id="3b6dda92-717d-7e68-590e-d35d73346493" hidden="false" targetId="6d02b74f-b832-0249-9ba0-01ac9c192099" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="4366dac4-8bbb-410d-8b0b-f1fdaf38f960" hidden="false" targetId="887c2e1c-8eae-d449-e212-7dddb39cf726" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="e0a0-3940-d945-f4aa" hidden="false" targetId="c7838603-9e18-8756-26b1-222a294c5c2c" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="65bb-fee3-2e8f-d233" hidden="false" targetId="e31cf870-3fa6-f2a2-8704-9bf05f7efcd8" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <selectionEntries/>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="dc2c6ca3-a225-0260-3ff8-f78721a64743" name="Legion-specific upgrade" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="fef7c8ce-cba9-22ac-c17b-97a94eab9a87" hidden="false" targetId="a15bdf56-4ffe-fe04-ff77-3d533ab99dfa" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="2165-1c2f-46f6-2b9a" hidden="false" targetId="c487-be13-ea53-917e" type="selectionEntryGroup">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </entryLink>
-      </entryLinks>
-      <costs>
-        <cost name="pts" costTypeId="points" value="300.0"/>
-      </costs>
-    </selectionEntry>
     <selectionEntry id="2ca9eca9-5c90-9634-b109-424090e4c03d" name="Alexis Polux" book="HH:LAICL" page="101" hidden="false" collective="false" categoryEntryId="485123232344415441232323" type="model">
       <profiles>
         <profile id="909f76c5-49d4-478b-cb90-78507632ce6a" name="Alexis Polux" book="HH:LAICL" page="101" hidden="false" profileTypeId="556e697423232344415441232323">
@@ -33845,6 +33738,13 @@ Ignores Cover special rule.</description>
       <modifiers/>
       <constraints/>
     </entryLink>
+    <entryLink id="1b95-0dfb-7fe8-37de" name="New EntryLink" hidden="false" targetId="24b2-3331-008d-2bd8" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </entryLink>
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="a9bf-b37e-126b-a699" name="&apos;Iron Circle&apos; Domitar-Ferrum Class Battle-automata Maniple" hidden="false" collective="false" categoryEntryId="456c6974657323232344415441232323" type="unit">
@@ -67221,6 +67121,113 @@ Explodes results add D3&quot; to radius.  </description>
       <entryLinks/>
       <costs>
         <cost name="pts" costTypeId="points" value="5.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="24b2-3331-008d-2bd8" name="Achilles-Alpha Pattern Land Raider" book="HH:LACAL" page="55" hidden="false" collective="false" categoryEntryId="486561767920537570706f727423232344415441232323" type="unit">
+      <profiles>
+        <profile id="94d2-c021-2e07-133a" name="Achilles-Alpha Pattern Land Raider" book="HH:LACAL" page="55" hidden="false" profileTypeId="56656869636c6523232344415441232323">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="4"/>
+            <characteristic name="Front" characteristicTypeId="46726f6e7423232344415441232323" value="14"/>
+            <characteristic name="Side" characteristicTypeId="5369646523232344415441232323" value="14"/>
+            <characteristic name="Rear" characteristicTypeId="5265617223232344415441232323" value="14"/>
+            <characteristic name="HP" characteristicTypeId="485023232344415441232323" value="4"/>
+            <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Tank, Transport"/>
+          </characteristics>
+        </profile>
+        <profile id="588f-bf62-c683-acb7" name="Quad Mortar (Shatter)" book="HH:LACAL" page="55" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="36&quot;"/>
+            <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="8"/>
+            <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="4"/>
+            <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 4, Sunder"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="7b20-ef5b-3986-5a0d" name="Enhanced Ferromantic Rites" book="HH:LACAL" page="55" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <description>Land Raider Achilles-Alpha is not subject to the effects of the Melta and Lance special rules by attacks made against it.  In addition it reduces the effects of all rolls on the damage chart by -1 (except Destroyer hits).  </description>
+        </rule>
+        <rule id="db9b-453a-bf9d-efcb" name="Galvanic Traction Drive" book="HH:LACAL" page="55" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <description>Must re-roll all failed Dangerous Terrain tests.  </description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="a72f-c8ff-6bac-ff36" hidden="false" targetId="6d02b74f-b832-0249-9ba0-01ac9c192099" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="9331-f648-c3ea-8942" hidden="false" targetId="887c2e1c-8eae-d449-e212-7dddb39cf726" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="6152-7578-714a-a775" hidden="false" targetId="c7838603-9e18-8756-26b1-222a294c5c2c" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="f94a-4c57-596f-87e0" hidden="false" targetId="e31cf870-3fa6-f2a2-8704-9bf05f7efcd8" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="62fa-c446-e3e7-d317" name="Legion-specific upgrade" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="8837-6aed-fe7d-23fe" hidden="false" targetId="a15bdf56-4ffe-fe04-ff77-3d533ab99dfa" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="cf48-f905-2129-33e2" hidden="false" targetId="c487-be13-ea53-917e" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="300.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -66562,7 +66562,8 @@ When conducting a Ram attack, use Strength 10, roll two dice and pick the higher
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <description>An enemy may re-roll a result of a 1 on the Vehicle Damage table against the Sicarian Venator.  Explodes results add D3&quot; to radius.  </description>
+          <description>If enemy inflicts a Penetrating hit against the Sicarian Cenator, they may re-roll a result of a 1 on the Vehicle Damage table.
+Explodes results add D3&quot; to radius.  </description>
         </rule>
       </rules>
       <infoLinks>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -44816,7 +44816,29 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
               <profiles/>
               <rules/>
               <infoLinks/>
-              <modifiers/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="b5dc5eb3-2070-ce68-0ca6-5d26f0d238d4" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="363b8c4d-a8c8-8faa-d78a-f8415f3ee2cc" type="greaterThan"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+            </infoLink>
+            <infoLink id="aed4-4f4b-e486-8cdb" name="New InfoLink" hidden="false" targetId="9fee-4776-4af3-200b" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="b5dc5eb3-2070-ce68-0ca6-5d26f0d238d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="363b8c4d-a8c8-8faa-d78a-f8415f3ee2cc" type="lessThan"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
             </infoLink>
           </infoLinks>
           <modifiers/>
@@ -45126,13 +45148,14 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="902a08ef-cda1-51c8-1c15-37aff66c0c1a" name="Exchange all Heavy Bolters for:" hidden="false" collective="false">
+        <selectionEntryGroup id="902a08ef-cda1-51c8-1c15-37aff66c0c1a" name="The entire squad may be equiped with:" hidden="false" collective="false" defaultSelectionEntryId="c927-9bc1-c180-b676">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6558-6cc9-025a-ab66" type="min"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="9768419b-c1f8-1896-8956-33c73e5c0c4c" name="Heavy Flamers" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
@@ -45346,7 +45369,7 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
           </selectionEntries>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="dab9-3c11-bb8a-e8be" hidden="false" targetId="2d56d45d-d276-7830-2b7d-026de64bbae8" type="selectionEntry">
+            <entryLink id="dab9-3c11-bb8a-e8be" name="" hidden="false" targetId="2d56d45d-d276-7830-2b7d-026de64bbae8" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -45371,6 +45394,13 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
                   <conditionGroups/>
                 </modifier>
               </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="c927-9bc1-c180-b676" name="New EntryLink" book="" hidden="false" targetId="a161-76b3-9ef1-da7b" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
               <constraints/>
             </entryLink>
           </entryLinks>
@@ -73165,6 +73195,24 @@ Kharybdis: After it has landed treat as a flyer in Hover mode. LA:AODAL P75</des
         <characteristic name="Rear" characteristicTypeId="5265617223232344415441232323" value="12"/>
         <characteristic name="HP" characteristicTypeId="485023232344415441232323" value="3"/>
         <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Open-topped"/>
+      </characteristics>
+    </profile>
+    <profile id="9fee-4776-4af3-200b" name="Legion Sergeant (Artificer Armour)" book="AL:AoDAL" page="131" hidden="false" profileTypeId="556e697423232344415441232323">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Unit Type" characteristicTypeId="556e6974205479706523232344415441232323" value="Infantry (Character)"/>
+        <characteristic name="WS" characteristicTypeId="575323232344415441232323" value="4"/>
+        <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="4"/>
+        <characteristic name="S" characteristicTypeId="5323232344415441232323" value="4"/>
+        <characteristic name="T" characteristicTypeId="5423232344415441232323" value="4"/>
+        <characteristic name="W" characteristicTypeId="5723232344415441232323" value="1"/>
+        <characteristic name="I" characteristicTypeId="4923232344415441232323" value="4"/>
+        <characteristic name="A" characteristicTypeId="4123232344415441232323" value="2"/>
+        <characteristic name="LD" characteristicTypeId="4c4423232344415441232323" value="9"/>
+        <characteristic name="Save" characteristicTypeId="5361766523232344415441232323" value="2+"/>
       </characteristics>
     </profile>
   </sharedProfiles>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -8313,7 +8313,19 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
-          <selectionEntries/>
+          <selectionEntries>
+            <selectionEntry id="65f7-552f-6699-b0ac" name="Breaching Charge" book="AD:AoDAL" page="" hidden="false" collective="false" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs/>
+            </selectionEntry>
+          </selectionEntries>
           <selectionEntryGroups>
             <selectionEntryGroup id="117b0374-572a-2f2a-517e-d63689430986" name="Exchange Bolter for:" hidden="false" collective="false" defaultSelectionEntryId="88b0-f429-62c1-2048">
               <profiles/>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -66550,15 +66550,7 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
           </characteristics>
         </profile>
       </profiles>
-      <rules>
-        <rule id="8dbd-3763-ae43-d862" name="Independent Turret Fire" book="HH:LACAL" page="54" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <description>Each waist turret may fire at a different target and do not count towards the number of weapons that may be fired in a turn.  </description>
-        </rule>
-      </rules>
+      <rules/>
       <infoLinks>
         <infoLink id="88c6-cc7d-04b5-6c68" name="New InfoLink" hidden="false" targetId="d219-2314-4834-c054" type="rule">
           <profiles/>
@@ -66579,6 +66571,12 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
           <modifiers/>
         </infoLink>
         <infoLink id="b556-e50d-3ef3-1745" name="New InfoLink" hidden="false" targetId="9ec5-6ea0-ad91-5c4b" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="794e-6a5a-e405-24b2" name="New InfoLink" hidden="false" targetId="64be-8c7f-db3c-58d7" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -70008,6 +70006,13 @@ Kharybdis: After it has landed treat as a flyer in Hover mode. LA:AODAL P75</des
       <infoLinks/>
       <modifiers/>
       <description>When shooting Assault, Heavy, Rapid Fire or Salvo weapons at Artillery, Beasts, Bikes, Cavalry, Infantry, Monstrous Creatures and vehicles without the Flyer or Skimmer type, this vehicle has +1 Ballistic Skill.</description>
+    </rule>
+    <rule id="64be-8c7f-db3c-58d7" name="Independent Turret Fire" book="HH:LACAL" page="54" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>So long as the Fire Raptor is eligible to fire a weapon in the shooting phase,each waist turret may fire at a different target and do not count towards the number of weapons that may be fired in a turn.  </description>
     </rule>
   </sharedRules>
   <sharedProfiles>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -33423,7 +33423,7 @@ Ignores Cover special rule.</description>
       </modifiers>
       <constraints/>
     </entryLink>
-    <entryLink id="e5d7-d7ed-3d5b-0101" hidden="false" targetId="b9f0-57cc-d0da-4ae3" type="selectionEntry" categoryEntryId="54726f6f707323232344415441232323">
+    <entryLink id="e5d7-d7ed-3d5b-0101" name="" hidden="false" targetId="b9f0-57cc-d0da-4ae3" type="selectionEntry" categoryEntryId="54726f6f707323232344415441232323">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -33746,6 +33746,13 @@ Ignores Cover special rule.</description>
       <constraints/>
     </entryLink>
     <entryLink id="93b1-e9d5-166d-fc52" name="Legion Malcador Assualt Tank" hidden="false" targetId="6885-6434-7ed7-ce46" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </entryLink>
+    <entryLink id="ccf8-7aa6-34af-651b" name="New EntryLink" hidden="false" targetId="9b0f-fe11-248c-953f" type="selectionEntry" categoryEntryId="486561767920537570706f727423232344415441232323">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -45248,14 +45255,14 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
               <rules/>
               <infoLinks/>
               <modifiers>
-                <modifier type="increment" field="points" value="15.0">
+                <modifier type="increment" field="points" value="15">
                   <repeats>
                     <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7cf102e8-d48f-92be-dc50-90c79d74d3a8" repeats="1"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
-                <modifier type="decrement" field="points" value="15.0">
+                <modifier type="decrement" field="points" value="15">
                   <repeats>
                     <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="10a134c9-dfdd-c921-6c14-17d0875f3b82" repeats="1"/>
                   </repeats>
@@ -45278,14 +45285,14 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
               <rules/>
               <infoLinks/>
               <modifiers>
-                <modifier type="increment" field="points" value="20.0">
+                <modifier type="increment" field="points" value="20">
                   <repeats>
                     <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7cf102e8-d48f-92be-dc50-90c79d74d3a8" repeats="1"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
-                <modifier type="decrement" field="points" value="20.0">
+                <modifier type="decrement" field="points" value="20">
                   <repeats>
                     <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="10a134c9-dfdd-c921-6c14-17d0875f3b82" repeats="1"/>
                   </repeats>
@@ -67917,16 +67924,16 @@ Explodes results add D3&quot; to radius.  </description>
           <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="02f8-fc1d-4e34-8fed" type="min"/>
-            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d7dc-e9ce-0517-a31f" type="max"/>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d7dc-e9ce-0517-a31f" type="max"/>
           </constraints>
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
           <costs>
-            <cost name="pts" costTypeId="points" value="35.0"/>
+            <cost name="pts" costTypeId="points" value="45.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="b932-2302-a52f-a269" name="Sky Slayer Sergeant" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+        <selectionEntry id="b932-2302-a52f-a269" name="One Sky Slayer may be upgraded to a Sky Slayer Sergeant" book="AL:AoDAL" page="60" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
           <profiles/>
           <rules/>
           <infoLinks>
@@ -68166,51 +68173,44 @@ Explodes results add D3&quot; to radius.  </description>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="079a-31e3-90c4-c7c0" name="The entire Squadron may exchange their Jetbike&apos;s Multi-Melta for:" hidden="false" collective="false" defaultSelectionEntryId="6cbe-1141-fb99-0cfa">
+        <selectionEntryGroup id="079a-31e3-90c4-c7c0" name="The entire Squadron may take (All squad members must be identically upgraded):" hidden="false" collective="false" defaultSelectionEntryId="cc49-468e-d126-ca37">
           <profiles/>
           <rules/>
           <infoLinks/>
-          <modifiers>
-            <modifier type="increment" field="724c-4d3e-b127-eabc" value="1">
-              <repeats>
-                <repeat field="selections" scope="9b0f-fe11-248c-953f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6112-73ef-3754-6518" repeats="1"/>
-              </repeats>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="724c-4d3e-b127-eabc" value="1">
-              <repeats>
-                <repeat field="selections" scope="9b0f-fe11-248c-953f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6112-73ef-3754-6518" repeats="1"/>
-              </repeats>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
+          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="724c-4d3e-b127-eabc" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6f2e-a1e7-987b-3078" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="6cbe-1141-fb99-0cfa" name="Multi-Melta" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2812-139d-6a5d-ccf6" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs/>
-            </selectionEntry>
             <selectionEntry id="5f2a-eb96-e759-e022" name="Plasma Cannon" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
               <profiles/>
               <rules/>
-              <infoLinks/>
-              <modifiers/>
+              <infoLinks>
+                <infoLink id="b54b-5211-53d9-acc7" name="New InfoLink" hidden="false" targetId="13df-d6b0-3f33-bf9b" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="de0a-fb40-528a-063c" name="New InfoLink" hidden="false" targetId="f4fd-d519-4769-5510" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers>
+                <modifier type="increment" field="points" value="15">
+                  <repeats>
+                    <repeat field="selections" scope="9b0f-fe11-248c-953f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6112-73ef-3754-6518" repeats="1"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e201-972b-14f9-e6c5" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e201-972b-14f9-e6c5" type="max"/>
               </constraints>
               <selectionEntries/>
               <selectionEntryGroups/>
@@ -68219,37 +68219,32 @@ Explodes results add D3&quot; to radius.  </description>
                 <cost name="pts" costTypeId="points" value="15.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="3e19-c26f-0062-828b" name="Volkite Culverin" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="8cdc-2d30-f09d-3d94" hidden="false" targetId="c7838603-9e18-8756-26b1-222a294c5c2c" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="4608-0b56-ae34-8fa0" hidden="false" targetId="e31cf870-3fa6-f2a2-8704-9bf05f7efcd8" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ba58-436d-3b34-778f" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="10.0"/>
-              </costs>
-            </selectionEntry>
           </selectionEntries>
           <selectionEntryGroups/>
-          <entryLinks/>
+          <entryLinks>
+            <entryLink id="cc49-468e-d126-ca37" name="Multi-Metla" hidden="false" targetId="d1c0-746f-2b39-5f17" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="4ee8-4526-a5f6-a229" name="Volkite Culverin" hidden="false" targetId="edadef72-c786-ab75-6888-15d0cc090857" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="10">
+                  <repeats>
+                    <repeat field="selections" scope="9b0f-fe11-248c-953f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6112-73ef-3754-6518" repeats="1"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="8637-c985-1bd4-16eb" name="Legion-specific upgrades:" hidden="false" collective="false">
           <profiles/>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -25703,19 +25703,11 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
               <profiles/>
               <rules/>
               <infoLinks/>
-              <modifiers>
-                <modifier type="set" field="minSelections" value="0.0">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="set" field="maxSelections" value="1.0">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9627-55cb-dac2-3c1a" type="max"/>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5c90-b11d-61c5-fffe" type="min"/>
+              </constraints>
             </entryLink>
             <entryLink id="5fed-9d41-a98a-b6e5" hidden="false" targetId="e6ae-2abb-2ddf-be8a" type="selectionEntry">
               <profiles/>
@@ -25727,7 +25719,7 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
-                <modifier type="set" field="maxSelections" value="1.0">
+                <modifier type="set" field="maxSelections" value="1">
                   <repeats/>
                   <conditions/>
                   <conditionGroups/>
@@ -33846,7 +33838,7 @@ Ignores Cover special rule.</description>
       <modifiers/>
       <constraints/>
     </entryLink>
-    <entryLink id="1e70-d901-5adc-f8ac" name="New EntryLink" hidden="false" targetId="b54f-18bb-f400-67d6" type="selectionEntry">
+    <entryLink id="1e70-d901-5adc-f8ac" name="New EntryLink" hidden="false" targetId="1068-ed8b-b7fb-44c9" type="selectionEntry">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -48204,203 +48196,61 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
       </costs>
     </selectionEntry>
     <selectionEntry id="a331-2e97-bd94-4103" name="Legion Sicaran Battle Tank" book="HH:LACAL" page="61" hidden="false" collective="false" categoryEntryId="486561767920537570706f727423232344415441232323" type="unit">
-      <profiles>
-        <profile id="6f43-e31f-8e59-2e63" name="Legion Sicaran Battle Tank" book="HH:LACAL" page="60" hidden="false" profileTypeId="56656869636c6523232344415441232323">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="96d5-b83b-decf-4bb7" name="New InfoLink" hidden="false" targetId="b33b-ae25-d3ca-3b18" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <characteristics>
-            <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="4"/>
-            <characteristic name="Front" characteristicTypeId="46726f6e7423232344415441232323" value="13"/>
-            <characteristic name="Side" characteristicTypeId="5369646523232344415441232323" value="12"/>
-            <characteristic name="Rear" characteristicTypeId="5265617223232344415441232323" value="12"/>
-            <characteristic name="HP" characteristicTypeId="485023232344415441232323" value="3"/>
-            <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Tank, Fast"/>
-          </characteristics>
-        </profile>
-        <profile id="1d29-b786-24ad-83a3" name="Accelerator Autocannon" book="HH:LACAL" page="61" hidden="false" profileTypeId="576561706f6e23232344415441232323">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="48&quot;"/>
-            <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="7"/>
-            <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="4"/>
-            <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 6, Rending, Rapid Tracking"/>
-          </characteristics>
-        </profile>
-      </profiles>
-      <rules>
-        <rule id="65d1-45b8-f361-79f4" name="Rapid Tracking" book="HH:LACAL" page="61" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <description>Targets may not take a Jink save against damage from this weapon.  </description>
-        </rule>
-      </rules>
-      <infoLinks/>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-        <constraint field="selections" scope="parent" value="-1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <selectionEntries/>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="1bc2-d22b-d99b-c487" name="May take any of the following:" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <selectionEntries>
-            <selectionEntry id="823c-7186-b8ec-3d82" name="Hunter-killer Missile" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="8ead-c2aa-eaa2-5fee" name="Accelerator Autocannon" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="9e6a-f4ba-7c9c-b092" name="Accelerator Autocannon" book="HH:LACAL" page="61" hidden="false" profileTypeId="576561706f6e23232344415441232323">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="10.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="d275-2b64-f39f-c54f" name="Dozer Blade" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <characteristics>
+                <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="48&quot;"/>
+                <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="7"/>
+                <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="4"/>
+                <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 6, Rending, Rapid Tracking"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks>
+            <infoLink id="9c82-c766-dbb7-fbfc" name="New InfoLink" hidden="false" targetId="3bc1-64f3-ed64-6959" type="rule">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="8723-e842-6a9e-4f67" name="Armoured Ceramite" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+            </infoLink>
+            <infoLink id="3981-4915-3790-e576" name="New InfoLink" hidden="false" targetId="8269-2cd6-9236-16e7" type="rule">
               <profiles/>
               <rules/>
-              <infoLinks>
-                <infoLink id="367a-455b-26c3-88e4" hidden="false" targetId="2e87b8ca-7cd1-78b9-2116-246015e7935e" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
+              <infoLinks/>
               <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="20.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="02f8-5d63-8a89-5fe8" name="Auxiliary Drive" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="930d-d589-f8a8-caea" hidden="false" targetId="d963a2dd-d9a3-8974-aac6-61ffcc78a99a" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="10.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups/>
-          <entryLinks/>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="d4fc-4a93-9155-0357" name="May take one set of two sponson weapons:" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
+            </infoLink>
+          </infoLinks>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8e1a-901a-789d-c79d" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7106-49b6-6e50-60c8" type="min"/>
           </constraints>
-          <selectionEntries>
-            <selectionEntry id="0f74-e095-c69a-ec5b" name="Heavy Bolters" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="20.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="366d-81de-2c2a-ea4b" name="Lascannons" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="40.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="b574-5e14-089d-a167" name="Heavy Flamers" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="set" field="hidden" value="true">
-                  <repeats/>
-                  <conditions>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a91f-3b51-950d-ba8a" type="equalTo"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="20.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
+          <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-        </selectionEntryGroup>
+          <costs/>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
         <selectionEntryGroup id="98cd-b28c-1b4e-4f93" name="Legion-specific upgrade" hidden="false" collective="false">
           <profiles/>
           <rules/>
@@ -48422,6 +48272,130 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
               <rules/>
               <infoLinks/>
               <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="31e8-61a3-c44d-ebec" name="May take any of the following:" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="b75f-e3fe-8a3c-b032" name="New EntryLink" hidden="false" targetId="a0a4-4e61-7118-fcff" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="9733-991c-a4f6-e2a7" name="New EntryLink" hidden="false" targetId="915f-bdbc-c3cb-9b0b" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="a039-92d9-11e6-0003" name="New EntryLink" hidden="false" targetId="f888-a294-fcff-8391" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="74e3-a008-3253-461f" name="New EntryLink" hidden="false" targetId="00d9-65e8-94b2-2396" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="9894-292a-d306-f2e9" name="May take one set of sponsons:" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1a0c-a92d-00c0-d445" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="8fcb-daea-125f-4eef" name="" hidden="false" targetId="2d56d45d-d276-7830-2b7d-026de64bbae8" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="20">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="append" field="name" value="Sponsons">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="b968-e77e-79b9-c540" name="New EntryLink" hidden="false" targetId="a161-76b3-9ef1-da7b" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="20">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="append" field="name" value="Sponsons">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="efdb-bfae-ab49-86cd" name="New EntryLink" hidden="false" targetId="f2d4a6e5-edf4-52b2-fa15-13b163113aa5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="20">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="append" field="name" value="Sponsons">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="d7aa-32e3-be17-aaa8" name="New EntryLink" hidden="false" targetId="8036-b730-d533-e31f" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="40">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="append" field="name" value="Sponsons">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
               <constraints/>
             </entryLink>
           </entryLinks>
@@ -66539,25 +66513,10 @@ When conducting a Ram attack, use Strength 10, roll two dice and pick the higher
       <entryLinks/>
       <costs/>
     </selectionEntry>
-    <selectionEntry id="b54f-18bb-f400-67d6" name="Sicaran Venator Tank Destroyer" book="HH:LACAL" page="60" hidden="false" collective="false" categoryEntryId="486561767920537570706f727423232344415441232323" type="unit">
-      <profiles>
-        <profile id="531b-8746-6d48-b8a6" name="Sicaran Venator Tank Destroyer" book="HH:LACAL" page="60" hidden="false" profileTypeId="56656869636c6523232344415441232323">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="4"/>
-            <characteristic name="Front" characteristicTypeId="46726f6e7423232344415441232323" value="13"/>
-            <characteristic name="Side" characteristicTypeId="5369646523232344415441232323" value="12"/>
-            <characteristic name="Rear" characteristicTypeId="5265617223232344415441232323" value="12"/>
-            <characteristic name="HP" characteristicTypeId="485023232344415441232323" value="3"/>
-            <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Vehicle (Tank, Fast)"/>
-          </characteristics>
-        </profile>
-      </profiles>
+    <selectionEntry id="1068-ed8b-b7fb-44c9" name="Sicaran Venator Tank Destroyer" book="HH:LACAL" page="60" hidden="false" collective="false" categoryEntryId="486561767920537570706f727423232344415441232323" type="unit">
+      <profiles/>
       <rules>
-        <rule id="d2e7-4843-97dc-52e6" name="Dangerous Reactor Core" book="AL:AoDAL" page="75" hidden="false">
+        <rule id="05c0-f6e1-f1d6-cecd" name="Dangerous Reactor Core" book="AL:AoDAL" page="75" hidden="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -66567,7 +66526,13 @@ Explodes results add D3&quot; to radius.  </description>
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="da02-ad44-9efe-0d80" name="New InfoLink" hidden="false" targetId="5283-9b50-3dcd-78e4" type="rule">
+        <infoLink id="8530-7786-b2d1-c2ae" name="New InfoLink" hidden="false" targetId="5283-9b50-3dcd-78e4" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="5956-f789-5c25-d5a9" name="New InfoLink" hidden="false" targetId="b33b-ae25-d3ca-3b18" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -66577,9 +66542,9 @@ Explodes results add D3&quot; to radius.  </description>
       <modifiers/>
       <constraints/>
       <selectionEntries>
-        <selectionEntry id="0672-9d5e-d484-c299" name="Hull Mounted Neutron Beam Laser" book="" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="45e9-0efa-0028-e88f" name="Hull Mounted Neutron Beam Laser" book="" hidden="false" collective="false" type="upgrade">
           <profiles>
-            <profile id="761a-0848-0786-38e0" name="Neutron Beam Laser" book="AL:AoDAL" page="72" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+            <profile id="473e-f12f-7a11-335c" name="Neutron Beam Laser" book="AL:AoDAL" page="72" hidden="false" profileTypeId="576561706f6e23232344415441232323">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -66594,13 +66559,13 @@ Explodes results add D3&quot; to radius.  </description>
           </profiles>
           <rules/>
           <infoLinks>
-            <infoLink id="7ece-32f7-e665-60a4" name="New InfoLink" hidden="false" targetId="9d85-46f7-f5e6-a5f7" type="rule">
+            <infoLink id="b2c6-c3bb-7786-e26a" name="New InfoLink" hidden="false" targetId="9d85-46f7-f5e6-a5f7" type="rule">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
             </infoLink>
-            <infoLink id="6305-a78e-43fa-5d02" name="New InfoLink" book="" hidden="false" targetId="b382-3da8-e6c2-48eb" type="rule">
+            <infoLink id="9c97-57c8-fd1d-e65e" name="New InfoLink" book="" hidden="false" targetId="b382-3da8-e6c2-48eb" type="rule">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -66609,8 +66574,8 @@ Explodes results add D3&quot; to radius.  </description>
           </infoLinks>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4a78-0e8f-1c0a-36c2" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c8ce-5977-f19d-3ca7" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e624-62cf-d22b-1ad9" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="54c1-82f4-b277-c5bd" type="min"/>
           </constraints>
           <selectionEntries/>
           <selectionEntryGroups/>
@@ -66619,7 +66584,7 @@ Explodes results add D3&quot; to radius.  </description>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="86c6-30ee-aa7a-a8c9" name="Legion-specific upgrade" hidden="false" collective="false">
+        <selectionEntryGroup id="9903-4004-dc4a-4f6c" name="Legion-specific upgrade" hidden="false" collective="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -66628,14 +66593,14 @@ Explodes results add D3&quot; to radius.  </description>
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="e4e6-6792-928a-8fba" hidden="false" targetId="a15bdf56-4ffe-fe04-ff77-3d533ab99dfa" type="selectionEntry">
+            <entryLink id="f386-6415-7ab5-9e13" hidden="false" targetId="a15bdf56-4ffe-fe04-ff77-3d533ab99dfa" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
               <constraints/>
             </entryLink>
-            <entryLink id="46d1-7d7c-857f-f5a5" hidden="false" targetId="f785888f-6dfa-08f4-054f-29b1a0e4f20c" type="selectionEntry">
+            <entryLink id="1d61-cac7-e574-c14f" hidden="false" targetId="f785888f-6dfa-08f4-054f-29b1a0e4f20c" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -66644,18 +66609,18 @@ Explodes results add D3&quot; to radius.  </description>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="93e1-ec52-eeaf-b8f8" name="May take one set of sponsons:" hidden="false" collective="false">
+        <selectionEntryGroup id="dc0c-7bf8-cd4a-4a0c" name="May take one set of sponsons:" hidden="false" collective="false">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5d0c-b9a6-054c-dc18" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9698-2af4-340a-5b5d" type="max"/>
           </constraints>
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="8000-f3cb-0dd6-c0f3" name="" hidden="false" targetId="2d56d45d-d276-7830-2b7d-026de64bbae8" type="selectionEntry">
+            <entryLink id="d66a-25e5-be09-eda9" name="" hidden="false" targetId="2d56d45d-d276-7830-2b7d-026de64bbae8" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -66673,7 +66638,7 @@ Explodes results add D3&quot; to radius.  </description>
               </modifiers>
               <constraints/>
             </entryLink>
-            <entryLink id="8a75-a6e4-ffe6-1adc" name="New EntryLink" hidden="false" targetId="a161-76b3-9ef1-da7b" type="selectionEntry">
+            <entryLink id="a551-4692-2eac-04cb" name="New EntryLink" hidden="false" targetId="a161-76b3-9ef1-da7b" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -66691,7 +66656,7 @@ Explodes results add D3&quot; to radius.  </description>
               </modifiers>
               <constraints/>
             </entryLink>
-            <entryLink id="d1d0-401d-d342-b75d" name="New EntryLink" hidden="false" targetId="f2d4a6e5-edf4-52b2-fa15-13b163113aa5" type="selectionEntry">
+            <entryLink id="96f7-7634-1e81-7d9a" name="New EntryLink" hidden="false" targetId="f2d4a6e5-edf4-52b2-fa15-13b163113aa5" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -66709,7 +66674,7 @@ Explodes results add D3&quot; to radius.  </description>
               </modifiers>
               <constraints/>
             </entryLink>
-            <entryLink id="be5f-788d-e2d0-257d" name="New EntryLink" hidden="false" targetId="8036-b730-d533-e31f" type="selectionEntry">
+            <entryLink id="31ab-fda6-8606-3df5" name="New EntryLink" hidden="false" targetId="8036-b730-d533-e31f" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -66729,7 +66694,7 @@ Explodes results add D3&quot; to radius.  </description>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="57b0-8209-9997-70dd" name="May take any of the following:" hidden="false" collective="false">
+        <selectionEntryGroup id="a3b4-daa1-1ff6-c654" name="May take any of the following:" hidden="false" collective="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -66738,28 +66703,28 @@ Explodes results add D3&quot; to radius.  </description>
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="ef2d-4bc7-a9ca-509d" name="New EntryLink" hidden="false" targetId="a0a4-4e61-7118-fcff" type="selectionEntry">
+            <entryLink id="dbaa-1d9d-e874-9318" name="New EntryLink" hidden="false" targetId="a0a4-4e61-7118-fcff" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
               <constraints/>
             </entryLink>
-            <entryLink id="c510-6e36-6b8b-829d" name="New EntryLink" hidden="false" targetId="915f-bdbc-c3cb-9b0b" type="selectionEntry">
+            <entryLink id="656a-630d-ce41-38c3" name="New EntryLink" hidden="false" targetId="915f-bdbc-c3cb-9b0b" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
               <constraints/>
             </entryLink>
-            <entryLink id="6185-73a8-234b-87dc" name="New EntryLink" hidden="false" targetId="f888-a294-fcff-8391" type="selectionEntry">
+            <entryLink id="df14-89ec-b04c-66ea" name="New EntryLink" hidden="false" targetId="f888-a294-fcff-8391" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
               <constraints/>
             </entryLink>
-            <entryLink id="c01e-ad06-63f6-0229" name="New EntryLink" hidden="false" targetId="00d9-65e8-94b2-2396" type="selectionEntry">
+            <entryLink id="8b49-1964-d6ec-dcc1" name="New EntryLink" hidden="false" targetId="00d9-65e8-94b2-2396" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -66770,28 +66735,28 @@ Explodes results add D3&quot; to radius.  </description>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="a07c-85da-c9a2-ad1a" hidden="false" targetId="c487-be13-ea53-917e" type="selectionEntryGroup">
+        <entryLink id="e546-5bea-8cdc-155c" hidden="false" targetId="c487-be13-ea53-917e" type="selectionEntryGroup">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <constraints/>
         </entryLink>
-        <entryLink id="832e-b449-1c77-1cbb" name="New EntryLink" hidden="false" targetId="fe17-5ed2-ca63-9379" type="selectionEntryGroup">
+        <entryLink id="2937-17cf-5341-eba6" name="New EntryLink" hidden="false" targetId="fe17-5ed2-ca63-9379" type="selectionEntryGroup">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <constraints/>
         </entryLink>
-        <entryLink id="6daf-94ad-7a20-d29f" name="New EntryLink" hidden="false" targetId="b572273e-2b93-4961-75c8-d9022c31a47d" type="selectionEntry">
+        <entryLink id="54af-4808-5d62-750b" name="New EntryLink" hidden="false" targetId="b572273e-2b93-4961-75c8-d9022c31a47d" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <constraints/>
         </entryLink>
-        <entryLink id="874f-5076-9248-4393" name="Hull Mounted Heavy Bolter" hidden="false" targetId="a161-76b3-9ef1-da7b" type="selectionEntry">
+        <entryLink id="221c-1c76-b72e-bfa2" name="Hull Mounted Heavy Bolter" hidden="false" targetId="a161-76b3-9ef1-da7b" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -66803,8 +66768,8 @@ Explodes results add D3&quot; to radius.  </description>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="479f-081d-cfa8-a129" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e37a-f3e4-62d7-6904" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2ae9-6ae6-5489-4c1c" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="80c0-326c-9a2a-f6bc" type="min"/>
           </constraints>
         </entryLink>
       </entryLinks>
@@ -71225,6 +71190,20 @@ Kharybdis: After it has landed treat as a flyer in Hover mode. LA:AODAL P75</des
       <modifiers/>
       <characteristics>
         <characteristic name="Description" characteristicTypeId="4465736372697074696f6e23232344415441232323" value="If the Dreadnought chooses to neither move nor Run in its turn it may, if its controlling player wishes, gain the Skyfire and Interceptor special rules for that entire game turn (ie, both the controlling player’s turn and their opponent’s following player turn) for all of its weapons except its heavy bolters/heavy flamers."/>
+      </characteristics>
+    </profile>
+    <profile id="b33b-ae25-d3ca-3b18" name="Sicaran Pattern Tank" book="AL:AoDAL" page="72 &amp; 73" hidden="false" profileTypeId="56656869636c6523232344415441232323">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="4"/>
+        <characteristic name="Front" characteristicTypeId="46726f6e7423232344415441232323" value="13"/>
+        <characteristic name="Side" characteristicTypeId="5369646523232344415441232323" value="12"/>
+        <characteristic name="Rear" characteristicTypeId="5265617223232344415441232323" value="12"/>
+        <characteristic name="HP" characteristicTypeId="485023232344415441232323" value="3"/>
+        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Vehicle (Tank, Fast)"/>
       </characteristics>
     </profile>
   </sharedProfiles>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -66601,7 +66601,7 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
     </selectionEntry>
     <selectionEntry id="9099-0989-0bda-ff4f" name="Legion Caestus Assault Ram" book="LA:AoDAL" page="" hidden="false" collective="false" categoryEntryId="486561767920537570706f727423232344415441232323" type="model">
       <profiles>
-        <profile id="aeb8-e6bf-3f8a-978d" name="Legion Caestus Assault Ram" book="HH:LACAL" page="59" hidden="false" profileTypeId="56656869636c6523232344415441232323">
+        <profile id="aeb8-e6bf-3f8a-978d" name="Legion Caestus Assault Ram" book="LA:AoDAL" page="71" hidden="false" profileTypeId="56656869636c6523232344415441232323">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -66612,23 +66612,31 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
             <characteristic name="Side" characteristicTypeId="5369646523232344415441232323" value="13"/>
             <characteristic name="Rear" characteristicTypeId="5265617223232344415441232323" value="11"/>
             <characteristic name="HP" characteristicTypeId="485023232344415441232323" value="4"/>
-            <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Tank*, Flyer, Hover, Transport"/>
+            <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Vehicle (Tank*, Flyer, Hover, Transport)"/>
           </characteristics>
         </profile>
-      </profiles>
-      <rules>
-        <rule id="36ed-79b7-8891-b6c5" name="Deep Strike" page="0" hidden="false">
+        <profile id="a9d7-fa80-cfdf-e126" name="Legion Caestus Assault Ram (Transport)" book="LA:AoDAL" page="71" hidden="false" profileTypeId="307d-047f-ca13-706b" profileTypeName="Transport">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-        </rule>
+          <characteristics>
+            <characteristic name="Capacity" characteristicTypeId="8285-4205-b6cd-8473" value="10 - See Misericord Rule"/>
+            <characteristic name="Fire Points" characteristicTypeId="b270-a7f9-22b2-3702" value="None"/>
+            <characteristic name="Access Points" characteristicTypeId="d17b-0342-b1dc-b8e7" value="Two, at the front of it&apos;s hull"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
         <rule id="c437-ed8a-5906-9c22" name="Caestus Ram" book="HH:LACAL" page="59" hidden="false">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <description>When conducting a Ram attack, use Strength 10, roll two dice and pick the higher when determining if it has penetrated the target&apos;s armour and add +1 to any rolls on the damage chart that is causes.  Additionally, the Caestus Ram has a 5++ Invulnerable save from any attacks made against its front armour, including damage from ramming or being rammed. </description>
+          <description>*Note that even though the Caestus is a Flyer, it may choose to ram just as if it were a tank. This attack must be declared at the start of the Caestus’ Movement phase.
+
+When conducting a Ram attack, use Strength 10, roll two dice and pick the higher when determining if it has penetrated the target&apos;s armour and add +1 to any rolls on the damage chart that is causes.  Additionally, the Caestus Ram has a 5++ Invulnerable save from any attacks made against its front armour, including damage from ramming or being rammed. 
+</description>
         </rule>
         <rule id="6aed-ea24-8417-e27c" name="Misericord" book="HH:LACAL" page="59" hidden="false">
           <profiles/>
@@ -66639,13 +66647,31 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="57b3-cff0-a651-b4df" hidden="false" targetId="890c-3cfe-af38-b022" type="profile">
+        <infoLink id="158c-c931-b133-a8fb" name="New InfoLink" hidden="false" targetId="45cf-653a-4ff6-f22d" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="158c-c931-b133-a8fb" name="New InfoLink" hidden="false" targetId="45cf-653a-4ff6-f22d" type="rule">
+        <infoLink id="bf34-4c77-a489-4342" name="New InfoLink" hidden="false" targetId="d219-2314-4834-c054" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="e1bf-ea2a-419d-3829" name="" hidden="false" targetId="890c-3cfe-af38-b022" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="set" field="name" value="Twin-linked Hull-mounted Magna-melta">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="4b6a-832d-c664-0b25" name="New InfoLink" hidden="false" targetId="5283-9b50-3dcd-78e4" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -66662,47 +66688,24 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
           <infoLinks/>
           <modifiers/>
           <constraints/>
-          <selectionEntries>
-            <selectionEntry id="4517-b720-dcd7-3f9e" name="Frag Assault Launchers" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="768f-d3e4-4b0d-5264" name="New EntryLink" hidden="false" targetId="eca0-004a-24f2-e2e9" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f1dd-be01-4d25-e757" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="10.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="19b3-2756-47ae-2ef9" name="Auxiliary Drive" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <constraints/>
+            </entryLink>
+            <entryLink id="737b-baf4-79c7-4144" name="New EntryLink" hidden="false" targetId="a0a4-4e61-7118-fcff" type="selectionEntry">
               <profiles/>
               <rules/>
-              <infoLinks>
-                <infoLink id="9fc4-d3b4-1643-8e19" hidden="false" targetId="d963a2dd-d9a3-8974-aac6-61ffcc78a99a" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
+              <infoLinks/>
               <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="07f4-d451-4593-81fc" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="10.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups/>
-          <entryLinks/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="122c-3039-a0cc-9444" name="Legion-specific upgrade" hidden="false" collective="false">
           <profiles/>
@@ -66781,6 +66784,22 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
           <infoLinks/>
           <modifiers/>
           <constraints/>
+        </entryLink>
+        <entryLink id="f582-d635-649b-eebc" name="New EntryLink" hidden="false" targetId="f888-a294-fcff-8391" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="set" field="points" value="0.0">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="62c7-65ad-7f4a-2767" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f86a-7393-ad0d-c2e6" type="min"/>
+          </constraints>
         </entryLink>
       </entryLinks>
       <costs>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -56318,7 +56318,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
         <cost name="pts" costTypeId="points" value="105.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="1de1f2d9-0857-67bf-d191-297d0f9f60bc" name="Phosphex Bomb" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+    <selectionEntry id="1de1f2d9-0857-67bf-d191-297d0f9f60bc" name="Phosphex Bombs" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
       <rules/>
       <infoLinks>
@@ -56712,7 +56712,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
           <selectionEntryGroups/>
           <entryLinks/>
         </selectionEntryGroup>
-        <selectionEntryGroup id="24ee567f-e8fc-b847-ed0a-e94b9872fd04" name="May equip three dual hardpoints:" hidden="false" collective="false">
+        <selectionEntryGroup id="24ee567f-e8fc-b847-ed0a-e94b9872fd04" name="d" hidden="false" collective="false">
           <profiles/>
           <rules/>
           <infoLinks/>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -10771,7 +10771,7 @@
                 <modifier type="set" field="hidden" value="true">
                   <repeats/>
                   <conditions>
-                    <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0df0a0f1-9ddf-f57b-cada-26dce57443ec" type="equalTo"/>
+                    <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0df0a0f1-9ddf-f57b-cada-26dce57443ec" type="equalTo"/>
                   </conditions>
                   <conditionGroups/>
                 </modifier>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -66200,7 +66200,7 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
           <selectionEntries>
             <selectionEntry id="d9bd-4556-c34c-c5f6" name="Legion Basilisk" book="" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
               <profiles>
-                <profile id="0cc0-ec1e-0704-1c6d" name="Legion Basilisk" book="HH:LACAL" page="56" hidden="false" profileTypeId="56656869636c6523232344415441232323">
+                <profile id="0cc0-ec1e-0704-1c6d" name="Legion Basilisk" book="LA:AoDAL" page="68" hidden="false" profileTypeId="56656869636c6523232344415441232323">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -66211,7 +66211,7 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
                     <characteristic name="Side" characteristicTypeId="5369646523232344415441232323" value="10"/>
                     <characteristic name="Rear" characteristicTypeId="5265617223232344415441232323" value="10"/>
                     <characteristic name="HP" characteristicTypeId="485023232344415441232323" value="3"/>
-                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Tank"/>
+                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Vehicle (Tank)"/>
                   </characteristics>
                 </profile>
                 <profile id="cb0e-78a5-d63d-cc4c" name="Earthshaker Cannon" book="HH:LACAL" page="92" hidden="false" profileTypeId="576561706f6e23232344415441232323">
@@ -66383,7 +66383,7 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
             </selectionEntry>
             <selectionEntry id="c34e-cd3b-dbb4-55e3" name="Legion Medusa" book="" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
               <profiles>
-                <profile id="607e-b741-7510-db94" name="Legion Medusa" book="HH:LACAL" page="56" hidden="false" profileTypeId="56656869636c6523232344415441232323">
+                <profile id="607e-b741-7510-db94" name="Legion Medusa" book="LA:AoDAL" page="86" hidden="false" profileTypeId="56656869636c6523232344415441232323">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -66394,7 +66394,7 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
                     <characteristic name="Side" characteristicTypeId="5369646523232344415441232323" value="10"/>
                     <characteristic name="Rear" characteristicTypeId="5265617223232344415441232323" value="10"/>
                     <characteristic name="HP" characteristicTypeId="485023232344415441232323" value="3"/>
-                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Tank"/>
+                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Vehicle (Tank)"/>
                   </characteristics>
                 </profile>
                 <profile id="bd2f-2698-8b1f-e0bb" name="Medusa Siege Gun" book="HH:LACAL" page="92" hidden="false" profileTypeId="576561706f6e23232344415441232323">
@@ -66602,7 +66602,7 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
             </selectionEntry>
             <selectionEntry id="b0d7-629c-5780-10f2" name="Legion Whirlwind" book="" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
               <profiles>
-                <profile id="6457-4193-e54c-9017" name="Legion Whirlwind" book="HH:LACAL" page="56" hidden="false" profileTypeId="56656869636c6523232344415441232323">
+                <profile id="6457-4193-e54c-9017" name="Legion Whirlwind" book="LA:AoDAL" page="68" hidden="false" profileTypeId="56656869636c6523232344415441232323">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -66613,7 +66613,7 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
                     <characteristic name="Side" characteristicTypeId="5369646523232344415441232323" value="11"/>
                     <characteristic name="Rear" characteristicTypeId="5265617223232344415441232323" value="10"/>
                     <characteristic name="HP" characteristicTypeId="485023232344415441232323" value="3"/>
-                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Tank"/>
+                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Vehicle (Tank)"/>
                   </characteristics>
                 </profile>
                 <profile id="a08d-6af0-36af-5a2c" name="Whirlwind Launcher: Vengeance Warhead" book="HH:LACAL" page="93" hidden="false" profileTypeId="576561706f6e23232344415441232323">

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -8323,7 +8323,9 @@
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks/>
-              <costs/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
             </selectionEntry>
           </selectionEntries>
           <selectionEntryGroups>
@@ -67087,24 +67089,6 @@ Explodes results add D3&quot; to radius.  </description>
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="9331-f648-c3ea-8942" hidden="false" targetId="887c2e1c-8eae-d449-e212-7dddb39cf726" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="6152-7578-714a-a775" hidden="false" targetId="c7838603-9e18-8756-26b1-222a294c5c2c" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="f94a-4c57-596f-87e0" hidden="false" targetId="e31cf870-3fa6-f2a2-8704-9bf05f7efcd8" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
         <infoLink id="46ce-d5b2-5115-3f94" name="New InfoLink" page="" hidden="false" targetId="79c7-90f6-b453-e799" type="profile">
           <profiles/>
           <rules/>
@@ -67120,7 +67104,36 @@ Explodes results add D3&quot; to radius.  </description>
       </infoLinks>
       <modifiers/>
       <constraints/>
-      <selectionEntries/>
+      <selectionEntries>
+        <selectionEntry id="4d66-c6a7-f3c9-502e" name="Sponson Mounts" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="94ec-4b33-ac95-e625" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aecc-ffba-3711-0270" type="min"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="d9de-1fef-d8cc-ce81" name="New EntryLink" hidden="false" targetId="d9c1-46b9-e742-8d83" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="name" value="Two Sponson-mount Twin-linked Volkite Culverin">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs/>
+        </selectionEntry>
+      </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="62fa-c446-e3e7-d317" name="Legion-specific upgrade" hidden="false" collective="false">
           <profiles/>
@@ -67156,22 +67169,6 @@ Explodes results add D3&quot; to radius.  </description>
           <modifiers/>
           <constraints/>
         </entryLink>
-        <entryLink id="cac5-f77d-bfd2-a3bc" name="New EntryLink" hidden="false" targetId="d9c1-46b9-e742-8d83" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="set" field="name" value="Two Sponson-mount Twin-linked Culverin">
-              <repeats/>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c816-7bfb-3b6f-6e6b" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a37a-2107-9c3e-c3da" type="min"/>
-          </constraints>
-        </entryLink>
         <entryLink id="b5b0-43b4-fddd-c3bb" name="New EntryLink" hidden="false" targetId="1914-1ced-69c6-585c" type="selectionEntry">
           <profiles/>
           <rules/>
@@ -67202,7 +67199,10 @@ Explodes results add D3&quot; to radius.  </description>
         </infoLink>
       </infoLinks>
       <modifiers/>
-      <constraints/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5e3c-e240-5d96-d1b4" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ad80-a178-99d3-53fc" type="max"/>
+      </constraints>
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks/>
@@ -67211,26 +67211,7 @@ Explodes results add D3&quot; to radius.  </description>
       </costs>
     </selectionEntry>
     <selectionEntry id="1914-1ced-69c6-585c" name="Quad Launcher" hidden="false" collective="false" type="upgrade">
-      <profiles>
-        <profile id="3f1d-2245-7ee6-4bb2" name="Quad Launcher" hidden="false" profileTypeId="556e697423232344415441232323" profileTypeName="Unit">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Unit Type" characteristicTypeId="556e6974205479706523232344415441232323"/>
-            <characteristic name="WS" characteristicTypeId="575323232344415441232323" value="-"/>
-            <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="-"/>
-            <characteristic name="S" characteristicTypeId="5323232344415441232323" value="-"/>
-            <characteristic name="T" characteristicTypeId="5423232344415441232323" value="7"/>
-            <characteristic name="W" characteristicTypeId="5723232344415441232323" value="2"/>
-            <characteristic name="I" characteristicTypeId="4923232344415441232323" value="-"/>
-            <characteristic name="A" characteristicTypeId="4123232344415441232323" value="-"/>
-            <characteristic name="LD" characteristicTypeId="4c4423232344415441232323" value="-"/>
-            <characteristic name="Save" characteristicTypeId="5361766523232344415441232323" value="3+"/>
-          </characteristics>
-        </profile>
-      </profiles>
+      <profiles/>
       <rules/>
       <infoLinks/>
       <modifiers/>
@@ -67335,7 +67316,15 @@ Explodes results add D3&quot; to radius.  </description>
                   <modifiers/>
                 </infoLink>
               </infoLinks>
-              <modifiers/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="66cb4a66-d860-119c-edfc-1749a899f258" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e59f-a981-7ffe-7edd" type="max"/>
               </constraints>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -64770,7 +64770,7 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
       <profiles/>
       <rules/>
       <infoLinks>
-        <infoLink id="d884-a341-1072-6717" name="New InfoLink" hidden="false" targetId="874d-45cf-6007-a1de" type="profile">
+        <infoLink id="f2e7-022b-92b4-1102" name="New InfoLink" hidden="false" targetId="3138-683d-a9a0-570d" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -66597,7 +66597,9 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="9099-0989-0bda-ff4f" name="Legion Caestus Assault Ram" book="LA:AoDAL" page="" hidden="false" collective="false" categoryEntryId="486561767920537570706f727423232344415441232323" type="model">
       <profiles>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -43868,32 +43868,19 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
             <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Open-topped, Transport (Special)"/>
           </characteristics>
         </profile>
+        <profile id="a6c0-bfd0-122a-ad47" name="Legion Dreadnought Drop Pod (Transport)" book="AD:AoDAL" page="47" hidden="false" profileTypeId="307d-047f-ca13-706b" profileTypeName="Transport">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Capacity" characteristicTypeId="8285-4205-b6cd-8473" value="1 Dreadnought variant (Inlcluding Contemptors)"/>
+            <characteristic name="Fire Points" characteristicTypeId="b270-a7f9-22b2-3702" value="Open-Topped"/>
+            <characteristic name="Access Points" characteristicTypeId="d17b-0342-b1dc-b8e7" value="-"/>
+          </characteristics>
+        </profile>
       </profiles>
       <rules>
-        <rule id="5d951aaa-3459-86fe-8e8f-4c2720d43e7d" name="Drop Pod Assault" page="0" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </rule>
-        <rule id="3c763bf6-4de5-9a1d-ca4c-f1841fe644e6" name="Immobile" page="0" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </rule>
-        <rule id="9d0e67d8-722f-f07c-8888-dea59b39859f" name="Inertial Guidance System" page="0" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </rule>
-        <rule id="6c20adcc-e569-006d-c627-241fa0d72ca7" name="Assault Vehicle" page="0" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </rule>
         <rule id="c93ef02e-09bf-1655-f438-79a1050f080d" name="Burning Retros" book="HH:LACAL" page="37" hidden="false">
           <profiles/>
           <rules/>
@@ -43902,7 +43889,32 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
           <description>Legion Dreadnought Drop Pods have the Shrouded special rule on the game turn that they arrive (also applying to interceptor fire or similar effects).  Upon landing, the doors open automatically, but the Dreadnought does not have to deploy.  In this case, the Dreadnought benefits from the effects of Shrouded, as do any units whose line of sight passes through or over the Drop Pod on the game turn of its arrival.  </description>
         </rule>
       </rules>
-      <infoLinks/>
+      <infoLinks>
+        <infoLink id="72b6-8fbb-ea26-28a6" name="New InfoLink" hidden="false" targetId="9bc2-f58b-4edd-8673" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="0606-704d-5d48-0812" name="New InfoLink" hidden="false" targetId="502e-1950-cef4-540b" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="fd2e-e4ba-518d-eb57" name="New InfoLink" hidden="false" targetId="e6ad-38b8-14e7-1c48" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="f373-01cf-5c16-1297" name="New InfoLink" hidden="false" targetId="45cf-653a-4ff6-f22d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <repeats/>
@@ -44657,7 +44669,18 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
     </selectionEntry>
     <selectionEntry id="8a93771a-74ca-98ed-4560-4125176e5193" name="Legion Drop Pod" book="AD:AoDAL" page="46" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles>
-        <profile id="ee05819d-6495-32ca-484a-b15c9bdf8b4d" name="Legion Drop Pod" book="HH:LACAL" page="36" hidden="false" profileTypeId="56656869636c6523232344415441232323">
+        <profile id="8894-e785-64e5-756e" name="Legion Drop Pod (Transport)" hidden="false" profileTypeId="307d-047f-ca13-706b" profileTypeName="Transport">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Capacity" characteristicTypeId="8285-4205-b6cd-8473" value="10, or 1 Legion Dreadnought, or 1 Rapier Carrier and crew"/>
+            <characteristic name="Fire Points" characteristicTypeId="b270-a7f9-22b2-3702" value="Open-Topped"/>
+            <characteristic name="Access Points" characteristicTypeId="d17b-0342-b1dc-b8e7" value="-"/>
+          </characteristics>
+        </profile>
+        <profile id="f7ba-e2e9-f9ef-e7e0" name="Legion Drop Pod" book="AD:AoDAL" page="46" hidden="false" profileTypeId="56656869636c6523232344415441232323">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -44669,17 +44692,6 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
             <characteristic name="Rear" characteristicTypeId="5265617223232344415441232323" value="12"/>
             <characteristic name="HP" characteristicTypeId="485023232344415441232323" value="3"/>
             <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Open-topped, Transport"/>
-          </characteristics>
-        </profile>
-        <profile id="8894-e785-64e5-756e" name="Legion Drop Pod (Transport)" hidden="false" profileTypeId="307d-047f-ca13-706b" profileTypeName="Transport">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Capacity" characteristicTypeId="8285-4205-b6cd-8473" value="10, or 1 Legion Dreadnought, or 1 Rapier Carrier and crew"/>
-            <characteristic name="Fire Points" characteristicTypeId="b270-a7f9-22b2-3702" value="Open-Topped"/>
-            <characteristic name="Access Points" characteristicTypeId="d17b-0342-b1dc-b8e7" value="-"/>
           </characteristics>
         </profile>
       </profiles>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -24574,137 +24574,6 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
         <cost name="pts" costTypeId="points" value="400.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="4fb43919-84f7-12ef-36a1-24c2de1626c0" name="Legion Whirlwind Scorpius" book="HH:LACAL" page="64" hidden="false" collective="false" categoryEntryId="486561767920537570706f727423232344415441232323" type="unit">
-      <profiles>
-        <profile id="7a371d05-12d0-fb8a-be68-0c9f380dfb64" name="Legion Whirlwind Scorpius" book="HH:LACAL" page="64" hidden="false" profileTypeId="56656869636c6523232344415441232323">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="4"/>
-            <characteristic name="Front" characteristicTypeId="46726f6e7423232344415441232323" value="13"/>
-            <characteristic name="Side" characteristicTypeId="5369646523232344415441232323" value="12"/>
-            <characteristic name="Rear" characteristicTypeId="5265617223232344415441232323" value="10"/>
-            <characteristic name="HP" characteristicTypeId="485023232344415441232323" value="3"/>
-            <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Tank"/>
-          </characteristics>
-        </profile>
-        <profile id="7ae4ba97-144d-bd06-5b24-2c7573f8c165" name="Scorpius Multi-launcher" book="HH:LACAL" page="64" hidden="false" profileTypeId="576561706f6e23232344415441232323">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="48&quot;"/>
-            <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="8"/>
-            <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="3"/>
-            <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 1, Barrage, Blast, Rocket Barrage"/>
-          </characteristics>
-        </profile>
-      </profiles>
-      <rules>
-        <rule id="07cdb773-ab36-0736-750a-afa6fbd601d1" name="Rocket Barrage" book="HH:LACAL" page="64" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <description>In a turn in which the vehicle has not moved, increase rate of fire to Heavy 1+D3.  </description>
-        </rule>
-      </rules>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <selectionEntries/>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="67398d99-9190-2fe7-e7dc-9425242047b7" name="May take any of the following:" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <selectionEntries>
-            <selectionEntry id="ecea02c6-8d29-f15e-be0e-aa65333cbac1" name="Hunter-killer Missile" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="10.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="83384113-aed2-acf6-e7cf-ab9f3502ec1b" name="Dozer Blade" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="a0d7f5c3-0b2c-ad47-8580-0762142dbb17" name="Extra Armour" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="10.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups/>
-          <entryLinks/>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="d8cef9f2-21e2-d5fc-1aa1-95b76334b218" name="Legion-specific upgrade" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="ad80b999-bc17-b937-b857-42a6c1f1bb83" hidden="false" targetId="a15bdf56-4ffe-fe04-ff77-3d533ab99dfa" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="d9b3-d883-bcf0-b7dc" hidden="false" targetId="c487-be13-ea53-917e" type="selectionEntryGroup">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </entryLink>
-      </entryLinks>
-      <costs>
-        <cost name="pts" costTypeId="points" value="115.0"/>
-      </costs>
-    </selectionEntry>
     <selectionEntry id="1a5477f7-0f80-153c-6fea-4f5bf33f915a" name="Lord Chaplain Nomus Rhy&apos;tan" book="HH:LAICL" page="71" hidden="false" collective="false" categoryEntryId="485123232344415441232323" type="model">
       <profiles>
         <profile id="9d706808-9be7-4ac6-b963-26dd987ddb95" name="Nomus Rhy&apos;tan" book="HH:LAICL" page="71" hidden="false" profileTypeId="556e697423232344415441232323">
@@ -34229,6 +34098,13 @@ Ignores Cover special rule.</description>
       <constraints/>
     </entryLink>
     <entryLink id="e247-b7c6-a2f4-7e0a" name="New EntryLink" hidden="false" targetId="9099-0989-0bda-ff4f" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </entryLink>
+    <entryLink id="a378-4e0d-0e7f-73c1" name="New EntryLink" hidden="false" targetId="2ec2-d7c8-d06b-8dff" type="selectionEntry">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -66836,6 +66712,137 @@ When conducting a Ram attack, use Strength 10, roll two dice and pick the higher
       <entryLinks/>
       <costs>
         <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2ec2-d7c8-d06b-8dff" name="Legion Whirlwind Scorpius" book="HH:LACAL" page="64" hidden="false" collective="false" categoryEntryId="486561767920537570706f727423232344415441232323" type="unit">
+      <profiles>
+        <profile id="d34e-dd17-622c-c8cf" name="Legion Whirlwind Scorpius" book="HH:LACAL" page="64" hidden="false" profileTypeId="56656869636c6523232344415441232323">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="4"/>
+            <characteristic name="Front" characteristicTypeId="46726f6e7423232344415441232323" value="13"/>
+            <characteristic name="Side" characteristicTypeId="5369646523232344415441232323" value="12"/>
+            <characteristic name="Rear" characteristicTypeId="5265617223232344415441232323" value="10"/>
+            <characteristic name="HP" characteristicTypeId="485023232344415441232323" value="3"/>
+            <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Tank"/>
+          </characteristics>
+        </profile>
+        <profile id="2fa1-ae30-0e71-24f7" name="Scorpius Multi-launcher" book="HH:LACAL" page="64" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="48&quot;"/>
+            <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="8"/>
+            <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="3"/>
+            <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 1, Barrage, Blast, Rocket Barrage"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="377f-8c2e-33b7-29d1" name="Rocket Barrage" book="HH:LACAL" page="64" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <description>In a turn in which the vehicle has not moved, increase rate of fire to Heavy 1+D3.  </description>
+        </rule>
+      </rules>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="d4bc-0a9f-6cc8-883b" name="May take any of the following:" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries>
+            <selectionEntry id="6a47-9f65-90a7-bd83" name="Hunter-killer Missile" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f611-d1f3-67b3-92f1" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="2ecf-581c-a6f8-88e3" name="Dozer Blade" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="83e2-4bf4-17db-f509" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="ae8c-8dbb-033a-979c" name="Extra Armour" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7161-7268-8adb-c181" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="10.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="2e8c-b3b5-4e2c-0faa" name="Legion-specific upgrade" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="74c4-955f-b6b7-dca0" hidden="false" targetId="a15bdf56-4ffe-fe04-ff77-3d533ab99dfa" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="665d-c55f-78fd-1a7a" hidden="false" targetId="c487-be13-ea53-917e" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="115.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -9099,194 +9099,6 @@
         <cost name="pts" costTypeId="points" value="65.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="eaa143bc-3040-7031-faaf-314871d4811a" name="Legion Caestus Assault Ram" book="HH:LACAL" page="59" hidden="false" collective="false" categoryEntryId="486561767920537570706f727423232344415441232323" type="model">
-      <profiles>
-        <profile id="32021eef-c4cb-4eee-1199-b84de04287a9" name="Legion Caestus Assault Ram" book="HH:LACAL" page="59" hidden="false" profileTypeId="56656869636c6523232344415441232323">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="4"/>
-            <characteristic name="Front" characteristicTypeId="46726f6e7423232344415441232323" value="13"/>
-            <characteristic name="Side" characteristicTypeId="5369646523232344415441232323" value="13"/>
-            <characteristic name="Rear" characteristicTypeId="5265617223232344415441232323" value="11"/>
-            <characteristic name="HP" characteristicTypeId="485023232344415441232323" value="4"/>
-            <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Tank*, Flyer, Hover, Transport"/>
-          </characteristics>
-        </profile>
-      </profiles>
-      <rules>
-        <rule id="b1a2409d-62d9-01a5-c707-9e0a490c0dcb" name="Deep Strike" page="0" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </rule>
-        <rule id="a7c2036a-dc4d-aeff-e21f-34518a67e1e3" name="Assault Vehicle" page="0" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </rule>
-        <rule id="fa0233c7-7b9a-2b72-cbc5-83edd6284a0a" name="Caestus Ram" book="HH:LACAL" page="59" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <description>When conducting a Ram attack, use Strength 10, roll two dice and pick the higher when determining if it has penetrated the target&apos;s armour and add +1 to any rolls on the damage chart that is causes.  Additionally, the Caestus Ram has a 5++ Invulnerable save from any attacks made against its front armour, including damage from ramming or being rammed. </description>
-        </rule>
-        <rule id="a1a75fb1-3dd3-2100-7d60-b4e2437e8f49" name="Misericord" book="HH:LACAL" page="59" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <description>Has transport capacity of 10 models, but may only transport models in power armour, artificer armour, and terminator armour (which do not count as bulky in the ram).  </description>
-        </rule>
-      </rules>
-      <infoLinks>
-        <infoLink id="6f2c-eff4-e969-2d30" hidden="false" targetId="890c-3cfe-af38-b022" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <selectionEntries/>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="692a321e-1b83-883a-5569-371d97d581ec" name="May be upgraded with any of the following:" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <selectionEntries>
-            <selectionEntry id="571abdc1-21df-40f0-3d6d-906ca905ae4e" name="Frag Assault Launchers" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="10.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="7172e8e1-0603-61be-d3d0-90a7d61ae427" name="Auxiliary Drive" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="94ce41b2-510c-27e5-2451-4102f643958d" hidden="false" targetId="d963a2dd-d9a3-8974-aac6-61ffcc78a99a" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="10.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups/>
-          <entryLinks/>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="084169a5-b733-a2a5-9bcd-614ca0001fa4" name="Legion-specific upgrade" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="5ff4db29-79ae-b897-4d3b-a3d0bcd7fda7" hidden="false" targetId="a15bdf56-4ffe-fe04-ff77-3d533ab99dfa" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="e33c-029b-910d-5520" name="Wing Weapons" hidden="false" collective="false" defaultSelectionEntryId="58a7-45ba-e1e3-61b3">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="58a7-45ba-e1e3-61b3" name="Two wing-mounted Havoc Launchers" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="b340-1ed2-7486-66aa" hidden="false" targetId="b3ea1d32-ba66-0585-d7f7-0dc56e707736" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="7df0-2ca7-26c3-9890" name="Two wing-mounted Missile Launchers" book="LACAL" page="59" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="10.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups/>
-          <entryLinks/>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="8a76-a815-eaf0-ab26" hidden="false" targetId="c487-be13-ea53-917e" type="selectionEntryGroup">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </entryLink>
-      </entryLinks>
-      <costs>
-        <cost name="pts" costTypeId="points" value="305.0"/>
-      </costs>
-    </selectionEntry>
     <selectionEntry id="5fab84ab-ab50-ecc0-a170-bb2ebc0059ad" name="Legion Castellax Class Battle-Automata Maniple" book="http://www.forgeworld.co.uk/resources/fw_site/fw_pdfs/Horus_Heresy/Horus_Heresy_7th_Edition.pdf" page="7" hidden="false" collective="false" categoryEntryId="486561767920537570706f727423232344415441232323" type="upgrade">
       <profiles/>
       <rules>
@@ -33460,7 +33272,7 @@ Ignores Cover special rule.</description>
       <modifiers/>
       <constraints/>
     </entryLink>
-    <entryLink id="2e8a-bc3d-baee-dd2f" hidden="false" targetId="604c-bdd0-25b9-2bed" type="selectionEntry" categoryEntryId="486561767920537570706f727423232344415441232323">
+    <entryLink id="2e8a-bc3d-baee-dd2f" name="" hidden="false" targetId="604c-bdd0-25b9-2bed" type="selectionEntry" categoryEntryId="486561767920537570706f727423232344415441232323">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -34410,6 +34222,13 @@ Ignores Cover special rule.</description>
       <constraints/>
     </entryLink>
     <entryLink id="4e90-9e3d-0cbd-c864" name="New EntryLink" hidden="false" targetId="0df5-83e7-a354-049e" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </entryLink>
+    <entryLink id="e247-b7c6-a2f4-7e0a" name="New EntryLink" hidden="false" targetId="9099-0989-0bda-ff4f" type="selectionEntry">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -66720,13 +66539,6 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
           <modifiers/>
           <constraints/>
         </entryLink>
-        <entryLink id="926c-94cd-2ba3-13b6" name="New EntryLink" hidden="false" targetId="10e739aa-3153-9348-3458-738dd5938617" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </entryLink>
       </entryLinks>
       <costs>
         <cost name="pts" costTypeId="points" value="120.0"/>
@@ -66786,6 +66598,194 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
       <selectionEntryGroups/>
       <entryLinks/>
       <costs/>
+    </selectionEntry>
+    <selectionEntry id="9099-0989-0bda-ff4f" name="Legion Caestus Assault Ram" book="LA:AoDAL" page="" hidden="false" collective="false" categoryEntryId="486561767920537570706f727423232344415441232323" type="model">
+      <profiles>
+        <profile id="aeb8-e6bf-3f8a-978d" name="Legion Caestus Assault Ram" book="HH:LACAL" page="59" hidden="false" profileTypeId="56656869636c6523232344415441232323">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="4"/>
+            <characteristic name="Front" characteristicTypeId="46726f6e7423232344415441232323" value="13"/>
+            <characteristic name="Side" characteristicTypeId="5369646523232344415441232323" value="13"/>
+            <characteristic name="Rear" characteristicTypeId="5265617223232344415441232323" value="11"/>
+            <characteristic name="HP" characteristicTypeId="485023232344415441232323" value="4"/>
+            <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Tank*, Flyer, Hover, Transport"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="36ed-79b7-8891-b6c5" name="Deep Strike" page="0" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </rule>
+        <rule id="c437-ed8a-5906-9c22" name="Caestus Ram" book="HH:LACAL" page="59" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <description>When conducting a Ram attack, use Strength 10, roll two dice and pick the higher when determining if it has penetrated the target&apos;s armour and add +1 to any rolls on the damage chart that is causes.  Additionally, the Caestus Ram has a 5++ Invulnerable save from any attacks made against its front armour, including damage from ramming or being rammed. </description>
+        </rule>
+        <rule id="6aed-ea24-8417-e27c" name="Misericord" book="HH:LACAL" page="59" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <description>Has transport capacity of 10 models, but may only transport models in power armour, artificer armour, and terminator armour (which do not count as bulky in the ram).  </description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="57b3-cff0-a651-b4df" hidden="false" targetId="890c-3cfe-af38-b022" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="158c-c931-b133-a8fb" name="New InfoLink" hidden="false" targetId="45cf-653a-4ff6-f22d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="3b1f-8501-7a28-342d" name="May be upgraded with any of the following:" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries>
+            <selectionEntry id="4517-b720-dcd7-3f9e" name="Frag Assault Launchers" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f1dd-be01-4d25-e757" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="19b3-2756-47ae-2ef9" name="Auxiliary Drive" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="9fc4-d3b4-1643-8e19" hidden="false" targetId="d963a2dd-d9a3-8974-aac6-61ffcc78a99a" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="07f4-d451-4593-81fc" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="10.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="122c-3039-a0cc-9444" name="Legion-specific upgrade" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="d23b-d378-6d4e-b0c8" hidden="false" targetId="a15bdf56-4ffe-fe04-ff77-3d533ab99dfa" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="5031-fabb-8e2b-30df" name="Wing Weapons" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ac60-d1bd-1f94-06f1" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="cde2-e92e-2a12-4a02" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="714f-e993-f4af-908e" name="Two wing-mounted Havoc Launchers" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="c923-1a49-b02f-1486" hidden="false" targetId="b3ea1d32-ba66-0585-d7f7-0dc56e707736" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f88a-269e-2c8a-3227" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="5635-04fa-c120-2066" name="Two wing-mounted Missile Launchers" book="LACAL" page="59" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4d9a-1de0-c7ec-9ee2" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="10.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="bbf6-37c3-089a-11c9" name="" hidden="false" targetId="c487-be13-ea53-917e" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="305.0"/>
+      </costs>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -65432,7 +65432,7 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="295f-9d76-706f-e8c6" hidden="false" targetId="c487-be13-ea53-917e" type="selectionEntryGroup">
+        <entryLink id="295f-9d76-706f-e8c6" name="" hidden="false" targetId="c487-be13-ea53-917e" type="selectionEntryGroup">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -66611,12 +66611,19 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
                             <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="48&quot;"/>
                             <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="8"/>
                             <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="3"/>
-                            <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 1, Skyfire, Interceptor"/>
+                            <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 1, Skyfire, Interceptor, Heatseaker"/>
                           </characteristics>
                         </profile>
                       </profiles>
                       <rules/>
-                      <infoLinks/>
+                      <infoLinks>
+                        <infoLink id="6440-61bf-b612-e52d" name="New InfoLink" hidden="false" targetId="6970-1bf3-b33e-5dce" type="rule">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                        </infoLink>
+                      </infoLinks>
                       <modifiers/>
                       <constraints>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b447-6cd6-af1e-4e59" type="max"/>
@@ -69948,6 +69955,13 @@ Kharybdis: After it has landed treat as a flyer in Hover mode. LA:AODAL P75</des
       <infoLinks/>
       <modifiers/>
       <description>So long as the Fire Raptor is eligible to fire a weapon in the shooting phase,each waist turret may fire at a different target and do not count towards the number of weapons that may be fired in a turn.  </description>
+    </rule>
+    <rule id="cdae-1226-8aa6-6e69" name="Heat Seeker" book="LA:AoDAL" page="95" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>A weapon with this special rule can re-roll all failed To Hit rolls against Flyers and Fast Skimmers.</description>
     </rule>
   </sharedRules>
   <sharedProfiles>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -44655,7 +44655,7 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="8a93771a-74ca-98ed-4560-4125176e5193" name="Legion Drop Pod" book="HH:LACAL" page="36" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+    <selectionEntry id="8a93771a-74ca-98ed-4560-4125176e5193" name="Legion Drop Pod" book="AD:AoDAL" page="46" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles>
         <profile id="ee05819d-6495-32ca-484a-b15c9bdf8b4d" name="Legion Drop Pod" book="HH:LACAL" page="36" hidden="false" profileTypeId="56656869636c6523232344415441232323">
           <profiles/>
@@ -44671,28 +44671,39 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
             <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Open-topped, Transport"/>
           </characteristics>
         </profile>
+        <profile id="8894-e785-64e5-756e" name="Legion Drop Pod (Transport)" hidden="false" profileTypeId="307d-047f-ca13-706b" profileTypeName="Transport">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Capacity" characteristicTypeId="8285-4205-b6cd-8473" value="10, or 1 Legion Dreadnought, or 1 Rapier Carrier and crew"/>
+            <characteristic name="Fire Points" characteristicTypeId="b270-a7f9-22b2-3702" value="Open-Topped"/>
+            <characteristic name="Access Points" characteristicTypeId="d17b-0342-b1dc-b8e7" value="-"/>
+          </characteristics>
+        </profile>
       </profiles>
-      <rules>
-        <rule id="5b8135cf-3c49-2c29-3575-a6939ead44c3" name="Drop Pod Assault" page="0" hidden="false">
+      <rules/>
+      <infoLinks>
+        <infoLink id="9334-55fa-298d-9f02" name="New InfoLink" hidden="false" targetId="9bc2-f58b-4edd-8673" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-        </rule>
-        <rule id="454c038f-d625-3b9c-c191-bb674d16f383" name="Immobile" page="0" hidden="false">
+        </infoLink>
+        <infoLink id="0a37-16c2-3cd1-ad33" name="New InfoLink" hidden="false" targetId="e6ad-38b8-14e7-1c48" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-        </rule>
-        <rule id="c846dbba-524b-bb1e-1fe9-a677410284d8" name="Inertial Guidance System" page="0" hidden="false">
+        </infoLink>
+        <infoLink id="6a02-b796-8345-18f6" name="New InfoLink" hidden="false" targetId="502e-1950-cef4-540b" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-        </rule>
-      </rules>
-      <infoLinks/>
+        </infoLink>
+      </infoLinks>
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <repeats/>
@@ -44726,7 +44737,18 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
-      <entryLinks/>
+      <entryLinks>
+        <entryLink id="21c4-a122-22d0-05c3" name="New EntryLink" hidden="false" targetId="30c2c848-c1d3-e61f-6632-a91bcee1fdc4" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3c83-27b5-b4d5-90d4" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ca0e-6188-3b53-962a" type="min"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
       <costs>
         <cost name="pts" costTypeId="points" value="35.0"/>
       </costs>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -33745,6 +33745,13 @@ Ignores Cover special rule.</description>
       <modifiers/>
       <constraints/>
     </entryLink>
+    <entryLink id="93b1-e9d5-166d-fc52" name="Legion Malcador Assualt Tank" hidden="false" targetId="6885-6434-7ed7-ce46" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </entryLink>
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="a9bf-b37e-126b-a699" name="&apos;Iron Circle&apos; Domitar-Ferrum Class Battle-automata Maniple" hidden="false" collective="false" categoryEntryId="456c6974657323232344415441232323" type="unit">
@@ -63972,6 +63979,13 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
           <modifiers/>
           <constraints/>
         </entryLink>
+        <entryLink id="26d9-5d3f-e074-80de" name="New EntryLink" page="" hidden="false" targetId="1914-1ced-69c6-585c" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="pts" costTypeId="points" value="275.0"/>
@@ -67485,6 +67499,377 @@ Explodes results add D3&quot; to radius.  </description>
           <entryLinks/>
         </selectionEntryGroup>
       </selectionEntryGroups>
+      <entryLinks/>
+      <costs/>
+    </selectionEntry>
+    <selectionEntry id="6683-c57a-0a90-e0f2" name="Legion Malcador Assault Tank" book="AL:AoDAL" page="81" hidden="false" collective="false" type="unit">
+      <profiles/>
+      <rules>
+        <rule id="4f99-0288-6e12-7da7" name="Sub-atomantic Reactor" book="LA:AoDAL" page="81" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <description>When rolling on the thunderblitz and/or Catastrophic Damage tables for the Malcador, roll 2D6 and select the lower result.</description>
+        </rule>
+        <rule id="9877-af46-2c99-b1cb" name="Battle Speed" book="AL:AoDAL" page="81" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <description>When the Malcador Assault Tank moves Flat Out in the Shooting phase, it may choose to fire its traverse-mounted weapon at its full Ballistic Skill, either before or after the Flat Out move, but may fire no other weapons.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="7d3d-d533-f9e6-b083" name="New InfoLink" hidden="false" targetId="0d05-348c-04c3-a0fc" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="b9b1-1a19-6258-99fd" name="May take one set of sponsons:" hidden="false" collective="false" defaultSelectionEntryId="662a-1c15-c1ba-ff22">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4482-c469-a763-9d34" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1848-9d32-f8ee-4529" type="min"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="8aa6-d1cf-59f5-ca66" name="" hidden="false" targetId="2d56d45d-d276-7830-2b7d-026de64bbae8" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="20">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="append" field="name" value="Sponsons">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="662a-1c15-c1ba-ff22" name="New EntryLink" hidden="false" targetId="a161-76b3-9ef1-da7b" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="append" field="name" value="Sponsons">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="1526-b8e0-f22e-1a9b" name="New EntryLink" hidden="false" targetId="ead9-305c-a7e7-323e" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="append" field="name" value="Sponsons">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="d53d-d2c4-af71-3690" name="New EntryLink" hidden="false" targetId="8036-b730-d533-e31f" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="15">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="append" field="name" value="Sponsons">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="1906-ef73-23cb-44d7" name="New EntryLink" hidden="false" targetId="0137-bfce-22c9-8f03" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="append" field="name" value="Sponsons">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="set" field="points" value="10">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="247d-5790-ebeb-fbc6" name="Hull-mounted:" book="" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="e682-4ca3-7b17-4003" name="New EntryLink" hidden="false" targetId="ead9-305c-a7e7-323e" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="be73-0e71-8277-9b9b" name="New EntryLink" hidden="false" targetId="0137-bfce-22c9-8f03" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="5">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="4ecc-6847-c0cf-a7bb" name="New EntryLink" hidden="false" targetId="8036-b730-d533-e31f" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="10">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="1a36-ff39-f934-47ea" name="May take any of the following:" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="689f-8884-697a-a25e" name="New EntryLink" hidden="false" targetId="a0a4-4e61-7118-fcff" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="9d02-cb59-350d-0ca2" name="New EntryLink" hidden="false" targetId="915f-bdbc-c3cb-9b0b" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="c04d-6728-8a37-8ccd" name="New EntryLink" hidden="false" targetId="f888-a294-fcff-8391" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="0666-1927-ca23-58ae" name="New EntryLink" hidden="false" targetId="eca0-004a-24f2-e2e9" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="6980-7d00-4658-9709" name="New EntryLink" hidden="false" targetId="7332-4181-03b9-d402" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="35">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="9594-c839-2e6e-b8ec" name="New EntryLink" hidden="false" targetId="7c81-4f38-1f4e-ac6b" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="6652-608a-54aa-02b7" name="Traverse-mounted:" hidden="false" collective="false" defaultSelectionEntryId="b34d-4a50-a2c1-617e">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d013-4193-e077-a5fe" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0864-c0d4-5f73-fc60" type="min"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="b34d-4a50-a2c1-617e" name="New EntryLink" hidden="false" targetId="a75b-d337-1f8b-d4af" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="0ab3-de27-7417-bc63" name="New EntryLink" hidden="false" targetId="8b1d-77d3-74f2-9d1c" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="390a-d383-2dd7-dd39" name="New EntryLink" hidden="false" targetId="b572273e-2b93-4961-75c8-d9022c31a47d" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="fbc8-7058-bbd5-3331" name="New EntryLink" hidden="false" targetId="fe17-5ed2-ca63-9379" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="275.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6885-6434-7ed7-ce46" name="Legion Malcador Assualt Tank Squadron" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="707b-06e1-e2d7-aece" name="In squadrons of three, one Vehicle may be upgraded to:" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="6889-040c-c017-e038" type="lessThan"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="a67a-0aa4-7ba9-8937" name="New EntryLink" hidden="false" targetId="2330-16be-009d-4a66" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="6889-040c-c017-e038" name="Squadron Vehicles:" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ceee-b470-3a5c-9933" type="min"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4cc2-0dd0-aeaa-1be3" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="8d7d-a289-10f6-9ac0" name="New EntryLink" hidden="false" targetId="6683-c57a-0a90-e0f2" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs/>
+    </selectionEntry>
+    <selectionEntry id="0137-bfce-22c9-8f03" name="Autocannon" book="BRB 7th" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="d11e-351e-94ce-7a54" name="New InfoLink" hidden="false" targetId="5e91-9a0b-0ea0-3fcc" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs/>
+    </selectionEntry>
+    <selectionEntry id="a75b-d337-1f8b-d4af" name="Battle Cannon" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="5b94-b270-182e-1913" name="New InfoLink" hidden="false" targetId="9cf3-e269-e86d-a66b" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
       <entryLinks/>
       <costs/>
     </selectionEntry>
@@ -71963,6 +72348,44 @@ Kharybdis: After it has landed treat as a flyer in Hover mode. LA:AODAL P75</des
         <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="4"/>
         <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="3"/>
         <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 4, Barrage, Poisoned, Crawling Fire, Lingering Death"/>
+      </characteristics>
+    </profile>
+    <profile id="0d05-348c-04c3-a0fc" name="Legion Malcador Assault Tank" book="AL:AoDAL" page="81" hidden="false" profileTypeId="56656869636c6523232344415441232323" profileTypeName="Vehicle">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="4"/>
+        <characteristic name="Front" characteristicTypeId="46726f6e7423232344415441232323" value="14"/>
+        <characteristic name="Side" characteristicTypeId="5369646523232344415441232323" value="13"/>
+        <characteristic name="Rear" characteristicTypeId="5265617223232344415441232323" value="12"/>
+        <characteristic name="HP" characteristicTypeId="485023232344415441232323" value="6"/>
+        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Vehicle (Super-heavy)"/>
+      </characteristics>
+    </profile>
+    <profile id="5e91-9a0b-0ea0-3fcc" name="Autocannon" book="BRB 7th" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="24&quot;"/>
+        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="6"/>
+        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="4"/>
+        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 4, Rending"/>
+      </characteristics>
+    </profile>
+    <profile id="9cf3-e269-e86d-a66b" name="Battle Cannon" book="BRB 7th" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="72&quot;"/>
+        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="8"/>
+        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="3"/>
+        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Ordnance 1, Large Blast"/>
       </characteristics>
     </profile>
   </sharedProfiles>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -24762,387 +24762,6 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
         <cost name="pts" costTypeId="points" value="400.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="be067474-b6d7-4ac3-5f36-71c86fcf5f79" name="Legion Vindicator Siege Tank Squadron" book="HH:LACAL" page="57" hidden="false" collective="false" categoryEntryId="486561767920537570706f727423232344415441232323" type="unit">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <selectionEntries>
-        <selectionEntry id="a909-9659-925d-cf82" name="Legion Vindicator Tank" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
-          <profiles>
-            <profile id="0af2-a884-9e1b-9516" name="Legion Vindicator" book="HH:LACAL" page="57" hidden="false" profileTypeId="56656869636c6523232344415441232323">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="4"/>
-                <characteristic name="Front" characteristicTypeId="46726f6e7423232344415441232323" value="13"/>
-                <characteristic name="Side" characteristicTypeId="5369646523232344415441232323" value="11"/>
-                <characteristic name="Rear" characteristicTypeId="5265617223232344415441232323" value="10"/>
-                <characteristic name="HP" characteristicTypeId="485023232344415441232323" value="3"/>
-                <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Tank"/>
-              </characteristics>
-            </profile>
-          </profiles>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <selectionEntries/>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="2737-ef3e-3c73-950f" name="Exchange Demolisher Cannon for:" hidden="false" collective="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <selectionEntries>
-                <selectionEntry id="ecf3-d525-2e1c-ff56" name="Laser Destroyer Array" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules>
-                    <rule id="c2e8-b9c9-dbea-fbcd" name="Power Capacitor" book="HH6: Retribution" page="241" hidden="false">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <description>- Capacitor Fire: If the tank has not moved this turn, the Laser Destroyer Array becomes an Ordnance 2 Twin-linked weapon.
-- Overcharged Fire: The owning player may declare an overcharged volley if the vehicle has not moved this turn.  The Laser Destroyer Array becomes Ordnance 3, Twin-linked.  After firing, roll a D6 - on a 1 the Vindicator suffers a single Hull Point of damage. </description>
-                    </rule>
-                  </rules>
-                  <infoLinks>
-                    <infoLink id="d4a5-4c23-4a5e-03c9" hidden="false" targetId="c4094da7-8d2e-8d6a-8af8-4cf88f5d7c06" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="10.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups/>
-              <entryLinks/>
-            </selectionEntryGroup>
-            <selectionEntryGroup id="d86d-565a-11a0-068a" name="Legion-specific upgrade" hidden="false" collective="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="352b-d99d-b67d-ce31" hidden="false" targetId="a15bdf56-4ffe-fe04-ff77-3d533ab99dfa" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-                <entryLink id="aec2-fc0b-6ebc-0eb1" hidden="false" targetId="86e70545-ed1a-7cf4-5a3d-d60662a6b3be" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-                <entryLink id="fca5-57da-92fe-d4ad" hidden="false" targetId="f785888f-6dfa-08f4-054f-29b1a0e4f20c" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-            <selectionEntryGroup id="9c7f-bd8c-3025-4095" name="May take a Pintle-Mounted Weapon:" hidden="false" collective="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries>
-                <selectionEntry id="4a2f-fdf9-4f69-1ae1" name="Twin-Linked Bolter" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="5.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="db45-357b-72f5-951e" name="Combi-Weapon" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="10.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="e039-0554-adc8-463b" name="Heavy Bolter" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="15.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="1191-ea4a-c3d6-2030" name="Heavy Flamer" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="10.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="8317-adc2-e42d-c991" name="Havoc Launcher" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="dd38-aba9-a79d-bbad" hidden="false" targetId="b3ea1d32-ba66-0585-d7f7-0dc56e707736" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="15.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="a4d5-fdbf-4360-f2d0" hidden="false" targetId="2d56d45d-d276-7830-2b7d-026de64bbae8" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-            <selectionEntryGroup id="6d45-1930-f3fb-9501" name="May take any of the following:" hidden="false" collective="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <selectionEntries>
-                <selectionEntry id="a7ee-eb7d-5187-f9c7" name="Auxiliary Drive" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="4cd7-1b08-6499-fc36" hidden="false" targetId="d963a2dd-d9a3-8974-aac6-61ffcc78a99a" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="10.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="9d8a-b172-efef-11c7" name="Hunter-killer Missile" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="10.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="6a0d-081e-1dcb-169f" name="Armoured Ceramite" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="6b8e-b034-a639-62df" hidden="false" targetId="2e87b8ca-7cd1-78b9-2116-246015e7935e" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="20.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="eaf0-068c-941a-05ce" name="Extra Armour" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="10.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="4f7e-e4a7-ac20-a65b" name="Machine Spirit" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="6100-ca9d-5811-b4bc" hidden="false" targetId="3a93202e-ac23-5508-2dda-248efcc8ff3d" type="rule">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="25.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups/>
-              <entryLinks/>
-            </selectionEntryGroup>
-            <selectionEntryGroup id="4150-a928-1187-5919" name="May take one of the following:" hidden="false" collective="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries>
-                <selectionEntry id="1d52-8a03-2d61-2f3f" name="Dozer Blade" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="5.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="a13e-9a59-42ff-cdd3" name="Mine Plough" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="10.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups/>
-              <entryLinks/>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="120.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups/>
-      <entryLinks>
-        <entryLink id="e302-400f-f316-014d" hidden="false" targetId="c487-be13-ea53-917e" type="selectionEntryGroup">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </entryLink>
-      </entryLinks>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
     <selectionEntry id="4fb43919-84f7-12ef-36a1-24c2de1626c0" name="Legion Whirlwind Scorpius" book="HH:LACAL" page="64" hidden="false" collective="false" categoryEntryId="486561767920537570706f727423232344415441232323" type="unit">
       <profiles>
         <profile id="7a371d05-12d0-fb8a-be68-0c9f380dfb64" name="Legion Whirlwind Scorpius" book="HH:LACAL" page="64" hidden="false" profileTypeId="56656869636c6523232344415441232323">
@@ -34784,6 +34403,13 @@ Ignores Cover special rule.</description>
       <constraints/>
     </entryLink>
     <entryLink id="b22d-6356-a2b3-695f" name="New EntryLink" hidden="false" targetId="57e7-980d-f042-f566" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </entryLink>
+    <entryLink id="4e90-9e3d-0cbd-c864" name="New EntryLink" hidden="false" targetId="0df5-83e7-a354-049e" type="selectionEntry">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -66605,7 +66231,7 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
                   <selectionEntries>
                     <selectionEntry id="910e-cea0-521f-5b79" name="Castellan and Vengeance Warheads" hidden="false" collective="false" type="upgrade">
                       <profiles>
-                        <profile id="f533-5a47-47a6-4e8b" name="Castellan Warhead" book="HH:LACAL" page="93" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+                        <profile id="f533-5a47-47a6-4e8b" name="Castellan Warhead" book="LA:AoDAL" page="125" hidden="false" profileTypeId="576561706f6e23232344415441232323">
                           <profiles/>
                           <rules/>
                           <infoLinks/>
@@ -66617,7 +66243,7 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
                             <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Ordnance 1, Barrage, Large Blast, Ignores Cover"/>
                           </characteristics>
                         </profile>
-                        <profile id="eee8-e6aa-bfcd-7de2" name="Vengeance Warhead" book="HH:LACAL" page="93" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+                        <profile id="eee8-e6aa-bfcd-7de2" name="Vengeance Warhead" book="LA:AoDAL" page="125" hidden="false" profileTypeId="576561706f6e23232344415441232323">
                           <profiles/>
                           <rules/>
                           <infoLinks/>
@@ -66802,7 +66428,7 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
     </selectionEntry>
     <selectionEntry id="8917-121a-d28f-4f03" name="Hyperios air-defence" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles>
-        <profile id="98f4-5e83-d6cf-96f9" name="Hyperios Warhead" book="HH:LACAL" page="93" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+        <profile id="98f4-5e83-d6cf-96f9" name="Hyperios Warhead" book="LA:AoDAL" page="125 &amp; 95" hidden="false" profileTypeId="576561706f6e23232344415441232323">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -66843,6 +66469,387 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0df5-83e7-a354-049e" name="Legion Vindicator Siege Tank Squadron" book="HH:LACAL" page="57" hidden="false" collective="false" categoryEntryId="486561767920537570706f727423232344415441232323" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="d1df-667a-f167-7e62" name="Legion Vindicator Tank" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles>
+            <profile id="2985-3017-61a9-adc1" name="Legion Vindicator" book="HH:LACAL" page="57" hidden="false" profileTypeId="56656869636c6523232344415441232323">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="4"/>
+                <characteristic name="Front" characteristicTypeId="46726f6e7423232344415441232323" value="13"/>
+                <characteristic name="Side" characteristicTypeId="5369646523232344415441232323" value="11"/>
+                <characteristic name="Rear" characteristicTypeId="5265617223232344415441232323" value="10"/>
+                <characteristic name="HP" characteristicTypeId="485023232344415441232323" value="3"/>
+                <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Tank"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b09e-34db-6219-f6e5" type="min"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7c47-1831-089e-f4a4" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="d7ed-f038-273a-b195" name="Exchange Demolisher Cannon for:" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <selectionEntries>
+                <selectionEntry id="a847-6304-1563-8960" name="Laser Destroyer Array" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules>
+                    <rule id="9254-006e-01a1-49ce" name="Power Capacitor" book="HH6: Retribution" page="241" hidden="false">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <description>- Capacitor Fire: If the tank has not moved this turn, the Laser Destroyer Array becomes an Ordnance 2 Twin-linked weapon.
+- Overcharged Fire: The owning player may declare an overcharged volley if the vehicle has not moved this turn.  The Laser Destroyer Array becomes Ordnance 3, Twin-linked.  After firing, roll a D6 - on a 1 the Vindicator suffers a single Hull Point of damage. </description>
+                    </rule>
+                  </rules>
+                  <infoLinks>
+                    <infoLink id="204b-a799-2b99-a2be" hidden="false" targetId="c4094da7-8d2e-8d6a-8af8-4cf88f5d7c06" type="profile">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ba10-69bf-1c2e-0d38" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks/>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="73c5-58d8-cacd-f44a" name="Legion-specific upgrade" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="6a2a-61dd-1d0d-3094" hidden="false" targetId="a15bdf56-4ffe-fe04-ff77-3d533ab99dfa" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="bb91-64e9-94ae-6165" hidden="false" targetId="86e70545-ed1a-7cf4-5a3d-d60662a6b3be" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="a3d6-7278-97cb-9ecd" hidden="false" targetId="f785888f-6dfa-08f4-054f-29b1a0e4f20c" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="fbe5-8215-1436-9ea5" name="May take a Pintle-Mounted Weapon:" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6080-448a-6196-1e26" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="ba1a-6019-0a3f-1205" name="Twin-Linked Bolter" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5761-811d-612c-5abe" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="5.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="7722-1a20-a027-09b9" name="Combi-Weapon" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1388-6d45-545b-60d8" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="39db-d2f4-858b-d0a8" name="Heavy Bolter" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d5ab-0884-ad16-3477" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="15.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="d69b-5a01-ea30-3ed7" name="Heavy Flamer" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2336-7dde-187a-7f5f" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="2b96-1545-79a4-2358" name="Havoc Launcher" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="d262-a941-7a52-c17d" hidden="false" targetId="b3ea1d32-ba66-0585-d7f7-0dc56e707736" type="profile">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1c05-3146-fa3c-4c74" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="15.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="d952-4c15-27ea-0b41" hidden="false" targetId="2d56d45d-d276-7830-2b7d-026de64bbae8" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="ae26-45a5-f561-0234" name="May take any of the following:" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <selectionEntries>
+                <selectionEntry id="2474-4d1a-f548-0c7b" name="Auxiliary Drive" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="5286-31f4-db65-7e76" hidden="false" targetId="d963a2dd-d9a3-8974-aac6-61ffcc78a99a" type="profile">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3eb3-08d6-3819-2db7" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="0524-f3d3-6951-4d35" name="Hunter-killer Missile" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a433-4950-3be2-7d39" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="ab69-9c8c-b34e-86b6" name="Armoured Ceramite" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="2e99-f4cb-c34f-7404" hidden="false" targetId="2e87b8ca-7cd1-78b9-2116-246015e7935e" type="profile">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="cbf5-59a4-1abc-84b0" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="20.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="2827-e4bd-1aab-fa94" name="Extra Armour" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7fc5-b925-a301-0ab9" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="392c-9f44-efd4-a040" name="Machine Spirit" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="463c-ef8a-8ca3-d97f" hidden="false" targetId="3a93202e-ac23-5508-2dda-248efcc8ff3d" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9181-dec2-9c3e-ab5d" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="25.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks/>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="37fb-ea9b-da4e-4b97" name="May take one of the following:" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6625-ec72-cddb-839a" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="eead-69a6-67bc-e9ec" name="Dozer Blade" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="192e-d410-83f0-fb37" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="5.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="5a1d-28d0-86b3-dd1b" name="Mine Plough" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2891-5ff6-2532-2708" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks/>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="120.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="a548-6a7c-aa84-c044" hidden="false" targetId="c487-be13-ea53-917e" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
       <costs>
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -46732,9 +46732,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
         </infoLink>
       </infoLinks>
       <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
+      <constraints/>
       <selectionEntries/>
       <selectionEntryGroups>
         <selectionEntryGroup id="201a-444e-1c6e-e0ce" name="Legion-specific upgrade" hidden="false" collective="false">

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -33919,7 +33919,7 @@ Ignores Cover special rule.</description>
       </modifiers>
       <constraints/>
     </entryLink>
-    <entryLink id="2e77-bcb4-9def-f7c5" hidden="false" targetId="b9f0-57cc-d0da-4ae3" type="selectionEntry" categoryEntryId="466173742041747461636b23232344415441232323">
+    <entryLink id="2e77-bcb4-9def-f7c5" name="" hidden="false" targetId="b9f0-57cc-d0da-4ae3" type="selectionEntry" categoryEntryId="466173742041747461636b23232344415441232323">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -46692,12 +46692,6 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
           <infoLinks/>
           <modifiers/>
         </rule>
-        <rule id="925a-8c58-281f-f5f3" name="Drop Pod Assault" page="0" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </rule>
         <rule id="86f1-39c0-5841-0b59" name="Heat Blast" book="HH:LACAL" page="63" hidden="false">
           <profiles/>
           <rules/>
@@ -46729,7 +46723,14 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
           <modifiers/>
         </rule>
       </rules>
-      <infoLinks/>
+      <infoLinks>
+        <infoLink id="250a-992f-3375-14f4" name="New InfoLink" hidden="false" targetId="9bc2-f58b-4edd-8673" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
@@ -66679,6 +66680,18 @@ When conducting a Ram attack, use Strength 10, roll two dice and pick the higher
           <infoLinks/>
           <modifiers/>
         </infoLink>
+        <infoLink id="0ff0-7dc7-11ea-4e32" name="New InfoLink" hidden="false" targetId="3138-683d-a9a0-570d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="32a0-6915-df49-cfb3" name="New InfoLink" hidden="false" targetId="3a93202e-ac23-5508-2dda-248efcc8ff3d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
       </infoLinks>
       <modifiers/>
       <constraints/>
@@ -66727,7 +66740,7 @@ When conducting a Ram attack, use Strength 10, roll two dice and pick the higher
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="5031-fabb-8e2b-30df" name="Wing Weapons" hidden="false" collective="false">
+        <selectionEntryGroup id="5031-fabb-8e2b-30df" name="Two wing-mounted:" hidden="false" collective="false" defaultSelectionEntryId="2ce4-cc59-9164-81f2">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -66736,47 +66749,30 @@ When conducting a Ram attack, use Strength 10, roll two dice and pick the higher
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ac60-d1bd-1f94-06f1" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="cde2-e92e-2a12-4a02" type="max"/>
           </constraints>
-          <selectionEntries>
-            <selectionEntry id="714f-e993-f4af-908e" name="Two wing-mounted Havoc Launchers" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="2ce4-cc59-9164-81f2" name="New EntryLink" hidden="false" targetId="d6bf-b694-8ca0-a6c5" type="selectionEntry">
               <profiles/>
               <rules/>
-              <infoLinks>
-                <infoLink id="c923-1a49-b02f-1486" hidden="false" targetId="b3ea1d32-ba66-0585-d7f7-0dc56e707736" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f88a-269e-2c8a-3227" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="5635-04fa-c120-2066" name="Two wing-mounted Missile Launchers" book="LACAL" page="59" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="0.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="d909-391e-eda3-f9de" name="New EntryLink" hidden="false" targetId="e5d2-e10d-1552-c5c6" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4d9a-1de0-c7ec-9ee2" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="10.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups/>
-          <entryLinks/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
@@ -66787,25 +66783,35 @@ When conducting a Ram attack, use Strength 10, roll two dice and pick the higher
           <modifiers/>
           <constraints/>
         </entryLink>
-        <entryLink id="f582-d635-649b-eebc" name="New EntryLink" hidden="false" targetId="f888-a294-fcff-8391" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="set" field="points" value="0.0">
-              <repeats/>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="62c7-65ad-7f4a-2767" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f86a-7393-ad0d-c2e6" type="min"/>
-          </constraints>
-        </entryLink>
       </entryLinks>
       <costs>
         <cost name="pts" costTypeId="points" value="305.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e5d2-e10d-1552-c5c6" name="Missile Launcher" book="BRB 7th" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="a01f-0962-3dba-deab" name="New InfoLink" hidden="false" targetId="40e6-c95c-7c8d-cf02" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="fa77-3f32-ad17-5ee7" name="New InfoLink" hidden="false" targetId="1e33-d8ec-f833-b584" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -66593,51 +66593,19 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
               </constraints>
               <selectionEntries/>
               <selectionEntryGroups>
-                <selectionEntryGroup id="a4ed-55f7-78c9-2ef4" name="Exchange Vengeance and Castellan missiles for:" hidden="false" collective="false" defaultSelectionEntryId="910e-cea0-521f-5b79">
+                <selectionEntryGroup id="a4ed-55f7-78c9-2ef4" name="Whirlwind Launcher Equiped with" hidden="false" collective="false" defaultSelectionEntryId="910e-cea0-521f-5b79">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
                   <modifiers/>
-                  <constraints/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bb03-00b2-2e42-dcb8" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="91ac-ffe8-9cd2-b3c6" type="max"/>
+                  </constraints>
                   <selectionEntries>
-                    <selectionEntry id="132d-f357-3e51-6e96" name="Hyperios air-defence Missiles" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                    <selectionEntry id="910e-cea0-521f-5b79" name="Castellan and Vengeance Warheads" hidden="false" collective="false" type="upgrade">
                       <profiles>
-                        <profile id="460a-ad43-ca82-d49b" name="Whirlwind Launcher: Hyperios Warhead" book="HH:LACAL" page="93" hidden="false" profileTypeId="576561706f6e23232344415441232323">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                          <characteristics>
-                            <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="48&quot;"/>
-                            <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="8"/>
-                            <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="3"/>
-                            <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 1, Skyfire, Interceptor, Heatseaker"/>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="6440-61bf-b612-e52d" name="New InfoLink" hidden="false" targetId="6970-1bf3-b33e-5dce" type="rule">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b447-6cd6-af1e-4e59" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="910e-cea0-521f-5b79" name="Whirlwind Launcher" hidden="false" collective="false" type="upgrade">
-                      <profiles>
-                        <profile id="f533-5a47-47a6-4e8b" name="Whirlwind Launcher: Castellan Warhead" book="HH:LACAL" page="93" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+                        <profile id="f533-5a47-47a6-4e8b" name="Castellan Warhead" book="HH:LACAL" page="93" hidden="false" profileTypeId="576561706f6e23232344415441232323">
                           <profiles/>
                           <rules/>
                           <infoLinks/>
@@ -66649,7 +66617,7 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
                             <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Ordnance 1, Barrage, Large Blast, Ignores Cover"/>
                           </characteristics>
                         </profile>
-                        <profile id="eee8-e6aa-bfcd-7de2" name="Whirlwind Launcher: Vengeance Warhead" book="HH:LACAL" page="93" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+                        <profile id="eee8-e6aa-bfcd-7de2" name="Vengeance Warhead" book="HH:LACAL" page="93" hidden="false" profileTypeId="576561706f6e23232344415441232323">
                           <profiles/>
                           <rules/>
                           <infoLinks/>
@@ -66663,7 +66631,14 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
                         </profile>
                       </profiles>
                       <rules/>
-                      <infoLinks/>
+                      <infoLinks>
+                        <infoLink id="4557-4f72-59f7-5ace" name="New InfoLink" hidden="false" targetId="acf2-681d-4188-94d7" type="rule">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                        </infoLink>
+                      </infoLinks>
                       <modifiers/>
                       <constraints>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c775-8ae0-99ab-b495" type="max"/>
@@ -66671,11 +66646,27 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
                       <selectionEntries/>
                       <selectionEntryGroups/>
                       <entryLinks/>
-                      <costs/>
+                      <costs>
+                        <cost name="pts" costTypeId="points" value="0.0"/>
+                      </costs>
                     </selectionEntry>
                   </selectionEntries>
                   <selectionEntryGroups/>
-                  <entryLinks/>
+                  <entryLinks>
+                    <entryLink id="ef1d-2315-c55c-d230" name="New EntryLink" hidden="false" targetId="8917-121a-d28f-4f03" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers>
+                        <modifier type="append" field="name" value="Missiles">
+                          <repeats/>
+                          <conditions/>
+                          <conditionGroups/>
+                        </modifier>
+                      </modifiers>
+                      <constraints/>
+                    </entryLink>
+                  </entryLinks>
                 </selectionEntryGroup>
                 <selectionEntryGroup id="923e-cff0-623f-c8b8" name="Legion-specific upgrade" hidden="false" collective="false">
                   <profiles/>
@@ -66805,6 +66796,53 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
           <constraints/>
         </entryLink>
       </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="8917-121a-d28f-4f03" name="Hyperios air-defence" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="98f4-5e83-d6cf-96f9" name="Hyperios Warhead" book="HH:LACAL" page="93" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="48&quot;"/>
+            <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="8"/>
+            <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="3"/>
+            <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 1, Skyfire, Interceptor, Heatseaker"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="dd2f-74c2-9e85-0b91" name="New InfoLink" hidden="false" targetId="cdae-1226-8aa6-6e69" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="f4ca-ae40-0a60-3187" name="New InfoLink" hidden="false" targetId="be7f-8146-6cb8-9a53" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="6066-98fe-7bfc-b382" name="New InfoLink" hidden="false" targetId="ca3e-e94e-58f6-75d9" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b080-7a95-902f-aa2b" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
       <costs>
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -66551,12 +66551,6 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
         </profile>
       </profiles>
       <rules>
-        <rule id="82fd-947c-096f-e4f8" name="Strafing Run" page="0" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </rule>
         <rule id="8dbd-3763-ae43-d862" name="Independent Turret Fire" book="HH:LACAL" page="54" hidden="false">
           <profiles/>
           <rules/>
@@ -66579,6 +66573,12 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
           <modifiers/>
         </infoLink>
         <infoLink id="873a-d709-f16a-2289" name="New InfoLink" hidden="false" targetId="1578-d22a-060c-4700" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="b556-e50d-3ef3-1745" name="New InfoLink" hidden="false" targetId="9ec5-6ea0-ad91-5c4b" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -70001,6 +70001,13 @@ Kharybdis: After it has landed treat as a flyer in Hover mode. LA:AODAL P75</des
       <infoLinks/>
       <modifiers/>
       <description>At the start of the controlling player&apos;s turn, prior to any reserve rolls, declare which mode is being used - it remains until their next player turn.  Disruption Mode: the oppsoing player suffers -1 to their reserve rolls.  Relay Mode: Owning player&apos;s reserve rolls may be re-rolled, whether successful or not.  Reduces transport capacity to 8.  </description>
+    </rule>
+    <rule id="9ec5-6ea0-ad91-5c4b" name="Strafing Run" book="BRB 7th" page="0" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>When shooting Assault, Heavy, Rapid Fire or Salvo weapons at Artillery, Beasts, Bikes, Cavalry, Infantry, Monstrous Creatures and vehicles without the Flyer or Skimmer type, this vehicle has +1 Ballistic Skill.</description>
     </rule>
   </sharedRules>
   <sharedProfiles>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -27548,247 +27548,6 @@ Ignores Cover special rule.</description>
         <cost name="pts" costTypeId="points" value="195.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="b4be0072-7dfb-4e00-6d14-ea5eea60d40c" name="Sicaran Venator Tank Destroyer" book="HH:LACAL" page="60" hidden="false" collective="false" categoryEntryId="486561767920537570706f727423232344415441232323" type="unit">
-      <profiles>
-        <profile id="6f261a2d-6f91-91ec-6399-80d6e39b9427" name="Sicaran Venator Tank Destroyer" book="HH:LACAL" page="60" hidden="false" profileTypeId="56656869636c6523232344415441232323">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="4"/>
-            <characteristic name="Front" characteristicTypeId="46726f6e7423232344415441232323" value="13"/>
-            <characteristic name="Side" characteristicTypeId="5369646523232344415441232323" value="12"/>
-            <characteristic name="Rear" characteristicTypeId="5265617223232344415441232323" value="12"/>
-            <characteristic name="HP" characteristicTypeId="485023232344415441232323" value="3"/>
-            <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Tank, Fast"/>
-          </characteristics>
-        </profile>
-        <profile id="613b4a09-626c-9a42-62cd-ec765f7a6ec6" name="Neutron Beam Laser" book="HH:LACAL" page="60" hidden="false" profileTypeId="576561706f6e23232344415441232323">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="36&quot;"/>
-            <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="10"/>
-            <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="1"/>
-            <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Ordnance 2, Concussive, Shock Pulse"/>
-          </characteristics>
-        </profile>
-      </profiles>
-      <rules>
-        <rule id="f9a009f0-a997-0c78-42b5-9cd8c9516fd6" name="Dangerous Reactor Core" book="HH:LACAL" page="60" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <description>An enemy may re-roll a result of a 1 on the Vehicle Damage table against the Sicarian Venator.  Explodes results add D3&quot; to radius.  </description>
-        </rule>
-        <rule id="f2400536-8a39-8961-18d4-97698fba78cf" name="Shock Pulse" book="HH:LACAL" page="60" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <description>Any vehicle, including super-heavies, that suffers a penetrating hit may only fire snap shots on the following game turn.  </description>
-        </rule>
-      </rules>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <selectionEntries/>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="1af36b36-4304-456f-bea6-f0c9e6b3d3b0" name="May take any of the following:" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <selectionEntries>
-            <selectionEntry id="141900c7-3f0d-76d5-93c4-bd2e44024800" name="Hunter-killer Missile" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="10.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="d1ebb668-6bd0-65a1-dd79-46fefe8abea4" name="Dozer Blade" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="425af40c-4887-bbae-c376-14725ccf4a49" name="Armoured Ceramite" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="5a9a5f87-e3a4-201c-7ebf-f10e2200d2e5" hidden="false" targetId="2e87b8ca-7cd1-78b9-2116-246015e7935e" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="20.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="e61f40e9-d09c-2086-a141-afd423f1ae27" name="Auxiliary Drive" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="9d463a3b-173a-79ff-315c-636389e7e3f3" hidden="false" targetId="d963a2dd-d9a3-8974-aac6-61ffcc78a99a" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="10.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups/>
-          <entryLinks/>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="d5da8eaa-d381-8403-d080-0bad275e1f50" name="May take one set of two sponson weapons:" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="3dd9967a-7fd3-f278-1472-bd415e0fa1d7" name="Heavy Bolters" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="20.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="ce49c9c3-59c1-5865-dc15-34e79551ecae" name="Lascannons" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="40.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="53c42306-fb8e-61b8-401c-88adc03d8ff6" name="Heavy Flamers" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="set" field="hidden" value="true">
-                  <repeats/>
-                  <conditions>
-                    <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a91f-3b51-950d-ba8a" type="equalTo"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="20.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups/>
-          <entryLinks/>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="14cbf293-3aef-d60f-eefe-564a816f9458" name="Legion-specific upgrade" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="a304b776-5037-0d64-32dd-c44a4dde8970" hidden="false" targetId="a15bdf56-4ffe-fe04-ff77-3d533ab99dfa" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </entryLink>
-            <entryLink id="3724f500-3bb6-5f79-11ab-9cdeb874f81d" hidden="false" targetId="f785888f-6dfa-08f4-054f-29b1a0e4f20c" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="11f4-8fdd-6461-85db" hidden="false" targetId="c487-be13-ea53-917e" type="selectionEntryGroup">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </entryLink>
-      </entryLinks>
-      <costs>
-        <cost name="pts" costTypeId="points" value="190.0"/>
-      </costs>
-    </selectionEntry>
     <selectionEntry id="463523e3-b8e6-65c3-3487-338b995629f5" name="Sigismund" book="HH:LAICL" page="100" hidden="false" collective="false" categoryEntryId="485123232344415441232323" type="model">
       <profiles>
         <profile id="e42eca8e-59fa-05c2-2816-4d6bc7533020" name="Sigismund" book="HH:LAICL" page="100" hidden="false" profileTypeId="556e697423232344415441232323">
@@ -34081,6 +33840,13 @@ Ignores Cover special rule.</description>
       <constraints/>
     </entryLink>
     <entryLink id="a378-4e0d-0e7f-73c1" name="New EntryLink" hidden="false" targetId="2ec2-d7c8-d06b-8dff" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </entryLink>
+    <entryLink id="1e70-d901-5adc-f8ac" name="New EntryLink" hidden="false" targetId="b54f-18bb-f400-67d6" type="selectionEntry">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -66773,6 +66539,254 @@ When conducting a Ram attack, use Strength 10, roll two dice and pick the higher
       <entryLinks/>
       <costs/>
     </selectionEntry>
+    <selectionEntry id="b54f-18bb-f400-67d6" name="Sicaran Venator Tank Destroyer" book="HH:LACAL" page="60" hidden="false" collective="false" categoryEntryId="486561767920537570706f727423232344415441232323" type="unit">
+      <profiles>
+        <profile id="531b-8746-6d48-b8a6" name="Sicaran Venator Tank Destroyer" book="HH:LACAL" page="60" hidden="false" profileTypeId="56656869636c6523232344415441232323">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="4"/>
+            <characteristic name="Front" characteristicTypeId="46726f6e7423232344415441232323" value="13"/>
+            <characteristic name="Side" characteristicTypeId="5369646523232344415441232323" value="12"/>
+            <characteristic name="Rear" characteristicTypeId="5265617223232344415441232323" value="12"/>
+            <characteristic name="HP" characteristicTypeId="485023232344415441232323" value="3"/>
+            <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Tank, Fast"/>
+          </characteristics>
+        </profile>
+        <profile id="5468-1738-9841-2669" name="Neutron Beam Laser" book="HH:LACAL" page="60" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="36&quot;"/>
+            <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="10"/>
+            <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="1"/>
+            <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Ordnance 2, Concussive, Shock Pulse"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="d2e7-4843-97dc-52e6" name="Dangerous Reactor Core" book="HH:LACAL" page="60" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <description>An enemy may re-roll a result of a 1 on the Vehicle Damage table against the Sicarian Venator.  Explodes results add D3&quot; to radius.  </description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="28c5-1a45-944b-ca2a" name="New InfoLink" hidden="false" targetId="b382-3da8-e6c2-48eb" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="e674-219e-efe4-7f68" name="May take any of the following:" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries>
+            <selectionEntry id="183d-d9ed-3a7c-6402" name="Hunter-killer Missile" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="30a2-c40d-7e2d-a8d4" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="75c2-de9b-fe9e-f55a" name="Dozer Blade" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="41a3-e496-f9b1-7908" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="8e1f-36b7-09fb-e3df" name="Armoured Ceramite" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="614b-1150-6770-730a" hidden="false" targetId="2e87b8ca-7cd1-78b9-2116-246015e7935e" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="027c-4cc7-2097-37e3" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="20.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="0632-9c2d-807c-bd4f" name="Auxiliary Drive" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="9a70-8450-7c83-0399" hidden="false" targetId="d963a2dd-d9a3-8974-aac6-61ffcc78a99a" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ca8f-3236-5897-450a" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="10.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="02b4-02c1-8387-86da" name="May take one set of two sponson weapons:" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="151c-51f4-c74a-f98b" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="9f67-e7f4-4544-134c" name="Heavy Bolters" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7968-b7ec-c46f-fce9" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="20.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="f307-4a53-b99a-e059" name="Lascannons" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0865-046e-4087-4d8b" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="40.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="646e-fb0b-4226-c88c" name="Heavy Flamers" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a91f-3b51-950d-ba8a" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="671b-521e-004f-9a39" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5f6d-8ebb-a511-bc40" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="20.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="86c6-30ee-aa7a-a8c9" name="Legion-specific upgrade" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="e4e6-6792-928a-8fba" hidden="false" targetId="a15bdf56-4ffe-fe04-ff77-3d533ab99dfa" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="46d1-7d7c-857f-f5a5" hidden="false" targetId="f785888f-6dfa-08f4-054f-29b1a0e4f20c" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="a07c-85da-c9a2-ad1a" hidden="false" targetId="c487-be13-ea53-917e" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="832e-b449-1c77-1cbb" name="New EntryLink" hidden="false" targetId="fe17-5ed2-ca63-9379" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="190.0"/>
+      </costs>
+    </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup id="fc8ed347-6cd6-c24e-942f-bda78004e894" name="Bodyguard" hidden="false" collective="false">
@@ -69948,6 +69962,13 @@ Kharybdis: After it has landed treat as a flyer in Hover mode. LA:AODAL P75</des
       <infoLinks/>
       <modifiers/>
       <description>If this weapon successfully scores a penetrating hit on a target, roll a D6. On the roll of a 4,+ a second automatic penetrating hit is in􀁵icted on the same target against which cover saves may not be taken.</description>
+    </rule>
+    <rule id="b382-3da8-e6c2-48eb" name="Shock Pulse" book="HH:LACAL" page="60" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>Any vehicle, including super-heavies, that suffers a penetrating hit may only fire snap shots on the following game turn.  </description>
     </rule>
   </sharedRules>
   <sharedProfiles>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -67139,19 +67139,7 @@ Explodes results add D3&quot; to radius.  </description>
             <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Tank, Transport"/>
           </characteristics>
         </profile>
-        <profile id="588f-bf62-c683-acb7" name="Quad Mortar (Shatter)" book="HH:LACAL" page="55" hidden="false" profileTypeId="576561706f6e23232344415441232323">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="36&quot;"/>
-            <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="8"/>
-            <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="4"/>
-            <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 4, Sunder"/>
-          </characteristics>
-        </profile>
-        <profile id="ff5a-79dd-62ff-4dfd" name="Achilles-Alpha Pattern Land Raider" book="AL:AoDAL" page="67" hidden="false" profileTypeId="307d-047f-ca13-706b" profileTypeName="Transport">
+        <profile id="ff5a-79dd-62ff-4dfd" name="Achilles-Alpha Pattern Land Raider (Transport)" book="AL:AoDAL" page="67" hidden="false" profileTypeId="307d-047f-ca13-706b" profileTypeName="Transport">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -67180,12 +67168,6 @@ Explodes results add D3&quot; to radius.  </description>
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="a72f-c8ff-6bac-ff36" hidden="false" targetId="6d02b74f-b832-0249-9ba0-01ac9c192099" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
         <infoLink id="9331-f648-c3ea-8942" hidden="false" targetId="887c2e1c-8eae-d449-e212-7dddb39cf726" type="rule">
           <profiles/>
           <rules/>
@@ -67268,6 +67250,13 @@ Explodes results add D3&quot; to radius.  </description>
           </modifiers>
           <constraints/>
         </entryLink>
+        <entryLink id="b5b0-43b4-fddd-c3bb" name="New EntryLink" hidden="false" targetId="1914-1ced-69c6-585c" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="pts" costTypeId="points" value="300.0"/>
@@ -67328,7 +67317,10 @@ Explodes results add D3&quot; to radius.  </description>
         </infoLink>
       </infoLinks>
       <modifiers/>
-      <constraints/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="302f-49b0-89f6-65da" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e526-83b5-8729-1321" type="min"/>
+      </constraints>
       <selectionEntries/>
       <selectionEntryGroups>
         <selectionEntryGroup id="00fa-34d6-294f-fb4e" name="May be upgraded with:" hidden="false" collective="false">

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -10193,15 +10193,7 @@
                   </constraints>
                   <selectionEntries/>
                   <selectionEntryGroups/>
-                  <entryLinks>
-                    <entryLink id="755b-5f88-938d-116e" name="New EntryLink" hidden="false" targetId="c419-45b3-44e8-b390" type="selectionEntry">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints/>
-                    </entryLink>
-                  </entryLinks>
+                  <entryLinks/>
                   <costs>
                     <cost name="pts" costTypeId="points" value="45.0"/>
                   </costs>
@@ -10819,13 +10811,13 @@
                   <conditionGroups>
                     <conditionGroup type="or">
                       <conditions>
-                        <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d0a9e1d2-830b-8897-3e90-ce1a562da014" type="equalTo"/>
-                        <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d768afd7-dcf2-b2b4-ba38-ec74900ba3da" type="equalTo"/>
-                        <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0df0a0f1-9ddf-f57b-cada-26dce57443ec" type="equalTo"/>
-                        <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="80a93122-ed98-a665-5b8c-370d0a83ac13" type="equalTo"/>
-                        <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="53d4a249-5fa9-8bac-fda2-0c9419bb3564" type="equalTo"/>
-                        <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="41c9-58e2-8aec-dd82" type="equalTo"/>
-                        <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ea6f-0a58-58b0-0d01" type="equalTo"/>
+                        <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0a9e1d2-830b-8897-3e90-ce1a562da014" type="equalTo"/>
+                        <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d768afd7-dcf2-b2b4-ba38-ec74900ba3da" type="equalTo"/>
+                        <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0df0a0f1-9ddf-f57b-cada-26dce57443ec" type="equalTo"/>
+                        <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="80a93122-ed98-a665-5b8c-370d0a83ac13" type="equalTo"/>
+                        <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="53d4a249-5fa9-8bac-fda2-0c9419bb3564" type="equalTo"/>
+                        <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="41c9-58e2-8aec-dd82" type="equalTo"/>
+                        <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ea6f-0a58-58b0-0d01" type="equalTo"/>
                       </conditions>
                       <conditionGroups/>
                     </conditionGroup>
@@ -10860,13 +10852,13 @@
                   <conditionGroups>
                     <conditionGroup type="or">
                       <conditions>
-                        <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d768afd7-dcf2-b2b4-ba38-ec74900ba3da" type="equalTo"/>
-                        <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="53d4a249-5fa9-8bac-fda2-0c9419bb3564" type="equalTo"/>
-                        <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0df0a0f1-9ddf-f57b-cada-26dce57443ec" type="equalTo"/>
-                        <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="80a93122-ed98-a665-5b8c-370d0a83ac13" type="equalTo"/>
-                        <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d0a9e1d2-830b-8897-3e90-ce1a562da014" type="equalTo"/>
-                        <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="41c9-58e2-8aec-dd82" type="equalTo"/>
-                        <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ea6f-0a58-58b0-0d01" type="equalTo"/>
+                        <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d768afd7-dcf2-b2b4-ba38-ec74900ba3da" type="equalTo"/>
+                        <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="53d4a249-5fa9-8bac-fda2-0c9419bb3564" type="equalTo"/>
+                        <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0df0a0f1-9ddf-f57b-cada-26dce57443ec" type="equalTo"/>
+                        <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="80a93122-ed98-a665-5b8c-370d0a83ac13" type="equalTo"/>
+                        <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0a9e1d2-830b-8897-3e90-ce1a562da014" type="equalTo"/>
+                        <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="41c9-58e2-8aec-dd82" type="equalTo"/>
+                        <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ea6f-0a58-58b0-0d01" type="equalTo"/>
                       </conditions>
                       <conditionGroups/>
                     </conditionGroup>
@@ -10891,7 +10883,7 @@
                 <modifier type="set" field="hidden" value="true">
                   <repeats/>
                   <conditions>
-                    <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="945b2009-7717-4bdc-90a8-44c0699ed01b" type="equalTo"/>
+                    <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="945b2009-7717-4bdc-90a8-44c0699ed01b" type="equalTo"/>
                   </conditions>
                   <conditionGroups/>
                 </modifier>
@@ -10947,8 +10939,8 @@
                   <conditionGroups>
                     <conditionGroup type="or">
                       <conditions>
-                        <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d0a9e1d2-830b-8897-3e90-ce1a562da014" type="equalTo"/>
-                        <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="53d4a249-5fa9-8bac-fda2-0c9419bb3564" type="equalTo"/>
+                        <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0a9e1d2-830b-8897-3e90-ce1a562da014" type="equalTo"/>
+                        <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="53d4a249-5fa9-8bac-fda2-0c9419bb3564" type="equalTo"/>
                       </conditions>
                       <conditionGroups/>
                     </conditionGroup>
@@ -11012,9 +11004,9 @@
                   <conditionGroups>
                     <conditionGroup type="or">
                       <conditions>
-                        <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0df0a0f1-9ddf-f57b-cada-26dce57443ec" type="equalTo"/>
-                        <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d0a9e1d2-830b-8897-3e90-ce1a562da014" type="equalTo"/>
-                        <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="53d4a249-5fa9-8bac-fda2-0c9419bb3564" type="equalTo"/>
+                        <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0df0a0f1-9ddf-f57b-cada-26dce57443ec" type="equalTo"/>
+                        <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0a9e1d2-830b-8897-3e90-ce1a562da014" type="equalTo"/>
+                        <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="53d4a249-5fa9-8bac-fda2-0c9419bb3564" type="equalTo"/>
                       </conditions>
                       <conditionGroups/>
                     </conditionGroup>
@@ -11057,8 +11049,8 @@
                   <conditionGroups>
                     <conditionGroup type="or">
                       <conditions>
-                        <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d0a9e1d2-830b-8897-3e90-ce1a562da014" type="equalTo"/>
-                        <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="53d4a249-5fa9-8bac-fda2-0c9419bb3564" type="equalTo"/>
+                        <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0a9e1d2-830b-8897-3e90-ce1a562da014" type="equalTo"/>
+                        <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="53d4a249-5fa9-8bac-fda2-0c9419bb3564" type="equalTo"/>
                       </conditions>
                       <conditionGroups/>
                     </conditionGroup>
@@ -11097,13 +11089,13 @@
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="59c90433-589a-8b8c-ae39-6117af908c13" type="equalTo"/>
-                    <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7817f79e-d687-9fee-cbd4-02ba76bab68a" type="equalTo"/>
-                    <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="45c41d46-871f-4cfc-758e-ad0ccb58aab5" type="equalTo"/>
-                    <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="41c9-58e2-8aec-dd82" type="equalTo"/>
-                    <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ea6f-0a58-58b0-0d01" type="equalTo"/>
-                    <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="30be-5058-a8e1-f161" type="equalTo"/>
-                    <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d768afd7-dcf2-b2b4-ba38-ec74900ba3da" type="equalTo"/>
+                    <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="59c90433-589a-8b8c-ae39-6117af908c13" type="equalTo"/>
+                    <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7817f79e-d687-9fee-cbd4-02ba76bab68a" type="equalTo"/>
+                    <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="45c41d46-871f-4cfc-758e-ad0ccb58aab5" type="equalTo"/>
+                    <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="41c9-58e2-8aec-dd82" type="equalTo"/>
+                    <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ea6f-0a58-58b0-0d01" type="equalTo"/>
+                    <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="30be-5058-a8e1-f161" type="equalTo"/>
+                    <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d768afd7-dcf2-b2b4-ba38-ec74900ba3da" type="equalTo"/>
                   </conditions>
                   <conditionGroups/>
                 </conditionGroup>
@@ -11157,11 +11149,11 @@
                   <conditionGroups>
                     <conditionGroup type="or">
                       <conditions>
-                        <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d768afd7-dcf2-b2b4-ba38-ec74900ba3da" type="equalTo"/>
-                        <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0df0a0f1-9ddf-f57b-cada-26dce57443ec" type="equalTo"/>
-                        <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="80a93122-ed98-a665-5b8c-370d0a83ac13" type="equalTo"/>
-                        <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d0a9e1d2-830b-8897-3e90-ce1a562da014" type="equalTo"/>
-                        <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="53d4a249-5fa9-8bac-fda2-0c9419bb3564" type="equalTo"/>
+                        <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d768afd7-dcf2-b2b4-ba38-ec74900ba3da" type="equalTo"/>
+                        <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0df0a0f1-9ddf-f57b-cada-26dce57443ec" type="equalTo"/>
+                        <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="80a93122-ed98-a665-5b8c-370d0a83ac13" type="equalTo"/>
+                        <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0a9e1d2-830b-8897-3e90-ce1a562da014" type="equalTo"/>
+                        <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="53d4a249-5fa9-8bac-fda2-0c9419bb3564" type="equalTo"/>
                       </conditions>
                       <conditionGroups/>
                     </conditionGroup>
@@ -11189,11 +11181,11 @@
                   <conditionGroups>
                     <conditionGroup type="or">
                       <conditions>
-                        <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="53d4a249-5fa9-8bac-fda2-0c9419bb3564" type="equalTo"/>
-                        <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d768afd7-dcf2-b2b4-ba38-ec74900ba3da" type="equalTo"/>
-                        <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="80a93122-ed98-a665-5b8c-370d0a83ac13" type="equalTo"/>
-                        <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0df0a0f1-9ddf-f57b-cada-26dce57443ec" type="equalTo"/>
-                        <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d0a9e1d2-830b-8897-3e90-ce1a562da014" type="equalTo"/>
+                        <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="53d4a249-5fa9-8bac-fda2-0c9419bb3564" type="equalTo"/>
+                        <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d768afd7-dcf2-b2b4-ba38-ec74900ba3da" type="equalTo"/>
+                        <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="80a93122-ed98-a665-5b8c-370d0a83ac13" type="equalTo"/>
+                        <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0df0a0f1-9ddf-f57b-cada-26dce57443ec" type="equalTo"/>
+                        <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0a9e1d2-830b-8897-3e90-ce1a562da014" type="equalTo"/>
                       </conditions>
                       <conditionGroups/>
                     </conditionGroup>
@@ -11262,9 +11254,9 @@
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
-                    <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7817f79e-d687-9fee-cbd4-02ba76bab68a" type="equalTo"/>
-                    <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="45c41d46-871f-4cfc-758e-ad0ccb58aab5" type="equalTo"/>
-                    <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="30be-5058-a8e1-f161" type="equalTo"/>
+                    <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7817f79e-d687-9fee-cbd4-02ba76bab68a" type="equalTo"/>
+                    <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="45c41d46-871f-4cfc-758e-ad0ccb58aab5" type="equalTo"/>
+                    <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="30be-5058-a8e1-f161" type="equalTo"/>
                   </conditions>
                   <conditionGroups/>
                 </conditionGroup>
@@ -11294,10 +11286,10 @@
                   <conditionGroups>
                     <conditionGroup type="or">
                       <conditions>
-                        <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d0a9e1d2-830b-8897-3e90-ce1a562da014" type="equalTo"/>
-                        <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="53d4a249-5fa9-8bac-fda2-0c9419bb3564" type="equalTo"/>
-                        <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0df0a0f1-9ddf-f57b-cada-26dce57443ec" type="equalTo"/>
-                        <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d768afd7-dcf2-b2b4-ba38-ec74900ba3da" type="equalTo"/>
+                        <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0a9e1d2-830b-8897-3e90-ce1a562da014" type="equalTo"/>
+                        <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="53d4a249-5fa9-8bac-fda2-0c9419bb3564" type="equalTo"/>
+                        <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0df0a0f1-9ddf-f57b-cada-26dce57443ec" type="equalTo"/>
+                        <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d768afd7-dcf2-b2b4-ba38-ec74900ba3da" type="equalTo"/>
                       </conditions>
                       <conditionGroups/>
                     </conditionGroup>
@@ -11482,11 +11474,11 @@
                       <conditionGroups>
                         <conditionGroup type="or">
                           <conditions>
-                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="80a93122-ed98-a665-5b8c-370d0a83ac13" type="equalTo"/>
-                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d0a9e1d2-830b-8897-3e90-ce1a562da014" type="equalTo"/>
-                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d768afd7-dcf2-b2b4-ba38-ec74900ba3da" type="equalTo"/>
-                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0df0a0f1-9ddf-f57b-cada-26dce57443ec" type="equalTo"/>
-                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="53d4a249-5fa9-8bac-fda2-0c9419bb3564" type="equalTo"/>
+                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="80a93122-ed98-a665-5b8c-370d0a83ac13" type="equalTo"/>
+                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0a9e1d2-830b-8897-3e90-ce1a562da014" type="equalTo"/>
+                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d768afd7-dcf2-b2b4-ba38-ec74900ba3da" type="equalTo"/>
+                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0df0a0f1-9ddf-f57b-cada-26dce57443ec" type="equalTo"/>
+                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="53d4a249-5fa9-8bac-fda2-0c9419bb3564" type="equalTo"/>
                           </conditions>
                           <conditionGroups/>
                         </conditionGroup>
@@ -11514,9 +11506,9 @@
                       <conditionGroups>
                         <conditionGroup type="or">
                           <conditions>
-                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="53d4a249-5fa9-8bac-fda2-0c9419bb3564" type="equalTo"/>
-                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0df0a0f1-9ddf-f57b-cada-26dce57443ec" type="equalTo"/>
-                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d0a9e1d2-830b-8897-3e90-ce1a562da014" type="equalTo"/>
+                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="53d4a249-5fa9-8bac-fda2-0c9419bb3564" type="equalTo"/>
+                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0df0a0f1-9ddf-f57b-cada-26dce57443ec" type="equalTo"/>
+                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0a9e1d2-830b-8897-3e90-ce1a562da014" type="equalTo"/>
                           </conditions>
                           <conditionGroups/>
                         </conditionGroup>
@@ -11544,11 +11536,11 @@
                       <conditionGroups>
                         <conditionGroup type="or">
                           <conditions>
-                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="80a93122-ed98-a665-5b8c-370d0a83ac13" type="equalTo"/>
-                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="53d4a249-5fa9-8bac-fda2-0c9419bb3564" type="equalTo"/>
-                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d768afd7-dcf2-b2b4-ba38-ec74900ba3da" type="equalTo"/>
-                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d0a9e1d2-830b-8897-3e90-ce1a562da014" type="equalTo"/>
-                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0df0a0f1-9ddf-f57b-cada-26dce57443ec" type="equalTo"/>
+                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="80a93122-ed98-a665-5b8c-370d0a83ac13" type="equalTo"/>
+                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="53d4a249-5fa9-8bac-fda2-0c9419bb3564" type="equalTo"/>
+                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d768afd7-dcf2-b2b4-ba38-ec74900ba3da" type="equalTo"/>
+                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0a9e1d2-830b-8897-3e90-ce1a562da014" type="equalTo"/>
+                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0df0a0f1-9ddf-f57b-cada-26dce57443ec" type="equalTo"/>
                           </conditions>
                           <conditionGroups/>
                         </conditionGroup>
@@ -11612,9 +11604,9 @@
                       <conditionGroups>
                         <conditionGroup type="or">
                           <conditions>
-                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="53d4a249-5fa9-8bac-fda2-0c9419bb3564" type="equalTo"/>
-                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d0a9e1d2-830b-8897-3e90-ce1a562da014" type="equalTo"/>
-                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0df0a0f1-9ddf-f57b-cada-26dce57443ec" type="equalTo"/>
+                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="53d4a249-5fa9-8bac-fda2-0c9419bb3564" type="equalTo"/>
+                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0a9e1d2-830b-8897-3e90-ce1a562da014" type="equalTo"/>
+                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0df0a0f1-9ddf-f57b-cada-26dce57443ec" type="equalTo"/>
                           </conditions>
                           <conditionGroups/>
                         </conditionGroup>
@@ -11639,9 +11631,9 @@
                       <conditionGroups>
                         <conditionGroup type="or">
                           <conditions>
-                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="53d4a249-5fa9-8bac-fda2-0c9419bb3564" type="equalTo"/>
-                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d0a9e1d2-830b-8897-3e90-ce1a562da014" type="equalTo"/>
-                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0df0a0f1-9ddf-f57b-cada-26dce57443ec" type="equalTo"/>
+                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="53d4a249-5fa9-8bac-fda2-0c9419bb3564" type="equalTo"/>
+                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0a9e1d2-830b-8897-3e90-ce1a562da014" type="equalTo"/>
+                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0df0a0f1-9ddf-f57b-cada-26dce57443ec" type="equalTo"/>
                           </conditions>
                           <conditionGroups/>
                         </conditionGroup>
@@ -11673,9 +11665,9 @@
                       <conditionGroups>
                         <conditionGroup type="or">
                           <conditions>
-                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="53d4a249-5fa9-8bac-fda2-0c9419bb3564" type="equalTo"/>
-                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0df0a0f1-9ddf-f57b-cada-26dce57443ec" type="equalTo"/>
-                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d0a9e1d2-830b-8897-3e90-ce1a562da014" type="equalTo"/>
+                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="53d4a249-5fa9-8bac-fda2-0c9419bb3564" type="equalTo"/>
+                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0df0a0f1-9ddf-f57b-cada-26dce57443ec" type="equalTo"/>
+                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0a9e1d2-830b-8897-3e90-ce1a562da014" type="equalTo"/>
                           </conditions>
                           <conditionGroups/>
                         </conditionGroup>
@@ -11728,11 +11720,11 @@
                       <conditionGroups>
                         <conditionGroup type="or">
                           <conditions>
-                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0df0a0f1-9ddf-f57b-cada-26dce57443ec" type="equalTo"/>
-                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d768afd7-dcf2-b2b4-ba38-ec74900ba3da" type="equalTo"/>
-                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d0a9e1d2-830b-8897-3e90-ce1a562da014" type="equalTo"/>
-                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="53d4a249-5fa9-8bac-fda2-0c9419bb3564" type="equalTo"/>
-                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="80a93122-ed98-a665-5b8c-370d0a83ac13" type="equalTo"/>
+                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0df0a0f1-9ddf-f57b-cada-26dce57443ec" type="equalTo"/>
+                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d768afd7-dcf2-b2b4-ba38-ec74900ba3da" type="equalTo"/>
+                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0a9e1d2-830b-8897-3e90-ce1a562da014" type="equalTo"/>
+                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="53d4a249-5fa9-8bac-fda2-0c9419bb3564" type="equalTo"/>
+                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="80a93122-ed98-a665-5b8c-370d0a83ac13" type="equalTo"/>
                           </conditions>
                           <conditionGroups/>
                         </conditionGroup>
@@ -11766,9 +11758,9 @@
                       <conditionGroups>
                         <conditionGroup type="or">
                           <conditions>
-                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0df0a0f1-9ddf-f57b-cada-26dce57443ec" type="equalTo"/>
-                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="53d4a249-5fa9-8bac-fda2-0c9419bb3564" type="equalTo"/>
-                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d0a9e1d2-830b-8897-3e90-ce1a562da014" type="equalTo"/>
+                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0df0a0f1-9ddf-f57b-cada-26dce57443ec" type="equalTo"/>
+                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="53d4a249-5fa9-8bac-fda2-0c9419bb3564" type="equalTo"/>
+                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0a9e1d2-830b-8897-3e90-ce1a562da014" type="equalTo"/>
                           </conditions>
                           <conditionGroups/>
                         </conditionGroup>
@@ -11873,11 +11865,11 @@
                       <conditionGroups>
                         <conditionGroup type="or">
                           <conditions>
-                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="80a93122-ed98-a665-5b8c-370d0a83ac13" type="equalTo"/>
-                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d0a9e1d2-830b-8897-3e90-ce1a562da014" type="equalTo"/>
-                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0df0a0f1-9ddf-f57b-cada-26dce57443ec" type="equalTo"/>
-                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="53d4a249-5fa9-8bac-fda2-0c9419bb3564" type="equalTo"/>
-                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d768afd7-dcf2-b2b4-ba38-ec74900ba3da" type="equalTo"/>
+                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="80a93122-ed98-a665-5b8c-370d0a83ac13" type="equalTo"/>
+                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0a9e1d2-830b-8897-3e90-ce1a562da014" type="equalTo"/>
+                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0df0a0f1-9ddf-f57b-cada-26dce57443ec" type="equalTo"/>
+                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="53d4a249-5fa9-8bac-fda2-0c9419bb3564" type="equalTo"/>
+                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d768afd7-dcf2-b2b4-ba38-ec74900ba3da" type="equalTo"/>
                           </conditions>
                           <conditionGroups/>
                         </conditionGroup>
@@ -11905,9 +11897,9 @@
                       <conditionGroups>
                         <conditionGroup type="or">
                           <conditions>
-                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0df0a0f1-9ddf-f57b-cada-26dce57443ec" type="equalTo"/>
-                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="53d4a249-5fa9-8bac-fda2-0c9419bb3564" type="equalTo"/>
-                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d0a9e1d2-830b-8897-3e90-ce1a562da014" type="equalTo"/>
+                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0df0a0f1-9ddf-f57b-cada-26dce57443ec" type="equalTo"/>
+                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="53d4a249-5fa9-8bac-fda2-0c9419bb3564" type="equalTo"/>
+                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0a9e1d2-830b-8897-3e90-ce1a562da014" type="equalTo"/>
                           </conditions>
                           <conditionGroups/>
                         </conditionGroup>
@@ -11935,11 +11927,11 @@
                       <conditionGroups>
                         <conditionGroup type="or">
                           <conditions>
-                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="53d4a249-5fa9-8bac-fda2-0c9419bb3564" type="equalTo"/>
-                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="80a93122-ed98-a665-5b8c-370d0a83ac13" type="equalTo"/>
-                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d0a9e1d2-830b-8897-3e90-ce1a562da014" type="equalTo"/>
-                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d768afd7-dcf2-b2b4-ba38-ec74900ba3da" type="equalTo"/>
-                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0df0a0f1-9ddf-f57b-cada-26dce57443ec" type="equalTo"/>
+                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="53d4a249-5fa9-8bac-fda2-0c9419bb3564" type="equalTo"/>
+                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="80a93122-ed98-a665-5b8c-370d0a83ac13" type="equalTo"/>
+                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0a9e1d2-830b-8897-3e90-ce1a562da014" type="equalTo"/>
+                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d768afd7-dcf2-b2b4-ba38-ec74900ba3da" type="equalTo"/>
+                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0df0a0f1-9ddf-f57b-cada-26dce57443ec" type="equalTo"/>
                           </conditions>
                           <conditionGroups/>
                         </conditionGroup>
@@ -12003,9 +11995,9 @@
                       <conditionGroups>
                         <conditionGroup type="or">
                           <conditions>
-                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d0a9e1d2-830b-8897-3e90-ce1a562da014" type="equalTo"/>
-                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="53d4a249-5fa9-8bac-fda2-0c9419bb3564" type="equalTo"/>
-                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0df0a0f1-9ddf-f57b-cada-26dce57443ec" type="equalTo"/>
+                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0a9e1d2-830b-8897-3e90-ce1a562da014" type="equalTo"/>
+                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="53d4a249-5fa9-8bac-fda2-0c9419bb3564" type="equalTo"/>
+                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0df0a0f1-9ddf-f57b-cada-26dce57443ec" type="equalTo"/>
                           </conditions>
                           <conditionGroups/>
                         </conditionGroup>
@@ -12030,9 +12022,9 @@
                       <conditionGroups>
                         <conditionGroup type="or">
                           <conditions>
-                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0df0a0f1-9ddf-f57b-cada-26dce57443ec" type="equalTo"/>
-                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d0a9e1d2-830b-8897-3e90-ce1a562da014" type="equalTo"/>
-                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="53d4a249-5fa9-8bac-fda2-0c9419bb3564" type="equalTo"/>
+                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0df0a0f1-9ddf-f57b-cada-26dce57443ec" type="equalTo"/>
+                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0a9e1d2-830b-8897-3e90-ce1a562da014" type="equalTo"/>
+                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="53d4a249-5fa9-8bac-fda2-0c9419bb3564" type="equalTo"/>
                           </conditions>
                           <conditionGroups/>
                         </conditionGroup>
@@ -12064,9 +12056,9 @@
                       <conditionGroups>
                         <conditionGroup type="or">
                           <conditions>
-                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0df0a0f1-9ddf-f57b-cada-26dce57443ec" type="equalTo"/>
-                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="53d4a249-5fa9-8bac-fda2-0c9419bb3564" type="equalTo"/>
-                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d0a9e1d2-830b-8897-3e90-ce1a562da014" type="equalTo"/>
+                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0df0a0f1-9ddf-f57b-cada-26dce57443ec" type="equalTo"/>
+                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="53d4a249-5fa9-8bac-fda2-0c9419bb3564" type="equalTo"/>
+                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0a9e1d2-830b-8897-3e90-ce1a562da014" type="equalTo"/>
                           </conditions>
                           <conditionGroups/>
                         </conditionGroup>
@@ -12133,11 +12125,11 @@
                       <conditionGroups>
                         <conditionGroup type="or">
                           <conditions>
-                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="80a93122-ed98-a665-5b8c-370d0a83ac13" type="equalTo"/>
-                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d0a9e1d2-830b-8897-3e90-ce1a562da014" type="equalTo"/>
-                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="53d4a249-5fa9-8bac-fda2-0c9419bb3564" type="equalTo"/>
-                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0df0a0f1-9ddf-f57b-cada-26dce57443ec" type="equalTo"/>
-                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d768afd7-dcf2-b2b4-ba38-ec74900ba3da" type="equalTo"/>
+                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="80a93122-ed98-a665-5b8c-370d0a83ac13" type="equalTo"/>
+                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0a9e1d2-830b-8897-3e90-ce1a562da014" type="equalTo"/>
+                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="53d4a249-5fa9-8bac-fda2-0c9419bb3564" type="equalTo"/>
+                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0df0a0f1-9ddf-f57b-cada-26dce57443ec" type="equalTo"/>
+                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d768afd7-dcf2-b2b4-ba38-ec74900ba3da" type="equalTo"/>
                           </conditions>
                           <conditionGroups/>
                         </conditionGroup>
@@ -12171,9 +12163,9 @@
                       <conditionGroups>
                         <conditionGroup type="or">
                           <conditions>
-                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0df0a0f1-9ddf-f57b-cada-26dce57443ec" type="equalTo"/>
-                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d0a9e1d2-830b-8897-3e90-ce1a562da014" type="equalTo"/>
-                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="53d4a249-5fa9-8bac-fda2-0c9419bb3564" type="equalTo"/>
+                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0df0a0f1-9ddf-f57b-cada-26dce57443ec" type="equalTo"/>
+                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0a9e1d2-830b-8897-3e90-ce1a562da014" type="equalTo"/>
+                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="53d4a249-5fa9-8bac-fda2-0c9419bb3564" type="equalTo"/>
                           </conditions>
                           <conditionGroups/>
                         </conditionGroup>
@@ -12211,9 +12203,9 @@
                       <conditionGroups>
                         <conditionGroup type="or">
                           <conditions>
-                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0df0a0f1-9ddf-f57b-cada-26dce57443ec" type="equalTo"/>
-                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d0a9e1d2-830b-8897-3e90-ce1a562da014" type="equalTo"/>
-                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="53d4a249-5fa9-8bac-fda2-0c9419bb3564" type="equalTo"/>
+                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0df0a0f1-9ddf-f57b-cada-26dce57443ec" type="equalTo"/>
+                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0a9e1d2-830b-8897-3e90-ce1a562da014" type="equalTo"/>
+                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="53d4a249-5fa9-8bac-fda2-0c9419bb3564" type="equalTo"/>
                           </conditions>
                           <conditionGroups/>
                         </conditionGroup>
@@ -12249,9 +12241,9 @@
                       <conditionGroups>
                         <conditionGroup type="or">
                           <conditions>
-                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0df0a0f1-9ddf-f57b-cada-26dce57443ec" type="equalTo"/>
-                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d0a9e1d2-830b-8897-3e90-ce1a562da014" type="equalTo"/>
-                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="53d4a249-5fa9-8bac-fda2-0c9419bb3564" type="equalTo"/>
+                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0df0a0f1-9ddf-f57b-cada-26dce57443ec" type="equalTo"/>
+                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0a9e1d2-830b-8897-3e90-ce1a562da014" type="equalTo"/>
+                            <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="53d4a249-5fa9-8bac-fda2-0c9419bb3564" type="equalTo"/>
                           </conditions>
                           <conditionGroups/>
                         </conditionGroup>
@@ -13445,7 +13437,7 @@
                   <conditions>
                     <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7817f79e-d687-9fee-cbd4-02ba76bab68a" type="equalTo"/>
                     <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="45c41d46-871f-4cfc-758e-ad0ccb58aab5" type="equalTo"/>
-                    <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d768afd7-dcf2-b2b4-ba38-ec74900ba3da" type="equalTo"/>
+                    <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d768afd7-dcf2-b2b4-ba38-ec74900ba3da" type="equalTo"/>
                     <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="30be-5058-a8e1-f161" type="equalTo"/>
                   </conditions>
                   <conditionGroups/>
@@ -33703,7 +33695,7 @@ Ignores Cover special rule.</description>
       <modifiers/>
       <constraints/>
     </entryLink>
-    <entryLink id="93b1-e9d5-166d-fc52" name="Legion Malcador Assualt Tank" hidden="false" targetId="6885-6434-7ed7-ce46" type="selectionEntry">
+    <entryLink id="93b1-e9d5-166d-fc52" name="Legion Malcador Assualt Tank" hidden="false" targetId="6885-6434-7ed7-ce46" type="selectionEntry" categoryEntryId="486561767920537570706f727423232344415441232323">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -37234,42 +37226,7 @@ Token representing the Cyber-hawk plays no other role in the game and may not be
       </costs>
     </selectionEntry>
     <selectionEntry id="5b8da8d0-7c0f-1744-bd13-550239ea056c" name="Deathstorm Drop Pod" book="LA:AODAL" page="61" hidden="false" collective="false" categoryEntryId="486561767920537570706f727423232344415441232323" type="upgrade">
-      <profiles>
-        <profile id="150a541e-7f0a-ea30-4f03-b02acb86ecd2" name="Deathstorm Drop Pod" book="HH:LACAL" page="49" hidden="false" profileTypeId="56656869636c6523232344415441232323">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="4"/>
-            <characteristic name="Front" characteristicTypeId="46726f6e7423232344415441232323" value="12"/>
-            <characteristic name="Side" characteristicTypeId="5369646523232344415441232323" value="12"/>
-            <characteristic name="Rear" characteristicTypeId="5265617223232344415441232323" value="12"/>
-            <characteristic name="HP" characteristicTypeId="485023232344415441232323" value="3"/>
-            <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Open-topped"/>
-          </characteristics>
-        </profile>
-        <profile id="6830aad2-2ad7-bbd1-f6b9-e1bc3934d31e" name="Deathstorm Frag Launcher" book="HH:LACAL" page="49" hidden="false" profileTypeId="576561706f6e23232344415441232323">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <repeats/>
-              <conditions>
-                <condition field="selections" scope="5b8da8d0-7c0f-1744-bd13-550239ea056c" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f80a33ab-58b8-2453-1d56-df8d4d9e4830" type="equalTo"/>
-              </conditions>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <characteristics>
-            <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="48&quot;"/>
-            <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="5"/>
-            <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="4"/>
-            <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 2, Blast, Pinning"/>
-          </characteristics>
-        </profile>
-      </profiles>
+      <profiles/>
       <rules/>
       <infoLinks>
         <infoLink id="90be-2ecb-2122-d985" name="Deep Strike" book="BRB" hidden="false" targetId="d219-2314-4834-c054" type="rule">
@@ -37284,25 +37241,31 @@ Token representing the Cyber-hawk plays no other role in the game and may not be
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="d903-cecb-8642-3ba7" name="New InfoLink" hidden="false" targetId="e6ad-38b8-14e7-1c48" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="26bf-53b7-de41-e6b2" name="" hidden="false" targetId="4cc0-7433-b76f-01f2" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="9f5d-376d-e921-ea64" name="" hidden="false" targetId="502e-1950-cef4-540b" type="rule">
+        <infoLink id="26bf-53b7-de41-e6b2" name="`x" hidden="false" targetId="4cc0-7433-b76f-01f2" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
         <infoLink id="cc35-1329-87e0-804a" name="" hidden="false" targetId="1e1f-97cd-3109-626d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="fd20-ceae-20e6-2bdc" name="New InfoLink" hidden="false" targetId="350c-4efd-4ea5-de8c" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="7cee-0006-02c4-5281" name="New InfoLink" hidden="false" targetId="e6ad-38b8-14e7-1c48" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="8a20-d51b-6df7-529d" name="New InfoLink" hidden="false" targetId="502e-1950-cef4-540b" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -37354,45 +37317,6 @@ Token representing the Cyber-hawk plays no other role in the game and may not be
           <selectionEntryGroups/>
           <entryLinks/>
         </selectionEntryGroup>
-        <selectionEntryGroup id="a31455a6-bea0-a569-e1aa-e231b36e3cd0" name="Replace all five Deathstorm Frag Launchers with:" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <selectionEntries>
-            <selectionEntry id="f80a33ab-58b8-2453-1d56-df8d4d9e4830" name="Five Deathstorm Krak Launchers" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles>
-                <profile id="27b1733a-a2b1-a797-06fe-6815eb2563e3" name="Deathstorm Krak Launchers" book="LA:AODAL" page="61" hidden="false" profileTypeId="576561706f6e23232344415441232323">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <characteristics>
-                    <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="48&quot;"/>
-                    <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="8"/>
-                    <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="3"/>
-                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 3"/>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="30.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups/>
-          <entryLinks/>
-        </selectionEntryGroup>
         <selectionEntryGroup id="1405dd5b-ba9b-fabb-01a6-2722975ca3f3" name="Legion-specific upgrade" hidden="false" collective="false">
           <profiles/>
           <rules/>
@@ -37418,6 +37342,76 @@ Token representing the Cyber-hawk plays no other role in the game and may not be
               <constraints/>
             </entryLink>
           </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="597f-7bdb-886d-358f" name="May be equiped with:" hidden="false" collective="false" defaultSelectionEntryId="632f-9bc8-a78b-657c">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0033-853d-ca6d-b814" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fbee-a826-3236-90ed" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="79c7-256a-aa1a-56b8" name="Five Deathstorm Krak Launchers" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles>
+                <profile id="4b91-ee97-e5ef-a870" name="Deathstorm Krak Launchers" book="LA:AODAL" page="61" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="48&quot;"/>
+                    <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="8"/>
+                    <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="3"/>
+                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 3"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c68e-9733-2bf7-485c" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="30.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="632f-9bc8-a78b-657c" name="Five Deathstorm Frag Launchers" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles>
+                <profile id="aff6-8f1d-a207-0c96" name="Deathstorm Frag Launcher" book="HH:LACAL" page="49" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="48&quot;"/>
+                    <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="5"/>
+                    <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="4"/>
+                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 2, Blast, Pinning"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="198b-8ca3-368e-7e8f" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="30.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
@@ -37451,18 +37445,6 @@ Token representing the Cyber-hawk plays no other role in the game and may not be
             <characteristic name="A" characteristicTypeId="4123232344415441232323" value="1"/>
             <characteristic name="HP" characteristicTypeId="485023232344415441232323" value="3"/>
             <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Vehicle (Walker)"/>
-          </characteristics>
-        </profile>
-        <profile id="21d5-748b-d7a7-3f52" name="Anvilus Pattern Autocannon Battery" book="HH5: Tempest" page="214" hidden="false" profileTypeId="576561706f6e23232344415441232323">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="48&quot;"/>
-            <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="8"/>
-            <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="4"/>
-            <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 4, Sunder"/>
           </characteristics>
         </profile>
       </profiles>
@@ -42916,7 +42898,7 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
           <rules/>
           <infoLinks/>
           <modifiers>
-            <modifier type="set" field="name" value="Two Sponson-mounted Twin-Linked Lascannons">
+            <modifier type="append" field="name" value="Sponsons">
               <repeats/>
               <conditions/>
               <conditionGroups/>
@@ -42990,58 +42972,6 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
       </constraints>
       <selectionEntries/>
       <selectionEntryGroups>
-        <selectionEntryGroup id="042077ba-42af-1108-91b1-300fd75e9291" name="May take one hull-mounted weapon" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="dbdc-409e-60f6-a9bd" name="New EntryLink" hidden="false" targetId="8b1d-77d3-74f2-9d1c" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="set" field="points" value="30">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints/>
-            </entryLink>
-            <entryLink id="bf76-2b36-ce1b-b590" name="New EntryLink" hidden="false" targetId="2bc5-53e9-b8fd-0b6b" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="set" field="points" value="20">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints/>
-            </entryLink>
-            <entryLink id="ab85-e275-13a2-e890" name="New EntryLink" hidden="false" targetId="aa78-540d-996f-52ff" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="set" field="points" value="20">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
         <selectionEntryGroup id="e1c6725a-509d-0659-196e-c7e07df00996" name="Legion-specific upgrade" hidden="false" collective="false">
           <profiles/>
           <rules/>
@@ -43074,7 +43004,7 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="2e2e-5221-2495-a709" name="May take any of the following:" hidden="false" collective="false">
+        <selectionEntryGroup id="f879-9ee3-39f5-c2e7" name="May take any of the following:" hidden="false" collective="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -43083,42 +43013,42 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="f6b7-c329-d652-9591" name="New EntryLink" hidden="false" targetId="a6cd-f04b-711e-c083" type="selectionEntry">
+            <entryLink id="0b3e-011e-edf5-015d" name="New EntryLink" hidden="false" targetId="a6cd-f04b-711e-c083" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
               <constraints/>
             </entryLink>
-            <entryLink id="a621-edd7-4007-2e92" name="New EntryLink" hidden="false" targetId="a0a4-4e61-7118-fcff" type="selectionEntry">
+            <entryLink id="5a51-78f5-d6b3-61ac" name="New EntryLink" hidden="false" targetId="a0a4-4e61-7118-fcff" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
               <constraints/>
             </entryLink>
-            <entryLink id="a208-a868-92ec-0d98" name="New EntryLink" hidden="false" targetId="915f-bdbc-c3cb-9b0b" type="selectionEntry">
+            <entryLink id="a3e5-1399-ea3b-0dfa" name="New EntryLink" hidden="false" targetId="915f-bdbc-c3cb-9b0b" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
               <constraints/>
             </entryLink>
-            <entryLink id="25c2-ac0b-01c3-e431" name="New EntryLink" hidden="false" targetId="f888-a294-fcff-8391" type="selectionEntry">
+            <entryLink id="277d-69e6-5276-7d57" name="New EntryLink" hidden="false" targetId="f888-a294-fcff-8391" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
               <constraints/>
             </entryLink>
-            <entryLink id="f30b-7b35-7352-4967" name="New EntryLink" hidden="false" targetId="00d9-65e8-94b2-2396" type="selectionEntry">
+            <entryLink id="25bd-b406-ce63-c3f7" name="New EntryLink" hidden="false" targetId="00d9-65e8-94b2-2396" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
               <constraints/>
             </entryLink>
-            <entryLink id="a608-5f42-02d2-d4ec" name="New EntryLink" hidden="false" targetId="eca0-004a-24f2-e2e9" type="selectionEntry">
+            <entryLink id="c9a6-b8f2-9a76-8fca" name="New EntryLink" hidden="false" targetId="eca0-004a-24f2-e2e9" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -43127,39 +43057,84 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="ee50-f2d9-dc30-e9fd" name="New EntryLink" hidden="false" targetId="2d56d45d-d276-7830-2b7d-026de64bbae8" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="set" field="points" value="25">
-              <repeats/>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="set" field="name" value="Twin-linked Iliastus Pattern Assault Cannon">
-              <repeats/>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints/>
-        </entryLink>
-        <entryLink id="2608-03d2-0f6c-c147" name="New EntryLink" hidden="false" targetId="fe17-5ed2-ca63-9379" type="selectionEntryGroup">
+        <selectionEntryGroup id="cc21-14d0-5b8d-695b" name="May take a Hull-mounted:" hidden="false" collective="false">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <constraints/>
-        </entryLink>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="afe8-371e-2127-b88f" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="f476-442f-c748-db65" name="New EntryLink" hidden="false" targetId="2d56d45d-d276-7830-2b7d-026de64bbae8" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="25">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="set" field="name" value="Twin-linked Iliastus Pattern Assault Cannon">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="99ef-efdd-bfa1-d039" name="New EntryLink" hidden="false" targetId="aa78-540d-996f-52ff" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="20">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="70f4-c23a-0ee3-3d38" name="New EntryLink" hidden="false" targetId="2bc5-53e9-b8fd-0b6b" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="20">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="71b4-49f0-3fd8-6d76" name="New EntryLink" hidden="false" targetId="8b1d-77d3-74f2-9d1c" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="30">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
         <entryLink id="bbd8-bc3f-11a2-e1c2" name="New EntryLink" hidden="false" targetId="8b1d-77d3-74f2-9d1c" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers>
-            <modifier type="set" field="name" value="Two Sponson-mounted Twin-Linked Lascannons">
+            <modifier type="append" field="name" value="Sponsons">
               <repeats/>
               <conditions/>
               <conditionGroups/>
@@ -43178,6 +43153,13 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
           <constraints/>
         </entryLink>
         <entryLink id="27ce-12c3-02c6-6fe6" name="New EntryLink" hidden="false" targetId="b572273e-2b93-4961-75c8-d9022c31a47d" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="eb5b-f0f2-1c70-e060" name="New EntryLink" hidden="false" targetId="fe17-5ed2-ca63-9379" type="selectionEntryGroup">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -43868,20 +43850,6 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
     </selectionEntry>
     <selectionEntry id="df4ceff0-6bd4-1cb9-b101-bef9ec61394e" name="Legion Dreadnought Drop Pod" book="HH:LACAL" page="37" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles>
-        <profile id="0810f533-8d5e-5437-b49d-33d047e24bd1" name="Legion Dreadnought Drop Pod" book="HH:LACAL" page="37" hidden="false" profileTypeId="56656869636c6523232344415441232323">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="4"/>
-            <characteristic name="Front" characteristicTypeId="46726f6e7423232344415441232323" value="12"/>
-            <characteristic name="Side" characteristicTypeId="5369646523232344415441232323" value="12"/>
-            <characteristic name="Rear" characteristicTypeId="5265617223232344415441232323" value="12"/>
-            <characteristic name="HP" characteristicTypeId="485023232344415441232323" value="3"/>
-            <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Open-topped, Transport (Special)"/>
-          </characteristics>
-        </profile>
         <profile id="a6c0-bfd0-122a-ad47" name="Legion Dreadnought Drop Pod (Transport)" book="AD:AoDAL" page="47" hidden="false" profileTypeId="307d-047f-ca13-706b" profileTypeName="Transport">
           <profiles/>
           <rules/>
@@ -43927,6 +43895,18 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
           <rules/>
           <infoLinks/>
           <modifiers/>
+        </infoLink>
+        <infoLink id="6da1-a1dd-471f-9e49" name="New InfoLink" hidden="false" targetId="350c-4efd-4ea5-de8c" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="append" field="5479706523232344415441232323" value=", Transport (special)">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
         </infoLink>
       </infoLinks>
       <modifiers>
@@ -44694,20 +44674,6 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
             <characteristic name="Access Points" characteristicTypeId="d17b-0342-b1dc-b8e7" value="-"/>
           </characteristics>
         </profile>
-        <profile id="f7ba-e2e9-f9ef-e7e0" name="Legion Drop Pod" book="AD:AoDAL" page="46" hidden="false" profileTypeId="56656869636c6523232344415441232323">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="4"/>
-            <characteristic name="Front" characteristicTypeId="46726f6e7423232344415441232323" value="12"/>
-            <characteristic name="Side" characteristicTypeId="5369646523232344415441232323" value="12"/>
-            <characteristic name="Rear" characteristicTypeId="5265617223232344415441232323" value="12"/>
-            <characteristic name="HP" characteristicTypeId="485023232344415441232323" value="3"/>
-            <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Open-topped, Transport"/>
-          </characteristics>
-        </profile>
       </profiles>
       <rules/>
       <infoLinks>
@@ -44717,17 +44683,29 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="0a37-16c2-3cd1-ad33" name="New InfoLink" hidden="false" targetId="e6ad-38b8-14e7-1c48" type="rule">
+        <infoLink id="f9f5-f996-6ed8-d550" name="New InfoLink" hidden="false" targetId="e6ad-38b8-14e7-1c48" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="6a02-b796-8345-18f6" name="New InfoLink" hidden="false" targetId="502e-1950-cef4-540b" type="rule">
+        <infoLink id="338e-5061-a5ff-e24b" name="New InfoLink" hidden="false" targetId="502e-1950-cef4-540b" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
+        </infoLink>
+        <infoLink id="cc25-9796-ef7f-8d86" name="New InfoLink" hidden="false" targetId="350c-4efd-4ea5-de8c" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="append" field="5479706523232344415441232323" value=", Transport">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
         </infoLink>
       </infoLinks>
       <modifiers>
@@ -47997,50 +47975,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
       </infoLinks>
       <modifiers/>
       <constraints/>
-      <selectionEntries>
-        <selectionEntry id="8ead-c2aa-eaa2-5fee" name="Accelerator Autocannon" hidden="false" collective="false" type="upgrade">
-          <profiles>
-            <profile id="9e6a-f4ba-7c9c-b092" name="Accelerator Autocannon" book="HH:LACAL" page="61" hidden="false" profileTypeId="576561706f6e23232344415441232323">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="48&quot;"/>
-                <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="7"/>
-                <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="4"/>
-                <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 6, Rending, Rapid Tracking"/>
-              </characteristics>
-            </profile>
-          </profiles>
-          <rules/>
-          <infoLinks>
-            <infoLink id="9c82-c766-dbb7-fbfc" name="New InfoLink" hidden="false" targetId="3bc1-64f3-ed64-6959" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="3981-4915-3790-e576" name="New InfoLink" hidden="false" targetId="8269-2cd6-9236-16e7" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8e1a-901a-789d-c79d" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7106-49b6-6e50-60c8" type="min"/>
-          </constraints>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
+      <selectionEntries/>
       <selectionEntryGroups>
         <selectionEntryGroup id="98cd-b28c-1b4e-4f93" name="Legion-specific upgrade" hidden="false" collective="false">
           <profiles/>
@@ -48112,7 +48047,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
           <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1a0c-a92d-00c0-d445" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2d8a-2602-9a5b-4c18" type="max"/>
           </constraints>
           <selectionEntries/>
           <selectionEntryGroups/>
@@ -48191,6 +48126,89 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
+        <selectionEntryGroup id="eb08-8a51-e4c4-67d6" name="Turret Weapon" hidden="false" collective="false" defaultSelectionEntryId="1961-c32d-e8f6-1641">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="31ea-e64d-2971-773d" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="78ca-74a0-0495-6b06" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="1961-c32d-e8f6-1641" name="Accelerator Autocannon" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="ee3a-b6cc-8ab6-1bdf" name="Accelerator Autocannon" book="HH:LACAL" page="61" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="48&quot;"/>
+                    <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="7"/>
+                    <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="4"/>
+                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 6, Rending, Rapid Tracking"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks>
+                <infoLink id="448b-5999-14e1-13e0" name="New InfoLink" hidden="false" targetId="3bc1-64f3-ed64-6959" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="6587-a4f6-a44e-02fd" name="New InfoLink" hidden="false" targetId="8269-2cd6-9236-16e7" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b375-e130-d254-ea65" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6b2c-e6cb-aac4-ca2e" type="min"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="ad12-0353-2206-819d" name="Pintle-mount" hidden="false" collective="false" defaultSelectionEntryId="4f84-e8fc-52f5-9a4d">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="4f84-e8fc-52f5-9a4d" name="Hull Mounted Heavy Bolter" hidden="false" targetId="a161-76b3-9ef1-da7b" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="name" value="Pintle-mounted Heavy Bolter">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c0ef-4d1a-6a9b-4cf1" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="cec6-33bf-6fae-91fb" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
         <entryLink id="6704-363c-d7fa-d671" hidden="false" targetId="c487-be13-ea53-917e" type="selectionEntryGroup">
@@ -48206,22 +48224,6 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
           <infoLinks/>
           <modifiers/>
           <constraints/>
-        </entryLink>
-        <entryLink id="e061-9df8-26de-4aae" name="Hull Mounted Heavy Bolter" hidden="false" targetId="a161-76b3-9ef1-da7b" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="set" field="name" value="Pintle-mounted Heavy Bolter">
-              <repeats/>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4947-e333-d0d0-1cfe" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ef8b-56b0-c126-dfb6" type="min"/>
-          </constraints>
         </entryLink>
       </entryLinks>
       <costs>
@@ -48316,7 +48318,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="Two Sponson Mounted" name="Two Sponson Mounted" hidden="false" collective="false" defaultSelectionEntryId="3982-8fc5-a225-c789">
+        <selectionEntryGroup id="Two Sponson Mounted" name="Sponson Mounts:" hidden="false" collective="false" defaultSelectionEntryId="3982-8fc5-a225-c789">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -48332,7 +48334,13 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
               <profiles/>
               <rules/>
               <infoLinks/>
-              <modifiers/>
+              <modifiers>
+                <modifier type="append" field="name" value="Sponsons">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
               <constraints/>
             </entryLink>
             <entryLink id="65a5-abee-644a-27e8" name="New EntryLink" page="" hidden="false" targetId="5708-9bd4-2edc-ddc9" type="selectionEntry">
@@ -48340,7 +48348,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
               <rules/>
               <infoLinks/>
               <modifiers>
-                <modifier type="set" field="name" value="Laser Destroyers">
+                <modifier type="append" field="name" value="Sponsons">
                   <repeats/>
                   <conditions/>
                   <conditionGroups/>
@@ -63813,7 +63821,7 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
               <modifiers/>
               <constraints/>
             </entryLink>
-            <entryLink id="65bb-7073-1bf3-e3b3" hidden="false" targetId="f785888f-6dfa-08f4-054f-29b1a0e4f20c" type="selectionEntry">
+            <entryLink id="65bb-7073-1bf3-e3b3" name="" hidden="false" targetId="f785888f-6dfa-08f4-054f-29b1a0e4f20c" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -63868,7 +63876,7 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
           <rules/>
           <infoLinks/>
           <modifiers>
-            <modifier type="set" field="name" value="Two Sponson-mounted Twin-Linked Multi-Meltas">
+            <modifier type="append" field="name" value="Sponsons">
               <repeats/>
               <conditions/>
               <conditionGroups/>
@@ -63943,7 +63951,9 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
         </infoLink>
       </infoLinks>
       <modifiers/>
-      <constraints/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9448-672e-e828-b4b8" type="max"/>
+      </constraints>
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks/>
@@ -63974,7 +63984,9 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
         </infoLink>
       </infoLinks>
       <modifiers/>
-      <constraints/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="731a-c5cb-6c97-9592" type="max"/>
+      </constraints>
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks/>
@@ -64029,18 +64041,13 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
               <conditions/>
               <conditionGroups/>
             </modifier>
-            <modifier type="increment" field="537472656e67746823232344415441232323" value="1">
-              <repeats/>
-              <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a91f-3b51-950d-ba8a" type="equalTo"/>
-              </conditions>
-              <conditionGroups/>
-            </modifier>
           </modifiers>
         </infoLink>
       </infoLinks>
       <modifiers/>
-      <constraints/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c8ad-ce96-e370-e273" type="max"/>
+      </constraints>
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks/>
@@ -64071,7 +64078,9 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
         </infoLink>
       </infoLinks>
       <modifiers/>
-      <constraints/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0efc-77c6-70db-e53a" type="max"/>
+      </constraints>
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks/>
@@ -64131,7 +64140,128 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
       </infoLinks>
       <modifiers/>
       <constraints/>
-      <selectionEntries/>
+      <selectionEntries>
+        <selectionEntry id="5f07-f16e-ad7e-c662" name="Two Turrent-mounted:" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d61a-aa55-5289-0c75" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="79a6-9d3d-cf88-0383" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="8717-c79a-f485-0ed3" name="May be equiped with:" page="" hidden="false" collective="false" defaultSelectionEntryId="ee6d-ad18-e163-8033">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e29d-c96f-e4bc-b221" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="449f-7b89-b05b-ac2d" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="ee6d-ad18-e163-8033" name="New EntryLink" hidden="false" targetId="b57f-e87a-69e2-0523" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="55c3-f5b8-6777-2961" name="New EntryLink" hidden="false" targetId="f1c2-20dc-2e53-ea8a" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="ac18-593f-e4fa-5f66" name="Four wing-mounted:" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bba3-e034-3394-ca5d" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f6d-f47e-4e5f-bf5a" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="1540-45a5-f61b-528f" name="Wing-mounted:" hidden="false" collective="false" defaultSelectionEntryId="ce25-8172-741d-1755">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a9ca-99ba-97e5-a2a7" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c0c5-aa79-de77-173e" type="min"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="ce25-8172-741d-1755" name="New EntryLink" hidden="false" targetId="688b-8c27-2579-ffdd" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="2ba2-4eec-7ee7-9dd8" name="New EntryLink" hidden="false" targetId="7a6c-699b-f816-764d" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="set" field="points" value="20">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="8071-bb82-e3ff-6ec7" name="Hull-mounted:" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1603-191b-c69c-c05c" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="108a-d30b-92a8-1351" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="0cec-fe7d-ac00-0a57" name="Twin Linked Avenger Bolt Cannon" hidden="false" targetId="9f7b-ce08-7726-63af" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="f260-10a3-c79f-abfc" name="May take any of the following:" hidden="false" collective="false">
           <profiles/>
@@ -64159,75 +64289,7 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
-              </modifiers>
-              <constraints/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="c0ba-0d78-6db3-cd6c" name="Two Turret Mounted:" hidden="false" collective="false" defaultSelectionEntryId="ce55-b5dc-c18b-fc38">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2322-b246-cd4c-6cd7" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3dda-3e36-eef9-28a9" type="max"/>
-          </constraints>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="ce55-b5dc-c18b-fc38" name="New EntryLink" hidden="false" targetId="b57f-e87a-69e2-0523" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </entryLink>
-            <entryLink id="1562-bd8b-8986-7dcb" name="New EntryLink" hidden="false" targetId="f1c2-20dc-2e53-ea8a" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="5f4c-ac10-74dc-cccd" name="Wing-mounted:" hidden="false" collective="false" defaultSelectionEntryId="d0ed-8860-b67a-6df2">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a2ac-61d4-9e88-f98d" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ab84-d97a-527a-9f6c" type="max"/>
-          </constraints>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="d0ed-8860-b67a-6df2" name="New EntryLink" hidden="false" targetId="688b-8c27-2579-ffdd" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="set" field="name" value="Four Tempest Rockets">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints/>
-            </entryLink>
-            <entryLink id="dcc6-9ca5-5822-2fcc" name="New EntryLink" hidden="false" targetId="7a6c-699b-f816-764d" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="set" field="name" value="Four Hellstrike Missiles">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="set" field="points" value="20">
+                <modifier type="set" field="minSelections" value="0">
                   <repeats/>
                   <conditions/>
                   <conditionGroups/>
@@ -64247,27 +64309,6 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
           <selectionEntryGroups/>
           <entryLinks>
             <entryLink id="97ba-b2b4-1266-fd14" hidden="false" targetId="a15bdf56-4ffe-fe04-ff77-3d533ab99dfa" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="bf2c-bb95-7b18-9431" name="Hull Mounted:" hidden="false" collective="false" defaultSelectionEntryId="a59c-512d-d8c8-9171">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ddb-1423-1551-95a9" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="60ff-fecc-e287-32f5" type="max"/>
-          </constraints>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="a59c-512d-d8c8-9171" name="Twin Linked Avenger Bolt Cannon" hidden="false" targetId="9f7b-ce08-7726-63af" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -64397,7 +64438,9 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
         </infoLink>
       </infoLinks>
       <modifiers/>
-      <constraints/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9b15-f302-8e48-7b67" type="max"/>
+      </constraints>
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks/>
@@ -64423,7 +64466,9 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
         </infoLink>
       </infoLinks>
       <modifiers/>
-      <constraints/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ea7-f5e3-3e21-d4dd" type="max"/>
+      </constraints>
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks/>
@@ -64476,6 +64521,7 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
       <modifiers/>
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8140-e3b2-d9fb-3b96" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="be20-42c4-0713-28ee" type="min"/>
       </constraints>
       <selectionEntries/>
       <selectionEntryGroups/>
@@ -64520,18 +64566,6 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
                     <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Vehicle (Tank)"/>
                   </characteristics>
                 </profile>
-                <profile id="cb0e-78a5-d63d-cc4c" name="Earthshaker Cannon" book="HH:LACAL" page="92" hidden="false" profileTypeId="576561706f6e23232344415441232323">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <characteristics>
-                    <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="36&quot; -  240&quot;"/>
-                    <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="9"/>
-                    <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="3"/>
-                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Ordnance 1, Barrage, Large Blast"/>
-                  </characteristics>
-                </profile>
               </profiles>
               <rules/>
               <infoLinks/>
@@ -64539,7 +64573,37 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
               <constraints>
                 <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5923-a24f-f6c2-7786" type="max"/>
               </constraints>
-              <selectionEntries/>
+              <selectionEntries>
+                <selectionEntry id="3b84-59b0-d33d-c84f" name="Earthshaker Cannon" hidden="false" collective="false" type="upgrade">
+                  <profiles>
+                    <profile id="0234-4ed1-f916-7b87" name="Earthshaker Cannon" book="HH:LACAL" page="92" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <characteristics>
+                        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="36&quot; -  240&quot;"/>
+                        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="9"/>
+                        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="3"/>
+                        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Ordnance 1, Barrage, Large Blast"/>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="be94-ac89-ceb4-a023" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="34fe-1c9f-d784-827d" type="min"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
               <selectionEntryGroups>
                 <selectionEntryGroup id="95c0-4993-9123-57d0" name="Legion-specific upgrade" hidden="false" collective="false">
                   <profiles/>
@@ -64687,18 +64751,6 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
                     <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Vehicle (Tank)"/>
                   </characteristics>
                 </profile>
-                <profile id="bd2f-2698-8b1f-e0bb" name="Medusa Siege Gun" book="HH:LACAL" page="92" hidden="false" profileTypeId="576561706f6e23232344415441232323">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <characteristics>
-                    <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="36&quot;"/>
-                    <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="10"/>
-                    <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="2"/>
-                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Ordnance 1, Barrage, Large Blast"/>
-                  </characteristics>
-                </profile>
               </profiles>
               <rules/>
               <infoLinks/>
@@ -64706,7 +64758,37 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
               <constraints>
                 <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="94fb-3635-371b-7cea" type="max"/>
               </constraints>
-              <selectionEntries/>
+              <selectionEntries>
+                <selectionEntry id="2f83-fae5-c788-2333" name="Medusa Siege Gun" hidden="false" collective="false" type="upgrade">
+                  <profiles>
+                    <profile id="bb13-ebc2-033b-5f7a" name="Medusa Siege Gun" book="HH:LACAL" page="92" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <characteristics>
+                        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="36&quot;"/>
+                        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="10"/>
+                        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="2"/>
+                        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Ordnance 1, Barrage, Large Blast"/>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2e31-9efe-d7c5-4065" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="45d5-5aa3-955f-d50f" type="min"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
               <selectionEntryGroups>
                 <selectionEntryGroup id="3c84-0d2f-0084-01a8" name="Legion-specific upgrade" hidden="false" collective="false">
                   <profiles/>
@@ -64892,7 +64974,7 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
               </constraints>
               <selectionEntries/>
               <selectionEntryGroups>
-                <selectionEntryGroup id="a4ed-55f7-78c9-2ef4" name="Whirlwind Launcher Equiped with" hidden="false" collective="false" defaultSelectionEntryId="910e-cea0-521f-5b79">
+                <selectionEntryGroup id="a4ed-55f7-78c9-2ef4" name="Whirlwind Launcher Equiped with" hidden="false" collective="false" defaultSelectionEntryId="6af3-3e15-2c33-d9cc">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -64902,70 +64984,117 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="91ac-ffe8-9cd2-b3c6" type="max"/>
                   </constraints>
                   <selectionEntries>
-                    <selectionEntry id="910e-cea0-521f-5b79" name="Castellan and Vengeance Warheads" hidden="false" collective="false" type="upgrade">
-                      <profiles>
-                        <profile id="f533-5a47-47a6-4e8b" name="Castellan Warhead" book="LA:AoDAL" page="125" hidden="false" profileTypeId="576561706f6e23232344415441232323">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                          <characteristics>
-                            <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="12&quot; - 48&quot;"/>
-                            <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="4"/>
-                            <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="5"/>
-                            <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Ordnance 1, Barrage, Large Blast, Ignores Cover"/>
-                          </characteristics>
-                        </profile>
-                        <profile id="eee8-e6aa-bfcd-7de2" name="Vengeance Warhead" book="LA:AoDAL" page="125" hidden="false" profileTypeId="576561706f6e23232344415441232323">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                          <characteristics>
-                            <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="12&quot; - 48&quot;"/>
-                            <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="5"/>
-                            <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="4"/>
-                            <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Ordnance 1, Barrage, Large Blast"/>
-                          </characteristics>
-                        </profile>
-                      </profiles>
+                    <selectionEntry id="6af3-3e15-2c33-d9cc" name="Castellan and Vengeance Warheads" hidden="false" collective="false" type="upgrade">
+                      <profiles/>
                       <rules/>
-                      <infoLinks>
-                        <infoLink id="4557-4f72-59f7-5ace" name="New InfoLink" hidden="false" targetId="acf2-681d-4188-94d7" type="rule">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
+                      <infoLinks/>
                       <modifiers/>
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c775-8ae0-99ab-b495" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="453c-bcf3-5a27-f785" type="max"/>
                       </constraints>
-                      <selectionEntries/>
+                      <selectionEntries>
+                        <selectionEntry id="5690-f132-18dd-723f" name="Castellan Warhead" hidden="false" collective="false" type="upgrade">
+                          <profiles>
+                            <profile id="189c-55bd-194c-5bd9" name="Castellan Warhead" book="LA:AoDAL" page="125" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+                              <profiles/>
+                              <rules/>
+                              <infoLinks/>
+                              <modifiers/>
+                              <characteristics>
+                                <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="12&quot; - 48&quot;"/>
+                                <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="4"/>
+                                <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="5"/>
+                                <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Ordnance 1, Barrage, Large Blast, Ignores Cover"/>
+                              </characteristics>
+                            </profile>
+                          </profiles>
+                          <rules/>
+                          <infoLinks>
+                            <infoLink id="4b61-3c0e-92c8-c06a" name="New InfoLink" hidden="false" targetId="acf2-681d-4188-94d7" type="rule">
+                              <profiles/>
+                              <rules/>
+                              <infoLinks/>
+                              <modifiers/>
+                            </infoLink>
+                          </infoLinks>
+                          <modifiers/>
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="cbdd-96b4-526a-3c5a" type="max"/>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0270-bbed-6dfd-8a47" type="min"/>
+                          </constraints>
+                          <selectionEntries/>
+                          <selectionEntryGroups/>
+                          <entryLinks/>
+                          <costs>
+                            <cost name="pts" costTypeId="points" value="0.0"/>
+                          </costs>
+                        </selectionEntry>
+                        <selectionEntry id="0393-d0ac-23d1-0107" name="Vengeance Warhead" hidden="false" collective="false" type="upgrade">
+                          <profiles>
+                            <profile id="408a-7380-3d2d-a6e5" name="Vengeance Warhead" book="LA:AoDAL" page="125" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+                              <profiles/>
+                              <rules/>
+                              <infoLinks/>
+                              <modifiers/>
+                              <characteristics>
+                                <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="12&quot; - 48&quot;"/>
+                                <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="5"/>
+                                <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="4"/>
+                                <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Ordnance 1, Barrage, Large Blast"/>
+                              </characteristics>
+                            </profile>
+                          </profiles>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ee10-ff08-7e4b-dc3b" type="max"/>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e0f1-edc6-19d7-cedb" type="min"/>
+                          </constraints>
+                          <selectionEntries/>
+                          <selectionEntryGroups/>
+                          <entryLinks/>
+                          <costs>
+                            <cost name="pts" costTypeId="points" value="0.0"/>
+                          </costs>
+                        </selectionEntry>
+                      </selectionEntries>
                       <selectionEntryGroups/>
                       <entryLinks/>
                       <costs>
                         <cost name="pts" costTypeId="points" value="0.0"/>
                       </costs>
                     </selectionEntry>
-                  </selectionEntries>
-                  <selectionEntryGroups/>
-                  <entryLinks>
-                    <entryLink id="ef1d-2315-c55c-d230" name="New EntryLink" hidden="false" targetId="8917-121a-d28f-4f03" type="selectionEntry">
+                    <selectionEntry id="2cae-8c96-41c5-dace" name="Hyperios air-defence" hidden="false" collective="false" type="upgrade">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
-                      <modifiers>
-                        <modifier type="append" field="name" value="Missiles">
-                          <repeats/>
-                          <conditions/>
-                          <conditionGroups/>
-                        </modifier>
-                      </modifiers>
+                      <modifiers/>
                       <constraints/>
-                    </entryLink>
-                  </entryLinks>
+                      <selectionEntries/>
+                      <selectionEntryGroups/>
+                      <entryLinks>
+                        <entryLink id="ccee-7f3d-142c-f651" name="New EntryLink" hidden="false" targetId="8917-121a-d28f-4f03" type="selectionEntry">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers>
+                            <modifier type="append" field="name" value="Missiles">
+                              <repeats/>
+                              <conditions/>
+                              <conditionGroups/>
+                            </modifier>
+                          </modifiers>
+                          <constraints/>
+                        </entryLink>
+                      </entryLinks>
+                      <costs>
+                        <cost name="pts" costTypeId="points" value="0.0"/>
+                      </costs>
+                    </selectionEntry>
+                  </selectionEntries>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
                 </selectionEntryGroup>
                 <selectionEntryGroup id="923e-cff0-623f-c8b8" name="Legion-specific upgrade" hidden="false" collective="false">
                   <profiles/>
@@ -65138,6 +65267,7 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
       <modifiers/>
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b080-7a95-902f-aa2b" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3191-b839-d4e3-7e93" type="min"/>
       </constraints>
       <selectionEntries/>
       <selectionEntryGroups/>
@@ -65154,7 +65284,7 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
       <constraints/>
       <selectionEntries/>
       <selectionEntryGroups>
-        <selectionEntryGroup id="403d-cf01-86c8-a116" name="Squadron Vehicles" hidden="false" collective="false">
+        <selectionEntryGroup id="403d-cf01-86c8-a116" name="Squadron Vehicles" hidden="false" collective="false" defaultSelectionEntryId="a5ae-c55c-b6d2-305b">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -65234,17 +65364,19 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
       </profiles>
       <rules/>
       <infoLinks>
-        <infoLink id="0ee4-0c13-41d9-7979" name="New InfoLink" hidden="false" targetId="21f23fa8-cf11-b9c3-d613-1b711b0897d7" type="profile">
+        <infoLink id="6f17-2117-0a5d-053c" name="New InfoLink" hidden="false" targetId="885d-81f6-6ace-3228" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="6c97-26a8-0921-e79d" name="New InfoLink" hidden="false" targetId="885d-81f6-6ace-3228" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="ddd7-5e93-1110-5a68" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5661-2ffe-9a77-8725" type="lessThan"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
         </infoLink>
       </infoLinks>
       <modifiers/>
@@ -65383,6 +65515,38 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
               <constraints/>
             </entryLink>
           </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="19e5-8e6a-09ac-888c" name="Pintle-Mounted:" hidden="false" collective="false" defaultSelectionEntryId="23f7-431d-0d48-16a3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6e24-8406-0b17-59b4" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="de5e-d41e-441a-33e6" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="23f7-431d-0d48-16a3" name="Combi-Bolter" hidden="false" collective="false" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="ecaf-18b6-f59b-2d84" name="New InfoLink" hidden="false" targetId="8546-d0ac-17ab-252a" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs/>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
@@ -65555,7 +65719,59 @@ When conducting a Ram attack, use Strength 10, roll two dice and pick the higher
       </infoLinks>
       <modifiers/>
       <constraints/>
-      <selectionEntries/>
+      <selectionEntries>
+        <selectionEntry id="ad5d-942b-b454-9b7e" name="Two wing mounted" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e707-b1aa-3578-ec08" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="bdfe-25e6-7455-d4df" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="b28d-4653-253f-d9ec" name="May be equiped with:" hidden="false" collective="false" defaultSelectionEntryId="b858-7f99-ccd3-4422">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="04f7-c091-ceae-20a5" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c9f9-a315-98f8-4c40" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="b858-7f99-ccd3-4422" name="New EntryLink" hidden="false" targetId="d6bf-b694-8ca0-a6c5" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="set" field="points" value="0.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="d897-273b-1e93-6e54" name="New EntryLink" hidden="false" targetId="e5d2-e10d-1552-c5c6" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="3b1f-8501-7a28-342d" name="May be upgraded with any of the following:" hidden="false" collective="false">
           <profiles/>
@@ -65592,40 +65808,6 @@ When conducting a Ram attack, use Strength 10, roll two dice and pick the higher
           <selectionEntryGroups/>
           <entryLinks>
             <entryLink id="d23b-d378-6d4e-b0c8" hidden="false" targetId="a15bdf56-4ffe-fe04-ff77-3d533ab99dfa" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="5031-fabb-8e2b-30df" name="Two wing-mounted:" hidden="false" collective="false" defaultSelectionEntryId="2ce4-cc59-9164-81f2">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ac60-d1bd-1f94-06f1" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="cde2-e92e-2a12-4a02" type="max"/>
-          </constraints>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="2ce4-cc59-9164-81f2" name="New EntryLink" hidden="false" targetId="d6bf-b694-8ca0-a6c5" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="set" field="points" value="0.0">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints/>
-            </entryLink>
-            <entryLink id="d909-391e-eda3-f9de" name="New EntryLink" hidden="false" targetId="e5d2-e10d-1552-c5c6" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -65778,7 +65960,7 @@ When conducting a Ram attack, use Strength 10, roll two dice and pick the higher
                   <rules/>
                   <infoLinks/>
                   <modifiers/>
-                  <description>In a turn in which the vehicle has not moved, increase rate of fire to Heavy 1+D3.  </description>
+                  <description>In a turn in which the vehicle has not moved, the multi-launcher’s rate of fire is increased to Heavy 1+D3.</description>
                 </rule>
               </rules>
               <infoLinks/>
@@ -65920,7 +66102,9 @@ When conducting a Ram attack, use Strength 10, roll two dice and pick the higher
         </infoLink>
       </infoLinks>
       <modifiers/>
-      <constraints/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c33d-2299-3f5c-3613" type="max"/>
+      </constraints>
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks/>
@@ -65946,7 +66130,9 @@ When conducting a Ram attack, use Strength 10, roll two dice and pick the higher
         </infoLink>
       </infoLinks>
       <modifiers/>
-      <constraints/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2580-45d6-2bad-b656" type="max"/>
+      </constraints>
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks/>
@@ -65985,7 +66171,7 @@ When conducting a Ram attack, use Strength 10, roll two dice and pick the higher
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <description>If enemy inflicts a Penetrating hit against the Sicarian Cenator, they may re-roll a result of a 1 on the Vehicle Damage table.
+          <description>If enemy inflicts a Penetrating hit against the Sicarian Venator, they may re-roll a result of a 1 on the Vehicle Damage table.
 Explodes results add D3&quot; to radius.  </description>
         </rule>
       </rules>
@@ -66984,7 +67170,7 @@ Explodes results add D3&quot; to radius.  </description>
         <cost name="pts" costTypeId="points" value="270.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="9fef-d14e-0e9f-1cc8" name="Heavy Flamer, Legion" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="9fef-d14e-0e9f-1cc8" name="Heavy Flamer" hidden="false" collective="false" type="upgrade">
       <profiles/>
       <rules/>
       <infoLinks>
@@ -67003,13 +67189,7 @@ Explodes results add D3&quot; to radius.  </description>
           </modifiers>
         </infoLink>
       </infoLinks>
-      <modifiers>
-        <modifier type="set" field="name" value="Heavy Flamer">
-          <repeats/>
-          <conditions/>
-          <conditionGroups/>
-        </modifier>
-      </modifiers>
+      <modifiers/>
       <constraints/>
       <selectionEntries/>
       <selectionEntryGroups/>
@@ -67105,24 +67285,24 @@ Explodes results add D3&quot; to radius.  </description>
       <modifiers/>
       <constraints/>
       <selectionEntries>
-        <selectionEntry id="4d66-c6a7-f3c9-502e" name="Sponson Mounts" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="78ca-c2e0-eeff-8162" name="Sponson Mounts" hidden="false" collective="false" type="upgrade">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="94ec-4b33-ac95-e625" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aecc-ffba-3711-0270" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0e42-46a6-f6fe-5ceb" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b108-99ea-bcc4-56f8" type="max"/>
           </constraints>
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="d9de-1fef-d8cc-ce81" name="New EntryLink" hidden="false" targetId="d9c1-46b9-e742-8d83" type="selectionEntry">
+            <entryLink id="a363-5a8e-56fa-2db0" name="New EntryLink" hidden="false" targetId="d9c1-46b9-e742-8d83" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers>
-                <modifier type="set" field="name" value="Two Sponson-mount Twin-linked Volkite Culverin">
+                <modifier type="set" field="name" value="2x Twin-linked Volkite Culverin">
                   <repeats/>
                   <conditions/>
                   <conditionGroups/>
@@ -67131,7 +67311,9 @@ Explodes results add D3&quot; to radius.  </description>
               <constraints/>
             </entryLink>
           </entryLinks>
-          <costs/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -67530,7 +67712,10 @@ Explodes results add D3&quot; to radius.  </description>
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <constraints/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3727-805f-10af-b924" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2e23-18f0-d65f-7157" type="min"/>
+          </constraints>
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
@@ -67539,7 +67724,9 @@ Explodes results add D3&quot; to radius.  </description>
               <rules/>
               <infoLinks/>
               <modifiers/>
-              <constraints/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4441-024c-5166-d955" type="max"/>
+              </constraints>
             </entryLink>
             <entryLink id="be73-0e71-8277-9b9b" name="New EntryLink" hidden="false" targetId="0137-bfce-22c9-8f03" type="selectionEntry">
               <profiles/>
@@ -67565,7 +67752,9 @@ Explodes results add D3&quot; to radius.  </description>
                   <conditionGroups/>
                 </modifier>
               </modifiers>
-              <constraints/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5249-76e2-7568-a5aa" type="max"/>
+              </constraints>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
@@ -67711,7 +67900,7 @@ Explodes results add D3&quot; to radius.  </description>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="6889-040c-c017-e038" name="Squadron Vehicles:" hidden="false" collective="false">
+        <selectionEntryGroup id="6889-040c-c017-e038" name="Squadron Vehicles:" hidden="false" collective="false" defaultSelectionEntryId="8d7d-a289-10f6-9ac0">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -67750,7 +67939,9 @@ Explodes results add D3&quot; to radius.  </description>
         </infoLink>
       </infoLinks>
       <modifiers/>
-      <constraints/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="55c3-237d-0dfe-345d" type="max"/>
+      </constraints>
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks/>
@@ -68069,6 +68260,44 @@ Explodes results add D3&quot; to radius.  </description>
           </entryLinks>
           <costs>
             <cost name="pts" costTypeId="points" value="15.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="e7e1-f31e-dd70-f444" name="Standard Wargear" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="bc7f-dd68-2479-f0a3" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f2cb-17ff-0323-9f4b" type="min"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="0267-2ccf-862f-7cec" name="New EntryLink" hidden="false" targetId="fe8d-1baa-d58d-00bc" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="25cb-51a0-6f9b-c31b" name="New EntryLink" hidden="false" targetId="0a96-04b6-7340-91a4" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="796e-db84-ab51-751b" name="New EntryLink" hidden="false" targetId="0a53-b471-df87-7b83" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -72785,7 +73014,7 @@ Kharybdis: After it has landed treat as a flyer in Hover mode. LA:AODAL P75</des
         <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 2, Exoshock"/>
       </characteristics>
     </profile>
-    <profile id="a654-c4d7-5e67-0a65" name="Helica Targeting Array" book="LA:AoDAL" page="79" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323" profileTypeName="Wargear Item">
+    <profile id="a654-c4d7-5e67-0a65" name="Helical Targeting Array" book="LA:AoDAL" page="79" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323" profileTypeName="Wargear Item">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -72922,6 +73151,20 @@ Kharybdis: After it has landed treat as a flyer in Hover mode. LA:AODAL P75</des
         <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="3"/>
         <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="6"/>
         <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Pistol"/>
+      </characteristics>
+    </profile>
+    <profile id="350c-4efd-4ea5-de8c" name="Drop Pod" book="HH:LACAL" page="49" hidden="false" profileTypeId="56656869636c6523232344415441232323">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="4"/>
+        <characteristic name="Front" characteristicTypeId="46726f6e7423232344415441232323" value="12"/>
+        <characteristic name="Side" characteristicTypeId="5369646523232344415441232323" value="12"/>
+        <characteristic name="Rear" characteristicTypeId="5265617223232344415441232323" value="12"/>
+        <characteristic name="HP" characteristicTypeId="485023232344415441232323" value="3"/>
+        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Open-topped"/>
       </characteristics>
     </profile>
   </sharedProfiles>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -47154,7 +47154,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
         <cost name="pts" costTypeId="points" value="75.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="3215e60a-5c78-9efe-e6d4-ba87f3e74a21" name="Legion Rhino Armoured Carrier" book="HH:LACAL" page="45" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+    <selectionEntry id="3215e60a-5c78-9efe-e6d4-ba87f3e74a21" name="Legion Rhino Armoured Carrier" book="AD:AoDAL" page="45" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles>
         <profile id="ffe93085-806c-773f-f403-2c7d4e8edce2" name="Legion Rhino" book="HH:LACAL" page="35" hidden="false" profileTypeId="56656869636c6523232344415441232323">
           <profiles/>
@@ -47168,6 +47168,17 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
             <characteristic name="Rear" characteristicTypeId="5265617223232344415441232323" value="10"/>
             <characteristic name="HP" characteristicTypeId="485023232344415441232323" value="3"/>
             <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Tank, Transport"/>
+          </characteristics>
+        </profile>
+        <profile id="dbec-0d7a-553e-bf50" name="Legion Rhino (Transport)" hidden="false" profileTypeId="307d-047f-ca13-706b" profileTypeName="Transport">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Capacity" characteristicTypeId="8285-4205-b6cd-8473" value="10"/>
+            <characteristic name="Fire Points" characteristicTypeId="b270-a7f9-22b2-3702" value="Two - Top Hatch"/>
+            <characteristic name="Access Points" characteristicTypeId="d17b-0342-b1dc-b8e7" value="Three. One on each side of the Hull and one at the rear."/>
           </characteristics>
         </profile>
       </profiles>
@@ -47203,7 +47214,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
               <modifiers/>
               <constraints/>
             </entryLink>
-            <entryLink id="9a9c0518-32f2-e450-886e-67887458ebc2" hidden="false" targetId="86e70545-ed1a-7cf4-5a3d-d60662a6b3be" type="selectionEntry">
+            <entryLink id="9a9c0518-32f2-e450-886e-67887458ebc2" name="" hidden="false" targetId="86e70545-ed1a-7cf4-5a3d-d60662a6b3be" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -61444,7 +61444,7 @@ Phalanx Breacher squads and Legion Terminator squads may be taken as troops in a
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="1e27e511-cf75-d55a-6807-b67be6f7474f" name="Searchlight" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+    <selectionEntry id="1e27e511-cf75-d55a-6807-b67be6f7474f" name="Searchlight" page="0" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -61521,7 +61521,7 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="b572273e-2b93-4961-75c8-d9022c31a47d" name="Searchlight and Smoke Launchers" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+    <selectionEntry id="b572273e-2b93-4961-75c8-d9022c31a47d" name="Searchlight and Smoke Launchers" page="0" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
       <rules/>
       <infoLinks>
@@ -66523,26 +66523,6 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
     </selectionEntry>
     <selectionEntry id="eb64-e310-ac49-08e7" name="Legion Fire Raptor Gunship" book="HH:LACAL" page="54" hidden="false" collective="false" categoryEntryId="486561767920537570706f727423232344415441232323" type="unit">
       <profiles>
-        <profile id="1aa7-62f5-51ab-2614" name="Tempest Rockets" book="HH:LACAL" page="47" hidden="false" profileTypeId="576561706f6e23232344415441232323">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <repeats/>
-              <conditions>
-                <condition field="selections" scope="ancestor" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d19d-a7b0-1a56-1cf7" type="instanceOf"/>
-              </conditions>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <characteristics>
-            <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="60&quot;"/>
-            <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="6"/>
-            <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="4"/>
-            <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 1, Sunder, One-shot"/>
-          </characteristics>
-        </profile>
         <profile id="a2ab-6b7c-4917-2f04" name="Legion Fire Raptor Gunship" book="HH:LACAL" page="54" hidden="false" profileTypeId="56656869636c6523232344415441232323">
           <profiles/>
           <rules/>
@@ -66571,12 +66551,6 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
         </profile>
       </profiles>
       <rules>
-        <rule id="671b-0496-2f61-1f4c" name="Deep Strike" page="0" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </rule>
         <rule id="82fd-947c-096f-e4f8" name="Strafing Run" page="0" hidden="false">
           <profiles/>
           <rules/>
@@ -66591,7 +66565,26 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
           <description>Each waist turret may fire at a different target and do not count towards the number of weapons that may be fired in a turn.  </description>
         </rule>
       </rules>
-      <infoLinks/>
+      <infoLinks>
+        <infoLink id="88c6-cc7d-04b5-6c68" name="New InfoLink" hidden="false" targetId="d219-2314-4834-c054" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="ae3c-63c2-e1c6-8202" name="New InfoLink" hidden="false" targetId="79c7-90f6-b453-e799" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="873a-d709-f16a-2289" name="New InfoLink" hidden="false" targetId="1578-d22a-060c-4700" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
       <constraints/>
       <selectionEntries/>
@@ -66672,31 +66665,50 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="5f4c-ac10-74dc-cccd" name="Exchange four Tempest Rockets for:" hidden="false" collective="false">
+        <selectionEntryGroup id="5f4c-ac10-74dc-cccd" name="Wing-mounted:" hidden="false" collective="false" defaultSelectionEntryId="d0ed-8860-b67a-6df2">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <constraints/>
-          <selectionEntries>
-            <selectionEntry id="d19d-a7b0-1a56-1cf7" name="Four Hellstrike Missiles" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a2ac-61d4-9e88-f98d" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ab84-d97a-527a-9f6c" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="d0ed-8860-b67a-6df2" name="New EntryLink" hidden="false" targetId="688b-8c27-2579-ffdd" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f349-f36a-b7f1-6842" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="20.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups/>
-          <entryLinks/>
+              <modifiers>
+                <modifier type="set" field="name" value="Four Tempest Rockets">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="dcc6-9ca5-5822-2fcc" name="New EntryLink" hidden="false" targetId="7a6c-699b-f816-764d" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="name" value="Four Hellstrike Missiles">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="set" field="points" value="20">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="02d3-f6b0-b643-ce34" name="Legion-specific upgrade" hidden="false" collective="false">
           <profiles/>
@@ -66818,6 +66830,54 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
       <costs>
         <cost name="pts" costTypeId="points" value="10.0"/>
       </costs>
+    </selectionEntry>
+    <selectionEntry id="688b-8c27-2579-ffdd" name="Tempest Rockets" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="2c94-12ec-83a4-ff75" name="New InfoLink" hidden="false" targetId="808b-34b7-2ca8-29fd" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="6cff-cd93-2462-390a" name="New InfoLink" hidden="false" targetId="b67a5fd8-9dcd-1d03-ef50-8170a6b1e839" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs/>
+    </selectionEntry>
+    <selectionEntry id="7a6c-699b-f816-764d" name="Hellstrike Missiles" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="d0f9-4e05-a27b-51d0" name="New InfoLink" hidden="false" targetId="16f6-887b-504f-56da" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="15f2-f0a7-ce75-e31e" name="New InfoLink" hidden="false" targetId="b67a5fd8-9dcd-1d03-ef50-8170a6b1e839" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs/>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
@@ -71129,6 +71189,30 @@ Kharybdis: After it has landed treat as a flyer in Hover mode. LA:AODAL P75</des
       <modifiers/>
       <characteristics>
         <characteristic name="Description" characteristicTypeId="4465736372697074696f6e23232344415441232323" value="At the start of the controlling player&apos;s turn, prior to any reserve rolls, declare which mode is being used - it remains until their next player turn.  Disruption Mode: the oppsoing player suffers -1 to their reserve rolls.  Relay Mode: Owning player&apos;s reserve rolls may be re-rolled, whether successful or not.  Reduces transport capacity to 8.  "/>
+      </characteristics>
+    </profile>
+    <profile id="808b-34b7-2ca8-29fd" name="Tempest Rockets" book="HH:LACAL" page="47" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="60&quot;"/>
+        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="6"/>
+        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="4"/>
+        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 1, Sunder, One-shot"/>
+      </characteristics>
+    </profile>
+    <profile id="16f6-887b-504f-56da" name="Hellstrike Missiles" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="72&quot;"/>
+        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="8"/>
+        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="2"/>
+        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 1, Sunder, One-Shot"/>
       </characteristics>
     </profile>
   </sharedProfiles>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -13088,51 +13088,7 @@
           <infoLinks/>
           <modifiers/>
           <constraints/>
-          <selectionEntries>
-            <selectionEntry id="e4adbb74-550c-5d0d-6bf3-990e98762ce8" name="Phosphex Bombs" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="6bc2d62d-c95e-44ff-2fdb-0a73c7329bc0" hidden="false" targetId="a9557337-b134-0000-3cb9-6e735eec5e5f" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="867f9ef1-9d92-6d56-823a-51f9b62056f2" hidden="false" targetId="c05245e1-0c49-a3e4-30d9-f6006c256839" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="8ee1f255-4305-e5f0-2171-464f47ac46a4" hidden="false" targetId="395c911d-e7ca-b2cc-c4e9-1e5d807187f1" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers>
-                <modifier type="set" field="hidden" value="true">
-                  <repeats/>
-                  <conditions>
-                    <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="66cb4a66-d860-119c-edfc-1749a899f258" type="equalTo"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="10.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
+          <selectionEntries/>
           <selectionEntryGroups>
             <selectionEntryGroup id="3cf77338-ec09-1e4f-eef7-6b7221e2738f" name="Psychic Mastery" hidden="false" collective="false">
               <profiles/>
@@ -13142,7 +13098,7 @@
                 <modifier type="set" field="hidden" value="true">
                   <repeats/>
                   <conditions>
-                    <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4d3fa743-0cd6-aa86-999d-2d29d915bcfa" type="equalTo"/>
+                    <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4d3fa743-0cd6-aa86-999d-2d29d915bcfa" type="equalTo"/>
                   </conditions>
                   <conditionGroups/>
                 </modifier>
@@ -13200,6 +13156,21 @@
               <rules/>
               <infoLinks/>
               <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="510e-66b0-5e7a-ca6f" name="New EntryLink" hidden="false" targetId="1de1f2d9-0857-67bf-d191-297d0f9f60bc" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="66cb4a66-d860-119c-edfc-1749a899f258" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
               <constraints/>
             </entryLink>
           </entryLinks>
@@ -14679,40 +14650,6 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="8defbeeb-d965-6d6a-10aa-83374dacf9cc" name="Phosphex Bombs" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="ba05dceb-6fdf-95f0-9b01-0199d365af02" hidden="false" targetId="a9557337-b134-0000-3cb9-6e735eec5e5f" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="3524336a-1f44-27c4-4550-45aad22d3412" hidden="false" targetId="c05245e1-0c49-a3e4-30d9-f6006c256839" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="e8db9ca6-2182-6d6d-33a6-996f44306e90" hidden="false" targetId="395c911d-e7ca-b2cc-c4e9-1e5d807187f1" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="10.0"/>
-              </costs>
-            </selectionEntry>
             <selectionEntry id="7c5c8278-bc96-52eb-3bfe-93314834857a" name="Artificer Armour" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
               <profiles/>
               <rules/>
@@ -14881,6 +14818,13 @@
           </selectionEntryGroups>
           <entryLinks>
             <entryLink id="bf3d69a3-756f-4981-7a3f-d340ce9ebc65" hidden="false" targetId="8b059b74-0029-efeb-ecc0-98a21dded43a" type="selectionEntryGroup">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="3a84-7f98-f96a-cc2f" name="New EntryLink" hidden="false" targetId="1de1f2d9-0857-67bf-d191-297d0f9f60bc" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -56399,7 +56343,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
       </infoLinks>
       <modifiers/>
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+        <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
       </constraints>
       <selectionEntries/>
       <selectionEntryGroups/>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -24139,7 +24139,7 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
               <profiles/>
               <rules/>
               <infoLinks>
-                <infoLink id="29f310e8-f923-264a-9c5a-f20202539188" hidden="false" targetId="a7069849-cdd7-ffb1-8088-8300704afcae" type="profile">
+                <infoLink id="29f310e8-f923-264a-9c5a-f20202539188" name="" hidden="false" targetId="48f1-0c16-d5e5-6d98" type="profile">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -24444,7 +24444,7 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
               <profiles/>
               <rules/>
               <infoLinks>
-                <infoLink id="31069a8d-dbd7-e695-6b93-7515992e1bd8" hidden="false" targetId="a7069849-cdd7-ffb1-8088-8300704afcae" type="profile">
+                <infoLink id="31069a8d-dbd7-e695-6b93-7515992e1bd8" hidden="false" targetId="48f1-0c16-d5e5-6d98" type="profile">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -31398,7 +31398,7 @@ Ignores Cover special rule.</description>
                       <profiles/>
                       <rules/>
                       <infoLinks>
-                        <infoLink id="932a1616-a54a-0cdc-a81c-838c225d6402" hidden="false" targetId="a7069849-cdd7-ffb1-8088-8300704afcae" type="profile">
+                        <infoLink id="932a1616-a54a-0cdc-a81c-838c225d6402" hidden="false" targetId="48f1-0c16-d5e5-6d98" type="profile">
                           <profiles/>
                           <rules/>
                           <infoLinks/>
@@ -48923,7 +48923,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
               <profiles/>
               <rules/>
               <infoLinks>
-                <infoLink id="5b7ab84a-10bf-2414-c6c9-9ac278390399" hidden="false" targetId="a7069849-cdd7-ffb1-8088-8300704afcae" type="profile">
+                <infoLink id="5b7ab84a-10bf-2414-c6c9-9ac278390399" hidden="false" targetId="48f1-0c16-d5e5-6d98" type="profile">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -59855,7 +59855,7 @@ Phalanx Breacher squads and Legion Terminator squads may be taken as troops in a
                   <profiles/>
                   <rules/>
                   <infoLinks>
-                    <infoLink id="db80-9438-13b0-1266" hidden="false" targetId="a7069849-cdd7-ffb1-8088-8300704afcae" type="profile">
+                    <infoLink id="db80-9438-13b0-1266" hidden="false" targetId="48f1-0c16-d5e5-6d98" type="profile">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -66827,7 +66827,9 @@ When conducting a Ram attack, use Strength 10, roll two dice and pick the higher
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks/>
-              <costs/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
             </selectionEntry>
           </selectionEntries>
           <selectionEntryGroups/>
@@ -70345,15 +70347,6 @@ Kharybdis: After it has landed treat as a flyer in Hover mode. LA:AODAL P75</des
       <modifiers/>
       <characteristics>
         <characteristic name="Description" characteristicTypeId="4465736372697074696f6e23232344415441232323" value="A model with this upgrade increases its BS by +1 and reduces enemy cover saves by -1. "/>
-      </characteristics>
-    </profile>
-    <profile id="a7069849-cdd7-ffb1-8088-8300704afcae" name="Flare Shield" book="HH:LACAL" page="89" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Description" characteristicTypeId="4465736372697074696f6e23232344415441232323" value="A flare shield operates against shooting attacks that strike the vehicle&apos;s front arc.  It reduces the strength of attacks by weapons with the Templae or Blast type by -2, and other shooting attacks by -1.  A flare shield has no effect on attacks from close combat or with the Destroyer rule.  "/>
       </characteristics>
     </profile>
     <profile id="f2f72945-09db-4b7c-e6aa-c50dfd7bdd72" name="Graviton Cannon" book="HH:LACAL" page="83" hidden="false" profileTypeId="576561706f6e23232344415441232323">

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -47187,208 +47187,6 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
       </constraints>
       <selectionEntries/>
       <selectionEntryGroups>
-        <selectionEntryGroup id="f800d454-355f-8562-8377-7389126f6f4a" name="May take a Pintle-Mounted Weapon:" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="b8379683-7132-75c6-123d-7f95cef9a195" name="Twin-Linked Bolter" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="f6cb69f3-8a93-c44d-e51a-6fb42f62b8e1" name="Combi-Weapon" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="92d38651-54d2-4811-6fb8-a6f3ad478f45" name="Heavy Bolter" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="10.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="dd63efdc-6224-e162-67ce-add247d21393" name="Heavy Flamer" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="10.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="29a7fb32-2858-e39a-0b72-fa22f7459cb9" name="Havoc Launcher" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="85996980-e142-6fc0-36e5-9460f8fdda93" hidden="false" targetId="b3ea1d32-ba66-0585-d7f7-0dc56e707736" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="15.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="aa29-ee91-5655-fe24" name="Multi-melta" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2dcb-0861-5c08-23db" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="15.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="9491-9ec3-0878-4aa8" hidden="false" targetId="2d56d45d-d276-7830-2b7d-026de64bbae8" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="increment" field="points" value="5">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="31999ff6-63aa-a461-6da1-47ded08a8a37" name="May take any of the following:" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <selectionEntries>
-            <selectionEntry id="42e89b36-5945-ac23-573b-1bb1f03c3a6c" name="Auxiliary Drive" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="e8432c41-7449-f4b2-6b5d-c8b57ed684ab" hidden="false" targetId="d963a2dd-d9a3-8974-aac6-61ffcc78a99a" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="10.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="50cf58d3-20c4-ea62-b5c1-0427f6dc9b9e" name="Dozer Blade" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="28caa2ec-6cf4-545f-8dac-4db200e9f313" name="Extra Armour" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="99153cec-bcd5-f04b-6bc7-bc0b8b818592" name="Hunter-Killer Missile" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups/>
-          <entryLinks/>
-        </selectionEntryGroup>
         <selectionEntryGroup id="a8e82035-24ce-482d-b62f-9510c2b1cfe2" name="Legion-specific upgrade" hidden="false" collective="false">
           <profiles/>
           <rules/>
@@ -47421,8 +47219,55 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
+        <selectionEntryGroup id="574a-3c18-44c4-b63a" name="May take any of the following:" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="fbc4-3fff-a543-d0db" name="New EntryLink" hidden="false" targetId="a6cd-f04b-711e-c083" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="c93e-474d-0404-cfd0" name="New EntryLink" hidden="false" targetId="a0a4-4e61-7118-fcff" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="1571-ec0d-86d0-6546" name="New EntryLink" hidden="false" targetId="915f-bdbc-c3cb-9b0b" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="3cdc-3b8c-bc3d-107c" name="New EntryLink" hidden="false" targetId="00d9-65e8-94b2-2396" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
       </selectionEntryGroups>
-      <entryLinks/>
+      <entryLinks>
+        <entryLink id="cde9-143b-4d46-d155" name="New EntryLink" hidden="false" targetId="fe17-5ed2-ca63-9379" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
       <costs>
         <cost name="pts" costTypeId="points" value="35.0"/>
       </costs>
@@ -56236,7 +56081,9 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
           </selectionEntries>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -68400,10 +68247,7 @@ Explodes results add D3&quot; to radius.  </description>
           <conditionGroups/>
         </modifier>
       </modifiers>
-      <constraints>
-        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="823c-4fc1-0154-35b6" type="min"/>
-        <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="26c4-599f-4885-b6e2" type="max"/>
-      </constraints>
+      <constraints/>
       <selectionEntries>
         <selectionEntry id="f244-04dc-f87f-745f" name="Master-crafted Paragon Blade" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
           <profiles/>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -24135,28 +24135,6 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                 <cost name="pts" costTypeId="points" value="15.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="5480b06d-1646-b997-7923-664278a9daab" name="Flare Shield" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="29f310e8-f923-264a-9c5a-f20202539188" name="" hidden="false" targetId="48f1-0c16-d5e5-6d98" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="50.0"/>
-              </costs>
-            </selectionEntry>
             <selectionEntry id="2328058f-72f6-b053-63f3-cfd04dcc3b28" name="Ramjet Diffraction Grid" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
               <profiles>
                 <profile id="37d7da24-6b99-e5bb-2c63-3b1623a0eb9c" name="Ramjet Diffraction Grid" book="HH:LACAL" page="42" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323">
@@ -24207,7 +24185,21 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
             </selectionEntry>
           </selectionEntries>
           <selectionEntryGroups/>
-          <entryLinks/>
+          <entryLinks>
+            <entryLink id="5de3-7c2a-6c42-30f6" name="New EntryLink" hidden="false" targetId="7332-4181-03b9-d402" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="50">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="56fe97a9-6652-c944-2ab8-225694855258" name="Replace all six Hellstrike Missiles with:" hidden="false" collective="false">
           <profiles/>
@@ -24440,28 +24432,6 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                 <cost name="pts" costTypeId="points" value="10.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="36f5a704-4431-50e1-269b-c8cf130bf9b1" name="Flare Shield" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="31069a8d-dbd7-e695-6b93-7515992e1bd8" hidden="false" targetId="48f1-0c16-d5e5-6d98" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="50.0"/>
-              </costs>
-            </selectionEntry>
             <selectionEntry id="92b760dd-6c2f-4165-1f25-779f5ba4cb12" name="Ramjet Diffraction Grid" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
               <profiles>
                 <profile id="301e3f2c-3e27-dc14-6679-df6266157cd9" name="Ramjet Diffraction Grid" book="HH:LACAL" page="42" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323">
@@ -24512,7 +24482,21 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
             </selectionEntry>
           </selectionEntries>
           <selectionEntryGroups/>
-          <entryLinks/>
+          <entryLinks>
+            <entryLink id="a9ae-4c7e-ff21-6aeb" name="New EntryLink" hidden="false" targetId="7332-4181-03b9-d402" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="50">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="b89edf17-a615-3e74-3156-49eb96cdfdee" name="May take up to six:" hidden="false" collective="false">
           <profiles/>
@@ -31394,31 +31378,23 @@ Ignores Cover special rule.</description>
                         <cost name="pts" costTypeId="points" value="20.0"/>
                       </costs>
                     </selectionEntry>
-                    <selectionEntry id="6aca5f12-d8e4-e1d5-856b-63aad9dbab76" name="Flare Shield" book="" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="932a1616-a54a-0cdc-a81c-838c225d6402" hidden="false" targetId="48f1-0c16-d5e5-6d98" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="25.0"/>
-                      </costs>
-                    </selectionEntry>
                   </selectionEntries>
                   <selectionEntryGroups/>
-                  <entryLinks/>
+                  <entryLinks>
+                    <entryLink id="6d41-cdf4-a638-76bd" name="New EntryLink" hidden="false" targetId="7332-4181-03b9-d402" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers>
+                        <modifier type="set" field="points" value="25">
+                          <repeats/>
+                          <conditions/>
+                          <conditionGroups/>
+                        </modifier>
+                      </modifiers>
+                      <constraints/>
+                    </entryLink>
+                  </entryLinks>
                 </selectionEntryGroup>
                 <selectionEntryGroup id="4d4ba513-c22d-3c27-05c7-17a2b78cc751" name="May take a Pintle-Mounted Weapon:" hidden="false" collective="false">
                   <profiles/>
@@ -48745,23 +48721,33 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
             <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Tank, Transport"/>
           </characteristics>
         </profile>
+        <profile id="74f8-ef48-50c9-4cd5" name="Legion Spartan Assault Tank (Transport)" book="HH:LACAL" page="58" hidden="false" profileTypeId="307d-047f-ca13-706b" profileTypeName="Transport">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Capacity" characteristicTypeId="8285-4205-b6cd-8473" value="25"/>
+            <characteristic name="Fire Points" characteristicTypeId="b270-a7f9-22b2-3702" value="None"/>
+            <characteristic name="Access Points" characteristicTypeId="d17b-0342-b1dc-b8e7" value="One access point at the front and two on each side."/>
+          </characteristics>
+        </profile>
       </profiles>
-      <rules>
-        <rule id="56e58a7c-884a-db74-96b3-fb0e7f3abedf" name="Extra Armour" page="0" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </rule>
-        <rule id="d47d12be-9bf6-065e-bd42-4d0cccb0c01f" name="Assault Vehicle" page="0" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </rule>
-      </rules>
+      <rules/>
       <infoLinks>
         <infoLink id="ce9cdf6c-ef85-fc72-4166-d427312fe70b" hidden="false" targetId="3a93202e-ac23-5508-2dda-248efcc8ff3d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="597b-8446-2433-b31d" name="New InfoLink" hidden="false" targetId="45cf-653a-4ff6-f22d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="f521-0cdc-b49c-a911" name="New InfoLink" hidden="false" targetId="5283-9b50-3dcd-78e4" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -48770,139 +48756,68 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
       </infoLinks>
       <modifiers/>
       <constraints/>
-      <selectionEntries>
-        <selectionEntry id="9a6b0ebf-2551-3939-f560-cf605401c9ab" name="Frag Assault Launchers" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="a7e1b946-4c3b-752d-08e4-e1f9349f0156" name="Hull-mounted" hidden="false" collective="false" defaultSelectionEntryId="53c8-4d3e-446f-ff81">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5c53-ba30-2622-14a0" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ad11-b600-4504-8516" type="min"/>
           </constraints>
           <selectionEntries/>
           <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="10.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="dedc2e55-eaa7-4b01-7513-db2a31f4e092" name="May take a Pintle-Mounted Weapon:" hidden="false" collective="false">
+          <entryLinks>
+            <entryLink id="53c8-4d3e-446f-ff81" name="New EntryLink" hidden="false" targetId="aa78-540d-996f-52ff" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="abdc-ef01-9144-5451" name="New EntryLink" hidden="false" targetId="2bc5-53e9-b8fd-0b6b" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="760c-acbc-8221-15d1" name="New EntryLink" hidden="false" targetId="5986-c8ef-d448-397b" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="Two Sponson Mounted" name="Two Sponson Mounted" hidden="false" collective="false" defaultSelectionEntryId="3982-8fc5-a225-c789">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="57b1-da06-8e38-8f67" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d300-b3d3-71a1-14de" type="min"/>
           </constraints>
-          <selectionEntries>
-            <selectionEntry id="6f862e1f-012c-6210-6b17-923256c8d9b8" name="Twin-Linked Bolter" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="def6c177-9595-b9af-3a43-635339ad8b03" name="Combi-Weapon" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="10.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="1718a009-4d16-6a32-e8d1-1c94821b0743" name="Heavy Bolter" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="15.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="59a62895-9af5-35db-fd11-6424bda86555" name="Heavy Flamer" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="15.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="619d8cb3-4719-6ebb-9b17-da6466d8c04b" name="Havoc Launcher" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="25af0590-a59d-7599-6373-64e5bcf1f087" hidden="false" targetId="b3ea1d32-ba66-0585-d7f7-0dc56e707736" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="15.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="bbb491b4-ff65-51cc-92dd-2269eccc7ddf" name="Multi-melta" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="20.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
+          <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="c3a3-a3ff-24b1-4caa" hidden="false" targetId="2d56d45d-d276-7830-2b7d-026de64bbae8" type="selectionEntry">
+            <entryLink id="3982-8fc5-a225-c789" name="New EntryLink" hidden="false" targetId="2ae8-3be0-05a5-f9aa" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="65a5-abee-644a-27e8" name="New EntryLink" page="" hidden="false" targetId="5708-9bd4-2edc-ddc9" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers>
-                <modifier type="increment" field="points" value="5.0">
+                <modifier type="set" field="name" value="Laser Destroyers">
                   <repeats/>
                   <conditions/>
                   <conditionGroups/>
@@ -48911,209 +48826,6 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
               <constraints/>
             </entryLink>
           </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="dd1cbbc4-abaa-e223-e2eb-87e70aa74ac2" name="May take any of the following:" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <selectionEntries>
-            <selectionEntry id="8c61ea40-5a92-26c6-abc3-268e5cf77855" name="Flare Shield" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="5b7ab84a-10bf-2414-c6c9-9ac278390399" hidden="false" targetId="48f1-0c16-d5e5-6d98" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="45.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="d34bd767-53e2-de8c-b256-2425abc79b8c" name="Dozer Blade" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="7c1afa3d-084b-efa8-7666-66933fa5304a" name="Auxiliary Drive" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="06fe485a-7f7e-33c5-ca4e-d427035abb30" hidden="false" targetId="d963a2dd-d9a3-8974-aac6-61ffcc78a99a" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="10.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="1853daf3-37c3-10ff-fb6a-403eadbbbffe" name="Hunter-killer Missile" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="10.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="332ac2a7-ccb8-d719-14d2-1b738dc106f7" name="Armoured Ceramite" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="45bf1642-98e5-b85b-c809-d8ab0c591006" hidden="false" targetId="2e87b8ca-7cd1-78b9-2116-246015e7935e" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="20.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups/>
-          <entryLinks/>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="a7e1b946-4c3b-752d-08e4-e1f9349f0156" name="Exchange Hull-mounted Twin-linked Heavy Bolters for:" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <selectionEntries>
-            <selectionEntry id="28ec11b4-7771-3834-026f-71176da91a8d" name="Twin-linked Heavy Flamer" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="201e-79d1-8ecc-9831" name="Twin-linked Iliastus Assault Cannons" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="b155-3972-ca32-129e" hidden="false" targetId="0d8bdd64-39f0-7759-d8ca-0702ee1f0fd0" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="3472-3ac3-48ee-391c" hidden="false" targetId="0d300426-e90a-4a8d-bff5-9b64949b128d" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers>
-                <modifier type="set" field="hidden" value="true">
-                  <repeats/>
-                  <conditions>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="16a2-56d6-9be5-ede0" type="equalTo"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups/>
-          <entryLinks/>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="394f6407-1a7a-3c38-7e3d-9814b2f18a64" name="Exchange Lascannon Sponsons for:" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <selectionEntries>
-            <selectionEntry id="897c6e5a-64fd-b120-9feb-8410986751c3" name="Laser Destroyers" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="288fae2e-2f26-aa38-b098-c9ef4d60289a" hidden="false" targetId="c4094da7-8d2e-8d6a-8af8-4cf88f5d7c06" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups/>
-          <entryLinks/>
         </selectionEntryGroup>
         <selectionEntryGroup id="6794d206-5908-62ec-aa3e-604c43327f53" name="Legion-specific upgrade" hidden="false" collective="false">
           <profiles/>
@@ -49147,9 +48859,75 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
+        <selectionEntryGroup id="82d5-d46a-3949-28ca" name="May take any of the following:" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="2a42-01d0-db9c-980e" name="New EntryLink" hidden="false" targetId="a0a4-4e61-7118-fcff" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="ebbe-4757-f890-568d" name="New EntryLink" hidden="false" targetId="915f-bdbc-c3cb-9b0b" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="e4d5-0e39-ec18-67cf" name="New EntryLink" hidden="false" targetId="f888-a294-fcff-8391" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="6220-7ef0-12c6-e2c3" name="New EntryLink" hidden="false" targetId="00d9-65e8-94b2-2396" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="f2d5-70a4-b61c-0b22" name="New EntryLink" hidden="false" targetId="eca0-004a-24f2-e2e9" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="819d-2606-e84a-c8d0" name="New EntryLink" hidden="false" targetId="7332-4181-03b9-d402" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="45">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
         <entryLink id="522b-9e59-e14d-b77c" hidden="false" targetId="c487-be13-ea53-917e" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="b740-a536-73bc-c194" name="New EntryLink" hidden="false" targetId="fe17-5ed2-ca63-9379" type="selectionEntryGroup">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -59851,28 +59629,6 @@ Phalanx Breacher squads and Legion Terminator squads may be taken as troops in a
                     <cost name="pts" costTypeId="points" value="15.0"/>
                   </costs>
                 </selectionEntry>
-                <selectionEntry id="5a30-66e0-357e-76e7" name="Flare Shield" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="db80-9438-13b0-1266" hidden="false" targetId="48f1-0c16-d5e5-6d98" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="50.0"/>
-                  </costs>
-                </selectionEntry>
                 <selectionEntry id="5d5c-8262-b17c-6e09" name="Ramjet Diffraction Grid" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
                   <profiles>
                     <profile id="de98-40bb-212f-c6e2" name="Ramjet Diffraction Grid" book="HH:LACAL" page="42" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323">
@@ -59923,7 +59679,21 @@ Phalanx Breacher squads and Legion Terminator squads may be taken as troops in a
                 </selectionEntry>
               </selectionEntries>
               <selectionEntryGroups/>
-              <entryLinks/>
+              <entryLinks>
+                <entryLink id="7ad2-59c0-1619-63c1" name="New EntryLink" hidden="false" targetId="7332-4181-03b9-d402" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="set" field="points" value="50">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="6efc-7935-9fde-3bde" name="Replace all six Hellstrike Missiles with:" hidden="false" collective="false">
               <profiles/>
@@ -64955,7 +64725,14 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
     <selectionEntry id="eca0-004a-24f2-e2e9" name="Frag Assault Launchers" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
       <rules/>
-      <infoLinks/>
+      <infoLinks>
+        <infoLink id="b74e-bff9-3221-06ea" name="New InfoLink" hidden="false" targetId="b982-55bc-0b5f-4875" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1816-461e-8759-23d4" type="max"/>
@@ -65074,6 +64851,13 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
             <modifier type="set" field="name" value="Twin-Linked Heavy Flamer">
               <repeats/>
               <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="537472656e67746823232344415441232323" value="1">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a91f-3b51-950d-ba8a" type="equalTo"/>
+              </conditions>
               <conditionGroups/>
             </modifier>
           </modifiers>
@@ -66871,6 +66655,68 @@ When conducting a Ram attack, use Strength 10, roll two dice and pick the higher
       </entryLinks>
       <costs>
         <cost name="pts" costTypeId="points" value="115.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2ae8-3be0-05a5-f9aa" name="Quad Lascannon" book="" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="3201-19d4-c136-4cde" name="New InfoLink" hidden="false" targetId="1cce-972c-022a-2590" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="set" field="5479706523232344415441232323" value="Heavy 2, Twin-linked">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="set" field="name" value="Quad Lascannon">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="set" field="52616e676523232344415441232323" value="48&quot;">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="22f3-3eae-9e52-6301" name="Flare Shield" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="f0b7-9bda-b2f7-7b5b" name="New InfoLink" hidden="false" targetId="bc3aeb96-92f2-e6f1-662f-f6632f61a360" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="04f1-ccdd-38bc-ca39" name="New InfoLink" page="" hidden="false" targetId="cb4a-644f-bd8d-7d97" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>
@@ -70034,6 +69880,13 @@ Kharybdis: After it has landed treat as a flyer in Hover mode. LA:AODAL P75</des
       <modifiers/>
       <description>- Capacitor Fire: If the tank has not moved this turn, the Laser Destroyer Array becomes an Ordnance 2 Twin-linked weapon.
 - Overcharged Fire: The owning player may declare an overcharged volley if the vehicle has not moved this turn.  The Laser Destroyer Array becomes Ordnance 3, Twin-linked.  After firing, roll a D6 - on a 1 the Vindicator suffers a single Hull Point of damage. </description>
+    </rule>
+    <rule id="b982-55bc-0b5f-4875" name="Frag Assault Launchers" book="LA:AoDAL" page="125" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>Any unit charging into close combat on the same turn it disembarks from a transport vehicle equipped with frag assault launchers counts as having frag grenades.</description>
     </rule>
   </sharedRules>
   <sharedProfiles>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -66567,12 +66567,6 @@ Explodes results add D3&quot; to radius.  </description>
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="28c5-1a45-944b-ca2a" name="New InfoLink" book="" hidden="false" targetId="b382-3da8-e6c2-48eb" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
         <infoLink id="da02-ad44-9efe-0d80" name="New InfoLink" hidden="false" targetId="5283-9b50-3dcd-78e4" type="rule">
           <profiles/>
           <rules/>
@@ -66599,7 +66593,20 @@ Explodes results add D3&quot; to radius.  </description>
             </profile>
           </profiles>
           <rules/>
-          <infoLinks/>
+          <infoLinks>
+            <infoLink id="7ece-32f7-e665-60a4" name="New InfoLink" hidden="false" targetId="9d85-46f7-f5e6-a5f7" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="6305-a78e-43fa-5d02" name="New InfoLink" book="" hidden="false" targetId="b382-3da8-e6c2-48eb" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
           <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4a78-0e8f-1c0a-36c2" type="max"/>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -14478,14 +14478,14 @@
             <modifier type="set" field="minSelections" value="0.0">
               <repeats/>
               <conditions>
-                <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="41c9-58e2-8aec-dd82" type="equalTo"/>
+                <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="41c9-58e2-8aec-dd82" type="equalTo"/>
               </conditions>
               <conditionGroups/>
             </modifier>
             <modifier type="set" field="hidden" value="true">
               <repeats/>
               <conditions>
-                <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="41c9-58e2-8aec-dd82" type="equalTo"/>
+                <condition field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="41c9-58e2-8aec-dd82" type="equalTo"/>
               </conditions>
               <conditionGroups/>
             </modifier>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -17140,7 +17140,7 @@
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="7174-ef5c-053e-4aca" hidden="false" targetId="9298-04e9-9b11-795b" type="rule">
+        <infoLink id="7174-ef5c-053e-4aca" hidden="false" targetId="45cf-653a-4ff6-f22d" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -43872,7 +43872,7 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="5a80-d423-07aa-d8fa" name="New InfoLink" hidden="false" targetId="9298-04e9-9b11-795b" type="rule">
+        <infoLink id="5a80-d423-07aa-d8fa" name="New InfoLink" hidden="false" targetId="45cf-653a-4ff6-f22d" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -66095,7 +66095,9 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="7a6c-699b-f816-764d" name="Hellstrike Missiles" hidden="false" collective="false" type="upgrade">
       <profiles/>
@@ -66119,7 +66121,9 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="4210-154f-6cf3-61d8" name="Avenger Bolt Cannon" hidden="false" collective="false" type="upgrade">
       <profiles/>
@@ -66137,7 +66141,9 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="9f7b-ce08-7726-63af" name="Twin-linked Avenger Bolt Cannon" hidden="false" collective="false" type="upgrade">
       <profiles/>
@@ -66168,7 +66174,9 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="57e7-980d-f042-f566" name="Legion Artillery Tank Squadron" book="HH:LACAL" page="56" hidden="false" collective="false" categoryEntryId="486561767920537570706f727423232344415441232323" type="unit">
       <profiles/>
@@ -69378,13 +69386,6 @@ Phalanx Warders</description>
       <infoLinks/>
       <modifiers/>
       <description>May be included as a HQ choice in a Legion army whose Legiones Astartes rule he does not share.  Where this is the case, he does not gain any benefits from the different Legiones Astartes rules nor does he negate those rules.  When his Leadership value is used to make tests for the unit, his special rules rather than any for the unit are used.  In the case of a Legion Command Squad, these must use the Legiones Astartes special rules from the detachment he is a part of, rather than his own.  </description>
-    </rule>
-    <rule id="9298-04e9-9b11-795b" name="Assault Vehicle" book="BRB 7th" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Passengers disembarking from Access Points on a vehicle with this special rule can charge on the turn they do so (even in a turn that the vehicle was destroyed, or in the following turn) unless the vehicle arrived from Reserve that turn.</description>
     </rule>
     <rule id="beb478f9-bf5e-772f-e627-8ea394beaa5c" name="Banestrike" book="HH:LAICL" page="9" hidden="false">
       <profiles/>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -45004,6 +45004,19 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
                       <modifiers/>
                       <constraints/>
                     </entryLink>
+                    <entryLink id="abda-12e5-d386-0648" name="New EntryLink" hidden="false" targetId="26db-484d-3757-03c8" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers>
+                        <modifier type="set" field="name" value="Single Lighting Claw">
+                          <repeats/>
+                          <conditions/>
+                          <conditionGroups/>
+                        </modifier>
+                      </modifiers>
+                      <constraints/>
+                    </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
                 <selectionEntryGroup id="a9562fa7-0394-d853-b777-fe2a35ebd2eb" name="May take one:" hidden="false" collective="false">
@@ -45415,16 +45428,30 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
                 <cost name="pts" costTypeId="points" value="25.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="9370e7dd-55d4-53d7-b907-9c687cba6a58" name="Flak Missiles" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+            <selectionEntry id="9370e7dd-55d4-53d7-b907-9c687cba6a58" name="Flakk Missiles" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
               <profiles/>
               <rules/>
-              <infoLinks/>
+              <infoLinks>
+                <infoLink id="604b-db11-0af1-0842" name="New InfoLink" hidden="false" targetId="1182-02a7-3325-8c51" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
               <modifiers>
-                <modifier type="set" field="maxSelections" value="1.0">
+                <modifier type="set" field="maxSelections" value="1">
                   <repeats>
                     <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="cfb48ef9-5d81-0b93-3a8b-02a8533e5a84" repeats="1"/>
                   </repeats>
                   <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="cfb48ef9-5d81-0b93-3a8b-02a8533e5a84" type="equalTo"/>
+                  </conditions>
                   <conditionGroups/>
                 </modifier>
               </modifiers>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -66727,31 +66727,11 @@ When conducting a Ram attack, use Strength 10, roll two dice and pick the higher
             <characteristic name="Side" characteristicTypeId="5369646523232344415441232323" value="12"/>
             <characteristic name="Rear" characteristicTypeId="5265617223232344415441232323" value="10"/>
             <characteristic name="HP" characteristicTypeId="485023232344415441232323" value="3"/>
-            <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Tank"/>
-          </characteristics>
-        </profile>
-        <profile id="2fa1-ae30-0e71-24f7" name="Scorpius Multi-launcher" book="HH:LACAL" page="64" hidden="false" profileTypeId="576561706f6e23232344415441232323">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="48&quot;"/>
-            <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="8"/>
-            <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="3"/>
-            <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 1, Barrage, Blast, Rocket Barrage"/>
+            <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Vehicle (Tank)"/>
           </characteristics>
         </profile>
       </profiles>
-      <rules>
-        <rule id="377f-8c2e-33b7-29d1" name="Rocket Barrage" book="HH:LACAL" page="64" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <description>In a turn in which the vehicle has not moved, increase rate of fire to Heavy 1+D3.  </description>
-        </rule>
-      </rules>
+      <rules/>
       <infoLinks/>
       <modifiers/>
       <constraints/>
@@ -66763,55 +66743,31 @@ When conducting a Ram attack, use Strength 10, roll two dice and pick the higher
           <infoLinks/>
           <modifiers/>
           <constraints/>
-          <selectionEntries>
-            <selectionEntry id="6a47-9f65-90a7-bd83" name="Hunter-killer Missile" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f611-d1f3-67b3-92f1" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="10.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="2ecf-581c-a6f8-88e3" name="Dozer Blade" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="83e2-4bf4-17db-f509" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="ae8c-8dbb-033a-979c" name="Extra Armour" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7161-7268-8adb-c181" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="10.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
+          <selectionEntries/>
           <selectionEntryGroups/>
-          <entryLinks/>
+          <entryLinks>
+            <entryLink id="4e74-ed82-7db5-9650" name="New EntryLink" hidden="false" targetId="915f-bdbc-c3cb-9b0b" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="4102-1b60-27b9-7b84" name="New EntryLink" hidden="false" targetId="00d9-65e8-94b2-2396" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="5c09-3a93-7489-14d5" name="New EntryLink" hidden="false" targetId="a6cd-f04b-711e-c083" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="2e8c-b3b5-4e2c-0faa" name="Legion-specific upgrade" hidden="false" collective="false">
           <profiles/>
@@ -66831,6 +66787,52 @@ When conducting a Ram attack, use Strength 10, roll two dice and pick the higher
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
+        <selectionEntryGroup id="dec4-a6d8-f380-a6f1" name="Scorpius Multi-Launcher" hidden="false" collective="false" defaultSelectionEntryId="b434-6d2d-8b4e-6653">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f526-cd6e-d624-1eac" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e845-0ba3-a976-32a9" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="b434-6d2d-8b4e-6653" name="Scorpius Multi-Launcher" book="LA:AoDLA" page="80" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="8333-d762-1ecf-fe22" name="Scorpius Multi-launcher" book="HH:LACAL" page="64" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="48&quot;"/>
+                    <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="8"/>
+                    <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="3"/>
+                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 1, Barrage, Blast, Rocket Barrage"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules>
+                <rule id="4967-56fb-c9bb-7f54" name="Rocket Barrage" book="HH:LACAL" page="64" hidden="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <description>In a turn in which the vehicle has not moved, increase rate of fire to Heavy 1+D3.  </description>
+                </rule>
+              </rules>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs/>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
         <entryLink id="665d-c55f-78fd-1a7a" hidden="false" targetId="c487-be13-ea53-917e" type="selectionEntryGroup">
@@ -66839,6 +66841,30 @@ When conducting a Ram attack, use Strength 10, roll two dice and pick the higher
           <infoLinks/>
           <modifiers/>
           <constraints/>
+        </entryLink>
+        <entryLink id="f0ee-31f4-391a-a31c" name="x" hidden="false" targetId="fe17-5ed2-ca63-9379" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="5f84-847a-de2d-9942" name="New EntryLink" hidden="false" targetId="b572273e-2b93-4961-75c8-d9022c31a47d" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="c0f1-d468-f343-bde2" name="New EntryLink" hidden="false" targetId="30c2c848-c1d3-e61f-6632-a91bcee1fdc4" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fc00-e1c9-7a73-35ab" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="24cd-70f7-7c98-7299" type="min"/>
+          </constraints>
         </entryLink>
       </entryLinks>
       <costs>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -66235,84 +66235,6 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
               </constraints>
               <selectionEntries/>
               <selectionEntryGroups>
-                <selectionEntryGroup id="9be6-6bef-3509-ccf6" name="May take any of the following:" hidden="false" collective="false">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <selectionEntries>
-                    <selectionEntry id="2ce5-d8b8-d633-f1c4" name="Dozer Blade" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="39d5-a217-107f-8744" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="5.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="2ad8-8336-c2e5-5f7e" name="Auxiliary Drive" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="618b-d5d7-471a-a95f" hidden="false" targetId="d963a2dd-d9a3-8974-aac6-61ffcc78a99a" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ecb6-840d-7e56-4572" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="10.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="0cfe-dc4f-35fc-9911" name="Hunter-killer Missile" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="159c-a897-df6c-a8a4" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="10.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="fbbc-2f70-d262-55f5" name="Extra Armour" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a760-0d77-fd52-2deb" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="10.0"/>
-                      </costs>
-                    </selectionEntry>
-                  </selectionEntries>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                </selectionEntryGroup>
                 <selectionEntryGroup id="95c0-4993-9123-57d0" name="Legion-specific upgrade" hidden="false" collective="false">
                   <profiles/>
                   <rules/>
@@ -66367,9 +66289,55 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
+                <selectionEntryGroup id="ddd6-9ba1-4a52-17f1" name="May take any of the following:" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="9f74-b23b-489f-6c80" name="New EntryLink" hidden="false" targetId="a6cd-f04b-711e-c083" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </entryLink>
+                    <entryLink id="6c51-c4f5-f3c9-d18d" name="New EntryLink" hidden="false" targetId="a0a4-4e61-7118-fcff" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </entryLink>
+                    <entryLink id="888a-f631-3dcf-e132" name="New EntryLink" hidden="false" targetId="915f-bdbc-c3cb-9b0b" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </entryLink>
+                    <entryLink id="c1eb-b958-85d3-e93e" name="New EntryLink" hidden="false" targetId="00d9-65e8-94b2-2396" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
               </selectionEntryGroups>
               <entryLinks>
                 <entryLink id="d47a-a15c-204e-9bb9" name="New EntryLink" hidden="false" targetId="fe17-5ed2-ca63-9379" type="selectionEntryGroup">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="7222-3c2c-d878-2aac" name="New EntryLink" hidden="false" targetId="b572273e-2b93-4961-75c8-d9022c31a47d" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -66418,84 +66386,6 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
               </constraints>
               <selectionEntries/>
               <selectionEntryGroups>
-                <selectionEntryGroup id="e3ce-390d-2fa0-59bf" name="May take any of the following:" hidden="false" collective="false">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <selectionEntries>
-                    <selectionEntry id="9be6-0a6d-704f-590a" name="Dozer Blade" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="bba4-63ce-7594-c89e" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="5.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="ebd5-f67f-f2b4-1448" name="Auxiliary Drive" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="196b-4536-517e-8a6a" hidden="false" targetId="d963a2dd-d9a3-8974-aac6-61ffcc78a99a" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5963-9d58-e4ff-131b" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="10.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="f5f9-9c87-786b-9814" name="Hunter-killer Missile" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e0bc-ca51-d222-bdb2" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="10.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="38bc-8299-3e06-a724" name="Extra Armour" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ddf4-a947-2b0e-0999" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="10.0"/>
-                      </costs>
-                    </selectionEntry>
-                  </selectionEntries>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                </selectionEntryGroup>
                 <selectionEntryGroup id="3c84-0d2f-0084-01a8" name="Legion-specific upgrade" hidden="false" collective="false">
                   <profiles/>
                   <rules/>
@@ -66586,9 +66476,55 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
+                <selectionEntryGroup id="acc0-d54c-ac27-8f73" name="May take any of the following:" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="d1f3-d095-3a41-97b7" name="New EntryLink" hidden="false" targetId="a6cd-f04b-711e-c083" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </entryLink>
+                    <entryLink id="b665-c541-45ad-e48a" name="New EntryLink" hidden="false" targetId="a0a4-4e61-7118-fcff" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </entryLink>
+                    <entryLink id="db7d-af22-0dd0-bdcf" name="New EntryLink" hidden="false" targetId="915f-bdbc-c3cb-9b0b" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </entryLink>
+                    <entryLink id="f297-3295-e762-c89f" name="New EntryLink" hidden="false" targetId="00d9-65e8-94b2-2396" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
               </selectionEntryGroups>
               <entryLinks>
                 <entryLink id="93c7-37f1-e9c1-9517" name="New EntryLink" hidden="false" targetId="fe17-5ed2-ca63-9379" type="selectionEntryGroup">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="b4ee-085a-fba1-fe1a" name="New EntryLink" hidden="false" targetId="b572273e-2b93-4961-75c8-d9022c31a47d" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -66649,84 +66585,6 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
               </constraints>
               <selectionEntries/>
               <selectionEntryGroups>
-                <selectionEntryGroup id="80dd-8bce-2cc7-bec5" name="May take any of the following:" hidden="false" collective="false">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <selectionEntries>
-                    <selectionEntry id="d9aa-11da-0d0a-f3f3" name="Dozer Blade" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0ae6-f2b9-50d7-9d91" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="5.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="f429-a8e1-6b86-674b" name="Auxiliary Drive" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="5d1e-d61c-a045-46c5" hidden="false" targetId="d963a2dd-d9a3-8974-aac6-61ffcc78a99a" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="df69-d52e-3cfd-da3a" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="10.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="fffe-03aa-41e8-f89d" name="Hunter-killer Missile" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5783-f35b-e62d-7ab7" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="10.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="a79e-c74c-2a4a-f434" name="Extra Armour" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="15f8-455b-7755-1ee0" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="10.0"/>
-                      </costs>
-                    </selectionEntry>
-                  </selectionEntries>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                </selectionEntryGroup>
                 <selectionEntryGroup id="a4ed-55f7-78c9-2ef4" name="Exchange Vengeance and Castellan missiles for:" hidden="false" collective="false">
                   <profiles/>
                   <rules/>
@@ -66784,9 +66642,55 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
+                <selectionEntryGroup id="2914-2ee8-f55d-b2e5" name="May take any of the following:" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="77e1-09aa-1e7f-ed85" name="New EntryLink" hidden="false" targetId="a6cd-f04b-711e-c083" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </entryLink>
+                    <entryLink id="0c3d-76f6-fcd9-680f" name="New EntryLink" hidden="false" targetId="a0a4-4e61-7118-fcff" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </entryLink>
+                    <entryLink id="8196-b97e-c546-602f" name="New EntryLink" hidden="false" targetId="915f-bdbc-c3cb-9b0b" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </entryLink>
+                    <entryLink id="0c97-68e6-d4a5-d595" name="New EntryLink" hidden="false" targetId="00d9-65e8-94b2-2396" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
               </selectionEntryGroups>
               <entryLinks>
                 <entryLink id="3210-f028-22b6-4c47" name="New EntryLink" hidden="false" targetId="fe17-5ed2-ca63-9379" type="selectionEntryGroup">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="1f2e-074b-0c33-f9d2" name="New EntryLink" hidden="false" targetId="b572273e-2b93-4961-75c8-d9022c31a47d" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -33703,6 +33703,13 @@ Ignores Cover special rule.</description>
       <modifiers/>
       <constraints/>
     </entryLink>
+    <entryLink id="17eb-40da-17d1-9a01" name="New EntryLink" hidden="false" targetId="5828-a1e9-28fc-b09b" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </entryLink>
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="a9bf-b37e-126b-a699" name="&apos;Iron Circle&apos; Domitar-Ferrum Class Battle-automata Maniple" hidden="false" collective="false" categoryEntryId="456c6974657323232344415441232323" type="unit">
@@ -68324,6 +68331,162 @@ Explodes results add D3&quot; to radius.  </description>
       <entryLinks/>
       <costs>
         <cost name="pts" costTypeId="points" value="15.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5828-a1e9-28fc-b09b" name="Legion Praetor Tribune" hidden="false" collective="false" categoryEntryId="485123232344415441232323" type="unit">
+      <profiles>
+        <profile id="8467-ffd0-1e2e-873b" name="Legion Praetor Tribune" book="Package" hidden="false" profileTypeId="556e697423232344415441232323">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Unit Type" characteristicTypeId="556e6974205479706523232344415441232323" value="Infantry (Character)"/>
+            <characteristic name="WS" characteristicTypeId="575323232344415441232323" value="6"/>
+            <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="5"/>
+            <characteristic name="S" characteristicTypeId="5323232344415441232323" value="4"/>
+            <characteristic name="T" characteristicTypeId="5423232344415441232323" value="4"/>
+            <characteristic name="W" characteristicTypeId="5723232344415441232323" value="3"/>
+            <characteristic name="I" characteristicTypeId="4923232344415441232323" value="5"/>
+            <characteristic name="A" characteristicTypeId="4123232344415441232323" value="4(5*)"/>
+            <characteristic name="LD" characteristicTypeId="4c4423232344415441232323" value="10"/>
+            <characteristic name="Save" characteristicTypeId="5361766523232344415441232323" value="2+"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="b93e-846a-aa2c-cda3" name="Exemplary Tribune" book="Package" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="44f7-1cec-4415-e01c" hidden="false" targetId="48ee-9a7f-07f1-22d0" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="7ae4-9dd8-6382-55cb" hidden="false" targetId="8199e922-e844-5d34-b04b-86edadffa2df" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="d175-f405-7886-01e9" hidden="false" targetId="d4a1a878-9ad4-6ae0-a864-08f58264c4a5" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <repeats/>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="274a-5c0d-319b-a20d" type="equalTo"/>
+          </conditions>
+          <conditionGroups/>
+        </modifier>
+        <modifier type="set" field="hidden" value="true">
+          <repeats>
+            <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3215-720d-8883-ab23" repeats="1"/>
+          </repeats>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1006-e22e-3aa4-f79a" type="equalTo"/>
+          </conditions>
+          <conditionGroups/>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="823c-4fc1-0154-35b6" type="min"/>
+        <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="26c4-599f-4885-b6e2" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="f244-04dc-f87f-745f" name="Master-crafted Paragon Blade" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="86ca-22be-bdd2-8de4" hidden="false" targetId="2fd78c56-eae0-49c5-9103-62ebadb9a05c" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b929-4423-1fc4-6953" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="15af-e15d-4016-cfb4" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="a852-e71c-f224-b2fa" name="Iron Halo" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="4a73-8c46-f621-afbb" hidden="false" targetId="10b59cf4-3c97-e3e0-2185-853bcde6d112" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a499-8acf-f816-20ab" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1ee2-47a2-4f8b-882a" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="58d6-9bb6-17cf-ffcf" name="Digital Lasers*" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="764b-86be-b8cc-fde4" hidden="false" targetId="0f5f4d88-fe1f-092e-ef2a-1601bcb2fc9d" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b3bd-5aa9-387f-ee7f" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b6e8-eac2-fcb9-184e" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="1ff0-7c10-fc3c-4771" name="" hidden="false" targetId="7f468ad2-37a2-384e-62c6-59a0ef008fe9" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="180.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>

--- a/(HH) Mechanicum - Taghmata Army List.cat
+++ b/(HH) Mechanicum - Taghmata Army List.cat
@@ -17503,7 +17503,9 @@ Reduces transport capacity to 8.  </description>
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="6242-bb77-c685-6171" name="Enchanced Targeting Array" hidden="false" collective="false" type="upgrade">
       <profiles/>
@@ -17524,7 +17526,9 @@ Reduces transport capacity to 8.  </description>
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="3e05-38ff-1f0e-2f2f" name="Vultarax" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
       <profiles>
@@ -17582,26 +17586,28 @@ Reduces transport capacity to 8.  </description>
       </infoLinks>
       <modifiers/>
       <constraints/>
-      <selectionEntries/>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="9600-0829-f8bc-96c2" name="Standard Wargear" hidden="false" collective="false">
+      <selectionEntries>
+        <selectionEntry id="c012-7d43-1475-ea1a" name="Standard Weapons" hidden="false" collective="false" type="upgrade">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <constraints/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ebc4-b33c-a3cd-7c4e" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="347c-049d-b52d-0ec9" type="max"/>
+          </constraints>
           <selectionEntries>
-            <selectionEntry id="bca5-d029-fe8f-bc13" name="Two Setheno Pattern havoc Launchers" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="77e7-632c-7bde-e2c1" name="Two Setheno Pattern havoc Launchers" hidden="false" collective="false" type="upgrade">
               <profiles/>
               <rules/>
               <infoLinks>
-                <infoLink id="6a52-3810-6aff-4dcc" name="New InfoLink" hidden="false" targetId="5c44-3270-e851-c796" type="rule">
+                <infoLink id="6675-1e69-26b9-6f77" name="New InfoLink" hidden="false" targetId="5c44-3270-e851-c796" type="rule">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
                   <modifiers/>
                 </infoLink>
-                <infoLink id="ef62-0c6e-adc9-e3e3" name="New InfoLink" hidden="false" targetId="516c-a244-36e3-e4b7" type="profile">
+                <infoLink id="c32b-4253-8e66-328e" name="New InfoLink" hidden="false" targetId="516c-a244-36e3-e4b7" type="profile">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -17610,8 +17616,8 @@ Reduces transport capacity to 8.  </description>
               </infoLinks>
               <modifiers/>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fb05-3798-a6d1-7a3d" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e9ac-3e71-1f74-52ea" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="097b-bb3d-c0cd-50c0" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="94dd-ea09-3538-9139" type="max"/>
               </constraints>
               <selectionEntries/>
               <selectionEntryGroups/>
@@ -17620,23 +17626,23 @@ Reduces transport capacity to 8.  </description>
                 <cost name="pts" costTypeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="1042-b6ca-5fdd-f4db" name="Vultarax Arc Blaster" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="bd5e-d1ec-0fb1-c537" name="Vultarax Arc Blaster" hidden="false" collective="false" type="upgrade">
               <profiles/>
               <rules/>
               <infoLinks>
-                <infoLink id="e786-5f26-319b-bda5" name="New InfoLink" hidden="false" targetId="89da-0cb5-bee4-8ec2" type="rule">
+                <infoLink id="ae37-baed-3bdc-6f6c" name="New InfoLink" hidden="false" targetId="89da-0cb5-bee4-8ec2" type="rule">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
                   <modifiers/>
                 </infoLink>
-                <infoLink id="32fd-2a8b-f949-ad5c" name="New InfoLink" hidden="false" targetId="6970-1bf3-b33e-5dce" type="rule">
+                <infoLink id="f1ef-e587-331f-6bca" name="New InfoLink" hidden="false" targetId="6970-1bf3-b33e-5dce" type="rule">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
                   <modifiers/>
                 </infoLink>
-                <infoLink id="972b-ac1b-8a73-553d" name="New InfoLink" hidden="false" targetId="f5b0-d321-4684-74da" type="profile">
+                <infoLink id="2d1c-94e3-be2f-c4e7" name="New InfoLink" hidden="false" targetId="f5b0-d321-4684-74da" type="profile">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -17645,25 +17651,40 @@ Reduces transport capacity to 8.  </description>
               </infoLinks>
               <modifiers/>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1794-4165-89a4-b390" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4caf-704e-48db-d405" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6df6-0cdd-fd78-6689" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8c5f-1a06-910b-39e8" type="max"/>
               </constraints>
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks/>
-              <costs/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
             </selectionEntry>
           </selectionEntries>
           <selectionEntryGroups/>
+          <entryLinks/>
+          <costs/>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="9600-0829-f8bc-96c2" name="Standard Wargear" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="96e1-c3f3-7e8a-4317" name="New EntryLink" page="" hidden="false" targetId="6242-bb77-c685-6171" type="selectionEntry">
+            <entryLink id="53ca-3bed-7f70-780b" name="New EntryLink" hidden="false" targetId="1e27e511-cf75-d55a-6807-b67be6f7474f" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
               <constraints/>
             </entryLink>
-            <entryLink id="53ca-3bed-7f70-780b" name="New EntryLink" hidden="false" targetId="1e27e511-cf75-d55a-6807-b67be6f7474f" type="selectionEntry">
+            <entryLink id="4f70-3c4e-cda6-c975" name="New EntryLink" page="" hidden="false" targetId="6242-bb77-c685-6171" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>

--- a/(HH) Mechanicum - Taghmata Army List.cat
+++ b/(HH) Mechanicum - Taghmata Army List.cat
@@ -2855,12 +2855,6 @@ Attacking player rolls 2D6.  If the target has a Toughness characteristic, they 
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="1baf-e9da-6311-5219" hidden="false" targetId="8fcf6a3e-2394-ea8b-62a4-b78168a2dd15" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
         <infoLink id="b661-86b0-8888-02cb" hidden="false" targetId="d77a5e49-6699-8eb3-f6cc-1e3560501f2a" type="rule">
           <profiles/>
           <rules/>
@@ -2868,6 +2862,12 @@ Attacking player rolls 2D6.  If the target has a Toughness characteristic, they 
           <modifiers/>
         </infoLink>
         <infoLink id="0942-002a-2f92-712e" hidden="false" targetId="6eb5b812-8b8b-9e7c-279e-c9e9c93fefe9" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="6582-54d8-341b-0055" hidden="false" targetId="8fcf6a3e-2394-ea8b-62a4-b78168a2dd15" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -12412,20 +12412,7 @@ Buildings and Fortifications                                          D
     </selectionEntry>
     <selectionEntry id="85fd-a4b3-a28f-9a98" name="Vorax Class Battle-automata Maniple" book="" hidden="false" collective="false" categoryEntryId="466173742041747461636b23232344415441232323" type="unit">
       <profiles/>
-      <rules>
-        <rule id="f07e-29d9-86da-983e" name="Fleet" page="0" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </rule>
-        <rule id="1aa6-02fa-3e8c-269e" name="Scout" page="0" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </rule>
-      </rules>
+      <rules/>
       <infoLinks>
         <infoLink id="b276-4bce-84a7-2742" hidden="false" targetId="75683330-6490-c0bf-560c-2e58617425a1" type="profile">
           <profiles/>
@@ -12445,7 +12432,25 @@ Buildings and Fortifications                                          D
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="be4c-1160-31a0-dd05" hidden="false" targetId="8fcf6a3e-2394-ea8b-62a4-b78168a2dd15" type="rule">
+        <infoLink id="be4c-1160-31a0-dd05" name="" hidden="false" targetId="8fcf6a3e-2394-ea8b-62a4-b78168a2dd15" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="append" field="description" value="*For the purposes of this special rule, a Stratosautomata counts as a Battle-automata except that the ‘Methodical’ provision does not apply, and in the case of the ‘Target Priority’ provision of the special rule, the controlling player may always attempt to target the nearest enemy Flyer or Flying Creature rather than just the closest enemy model when this special rule comes into effect.">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="ac91-89d2-e472-623b" name="New InfoLink" hidden="false" targetId="9b30-1da3-eb8d-ce7a" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="e5a0-473b-71f7-b2b7" name="New InfoLink" hidden="false" targetId="69e5-fc02-1f9d-63c2" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -12477,14 +12482,40 @@ Buildings and Fortifications                                          D
             </profile>
           </profiles>
           <rules/>
-          <infoLinks/>
+          <infoLinks>
+            <infoLink id="fec1-7e56-9795-5882" name="New InfoLink" hidden="false" targetId="d0b7-ed3f-25c8-1e63" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
           <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
             <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <selectionEntries/>
-          <selectionEntryGroups/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="a281-32f4-442b-55fd" name="Standard Wargear" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="0670-7cb3-0eca-6d94" name="New EntryLink" hidden="false" targetId="1e27e511-cf75-d55a-6807-b67be6f7474f" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
           <entryLinks/>
           <costs>
             <cost name="pts" costTypeId="points" value="65.0"/>
@@ -13959,6 +13990,71 @@ Buildings and Fortifications                                          D
           <infoLinks/>
           <modifiers/>
           <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0fbb-6dc7-ee41-7f17" name="Vultarax Stratos-automata Maniple" hidden="false" collective="false" categoryEntryId="466173742041747461636b23232344415441232323" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="6a02-7a93-73b3-8320" name="The Maniple may be upgrade to take:" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="ed57-f53a-4565-2671" name="New EntryLink" hidden="false" targetId="fb66-11c0-3cb4-aac3" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="20">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6653-c42b-0326-094a" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="set" field="points" value="30">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6653-c42b-0326-094a" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="a124-f586-3578-5092" name="New EntryLink" hidden="false" targetId="0533-d54e-8dc0-9c57" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="6653-c42b-0326-094a" name="New EntryLink" hidden="false" targetId="3e05-38ff-1f0e-2f2f" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="46b0-479f-00dd-ca5a" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0de8-e440-f657-ae0c" type="min"/>
+          </constraints>
         </entryLink>
       </entryLinks>
       <costs>
@@ -17398,6 +17494,236 @@ Reduces transport capacity to 8.  </description>
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
+    <selectionEntry id="3041-09bd-d512-8568" name="Sethe" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs/>
+    </selectionEntry>
+    <selectionEntry id="6242-bb77-c685-6171" name="Enchanced Targeting Array" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="102b-65d4-0007-9cbb" name="New InfoLink" hidden="false" targetId="c85c-3be5-d699-b6f3" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="943d-5acf-5fdb-f4d5" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d710-122e-40b7-307d" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs/>
+    </selectionEntry>
+    <selectionEntry id="3e05-38ff-1f0e-2f2f" name="Vultarax" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+      <profiles>
+        <profile id="11d2-97d1-7e65-5afd" name="Vultarax" book="" page="" hidden="false" profileTypeId="556e697423232344415441232323">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Unit Type" characteristicTypeId="556e6974205479706523232344415441232323" value="Flying Monstrous Creature"/>
+            <characteristic name="WS" characteristicTypeId="575323232344415441232323" value="3"/>
+            <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="4"/>
+            <characteristic name="S" characteristicTypeId="5323232344415441232323" value="4"/>
+            <characteristic name="T" characteristicTypeId="5423232344415441232323" value="7"/>
+            <characteristic name="W" characteristicTypeId="5723232344415441232323" value="4"/>
+            <characteristic name="I" characteristicTypeId="4923232344415441232323" value="3"/>
+            <characteristic name="A" characteristicTypeId="4123232344415441232323" value="2"/>
+            <characteristic name="LD" characteristicTypeId="4c4423232344415441232323" value="8"/>
+            <characteristic name="Save" characteristicTypeId="5361766523232344415441232323" value="3+"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="5883-08a8-bd74-ffe4" name="New InfoLink" hidden="false" targetId="f6c9-cdb7-c695-5b6b" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="append" field="description" value="*For the purposes of this special rule, a Stratosautomata counts as a Battle-automata except that the ‘Methodical’ provision does not apply, and in the case of the ‘Target Priority’ provision of the special rule, the controlling player may always attempt to target the nearest enemy Flyer or Flying Creature rather than just the closest enemy model when this special rule comes into effect.">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="f916-2011-7bc8-f30f" name="New InfoLink" hidden="false" targetId="a225-e39b-3699-c8f8" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="a9bf-d9eb-e926-c736" name="New InfoLink" hidden="false" targetId="d5cf-bd98-2854-13cf" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="append" field="description" value=" – in the case of the Vultarax, measure from the edge of the model’s base.">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="9600-0829-f8bc-96c2" name="Standard Wargear" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries>
+            <selectionEntry id="bca5-d029-fe8f-bc13" name="Two Setheno Pattern havoc Launchers" hidden="false" collective="false" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="6a52-3810-6aff-4dcc" name="New InfoLink" hidden="false" targetId="5c44-3270-e851-c796" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="ef62-0c6e-adc9-e3e3" name="New InfoLink" hidden="false" targetId="516c-a244-36e3-e4b7" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fb05-3798-a6d1-7a3d" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e9ac-3e71-1f74-52ea" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="1042-b6ca-5fdd-f4db" name="Vultarax Arc Blaster" hidden="false" collective="false" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="e786-5f26-319b-bda5" name="New InfoLink" hidden="false" targetId="89da-0cb5-bee4-8ec2" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="32fd-2a8b-f949-ad5c" name="New InfoLink" hidden="false" targetId="6970-1bf3-b33e-5dce" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="972b-ac1b-8a73-553d" name="New InfoLink" hidden="false" targetId="f5b0-d321-4684-74da" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1794-4165-89a4-b390" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4caf-704e-48db-d405" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs/>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="96e1-c3f3-7e8a-4317" name="New EntryLink" page="" hidden="false" targetId="6242-bb77-c685-6171" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="53ca-3bed-7f70-780b" name="New EntryLink" hidden="false" targetId="1e27e511-cf75-d55a-6807-b67be6f7474f" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="3aa9-c132-bffe-f1a5" name="May be upgrade with:" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries>
+            <selectionEntry id="e7b9-9371-8e4e-3b8b" name="Battle-automata power blades" hidden="false" collective="false" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="1598-6dac-e4d2-6aea" name="New InfoLink" page="" hidden="false" targetId="7544-1891-3c0b-e9d0" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="2c04-7a94-2182-6188" name="New InfoLink" hidden="false" targetId="8269-2cd6-9236-16e7" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="c3b2-5dda-a548-1969" name="New InfoLink" hidden="false" targetId="c56e-d46b-a4ca-8cdc" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5efe-86e0-b3f0-85cc" type="max"/>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a0c9-a76c-70dc-8648" type="min"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="15.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="175.0"/>
+      </costs>
+    </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup id="d696-042d-2afa-b026" name="Heavy Bolter or Heavy Flamer" hidden="false" collective="false">
@@ -17691,6 +18017,24 @@ Reduces transport capacity to 8.  </description>
       </selectionEntries>
       <selectionEntryGroups/>
       <entryLinks/>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="0533-d54e-8dc0-9c57" name="A single Maniple may take:" hidden="false" collective="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="cd4d-9871-6699-9321" hidden="false" targetId="34924deb-f4e5-7739-5606-87600d1740bb" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <sharedRules>
@@ -18097,6 +18441,20 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
       <infoLinks/>
       <modifiers/>
       <description>Attacks with this special rule may re-roll failed armour penetration rolls against fortifications and immobile structures and add +1 to any result rolled on the Building Damage chart.  If this attack damages a bulkhead or wall section of terrain and destroys it, remove that section of terrain from play if possible.  </description>
+    </rule>
+    <rule id="7544-1891-3c0b-e9d0" name="Paired Weapons" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>Battle-automata power blades are paired weapons and so add +1 to the model’s attacks and count as being Two-handed.</description>
+    </rule>
+    <rule id="5c44-3270-e851-c796" name="Setheno-Djinn" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>Successful cover saves against this weapon must be re-rolled.</description>
     </rule>
   </sharedRules>
   <sharedProfiles>
@@ -19619,6 +19977,42 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
         <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="6"/>
         <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="3"/>
         <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 15"/>
+      </characteristics>
+    </profile>
+    <profile id="c56e-d46b-a4ca-8cdc" name="Battle-automata power blades" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="-"/>
+        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="As User"/>
+        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="2"/>
+        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Melee, Rending, Paried Weapons"/>
+      </characteristics>
+    </profile>
+    <profile id="516c-a244-36e3-e4b7" name="Setheno Pattern havoc Launcher" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="48&quot;"/>
+        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="5"/>
+        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="5"/>
+        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 2, Blast (3&quot;), Twin-Linked, Sethno-Djinn"/>
+      </characteristics>
+    </profile>
+    <profile id="f5b0-d321-4684-74da" name="Vultarax Arc Blaster" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="24&quot;"/>
+        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="6"/>
+        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="5"/>
+        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 3, Shred, Haywire"/>
       </characteristics>
     </profile>
   </sharedProfiles>

--- a/(HH) Mechanicum - Taghmata Army List.cat
+++ b/(HH) Mechanicum - Taghmata Army List.cat
@@ -5313,14 +5313,7 @@ D6    Result		S	AP
           </characteristics>
         </profile>
       </profiles>
-      <rules>
-        <rule id="d42e-ec28-80b7-0bf4" name="Stubborn" page="0" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </rule>
-      </rules>
+      <rules/>
       <infoLinks>
         <infoLink id="a485-a69c-90a4-5f9c" hidden="false" targetId="5aad03df-0fd0-5920-0aec-2aefbe5bcf5b" type="rule">
           <profiles/>
@@ -5353,6 +5346,12 @@ D6    Result		S	AP
           <modifiers/>
         </infoLink>
         <infoLink id="7ef1-581d-ef25-2562" hidden="false" targetId="a41e-00bb-2ace-734f" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="b7d0-2e92-9781-f09a" name="New InfoLink" hidden="false" targetId="7be5-30af-1a02-0a89" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -7279,20 +7278,7 @@ D6    Result		S	AP
           </characteristics>
         </profile>
       </profiles>
-      <rules>
-        <rule id="f5af-c007-f435-cf29" name="Stubborn" page="0" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </rule>
-        <rule id="73d9-1172-2ec5-41e2" name="Tank Hunters" page="0" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </rule>
-      </rules>
+      <rules/>
       <infoLinks>
         <infoLink id="7fac-c9be-2c89-bd7b" hidden="false" targetId="5aad03df-0fd0-5920-0aec-2aefbe5bcf5b" type="rule">
           <profiles/>
@@ -7313,6 +7299,18 @@ D6    Result		S	AP
           <modifiers/>
         </infoLink>
         <infoLink id="1ce8-70d6-67dc-7e5f" hidden="false" targetId="c2e6-597c-db69-3685" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="da40-30c8-8543-37aa" name="New InfoLink" hidden="false" targetId="7be5-30af-1a02-0a89" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="8f50-1acf-ead4-d178" name="New InfoLink" hidden="false" targetId="5d88-bcf6-e410-6e01" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -8378,12 +8376,6 @@ D6    Result		S	AP
         </profile>
       </profiles>
       <rules>
-        <rule id="eb088094-648b-6b5d-c38f-864c91927169" name="Stubborn" page="0" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </rule>
         <rule id="699d4d00-406f-3fdf-e81e-b2bd515962be" name="Master of Destruction" book="HH1: Betrayal" page="278" hidden="false">
           <profiles/>
           <rules/>
@@ -8427,6 +8419,12 @@ D6    Result		S	AP
           <modifiers/>
         </infoLink>
         <infoLink id="ccdd-de55-4b2c-2903" hidden="false" targetId="8199e922-e844-5d34-b04b-86edadffa2df" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="fe5a-21d3-1d34-186b" name="New InfoLink" hidden="false" targetId="7be5-30af-1a02-0a89" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -8654,18 +8652,6 @@ D6    Result		S	AP
           <infoLinks/>
           <modifiers/>
         </rule>
-        <rule id="c9a8-6029-bf0a-2119" name="Bulky" page="0" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </rule>
-        <rule id="ed43-4cfd-fc6c-5d59" name="Relentless" page="0" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </rule>
       </rules>
       <infoLinks>
         <infoLink id="8fbb-b87b-ba30-f2de" hidden="false" targetId="d94ec38f-20c8-84b8-79e6-6aba811aae26" type="profile">
@@ -8686,7 +8672,19 @@ D6    Result		S	AP
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="5517-acd8-4cc2-6496" hidden="false" targetId="6187-9edf-ea79-4188" type="rule">
+        <infoLink id="f0d2-237e-ce12-f817" name="New InfoLink" hidden="false" targetId="3c7d-a1fa-c68b-caad" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="bb96-9413-cead-6940" name="New InfoLink" hidden="false" targetId="38d5-b6eb-bda8-2497" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="26a1-d1e9-a2c0-bd61" name="New InfoLink" hidden="false" targetId="7be5-30af-1a02-0a89" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -8861,7 +8859,7 @@ D6    Result		S	AP
                     <cost name="pts" costTypeId="points" value="35.0"/>
                   </costs>
                 </selectionEntry>
-                <selectionEntry id="61ea-5b64-66d6-08f7" name="Photo Thruster Cannon" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                <selectionEntry id="61ea-5b64-66d6-08f7" name="Photon Thruster Cannon" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
                   <profiles/>
                   <rules/>
                   <infoLinks>
@@ -9032,7 +9030,7 @@ D6    Result		S	AP
                 <cost name="pts" costTypeId="points" value="35.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="352e-03da-de70-4bf1" name="Photo Thruster Cannon" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+            <selectionEntry id="352e-03da-de70-4bf1" name="Photon Thruster Cannon" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
               <profiles/>
               <rules/>
               <infoLinks>
@@ -9096,26 +9094,7 @@ D6    Result		S	AP
     </selectionEntry>
     <selectionEntry id="004c-e012-5637-e09e" name="Myrmidon Secutors" book="HH3: Extermination" page="220" hidden="false" collective="false" categoryEntryId="456c6974657323232344415441232323" type="unit">
       <profiles/>
-      <rules>
-        <rule id="460b-e83b-462e-9766" name="Stubborn" page="0" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </rule>
-        <rule id="7380-8ef7-f4b3-611d" name="Bulky" page="0" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </rule>
-        <rule id="5d54-a366-1a8d-c1ae" name="Relentless" page="0" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </rule>
-      </rules>
+      <rules/>
       <infoLinks>
         <infoLink id="7e10-4441-5765-1ffe" hidden="false" targetId="8e53a9a8-1408-23bf-5be8-4601caec5d10" type="rule">
           <profiles/>
@@ -9136,6 +9115,24 @@ D6    Result		S	AP
           <modifiers/>
         </infoLink>
         <infoLink id="c1e0-93f2-0e6d-3832" hidden="false" targetId="4d0a2655-b103-5681-15a0-74973416358a" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="bd12-1696-d13a-3e88" name="New InfoLink" hidden="false" targetId="3c7d-a1fa-c68b-caad" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="0ec8-41ef-0f4a-3dbc" name="New InfoLink" hidden="false" targetId="38d5-b6eb-bda8-2497" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="f022-241c-0881-5fc5" name="New InfoLink" hidden="false" targetId="7be5-30af-1a02-0a89" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -12318,18 +12315,6 @@ Buildings and Fortifications                                          D
         </profile>
       </profiles>
       <rules>
-        <rule id="f53e-269a-d640-78c7" name="Bulky" page="0" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </rule>
-        <rule id="9a50-057f-982c-ae74" name="Stubborn" page="0" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </rule>
         <rule id="d848-b9c0-87ab-a45c" name="Feel No Pain" page="0" hidden="false">
           <profiles/>
           <rules/>
@@ -12346,6 +12331,18 @@ Buildings and Fortifications                                          D
       </rules>
       <infoLinks>
         <infoLink id="bbba-7473-d78a-1789" hidden="false" targetId="405d3ced-c3a6-9f99-2018-9ab90162b6b1" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="1b13-7b83-687a-a522" name="New InfoLink" hidden="false" targetId="7be5-30af-1a02-0a89" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="2548-93aa-f93c-b8f0" name="New InfoLink" hidden="false" targetId="38d5-b6eb-bda8-2497" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>

--- a/The Horus Heresy.gst
+++ b/The Horus Heresy.gst
@@ -5955,9 +5955,7 @@ D6    Result		S	AP
         </infoLink>
       </infoLinks>
       <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0708-fbf0-d536-a48c" type="max"/>
-      </constraints>
+      <constraints/>
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks/>

--- a/The Horus Heresy.gst
+++ b/The Horus Heresy.gst
@@ -14197,5 +14197,14 @@ D6 - Result
         <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 1"/>
       </characteristics>
     </profile>
+    <profile id="48f1-0c16-d5e5-6d98" name="Flare Shield" book="LA:AoDAL" page="132" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Description" characteristicTypeId="4465736372697074696f6e23232344415441232323" value="A flare shield operates against shooting attacks that strike the vehicle&apos;s front arc.  It reduces the strength of attacks by weapons with the Templae or Blast type by -2, and other shooting attacks by -1.  A flare shield has no effect on attacks from close combat or with the Destroyer rule.  "/>
+      </characteristics>
+    </profile>
   </sharedProfiles>
 </gameSystem>

--- a/The Horus Heresy.gst
+++ b/The Horus Heresy.gst
@@ -10405,7 +10405,7 @@ Command Benefits:
             <cost name="pts" costTypeId="points" value="5.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="1720-1fb3-a76f-c0fd" name="Hand flamer" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+        <selectionEntry id="1720-1fb3-a76f-c0fd" name="Hand flamer (Blood Angels)" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
           <profiles/>
           <rules/>
           <infoLinks>
@@ -13763,7 +13763,7 @@ D6 - Result
         <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Assault 1, Melta"/>
       </characteristics>
     </profile>
-    <profile id="87c7-bd37-70f7-1933" name="Plasma gun" book="BRB 7th" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
+    <profile id="87c7-bd37-70f7-1933" name="Plasma Gun" book="BRB 7th" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -14202,6 +14202,18 @@ D6 - Result
         <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="8"/>
         <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="3"/>
         <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 1"/>
+      </characteristics>
+    </profile>
+    <profile id="13df-d6b0-3f33-bf9b" name="Plasma Cannon" book="BRB 7th" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="36&quot;"/>
+        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="7"/>
+        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="2"/>
+        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 1, Blast, Gets Hot"/>
       </characteristics>
     </profile>
   </sharedProfiles>

--- a/The Horus Heresy.gst
+++ b/The Horus Heresy.gst
@@ -12907,6 +12907,13 @@ D6 - Result
       <modifiers/>
       <description>At the end of the enemy Movement phase, a weapon with the Interceptor special rule can be fired at any one unit that has arrived from Reserve within its range and line of sight. If this rule is used, the weapon cannot be fired in the next turn, but the firing model can shoot a different weapon if it has one.</description>
     </rule>
+    <rule id="3138-683d-a9a0-570d" name="Armoured Ceramite" book="LA:AoDLA" page="131" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>A vehicle with this wargear is not subject to the additional D6 armour penetration caused by weapons with the Melta special rule.</description>
+    </rule>
   </sharedRules>
   <sharedProfiles>
     <profile id="09fd-8af1-a6b1-51f7" name="Bolter" book="BRB 7th" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">

--- a/The Horus Heresy.gst
+++ b/The Horus Heresy.gst
@@ -12893,6 +12893,13 @@ D6 - Result
       <modifiers/>
       <description>Targets may not take Jink saves against damage from this weapon.  </description>
     </rule>
+    <rule id="45cf-653a-4ff6-f22d" name="Assault Vehicle" book="BRB 7th" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>Passengers disembarking from Access Points on a vehicle with this special rule can charge on the turn they do so (even in a turn that the vehicle was destroyed, or in the following turn) unless the vehicle arrived from Reserve that turn.</description>
+    </rule>
   </sharedRules>
   <sharedProfiles>
     <profile id="09fd-8af1-a6b1-51f7" name="Bolter" book="BRB 7th" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">

--- a/The Horus Heresy.gst
+++ b/The Horus Heresy.gst
@@ -12900,6 +12900,13 @@ D6 - Result
       <modifiers/>
       <description>Passengers disembarking from Access Points on a vehicle with this special rule can charge on the turn they do so (even in a turn that the vehicle was destroyed, or in the following turn) unless the vehicle arrived from Reserve that turn.</description>
     </rule>
+    <rule id="ca3e-e94e-58f6-75d9" name="Interceptor" book="BRB 7th" page="" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>At the end of the enemy Movement phase, a weapon with the Interceptor special rule can be fired at any one unit that has arrived from Reserve within its range and line of sight. If this rule is used, the weapon cannot be fired in the next turn, but the firing model can shoot a different weapon if it has one.</description>
+    </rule>
   </sharedRules>
   <sharedProfiles>
     <profile id="09fd-8af1-a6b1-51f7" name="Bolter" book="BRB 7th" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">

--- a/The Horus Heresy.gst
+++ b/The Horus Heresy.gst
@@ -14173,5 +14173,41 @@ D6 - Result
         <characteristic name="Description" characteristicTypeId="4465736372697074696f6e23232344415441232323" value="A vehicle with this wargear is not subject to the additional D6 armour penetration caused by weapons with the Melta special rule.  "/>
       </characteristics>
     </profile>
+    <profile id="40e6-c95c-7c8d-cf02" name="Frag Missile" book="BRB 7th" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="48&quot;"/>
+        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="4"/>
+        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="6"/>
+        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 1, Blast"/>
+      </characteristics>
+    </profile>
+    <profile id="e2f7-5bdf-479c-8107" name="Krak Missile" book="BRB 7th" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="48&quot;"/>
+        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="8"/>
+        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="3"/>
+        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 1"/>
+      </characteristics>
+    </profile>
+    <profile id="15cd-55d1-8460-3ca8" name="Flakk Missile" book="BRB 7th" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="48&quot;"/>
+        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="7"/>
+        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="4"/>
+        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 1, Skyfire"/>
+      </characteristics>
+    </profile>
   </sharedProfiles>
 </gameSystem>

--- a/The Horus Heresy.gst
+++ b/The Horus Heresy.gst
@@ -13357,7 +13357,7 @@ D6 - Result
         <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Assault 1, Fleshbane, Rad-phage"/>
       </characteristics>
     </profile>
-    <profile id="1182-02a7-3325-8c51" name="Flak Missile" book="BRB 7th" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
+    <profile id="1182-02a7-3325-8c51" name="Flakk Missile" book="BRB 7th" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -14195,18 +14195,6 @@ D6 - Result
         <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="8"/>
         <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="3"/>
         <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 1"/>
-      </characteristics>
-    </profile>
-    <profile id="15cd-55d1-8460-3ca8" name="Flakk Missile" book="BRB 7th" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="48&quot;"/>
-        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="7"/>
-        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="4"/>
-        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 1, Skyfire"/>
       </characteristics>
     </profile>
   </sharedProfiles>

--- a/The Horus Heresy.gst
+++ b/The Horus Heresy.gst
@@ -11902,7 +11902,7 @@ Command Benefits:
           <profiles/>
           <rules/>
           <infoLinks>
-            <infoLink id="e687-26b6-3de9-97e9" name="New InfoLink" hidden="false" targetId="cb4a-644f-bd8d-7d97" type="profile">
+            <infoLink id="3052-7b26-9eed-36b1" name="New InfoLink" hidden="false" targetId="d0b7-ed3f-25c8-1e63" type="rule">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -12913,6 +12913,13 @@ D6 - Result
       <infoLinks/>
       <modifiers/>
       <description>A vehicle with this wargear is not subject to the additional D6 armour penetration caused by weapons with the Melta special rule.</description>
+    </rule>
+    <rule id="d0b7-ed3f-25c8-1e63" name="Flare Shield" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>A flare shield operates against shooting attacks that strike the vehicle&apos;s front arc.  It reduces the strength of attacks by weapons with the Templae or Blast type by -2, and other shooting attacks by -1.  A flare shield has no effect on attacks from close combat or with the Destroyer rule.</description>
     </rule>
   </sharedRules>
   <sharedProfiles>
@@ -14195,15 +14202,6 @@ D6 - Result
         <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="8"/>
         <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="3"/>
         <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 1"/>
-      </characteristics>
-    </profile>
-    <profile id="48f1-0c16-d5e5-6d98" name="Flare Shield" book="LA:AoDAL" page="132" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Description" characteristicTypeId="4465736372697074696f6e23232344415441232323" value="A flare shield operates against shooting attacks that strike the vehicle&apos;s front arc.  It reduces the strength of attacks by weapons with the Templae or Blast type by -2, and other shooting attacks by -1.  A flare shield has no effect on attacks from close combat or with the Destroyer rule.  "/>
       </characteristics>
     </profile>
   </sharedProfiles>


### PR DESCRIPTION
This is a complete fix for the basic Heavy Support units of Astartes's list, it covers all the entries in #568 and fixes them. I haven't made changes (much at least) to the other sections, rites or legion equipment. The aim of this fix is to get the basic units fixed and correct before moving on to another slot (like elites, troops, etc) eventually working up to HQ, rites and then legion modifiers. Some legion modifiers are in place from work carried out before me, so if your legion stuff is in and working (mostly Heavy Flamers strength change for salamanders and assualt cannon's for BA) then great! We'll get to the rest in future fixes.

Please reivew and let me know of any changes that need to be made! Either from a roster editor perspective or a data file perspective.