### PR TITLE
Minor Heavy Support, Milita and catalogue version updates

### DIFF
--- a/(HH) Imperialis Militia and Cults Army List.cat
+++ b/(HH) Imperialis Militia and Cults Army List.cat
@@ -7690,7 +7690,21 @@ D3     Mutation
       </costs>
     </selectionEntry>
   </selectionEntries>
-  <entryLinks/>
+  <entryLinks>
+    <entryLink id="346e-4f96-da50-f2c4" name="New EntryLink" hidden="false" targetId="2f44-0ed6-d014-be2f" type="selectionEntry" categoryEntryId="466173742041747461636b23232344415441232323">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers>
+        <modifier type="set" field="maxSelections" value="-1">
+          <repeats/>
+          <conditions/>
+          <conditionGroups/>
+        </modifier>
+      </modifiers>
+      <constraints/>
+    </entryLink>
+  </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="1072-a486-548b-2be7" name="Abhuman Helots" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
@@ -7773,16 +7787,27 @@ D3     Mutation
             <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Flyer (Hover, Transport)"/>
           </characteristics>
         </profile>
-      </profiles>
-      <rules>
-        <rule id="d82a-1f70-99a4-e0cf" name="Deep Strike" hidden="false">
+        <profile id="7759-4e5c-6f3c-08c5" name="Auxilia Arvus Lighter (Transport)" book="HH5: Tempest" page="202" hidden="false" profileTypeId="307d-047f-ca13-706b" profileTypeName="Transport">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-        </rule>
-      </rules>
-      <infoLinks/>
+          <characteristics>
+            <characteristic name="Capacity" characteristicTypeId="8285-4205-b6cd-8473" value="12"/>
+            <characteristic name="Fire Points" characteristicTypeId="b270-a7f9-22b2-3702" value="None"/>
+            <characteristic name="Access Points" characteristicTypeId="d17b-0342-b1dc-b8e7" value="Access hatch on the rear"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="0b31-831f-5490-ccfc" name="New InfoLink" hidden="false" targetId="d219-2314-4834-c054" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
@@ -7877,9 +7902,39 @@ D3     Mutation
                 <cost name="pts" costTypeId="points" value="1.0"/>
               </costs>
             </selectionEntry>
+            <selectionEntry id="d9db-6075-c219-bc80" name="Flare Shield" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="34a1-06eb-8139-08d8" hidden="false" targetId="130b-5a7b-fb5e-db81" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2c65-dc55-79c7-99c3" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="20.0"/>
+              </costs>
+            </selectionEntry>
           </selectionEntries>
           <selectionEntryGroups/>
-          <entryLinks/>
+          <entryLinks>
+            <entryLink id="e7c3-04b9-1e1f-cd6c" name="New EntryLink" hidden="false" targetId="eb3c-2350-27fe-8d9d" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="406b-99cc-5df7-a639" name="May take one of the following:" hidden="false" collective="false">
           <profiles/>
@@ -7930,7 +7985,14 @@ D3     Mutation
             <selectionEntry id="7a0c-70ee-18a5-b9a8" name="Lascannon" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
               <profiles/>
               <rules/>
-              <infoLinks/>
+              <infoLinks>
+                <infoLink id="9662-fa77-1754-1d07" name="New InfoLink" hidden="false" targetId="1cce-972c-022a-2590" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
               <modifiers/>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
@@ -7967,7 +8029,14 @@ D3     Mutation
             <selectionEntry id="b6c1-cb35-f11c-2c5a" name="Twin-linked Lascannon" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
               <profiles/>
               <rules/>
-              <infoLinks/>
+              <infoLinks>
+                <infoLink id="6409-6c9f-4f10-57bb" name="New InfoLink" hidden="false" targetId="1cce-972c-022a-2590" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
               <modifiers/>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="839b6f2a-4041-398b-fc2d-dc6a31d5f75e" name="Legiones Astartes: Age of Darkness Army List" book="Forgeworld Horus Heresy Series" revision="203" battleScribeVersion="2.00" authorName="Millicant" authorContact="Please submit any bugs to the website below" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="20" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="839b6f2a-4041-398b-fc2d-dc6a31d5f75e" name="Legiones Astartes: Age of Darkness Army List" book="Forgeworld Horus Heresy Series" revision="204" battleScribeVersion="2.00" authorName="Millicant" authorContact="Please submit any bugs to the website below" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="20" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules/>
   <infoLinks/>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -31996,7 +31996,7 @@ Ignores Cover special rule.</description>
         <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="290e-4e10-cfcb-6e8e" type="min"/>
       </constraints>
     </entryLink>
-    <entryLink id="aac41820-75ad-ce7a-65d3-b3a7cd79cfd4" hidden="false" targetId="5b8da8d0-7c0f-1744-bd13-550239ea056c" type="selectionEntry" categoryEntryId="486561767920537570706f727423232344415441232323">
+    <entryLink id="aac41820-75ad-ce7a-65d3-b3a7cd79cfd4" name="" hidden="false" targetId="5b8da8d0-7c0f-1744-bd13-550239ea056c" type="selectionEntry" categoryEntryId="486561767920537570706f727423232344415441232323">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -32004,7 +32004,7 @@ Ignores Cover special rule.</description>
         <modifier type="set" field="hidden" value="true">
           <repeats/>
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8c4d-a5af-f886-05cc" type="greaterThan"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f936-231d-4ff4-9475" type="greaterThan"/>
           </conditions>
           <conditionGroups/>
         </modifier>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -41153,7 +41153,7 @@ In addtion, all units with the Legiones Astartes (Emperor&apos;s Children) rule 
       <selectionEntryGroups/>
       <entryLinks/>
       <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
+        <cost name="pts" costTypeId="points" value="35.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="f2d4a6e5-edf4-52b2-fa15-13b163113aa5" name="Heavy Flamer (Salamander)" book="" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
@@ -47187,6 +47187,13 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
               <modifiers/>
               <constraints/>
             </entryLink>
+            <entryLink id="99f5-f5b0-0d9a-0215" name="New EntryLink" hidden="false" targetId="8bdb-f61c-f783-3771" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
@@ -48249,6 +48256,13 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
           <constraints/>
         </entryLink>
         <entryLink id="d033-f495-3cf6-c007" name="New EntryLink" hidden="false" targetId="b572273e-2b93-4961-75c8-d9022c31a47d" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="4ab2-75f8-ba1d-7d82" name="New EntryLink" hidden="false" targetId="fe17-5ed2-ca63-9379" type="selectionEntryGroup">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -56329,7 +56343,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
       <selectionEntryGroups/>
       <entryLinks/>
       <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
+        <cost name="pts" costTypeId="points" value="10.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="d4e8-6e08-581a-79bd" name="Plasma Repeater" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
@@ -63475,19 +63489,6 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
         <cost name="pts" costTypeId="points" value="15.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="ec96-607e-4374-8906" name="Executioner Plasma Cannon" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="55.0"/>
-      </costs>
-    </selectionEntry>
     <selectionEntry id="5986-c8ef-d448-397b" name="Twin-Linked Iliastus Pattern Assault Cannon" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
       <rules/>
@@ -65572,7 +65573,9 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks/>
-              <costs/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
             </selectionEntry>
           </selectionEntries>
           <selectionEntryGroups/>
@@ -68636,6 +68639,26 @@ Explodes results add D3&quot; to radius.  </description>
       </entryLinks>
       <costs>
         <cost name="pts" costTypeId="points" value="180.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="8bdb-f61c-f783-3771" name="Executioner Plasma Destroyer" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="815c-49ab-6d75-6142" name="New InfoLink" hidden="false" targetId="c9ab-e5ee-05cd-da3e" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="55.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>

--- a/The Horus Heresy.gst
+++ b/The Horus Heresy.gst
@@ -14214,5 +14214,17 @@ D6 - Result
         <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 1, Blast, Gets Hot"/>
       </characteristics>
     </profile>
+    <profile id="c9ab-e5ee-05cd-da3e" name="Plasma Executioner" book="LA:AoDL" page="127" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="36&quot;"/>
+        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="7"/>
+        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="2"/>
+        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 3, Blast (3&quot;)"/>
+      </characteristics>
+    </profile>
   </sharedProfiles>
 </gameSystem>

--- a/The Horus Heresy.gst
+++ b/The Horus Heresy.gst
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<gameSystem id="ca571888-56a9-c58e-ddaf-54f4713538bc" name="Warhammer 30,000 - The Horus Heresy" book="Forgeworld Horus Heresy Series" revision="42" battleScribeVersion="2.00" authorName="Millicant" authorContact="Please submit any bugs to the website below" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
+<gameSystem id="ca571888-56a9-c58e-ddaf-54f4713538bc" name="Warhammer 30,000 - The Horus Heresy" book="Forgeworld Horus Heresy Series" revision="43" battleScribeVersion="2.00" authorName="Millicant" authorContact="Please submit any bugs to the website below" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
   <profiles/>
   <rules/>
   <infoLinks/>


### PR DESCRIPTION
Astarte changes and fixes:
Added: Predator Plasma Executioner turret
Correction: Predator heavy conversion Beamer has no cost.
Fixed: Sicaran battle tank missing optional pintle-mount.
Fixed: Phosphex Grenades had no cost.
Fixed: Deathstorm not showing in Orbital RoW as a fast attack choice.
Fixed: Deathstorm showing in Stone Gauntlet as no deep strike is allowed by that RoW.

Cults and Militia Changes:
Arvus Lighter available as fast attack choice.

Misc:
The main GST catalogue wasn't incremented, this would have caused some errors when files were pulled in by the app. It wouldn't update the GST file. Deleting files and refreshing them would fix it but this shouldn't be needed.