### PR TITLE
Fixes astarte fast attack

### DIFF
--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -27355,7 +27355,26 @@ Ignores Cover special rule.</description>
           </costs>
         </selectionEntry>
       </selectionEntries>
-      <selectionEntryGroups/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="c8be-2c4f-bdc8-36a7" name="Retuine Command Squad" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="3a6d-90f9-c323-937a" name="New EntryLink" hidden="false" targetId="cba7eacc-627d-ad1f-3c72-70e35c15fd9f" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
       <entryLinks>
         <entryLink id="4c50-06ab-28e0-b568" hidden="false" targetId="7f468ad2-37a2-384e-62c6-59a0ef008fe9" type="selectionEntry">
           <profiles/>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -2111,7 +2111,7 @@
                   <infoLinks/>
                   <modifiers/>
                 </infoLink>
-                <infoLink id="6dd7-3973-7702-edab" hidden="false" targetId="e31cf870-3fa6-f2a2-8704-9bf05f7efcd8" type="rule">
+                <infoLink id="6dd7-3973-7702-edab" hidden="false" targetId="cbcf-5f25-f8ea-7cfd" type="rule">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -2577,7 +2577,7 @@
                       <infoLinks/>
                       <modifiers/>
                     </infoLink>
-                    <infoLink id="95c0-0c2d-5f63-ad8a" hidden="false" targetId="e31cf870-3fa6-f2a2-8704-9bf05f7efcd8" type="rule">
+                    <infoLink id="95c0-0c2d-5f63-ad8a" hidden="false" targetId="cbcf-5f25-f8ea-7cfd" type="rule">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -2780,7 +2780,7 @@
                       <infoLinks/>
                       <modifiers/>
                     </infoLink>
-                    <infoLink id="6d6b-0331-e037-e944" hidden="false" targetId="e31cf870-3fa6-f2a2-8704-9bf05f7efcd8" type="rule">
+                    <infoLink id="6d6b-0331-e037-e944" hidden="false" targetId="cbcf-5f25-f8ea-7cfd" type="rule">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -2927,7 +2927,7 @@
                       <infoLinks/>
                       <modifiers/>
                     </infoLink>
-                    <infoLink id="f085-9dbf-1dc2-a3a3" hidden="false" targetId="e31cf870-3fa6-f2a2-8704-9bf05f7efcd8" type="rule">
+                    <infoLink id="f085-9dbf-1dc2-a3a3" hidden="false" targetId="cbcf-5f25-f8ea-7cfd" type="rule">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -6757,7 +6757,7 @@
                   <infoLinks/>
                   <modifiers/>
                 </infoLink>
-                <infoLink id="7026-3397-ee12-4f4d" hidden="false" targetId="e31cf870-3fa6-f2a2-8704-9bf05f7efcd8" type="rule">
+                <infoLink id="7026-3397-ee12-4f4d" hidden="false" targetId="cbcf-5f25-f8ea-7cfd" type="rule">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -10975,7 +10975,7 @@
                   <infoLinks/>
                   <modifiers/>
                 </infoLink>
-                <infoLink id="5404941c-514f-bdc0-9915-592c2b389df9" hidden="false" targetId="e31cf870-3fa6-f2a2-8704-9bf05f7efcd8" type="rule">
+                <infoLink id="5404941c-514f-bdc0-9915-592c2b389df9" hidden="false" targetId="cbcf-5f25-f8ea-7cfd" type="rule">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -11567,7 +11567,7 @@
                       <infoLinks/>
                       <modifiers/>
                     </infoLink>
-                    <infoLink id="9e165186-0fcb-9ede-b7f6-ffbbcfdc7343" hidden="false" targetId="e31cf870-3fa6-f2a2-8704-9bf05f7efcd8" type="rule">
+                    <infoLink id="9e165186-0fcb-9ede-b7f6-ffbbcfdc7343" hidden="false" targetId="cbcf-5f25-f8ea-7cfd" type="rule">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -11958,7 +11958,7 @@
                       <infoLinks/>
                       <modifiers/>
                     </infoLink>
-                    <infoLink id="2c8e6890-b1a8-d082-a0c7-a0b01b95144b" hidden="false" targetId="e31cf870-3fa6-f2a2-8704-9bf05f7efcd8" type="rule">
+                    <infoLink id="2c8e6890-b1a8-d082-a0c7-a0b01b95144b" hidden="false" targetId="cbcf-5f25-f8ea-7cfd" type="rule">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -12318,7 +12318,7 @@
                       <infoLinks/>
                       <modifiers/>
                     </infoLink>
-                    <infoLink id="4ad37bf3-2541-b9b2-a94d-d8316ea0a832" hidden="false" targetId="e31cf870-3fa6-f2a2-8704-9bf05f7efcd8" type="rule">
+                    <infoLink id="4ad37bf3-2541-b9b2-a94d-d8316ea0a832" hidden="false" targetId="cbcf-5f25-f8ea-7cfd" type="rule">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -12950,7 +12950,7 @@
                       <infoLinks/>
                       <modifiers/>
                     </infoLink>
-                    <infoLink id="8386eaa9-9e00-3b9b-1f8c-6475554fdc10" hidden="false" targetId="e31cf870-3fa6-f2a2-8704-9bf05f7efcd8" type="rule">
+                    <infoLink id="8386eaa9-9e00-3b9b-1f8c-6475554fdc10" hidden="false" targetId="cbcf-5f25-f8ea-7cfd" type="rule">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -13949,7 +13949,7 @@
                               <infoLinks/>
                               <modifiers/>
                             </infoLink>
-                            <infoLink id="48c2-4340-604e-df71" hidden="false" targetId="e31cf870-3fa6-f2a2-8704-9bf05f7efcd8" type="rule">
+                            <infoLink id="48c2-4340-604e-df71" hidden="false" targetId="cbcf-5f25-f8ea-7cfd" type="rule">
                               <profiles/>
                               <rules/>
                               <infoLinks/>
@@ -14929,7 +14929,7 @@
                   <infoLinks/>
                   <modifiers/>
                 </infoLink>
-                <infoLink id="aafacae9-c025-0ba2-1bbd-15da454d852c" hidden="false" targetId="e31cf870-3fa6-f2a2-8704-9bf05f7efcd8" type="rule">
+                <infoLink id="aafacae9-c025-0ba2-1bbd-15da454d852c" hidden="false" targetId="cbcf-5f25-f8ea-7cfd" type="rule">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -15977,7 +15977,7 @@
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="d9a1ce74-cd75-0dd6-eb8b-750e2dcc5b43" hidden="false" targetId="e31cf870-3fa6-f2a2-8704-9bf05f7efcd8" type="rule">
+        <infoLink id="d9a1ce74-cd75-0dd6-eb8b-750e2dcc5b43" hidden="false" targetId="cbcf-5f25-f8ea-7cfd" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -16521,7 +16521,7 @@
                       <infoLinks/>
                       <modifiers/>
                     </infoLink>
-                    <infoLink id="fb09ce88-dd0e-aeaf-f63a-26c7837b7532" hidden="false" targetId="e31cf870-3fa6-f2a2-8704-9bf05f7efcd8" type="rule">
+                    <infoLink id="fb09ce88-dd0e-aeaf-f63a-26c7837b7532" hidden="false" targetId="cbcf-5f25-f8ea-7cfd" type="rule">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -17787,7 +17787,7 @@
                               <infoLinks/>
                               <modifiers/>
                             </infoLink>
-                            <infoLink id="b60e386b-8cfc-c6be-dd13-d9de0eb1dacd" hidden="false" targetId="e31cf870-3fa6-f2a2-8704-9bf05f7efcd8" type="rule">
+                            <infoLink id="b60e386b-8cfc-c6be-dd13-d9de0eb1dacd" hidden="false" targetId="cbcf-5f25-f8ea-7cfd" type="rule">
                               <profiles/>
                               <rules/>
                               <infoLinks/>
@@ -18365,7 +18365,7 @@
                   <infoLinks/>
                   <modifiers/>
                 </infoLink>
-                <infoLink id="84b2c323-c265-e0f5-75e3-ddbfa3dcf6d0" hidden="false" targetId="e31cf870-3fa6-f2a2-8704-9bf05f7efcd8" type="rule">
+                <infoLink id="84b2c323-c265-e0f5-75e3-ddbfa3dcf6d0" hidden="false" targetId="cbcf-5f25-f8ea-7cfd" type="rule">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -19158,7 +19158,7 @@
                       <infoLinks/>
                       <modifiers/>
                     </infoLink>
-                    <infoLink id="399c5a70-62cc-128d-fde5-16e73b4fed21" hidden="false" targetId="e31cf870-3fa6-f2a2-8704-9bf05f7efcd8" type="rule">
+                    <infoLink id="399c5a70-62cc-128d-fde5-16e73b4fed21" hidden="false" targetId="cbcf-5f25-f8ea-7cfd" type="rule">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -19484,7 +19484,7 @@
                       <infoLinks/>
                       <modifiers/>
                     </infoLink>
-                    <infoLink id="cb052fa9-a931-49c2-50f6-28c874a4a8d3" hidden="false" targetId="e31cf870-3fa6-f2a2-8704-9bf05f7efcd8" type="rule">
+                    <infoLink id="cb052fa9-a931-49c2-50f6-28c874a4a8d3" hidden="false" targetId="cbcf-5f25-f8ea-7cfd" type="rule">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -19776,7 +19776,7 @@
                       <infoLinks/>
                       <modifiers/>
                     </infoLink>
-                    <infoLink id="c7fcebcb-540b-4d44-af82-e876f25c306d" hidden="false" targetId="e31cf870-3fa6-f2a2-8704-9bf05f7efcd8" type="rule">
+                    <infoLink id="c7fcebcb-540b-4d44-af82-e876f25c306d" hidden="false" targetId="cbcf-5f25-f8ea-7cfd" type="rule">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -20898,7 +20898,7 @@
                       <infoLinks/>
                       <modifiers/>
                     </infoLink>
-                    <infoLink id="ede1b375-8bc1-8588-d09a-b7b75553a848" hidden="false" targetId="e31cf870-3fa6-f2a2-8704-9bf05f7efcd8" type="rule">
+                    <infoLink id="ede1b375-8bc1-8588-d09a-b7b75553a848" hidden="false" targetId="cbcf-5f25-f8ea-7cfd" type="rule">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -23547,7 +23547,7 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                   <infoLinks/>
                   <modifiers/>
                 </infoLink>
-                <infoLink id="6eb1b962-eb7b-8312-edfe-e99d00dfcb80" hidden="false" targetId="e31cf870-3fa6-f2a2-8704-9bf05f7efcd8" type="rule">
+                <infoLink id="6eb1b962-eb7b-8312-edfe-e99d00dfcb80" hidden="false" targetId="cbcf-5f25-f8ea-7cfd" type="rule">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -23620,7 +23620,7 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                   <infoLinks/>
                   <modifiers/>
                 </infoLink>
-                <infoLink id="fb978155-496a-e644-bf66-909bef4f7131" hidden="false" targetId="e31cf870-3fa6-f2a2-8704-9bf05f7efcd8" type="rule">
+                <infoLink id="fb978155-496a-e644-bf66-909bef4f7131" hidden="false" targetId="cbcf-5f25-f8ea-7cfd" type="rule">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -25167,7 +25167,7 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                               <infoLinks/>
                               <modifiers/>
                             </infoLink>
-                            <infoLink id="457a-8b46-1872-0228" hidden="false" targetId="e31cf870-3fa6-f2a2-8704-9bf05f7efcd8" type="rule">
+                            <infoLink id="457a-8b46-1872-0228" hidden="false" targetId="cbcf-5f25-f8ea-7cfd" type="rule">
                               <profiles/>
                               <rules/>
                               <infoLinks/>
@@ -28914,7 +28914,7 @@ Ignores Cover special rule.</description>
                       <infoLinks/>
                       <modifiers/>
                     </infoLink>
-                    <infoLink id="19619a4e-b881-63f9-78e0-7799fc1653b8" hidden="false" targetId="e31cf870-3fa6-f2a2-8704-9bf05f7efcd8" type="rule">
+                    <infoLink id="19619a4e-b881-63f9-78e0-7799fc1653b8" hidden="false" targetId="cbcf-5f25-f8ea-7cfd" type="rule">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -33735,6 +33735,37 @@ Ignores Cover special rule.</description>
       <modifiers/>
       <constraints/>
     </entryLink>
+    <entryLink id="dafd-ff23-c200-dbc8" name="New EntryLink" hidden="false" targetId="f564-00e6-b6e6-9929" type="selectionEntry" categoryEntryId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <repeats/>
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a828-3d0e-9af9-3102" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bf4c-841e-7cf2-4437" type="equalTo"/>
+          </conditions>
+          <conditionGroups/>
+        </modifier>
+      </modifiers>
+      <constraints/>
+    </entryLink>
+    <entryLink id="7b4e-103e-c5fb-af64" name="New EntryLink" hidden="false" targetId="f564-00e6-b6e6-9929" type="selectionEntry" categoryEntryId="485123232344415441232323">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <repeats/>
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ef78-414f-633c-293c" type="equalTo"/>
+          </conditions>
+          <conditionGroups/>
+        </modifier>
+      </modifiers>
+      <constraints/>
+    </entryLink>
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="a9bf-b37e-126b-a699" name="&apos;Iron Circle&apos; Domitar-Ferrum Class Battle-automata Maniple" hidden="false" collective="false" categoryEntryId="456c6974657323232344415441232323" type="unit">
@@ -34950,7 +34981,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
                       <infoLinks/>
                       <modifiers/>
                     </infoLink>
-                    <infoLink id="87d7-5bb6-814d-3bbd" hidden="false" targetId="e31cf870-3fa6-f2a2-8704-9bf05f7efcd8" type="rule">
+                    <infoLink id="87d7-5bb6-814d-3bbd" hidden="false" targetId="cbcf-5f25-f8ea-7cfd" type="rule">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -35111,7 +35142,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
                       <infoLinks/>
                       <modifiers/>
                     </infoLink>
-                    <infoLink id="fb19-6bed-11d2-f1f4" hidden="false" targetId="e31cf870-3fa6-f2a2-8704-9bf05f7efcd8" type="rule">
+                    <infoLink id="fb19-6bed-11d2-f1f4" hidden="false" targetId="cbcf-5f25-f8ea-7cfd" type="rule">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -35556,7 +35587,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
                       <infoLinks/>
                       <modifiers/>
                     </infoLink>
-                    <infoLink id="5622-48ee-5247-c70c" hidden="false" targetId="e31cf870-3fa6-f2a2-8704-9bf05f7efcd8" type="rule">
+                    <infoLink id="5622-48ee-5247-c70c" hidden="false" targetId="cbcf-5f25-f8ea-7cfd" type="rule">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -35734,7 +35765,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
                       <infoLinks/>
                       <modifiers/>
                     </infoLink>
-                    <infoLink id="4d21-3cc0-043f-0430" hidden="false" targetId="e31cf870-3fa6-f2a2-8704-9bf05f7efcd8" type="rule">
+                    <infoLink id="4d21-3cc0-043f-0430" hidden="false" targetId="cbcf-5f25-f8ea-7cfd" type="rule">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -43763,7 +43794,7 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
                       <infoLinks/>
                       <modifiers/>
                     </infoLink>
-                    <infoLink id="b0aa1918-599e-a0fe-7cc1-aff4e9fe455a" hidden="false" targetId="e31cf870-3fa6-f2a2-8704-9bf05f7efcd8" type="rule">
+                    <infoLink id="b0aa1918-599e-a0fe-7cc1-aff4e9fe455a" hidden="false" targetId="cbcf-5f25-f8ea-7cfd" type="rule">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -44137,7 +44168,7 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
                       <infoLinks/>
                       <modifiers/>
                     </infoLink>
-                    <infoLink id="766a37d5-687c-4379-862c-009dc6dfe762" hidden="false" targetId="e31cf870-3fa6-f2a2-8704-9bf05f7efcd8" type="rule">
+                    <infoLink id="766a37d5-687c-4379-862c-009dc6dfe762" hidden="false" targetId="cbcf-5f25-f8ea-7cfd" type="rule">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -44274,7 +44305,7 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
                       <infoLinks/>
                       <modifiers/>
                     </infoLink>
-                    <infoLink id="0ad07b82-3fa3-1792-265b-26cdda0e856a" hidden="false" targetId="e31cf870-3fa6-f2a2-8704-9bf05f7efcd8" type="rule">
+                    <infoLink id="0ad07b82-3fa3-1792-265b-26cdda0e856a" hidden="false" targetId="cbcf-5f25-f8ea-7cfd" type="rule">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -45959,7 +45990,7 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
                   <infoLinks/>
                   <modifiers/>
                 </infoLink>
-                <infoLink id="b1b1-d2a4-ec71-da31" hidden="false" targetId="e31cf870-3fa6-f2a2-8704-9bf05f7efcd8" type="rule">
+                <infoLink id="b1b1-d2a4-ec71-da31" hidden="false" targetId="cbcf-5f25-f8ea-7cfd" type="rule">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -48994,7 +49025,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
                       <infoLinks/>
                       <modifiers/>
                     </infoLink>
-                    <infoLink id="d0536fe7-bc29-189a-27da-d2079af4de15" hidden="false" targetId="e31cf870-3fa6-f2a2-8704-9bf05f7efcd8" type="rule">
+                    <infoLink id="d0536fe7-bc29-189a-27da-d2079af4de15" hidden="false" targetId="cbcf-5f25-f8ea-7cfd" type="rule">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -49585,7 +49616,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
                           <infoLinks/>
                           <modifiers/>
                         </infoLink>
-                        <infoLink id="6b030ea7-52db-4185-da46-2a4b7f7b05a4" hidden="false" targetId="e31cf870-3fa6-f2a2-8704-9bf05f7efcd8" type="rule">
+                        <infoLink id="6b030ea7-52db-4185-da46-2a4b7f7b05a4" hidden="false" targetId="cbcf-5f25-f8ea-7cfd" type="rule">
                           <profiles/>
                           <rules/>
                           <infoLinks/>
@@ -49937,7 +49968,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
                       <infoLinks/>
                       <modifiers/>
                     </infoLink>
-                    <infoLink id="02ba6d46-0224-3f92-d01e-fa8f78c3d365" hidden="false" targetId="e31cf870-3fa6-f2a2-8704-9bf05f7efcd8" type="rule">
+                    <infoLink id="02ba6d46-0224-3f92-d01e-fa8f78c3d365" hidden="false" targetId="cbcf-5f25-f8ea-7cfd" type="rule">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -53111,7 +53142,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
                       <infoLinks/>
                       <modifiers/>
                     </infoLink>
-                    <infoLink id="612e16bc-15fa-6213-59a4-eb48458eda2d" hidden="false" targetId="e31cf870-3fa6-f2a2-8704-9bf05f7efcd8" type="rule">
+                    <infoLink id="612e16bc-15fa-6213-59a4-eb48458eda2d" hidden="false" targetId="cbcf-5f25-f8ea-7cfd" type="rule">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -53228,7 +53259,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
                       <infoLinks/>
                       <modifiers/>
                     </infoLink>
-                    <infoLink id="87ee7704-9027-6390-e9b8-f6212b79117d" hidden="false" targetId="e31cf870-3fa6-f2a2-8704-9bf05f7efcd8" type="rule">
+                    <infoLink id="87ee7704-9027-6390-e9b8-f6212b79117d" hidden="false" targetId="cbcf-5f25-f8ea-7cfd" type="rule">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -53922,7 +53953,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
                       <infoLinks/>
                       <modifiers/>
                     </infoLink>
-                    <infoLink id="bc51ee10-f086-8d68-8ed4-16336d532002" hidden="false" targetId="e31cf870-3fa6-f2a2-8704-9bf05f7efcd8" type="rule">
+                    <infoLink id="bc51ee10-f086-8d68-8ed4-16336d532002" hidden="false" targetId="cbcf-5f25-f8ea-7cfd" type="rule">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -54400,7 +54431,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
                           <infoLinks/>
                           <modifiers/>
                         </infoLink>
-                        <infoLink id="ed12c2bd-1e82-2d4f-fa5f-4cc5264f33e4" hidden="false" targetId="e31cf870-3fa6-f2a2-8704-9bf05f7efcd8" type="rule">
+                        <infoLink id="ed12c2bd-1e82-2d4f-fa5f-4cc5264f33e4" hidden="false" targetId="cbcf-5f25-f8ea-7cfd" type="rule">
                           <profiles/>
                           <rules/>
                           <infoLinks/>
@@ -56432,26 +56463,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
     </selectionEntry>
     <selectionEntry id="3b34336e-0f22-6a62-f665-74f37f5305f5" name="Primarch" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <rules>
-        <rule id="87186171-8615-9e6e-777b-115509ab6986" name="Eternal Warrior" page="0" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </rule>
-        <rule id="442d6d2d-71b1-32bf-30cb-27436c20594f" name="Adamantium Will" page="0" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </rule>
-        <rule id="028b35ba-2094-eea5-9234-88ecdd47a08d" name="Fearless" page="0" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </rule>
-      </rules>
+      <rules/>
       <infoLinks>
         <infoLink id="4956529c-d22d-cf21-08ed-0301654b1943" hidden="false" targetId="8199e922-e844-5d34-b04b-86edadffa2df" type="rule">
           <profiles/>
@@ -56472,6 +56484,36 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
           <modifiers/>
         </infoLink>
         <infoLink id="5b3c-5727-6786-0a82" name="New InfoLink" hidden="false" targetId="52ff-4074-570b-4ea1" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="129f-8ccc-1196-e82a" name="New InfoLink" hidden="false" targetId="dc70-e199-5525-e78c" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="b6c9-a781-10c8-7f80" name="New InfoLink" hidden="false" targetId="3e0b-be9f-b7eb-8c5e" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="26cb-e08c-775a-606c" name="New InfoLink" hidden="false" targetId="df87-e991-2d30-dc38" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="58ef-348d-9698-16dc" name="New InfoLink" hidden="false" targetId="a080-af1b-fb2e-4860" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="80c8-eefd-cdc2-6d21" name="New InfoLink" hidden="false" targetId="4771-b711-0e74-3aee" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -58002,7 +58044,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
                   <infoLinks/>
                   <modifiers/>
                 </infoLink>
-                <infoLink id="b00f0eaf-3564-4f9a-7a2d-7920c5afe6fc" hidden="false" targetId="e31cf870-3fa6-f2a2-8704-9bf05f7efcd8" type="rule">
+                <infoLink id="b00f0eaf-3564-4f9a-7a2d-7920c5afe6fc" hidden="false" targetId="cbcf-5f25-f8ea-7cfd" type="rule">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -60272,7 +60314,7 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
                   <infoLinks/>
                   <modifiers/>
                 </infoLink>
-                <infoLink id="5ce27ac1-fd25-816d-2e97-c02daec95154" hidden="false" targetId="e31cf870-3fa6-f2a2-8704-9bf05f7efcd8" type="rule">
+                <infoLink id="5ce27ac1-fd25-816d-2e97-c02daec95154" hidden="false" targetId="cbcf-5f25-f8ea-7cfd" type="rule">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -62753,7 +62795,7 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="4b14940e-32b2-03df-d956-32ccea4920d4" hidden="false" targetId="e31cf870-3fa6-f2a2-8704-9bf05f7efcd8" type="rule">
+        <infoLink id="4b14940e-32b2-03df-d956-32ccea4920d4" hidden="false" targetId="cbcf-5f25-f8ea-7cfd" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -62781,7 +62823,7 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="7c62e21b-119d-9283-b2c4-b75427503e32" hidden="false" targetId="e31cf870-3fa6-f2a2-8704-9bf05f7efcd8" type="rule">
+        <infoLink id="7c62e21b-119d-9283-b2c4-b75427503e32" hidden="false" targetId="cbcf-5f25-f8ea-7cfd" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -62809,7 +62851,7 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="dc21b40f-0ca0-be2a-0113-b7c0ee38566e" hidden="false" targetId="e31cf870-3fa6-f2a2-8704-9bf05f7efcd8" type="rule">
+        <infoLink id="dc21b40f-0ca0-be2a-0113-b7c0ee38566e" hidden="false" targetId="cbcf-5f25-f8ea-7cfd" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -62837,7 +62879,7 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="bb5546c8-489e-a30b-8680-681260fc7d8f" hidden="false" targetId="e31cf870-3fa6-f2a2-8704-9bf05f7efcd8" type="rule">
+        <infoLink id="bb5546c8-489e-a30b-8680-681260fc7d8f" hidden="false" targetId="cbcf-5f25-f8ea-7cfd" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -67181,7 +67223,7 @@ Explodes results add D3&quot; to radius.  </description>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="c319-3771-c114-f48b" hidden="false" targetId="e31cf870-3fa6-f2a2-8704-9bf05f7efcd8" type="rule">
+        <infoLink id="c319-3771-c114-f48b" hidden="false" targetId="cbcf-5f25-f8ea-7cfd" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -68619,7 +68661,243 @@ Explodes results add D3&quot; to radius.  </description>
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f564-00e6-b6e6-9929" name="Leman Russell" book="FW Leman Russ product page" page="PDF" hidden="false" collective="false" categoryEntryId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" type="model">
+      <profiles>
+        <profile id="da1a-ada6-832f-0d24" name="Leman Russ" book="" page="" hidden="false" profileTypeId="556e697423232344415441232323">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Unit Type" characteristicTypeId="556e6974205479706523232344415441232323" value="Infantry (Character)"/>
+            <characteristic name="WS" characteristicTypeId="575323232344415441232323" value="9"/>
+            <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="6"/>
+            <characteristic name="S" characteristicTypeId="5323232344415441232323" value="6"/>
+            <characteristic name="T" characteristicTypeId="5423232344415441232323" value="6"/>
+            <characteristic name="W" characteristicTypeId="5723232344415441232323" value="6"/>
+            <characteristic name="I" characteristicTypeId="4923232344415441232323" value="7"/>
+            <characteristic name="A" characteristicTypeId="4123232344415441232323" value="6"/>
+            <characteristic name="LD" characteristicTypeId="4c4423232344415441232323" value="10"/>
+            <characteristic name="Save" characteristicTypeId="5361766523232344415441232323" value="2+"/>
+          </characteristics>
+        </profile>
+        <profile id="c419-ba87-be2e-5854" name="The Armour Elavagar" book="" page="" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Description" characteristicTypeId="4465736372697074696f6e23232344415441232323" value="Provides 2+ armour and 4++ invulnerable save."/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="77f4-5b89-03dc-52b9" name="Sire of the Space Wolves" book="" page="" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <description>Counts as a Legion Vexilla.</description>
+        </rule>
+        <rule id="f6ad-3232-311c-f875" name="Leman Russell" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <description>Full rules for Leman Russ, Primarch of the Space Wolves Legion will be available in the forthcoming The Horus Heresy Book Seven – Inferno, until then you can use these temporary rules to represent him in your games.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="dbd3-73d2-e2e6-0a61" name="New InfoLink" hidden="false" targetId="38d5-b6eb-bda8-2497" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <repeats/>
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e39e-3834-389d-086c" type="equalTo"/>
+          </conditions>
+          <conditionGroups/>
+        </modifier>
+        <modifier type="set" field="hidden" value="true">
+          <repeats/>
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ebc0-3d8d-c43a-8994" type="equalTo"/>
+          </conditions>
+          <conditionGroups/>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="004c-502d-8aba-5057" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9679-4280-0552-18e5" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="725b-d596-95e1-797e" name="Breaker of Shields, Bringer of Ruin" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="68cf-2ecf-da76-44a5" name="New InfoLink" hidden="false" targetId="2b06-29a6-641a-b22e" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="6d75-fc52-a0af-3e96" name="New InfoLink" hidden="false" targetId="0900-71d5-1937-aa96" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f3db-f9aa-5394-ccbc" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c99d-2278-ca94-9a83" type="min"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="9c11-7931-99c7-0891" name="Bodyguard" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3ba8-4e27-94d4-7f99" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="2a0e-c55f-2f7f-028f" hidden="false" targetId="cba7eacc-627d-ad1f-3c72-70e35c15fd9f" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="c24d-5c32-e4c9-50ef" hidden="false" targetId="0af4be1b-e2a3-c1dd-c49d-18c53e1088f8" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="acc1-33a5-902a-a66a" name="Wargear" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries>
+            <selectionEntry id="6b13-fbff-b598-5736" name="Scornsplitter" hidden="false" collective="false" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="ed8e-29dd-2143-c80a" name="New InfoLink" hidden="false" targetId="21f23fa8-cf11-b9c3-d613-1b711b0897d7" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8b63-a8b2-7542-2774" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1415-ab79-447d-cd8c" type="min"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="4d9e-983a-8189-5d4c" name="The Axe of Helwinter" hidden="false" collective="false" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="a629-5313-73b1-27a5" name="New InfoLink" hidden="false" targetId="b3af-1eca-6629-4894" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7495-1dc1-f8e0-a372" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0e8d-6072-33f3-5139" type="min"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="4521-5893-c365-ce39" name="The Sword of Balenight" hidden="false" collective="false" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="5bdd-e972-fa44-a19c" name="New InfoLink" hidden="false" targetId="2fd78c56-eae0-49c5-9103-62ebadb9a05c" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="66ea-cfd2-c5e0-f28e" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c469-1802-396f-0332" type="min"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="623e-4bd2-467c-5ea2" hidden="false" targetId="3b34336e-0f22-6a62-f665-74f37f5305f5" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="890a-7366-c0fd-8c31" hidden="false" targetId="7f468ad2-37a2-384e-62c6-59a0ef008fe9" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="400.0"/>
+      </costs>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
@@ -71294,13 +71572,6 @@ When the entire squadron fires at a single target within 24&quot;, the squadron 
       <infoLinks/>
       <modifiers/>
       <description>A unit that has suffered one or more wounds from a weapon with the Deathlock special rule must take a Leadership test at the end of the Shooting phase before any Pinning tests or Morale checks are taken.  The test has a negative modifier equal to the number of wounds the target unit suffered with the Deathlock effect that turn.  If the unit is Stubborn or Fearless, the test is still taken but without the negative modifiers for the casualties caused.  If the test is failed, the unit immediately suffers D6 extra wounds which may be saved normally.  </description>
-    </rule>
-    <rule id="e31cf870-3fa6-f2a2-8704-9bf05f7efcd8" name="Deflagrate" book="HH:LACAL" page="85" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>After normal attacks by this weapon have been resolved, count the number of unsaved wounds caused on the target unit.  Immediately resolve a number of additional automatic hits on the same unit using the weapon&apos;s profile equal to the number of unsaved wounds - these can then be saved normally.  Models must still be in range in order for the additional hits to take effect.  These additional hits do not themselves cause more hits.  </description>
     </rule>
     <rule id="483ce418-4410-b57f-c6da-0abdeba6e2d5" name="Djinn-sight" book="HH3: Extermination" page="222" hidden="false">
       <profiles/>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -27984,399 +27984,6 @@ Ignores Cover special rule.</description>
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="402b-d064-160d-e6dd" name="Tarantula Sentry Gun Battery" hidden="false" collective="false" categoryEntryId="466173742041747461636b23232344415441232323" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <repeats/>
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="89fc-8558-ded2-c901" type="equalTo"/>
-          </conditions>
-          <conditionGroups/>
-        </modifier>
-      </modifiers>
-      <constraints/>
-      <selectionEntries>
-        <selectionEntry id="d272-97ae-020e-2d32" name="Tarantula Sentry Gun" book="HH:LACAL" page="44" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-          <profiles>
-            <profile id="e8be-d639-3862-7072" name="Tarantula Sentry Gun" book="HH:LACAL" page="44" hidden="false" profileTypeId="556e697423232344415441232323">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="Unit Type" characteristicTypeId="556e6974205479706523232344415441232323" value="Artillery (Immobile)"/>
-                <characteristic name="WS" characteristicTypeId="575323232344415441232323" value="-"/>
-                <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="3"/>
-                <characteristic name="S" characteristicTypeId="5323232344415441232323" value="-"/>
-                <characteristic name="T" characteristicTypeId="5423232344415441232323" value="6"/>
-                <characteristic name="W" characteristicTypeId="5723232344415441232323" value="2"/>
-                <characteristic name="I" characteristicTypeId="4923232344415441232323" value="-"/>
-                <characteristic name="A" characteristicTypeId="4123232344415441232323" value="-"/>
-                <characteristic name="LD" characteristicTypeId="4c4423232344415441232323" value="-"/>
-                <characteristic name="Save" characteristicTypeId="5361766523232344415441232323" value="3+"/>
-              </characteristics>
-            </profile>
-          </profiles>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="35.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="96f4-88c7-1da8-b8b0" name="Entire battery may take one upgrade:" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="a01d-0898-8c5f-08cb" name="Concealment" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules>
-                <rule id="014c-1ac9-787c-cb2b" name="Concealment" book="HH:LACAL" page="44" hidden="false">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <description>Sentry Gun Battery has Shrouded special rule until the first time it fires a weapon.  </description>
-                </rule>
-              </rules>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="increment" field="points" value="10.0">
-                  <repeats>
-                    <repeat field="selections" scope="402b-d064-160d-e6dd" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d272-97ae-020e-2d32" repeats="1"/>
-                  </repeats>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="3cb1-7730-8d4a-7273" name="Forward Deployment" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules>
-                <rule id="0cd6-29b5-05b9-074e" name="Forward Deployment" book="HH:LACAL" page="44" hidden="false">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <description>The Sentry Gun Battery has the Scout special rule. </description>
-                </rule>
-              </rules>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="increment" field="points" value="5.0">
-                  <repeats>
-                    <repeat field="selections" scope="402b-d064-160d-e6dd" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d272-97ae-020e-2d32" repeats="1"/>
-                  </repeats>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups/>
-          <entryLinks/>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="d2f2-3157-bb34-5034" name="Entire battery may exchange Twin-linked heavy bolters for:" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <selectionEntries>
-            <selectionEntry id="1161-914f-61be-589b" name="Hyperios Air-defence Missile Launchers" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="2010-ebc8-2dbc-d3fe" hidden="false" targetId="b8643d20-d7ef-7974-7261-11c7b9787be0" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers>
-                <modifier type="increment" field="points" value="20.0">
-                  <repeats>
-                    <repeat field="selections" scope="402b-d064-160d-e6dd" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d272-97ae-020e-2d32" repeats="1"/>
-                  </repeats>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups/>
-          <entryLinks/>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="07e4-98db-dccb-a8f9" name="Exchange any Twin-linked Heavy Bolter for:" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <repeats/>
-              <conditions>
-                <condition field="selections" scope="402b-d064-160d-e6dd" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1161-914f-61be-589b" type="equalTo"/>
-              </conditions>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="maxSelections" value="1.0">
-              <repeats>
-                <repeat field="selections" scope="402b-d064-160d-e6dd" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d272-97ae-020e-2d32" repeats="1"/>
-              </repeats>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="0aeb-dac8-73d4-6bba" name="Twin-linked Heavy Flamers" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles>
-                <profile id="f34a-b266-e446-4bb7" name="Twin-linked Heavy Flamers" hidden="false" profileTypeId="576561706f6e23232344415441232323">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <characteristics>
-                    <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="Template"/>
-                    <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="5"/>
-                    <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="4"/>
-                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Assault 1"/>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="41b2-c770-a3c5-ef0a" name="Two twin-linked Rotor Cannons" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="eb35-6f46-7050-d94e" hidden="false" targetId="75683330-6490-c0bf-560c-2e58617425a1" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="6f8e-3ca7-9304-edfa" name="Twin-linked Lascannon" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="10.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="879d-b28b-3556-09b7" name="Multi-melta and Searchlight" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="edd8-79e9-938e-192c" name="Twin-linked Iliastus Assault Cannons" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="6e00-6123-5890-7fca" hidden="false" targetId="0d8bdd64-39f0-7759-d8ca-0702ee1f0fd0" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="d3a8-25b2-5163-d867" hidden="false" targetId="0d300426-e90a-4a8d-bff5-9b64949b128d" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers>
-                <modifier type="set" field="hidden" value="true">
-                  <repeats/>
-                  <conditions>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="16a2-56d6-9be5-ede0" type="equalTo"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups/>
-          <entryLinks/>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="be3c-7183-1b05-a064" name="Exchange any Hyperios Air-defence Missile Launcher for:" hidden="true" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="set" field="hidden" value="false">
-              <repeats/>
-              <conditions>
-                <condition field="selections" scope="402b-d064-160d-e6dd" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1161-914f-61be-589b" type="equalTo"/>
-              </conditions>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="a264-a424-182b-2495" name="Hyperios Command Platform" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules>
-                <rule id="14c8-e755-af6b-667b" name="Hyperios Command Platform" book="HH:LACAL" page="44" hidden="false">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <description>While on the table, all Hyperios Air-defence Missile Launcher equipped Tarantula Sentry Guns in the same unit receive the Split Fire special rule.  The test is automatically passed for Split Fire.  </description>
-                </rule>
-              </rules>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="increment" field="maxSelections" value="1.0">
-                  <repeats>
-                    <repeat field="selections" scope="402b-d064-160d-e6dd" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d272-97ae-020e-2d32" repeats="1"/>
-                  </repeats>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="10.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups/>
-          <entryLinks/>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="5a06-b2fc-b07b-ff81" hidden="false" targetId="86e70545-ed1a-7cf4-5a3d-d60662a6b3be" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </entryLink>
-        <entryLink id="0014-fcf7-e8b8-a900" hidden="false" targetId="f785888f-6dfa-08f4-054f-29b1a0e4f20c" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </entryLink>
-        <entryLink id="31c8-3238-201c-da66" hidden="false" targetId="c487-be13-ea53-917e" type="selectionEntryGroup">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </entryLink>
-      </entryLinks>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
     <selectionEntry id="12d746d3-ae08-8959-c298-0d748159d672" name="Techmarine Covenant" book="HH:LACAL" page="23" hidden="false" collective="false" categoryEntryId="456c6974657323232344415441232323" type="upgrade">
       <profiles/>
       <rules/>
@@ -33470,6 +33077,21 @@ Ignores Cover special rule.</description>
       <rules/>
       <infoLinks/>
       <modifiers/>
+      <constraints/>
+    </entryLink>
+    <entryLink id="5991-c4b8-a6d3-e0a4" name="Legion Tarantual Sentry Gun Battery" hidden="false" targetId="7218-3d68-4761-d7fd" type="selectionEntry" categoryEntryId="466173742041747461636b23232344415441232323">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <repeats/>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="89fc-8558-ded2-c901" type="equalTo"/>
+          </conditions>
+          <conditionGroups/>
+        </modifier>
+      </modifiers>
       <constraints/>
     </entryLink>
   </entryLinks>
@@ -58752,7 +58374,7 @@ Phalanx Breacher squads and Legion Terminator squads may be taken as troops in a
         <cost name="pts" costTypeId="points" value="385.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="0e7b97c8-732a-74fa-6bf2-de2e1f747483" name="Rotor Cannon" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+    <selectionEntry id="fe75-7b06-f9a5-26bd" name="Rotor Cannon" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
       <rules/>
       <infoLinks>
@@ -62998,6 +62620,12 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
           <infoLinks/>
           <modifiers/>
         </infoLink>
+        <infoLink id="8056-a01f-399d-1f32" name="New InfoLink" hidden="false" targetId="b35f-72bc-bdac-c298" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
       </infoLinks>
       <modifiers/>
       <constraints>
@@ -65039,7 +64667,6 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
       <modifiers/>
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b080-7a95-902f-aa2b" type="max"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3191-b839-d4e3-7e93" type="min"/>
       </constraints>
       <selectionEntries/>
       <selectionEntryGroups/>
@@ -69027,7 +68654,9 @@ Explodes results add D3&quot; to radius.  </description>
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="3b01-3691-b570-475d" name="Twin-linked Missile Launcher" book="BRB 7th" page="" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
@@ -69223,6 +68852,475 @@ Explodes results add D3&quot; to radius.  </description>
       <costs>
         <cost name="pts" costTypeId="points" value="15.0"/>
       </costs>
+    </selectionEntry>
+    <selectionEntry id="7218-3d68-4761-d7fd" name="Legion Tarantula Sentry Gun Battery" hidden="false" collective="false" categoryEntryId="466173742041747461636b23232344415441232323" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="2497-d6ca-d5d9-634e" name="Trantula Sentry Gun" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries>
+            <selectionEntry id="6fe4-e743-ab98-5e44" name="Tarantula Sentry Gun" book="HH:LACAL" page="44" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles>
+                <profile id="c54b-71b3-9c02-6de9" name="Tarantula Sentry Gun" book="AL:AoDAL" page="54" hidden="false" profileTypeId="556e697423232344415441232323" profileTypeName="Unit">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Unit Type" characteristicTypeId="556e6974205479706523232344415441232323" value="Artillery (Immobile)"/>
+                    <characteristic name="WS" characteristicTypeId="575323232344415441232323" value="-"/>
+                    <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="3"/>
+                    <characteristic name="S" characteristicTypeId="5323232344415441232323" value="-"/>
+                    <characteristic name="T" characteristicTypeId="5423232344415441232323" value="6"/>
+                    <characteristic name="W" characteristicTypeId="5723232344415441232323" value="2"/>
+                    <characteristic name="I" characteristicTypeId="4923232344415441232323" value="-"/>
+                    <characteristic name="A" characteristicTypeId="4123232344415441232323" value="-"/>
+                    <characteristic name="LD" characteristicTypeId="4c4423232344415441232323" value="-"/>
+                    <characteristic name="Save" characteristicTypeId="5361766523232344415441232323" value="3+"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules>
+                <rule id="e78d-c1b1-cdaa-7888" name="Targeting" book="AL:AoDAL" page="54" hidden="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <repeats/>
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="edd8-6ef1-4bc3-637e" type="instanceOf"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <description>Which enemy unit within range is the Sentry Gun’s preferred target is determined by its armament. If no preferred target exists in its line of sight, it will simply attack the nearest enemy target in range:
+
+A heavy bolter, heavy flamer or rotor cannon-equipped Sentry Gun will fire at the nearest enemy non-Vehicle target according to its firing mode.
+
+A lascannon or multi-melta equipped Sentry Gun will fire at the nearest enemy Vehicle or Monstrous Creature according to its firing mode (note that immobilised vehicles still count as viable targets, only wrecked vehicles will be ignored).
+
+Hyperios Tarantulas may only target Flyers.
+
+Note that this means while a preferred target type is within range, it is possible for a unit of
+differently armed Sentry Guns to fire at two separate targets.</description>
+                </rule>
+              </rules>
+              <infoLinks>
+                <infoLink id="13a0-bfc7-f0d1-8388" name="New InfoLink" hidden="false" targetId="56ad-c026-7680-1d4d" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="745c-967e-6f9a-ada4" name="New InfoLink" hidden="false" targetId="9846-a03b-5721-3355" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="044d-279d-df1a-37d3" name="New InfoLink" hidden="false" targetId="2e40-b450-8714-586e" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4edf-1777-ccfc-ec04" type="min"/>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9af9-7b97-5a16-8977" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="35.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="2856-d161-fb2a-4d23" name="Any Sentry Gun in the battery make take" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="9489-2191-9d76-96b5" value="1">
+                  <repeats>
+                    <repeat field="selections" scope="7218-3d68-4761-d7fd" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fe4-e743-ab98-5e44" repeats="1"/>
+                  </repeats>
+                  <conditions>
+                    <condition field="selections" scope="7218-3d68-4761-d7fd" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="edd8-6ef1-4bc3-637e" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="increment" field="1228-49ef-c35c-8b88" value="1">
+                  <repeats>
+                    <repeat field="selections" scope="7218-3d68-4761-d7fd" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fe4-e743-ab98-5e44" repeats="1"/>
+                  </repeats>
+                  <conditions>
+                    <condition field="selections" scope="7218-3d68-4761-d7fd" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="edd8-6ef1-4bc3-637e" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="7218-3d68-4761-d7fd" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="edd8-6ef1-4bc3-637e" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9489-2191-9d76-96b5" type="max"/>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1228-49ef-c35c-8b88" type="min"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="6e54-df15-8b7c-b2b5" name="Multi-Melta with Searchlight" hidden="false" collective="false" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="114b-f6a4-a227-299f" name="New InfoLink" hidden="false" targetId="4fc7-8b16-afe4-dad3" type="profile">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                    <infoLink id="c5ce-48b1-7107-bf3d" name="New InfoLink" hidden="false" targetId="9bb4-3833-5343-0dd9" type="profile">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e210-d8c1-7f33-f0c0" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="5.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="1bd1-43cb-4cd7-a7a2" name="New EntryLink" hidden="false" targetId="8b1d-77d3-74f2-9d1c" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="set" field="731a-c5cb-6c97-9592" value="3">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                    <modifier type="set" field="points" value="10">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="39a8-fb37-b037-434e" name="New EntryLink" hidden="false" targetId="5986-c8ef-d448-397b" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="set" field="5392-4570-be89-40d2" value="3">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="3a42-285e-7493-9a42" name="New EntryLink" hidden="false" targetId="2bc5-53e9-b8fd-0b6b" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="set" field="c8ad-ce96-e370-e273" value="3">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="dc94-000c-fdcb-8554" name="New EntryLink" hidden="false" targetId="aa78-540d-996f-52ff" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="set" field="0efc-77c6-70db-e53a" value="3">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="f591-c193-4e77-d46b" name="New EntryLink" hidden="false" targetId="15c1-2cf9-0fa4-6093" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="set" field="9842-3456-56a5-67ac" value="3">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                    <modifier type="set" field="name" value="Two Twin-linked Rotor Cannons">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="7ccb-0c29-f81f-cf1f" name="Entire battery may exchange its wargear for" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e731-7871-b2c7-69d9" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="edd8-6ef1-4bc3-637e" name="hyperios" hidden="false" targetId="8917-121a-d28f-4f03" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="20">
+                      <repeats>
+                        <repeat field="selections" scope="7218-3d68-4761-d7fd" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fe4-e743-ab98-5e44" repeats="1"/>
+                      </repeats>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="4af2-8591-06a4-1820" name="The entire battery may be upgrade to have" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <selectionEntries>
+                <selectionEntry id="98c3-b3fd-cdaa-4bec" name="May repace one Hyperos Missile Launcher with one Hyperios Command Platform" hidden="true" collective="false" type="upgrade">
+                  <profiles/>
+                  <rules>
+                    <rule id="1432-5aaf-f8c8-0fd9" name="Hyperios Command Platform" book="AL:AoDAL" page="54" hidden="false">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <description>While on the table, all Hyperios Air-defence Missile Launcher equipped Tarantula Sentry Guns in the same unit receive the Split Fire special rule.  The test is automatically passed for Split Fire.  </description>
+                    </rule>
+                  </rules>
+                  <infoLinks>
+                    <infoLink id="2285-37ad-d3de-f724" name="New InfoLink" hidden="false" targetId="38ff-a919-70c4-aec4" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <repeats/>
+                      <conditions>
+                        <condition field="selections" scope="7218-3d68-4761-d7fd" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="edd8-6ef1-4bc3-637e" type="greaterThan"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="2ca4-b1f3-20d1-5887" name="New EntryLink" hidden="false" targetId="75a8-04ea-77af-e8bc" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="set" field="points" value="10">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="ae38-417d-a88d-31bb" hidden="false" targetId="f785888f-6dfa-08f4-054f-29b1a0e4f20c" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="5bd4-3616-6076-e582" name="" hidden="false" targetId="86e70545-ed1a-7cf4-5a3d-d60662a6b3be" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="5ee2-a494-d922-e665" name="Entire battery may deploy using" hidden="false" collective="false" defaultSelectionEntryId="5672-1c71-652a-3942">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0280-3b2c-8022-503f" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9115-6895-d71e-8458" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="5672-1c71-652a-3942" name="Forward Deployment" hidden="false" collective="false" type="upgrade">
+              <profiles/>
+              <rules>
+                <rule id="abe4-aa04-77da-4c8a" name="Forward Deployment" book="AL:AoDAL" page="54" hidden="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <description>The Sentry Gun Battery has the Scout special rule. (note that it still may not be deployed from Reserve).</description>
+                </rule>
+              </rules>
+              <infoLinks>
+                <infoLink id="09f0-6cbb-03c2-ee08" name="New InfoLink" hidden="false" targetId="9b30-1da3-eb8d-ce7a" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="879d-4a5f-dfde-da0a" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs/>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="083a-e79e-522b-8a36" name="New EntryLink" hidden="false" targetId="75a8-04ea-77af-e8bc" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="5709-d426-291c-d9d2" hidden="false" targetId="c487-be13-ea53-917e" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="75a8-04ea-77af-e8bc" name="Concealment" book="AL:AoDAL" page="54" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules>
+        <rule id="9a22-ab29-3d19-f973" name="Concealment" book="AL:AoDAL" page="54" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <description>Sentry Gun Battery has Shrouded special rule until the first time it fires a weapon, afterwards the effects of this rule no longer apply</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="6f82-1199-4ce6-0660" name="New InfoLink" hidden="false" targetId="9c80-5c1a-3b9d-971e" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7b84-09ad-38ee-9343" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs/>
+    </selectionEntry>
+    <selectionEntry id="15c1-2cf9-0fa4-6093" name="Twin-linked Rotor Cannon" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="b536-c573-a6c0-978d" name="New InfoLink" hidden="false" targetId="c32e-0d1a-f6db-2007" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="append" field="5479706523232344415441232323" value=", Twin-Linked">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="set" field="name" value="Twin-Linked Multi-melta">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9842-3456-56a5-67ac" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs/>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
@@ -72362,7 +72460,7 @@ Kharybdis: After it has landed treat as a flyer in Hover mode. LA:AODAL P75</des
       <rules/>
       <infoLinks/>
       <modifiers/>
-      <description>A weapon with this special rule can re-roll all failed To Hit rolls against Flyers and Fast Skimmers.</description>
+      <description>Failed To Hit and AP rolls of a 1 must be re-rolled.</description>
     </rule>
     <rule id="885d-81f6-6ace-3228" name="Power Capacitor" book="LA:AoDAL" page="69" hidden="false">
       <profiles/>
@@ -72404,6 +72502,22 @@ Kharybdis: After it has landed treat as a flyer in Hover mode. LA:AODAL P75</des
       <rules/>
       <infoLinks/>
       <modifiers/>
+    </rule>
+    <rule id="56ad-c026-7680-1d4d" name="Automated Artillery" book="AL:AoDAL" page="122" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>does not require crew in order to function. It is no removed from play due to a lack of crew and each gun must be destroyed normally before it removed. Automated Artillery cannot move and cannot charge. If assaulted they do not Pile In and cannot be locked in combat; their attackers will hit automatically, but must roll To Wound normally.
+If a unit of Automated Artillery loses an assault nothing happens, there are no Sweeping Advances, no Pile Ins and no Consolidation moves. The Automated Artillery remains in place and may fire normally in future turns. If the Automated Artillery wins an assault, the enemy must take a Moral check as normal, although the artillery piece cannot Consolidate or make a Sweeping Advance.</description>
+    </rule>
+    <rule id="9846-a03b-5721-3355" name="Immobile (Artillery Type)" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>An Immobile Artillery piece cannot be moved after it has been deployed except by the use of a specialised vehicle, and ignores any effect which forces it to move. This only affects the platform – not any crew who are subject to all normal Artillery rules. When called upon to Fall Back, the crew must leave their guns behind and fall back; the platforms are then removed as casualties.
+Note that an Immobile unit may still have the Scout or Deep Strike special rules as these reflect redeployment or deployment during battle, rather than game movement. Only if it has the Deep Strike special rule may an Immobile unit be held in Reserve.</description>
     </rule>
   </sharedRules>
   <sharedProfiles>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="839b6f2a-4041-398b-fc2d-dc6a31d5f75e" name="Legiones Astartes: Age of Darkness Army List" book="Forgeworld Horus Heresy Series" revision="204" battleScribeVersion="2.00" authorName="Millicant" authorContact="Please submit any bugs to the website below" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="20" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="839b6f2a-4041-398b-fc2d-dc6a31d5f75e" name="Legiones Astartes: Age of Darkness Army List" book="Forgeworld Horus Heresy Series" revision="205" battleScribeVersion="2.00" authorName="Millicant" authorContact="Please submit any bugs to the website below" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="20" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules/>
   <infoLinks/>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -44785,7 +44785,7 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
       <modifiers/>
       <constraints/>
       <selectionEntries>
-        <selectionEntry id="7cf102e8-d48f-92be-dc50-90c79d74d3a8" name="Legion Space Marines" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+        <selectionEntry id="b8f1-e2a7-0c25-1c08" name="Legion Space Marines" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
           <profiles/>
           <rules/>
           <infoLinks>
@@ -44808,7 +44808,7 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
             <cost name="pts" costTypeId="points" value="20.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="b5dc5eb3-2070-ce68-0ca6-5d26f0d238d4" name="Legion Sergeant" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+        <selectionEntry id="96b2-6181-f48f-e08f" name="Legion Sergeant" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
           <profiles/>
           <rules/>
           <infoLinks>
@@ -44820,7 +44820,7 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
                 <modifier type="set" field="hidden" value="true">
                   <repeats/>
                   <conditions>
-                    <condition field="selections" scope="b5dc5eb3-2070-ce68-0ca6-5d26f0d238d4" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="363b8c4d-a8c8-8faa-d78a-f8415f3ee2cc" type="greaterThan"/>
+                    <condition field="selections" scope="96b2-6181-f48f-e08f" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="363b8c4d-a8c8-8faa-d78a-f8415f3ee2cc" type="greaterThan"/>
                   </conditions>
                   <conditionGroups/>
                 </modifier>
@@ -44834,7 +44834,7 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
                 <modifier type="set" field="hidden" value="true">
                   <repeats/>
                   <conditions>
-                    <condition field="selections" scope="b5dc5eb3-2070-ce68-0ca6-5d26f0d238d4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="363b8c4d-a8c8-8faa-d78a-f8415f3ee2cc" type="lessThan"/>
+                    <condition field="selections" scope="96b2-6181-f48f-e08f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="363b8c4d-a8c8-8faa-d78a-f8415f3ee2cc" type="lessThan"/>
                   </conditions>
                   <conditionGroups/>
                 </modifier>
@@ -45157,216 +45157,7 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6558-6cc9-025a-ab66" type="min"/>
           </constraints>
-          <selectionEntries>
-            <selectionEntry id="9768419b-c1f8-1896-8956-33c73e5c0c4c" name="Heavy Flamers" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="8e5bbf8f-3441-a3c9-1a8c-01a1b6d964a2" name="Autocannons" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="increment" field="points" value="5.0">
-                  <repeats>
-                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7cf102e8-d48f-92be-dc50-90c79d74d3a8" repeats="1"/>
-                  </repeats>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="decrement" field="points" value="5.0">
-                  <repeats>
-                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="10a134c9-dfdd-c921-6c14-17d0875f3b82" repeats="1"/>
-                  </repeats>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="cfb48ef9-5d81-0b93-3a8b-02a8533e5a84" name="Missile Launchers" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="increment" field="points" value="5.0">
-                  <repeats>
-                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7cf102e8-d48f-92be-dc50-90c79d74d3a8" repeats="1"/>
-                  </repeats>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="decrement" field="points" value="5.0">
-                  <repeats>
-                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="10a134c9-dfdd-c921-6c14-17d0875f3b82" repeats="1"/>
-                  </repeats>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="24d48262-d1e5-07f3-7f54-8ab319d4dfc4" name="Multi-meltas" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="increment" field="points" value="10.0">
-                  <repeats>
-                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7cf102e8-d48f-92be-dc50-90c79d74d3a8" repeats="1"/>
-                  </repeats>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="decrement" field="points" value="10.0">
-                  <repeats>
-                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="10a134c9-dfdd-c921-6c14-17d0875f3b82" repeats="1"/>
-                  </repeats>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="10.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="92203450-803a-2a7d-eea5-b3e5df88829d" name="Plasma Cannons" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="increment" field="points" value="15">
-                  <repeats>
-                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7cf102e8-d48f-92be-dc50-90c79d74d3a8" repeats="1"/>
-                  </repeats>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="decrement" field="points" value="15">
-                  <repeats>
-                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="10a134c9-dfdd-c921-6c14-17d0875f3b82" repeats="1"/>
-                  </repeats>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="15.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="b44d81e3-5260-2118-f38d-cb8ec49a86b9" name="Lascannons" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="increment" field="points" value="20">
-                  <repeats>
-                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7cf102e8-d48f-92be-dc50-90c79d74d3a8" repeats="1"/>
-                  </repeats>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="decrement" field="points" value="20">
-                  <repeats>
-                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="10a134c9-dfdd-c921-6c14-17d0875f3b82" repeats="1"/>
-                  </repeats>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="20.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="2ebbfe7d-eeb4-81c1-84ff-d80ff254a72c" name="Volkite Culverin" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="aabee062-1a8b-9f4b-fd60-b7bb19b6017f" hidden="false" targetId="c7838603-9e18-8756-26b1-222a294c5c2c" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="e7f7e659-3da0-e727-231e-58b9332ba9aa" hidden="false" targetId="e31cf870-3fa6-f2a2-8704-9bf05f7efcd8" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers>
-                <modifier type="increment" field="points" value="10.0">
-                  <repeats>
-                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7cf102e8-d48f-92be-dc50-90c79d74d3a8" repeats="1"/>
-                  </repeats>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="decrement" field="points" value="10.0">
-                  <repeats>
-                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="10a134c9-dfdd-c921-6c14-17d0875f3b82" repeats="1"/>
-                  </repeats>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="10.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
+          <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
             <entryLink id="dab9-3c11-bb8a-e8be" name="" hidden="false" targetId="2d56d45d-d276-7830-2b7d-026de64bbae8" type="selectionEntry">
@@ -45376,20 +45167,15 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
               <modifiers>
                 <modifier type="increment" field="points" value="5.0">
                   <repeats>
-                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7cf102e8-d48f-92be-dc50-90c79d74d3a8" repeats="1"/>
+                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b8f1-e2a7-0c25-1c08" repeats="1"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
-                <modifier type="decrement" field="points" value="5.0">
+                <modifier type="decrement" field="points" value="5">
                   <repeats>
-                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="10a134c9-dfdd-c921-6c14-17d0875f3b82" repeats="1"/>
+                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="10a134c9-dfdd-c921-6c14-17d0875f3b82" repeats="1"/>
                   </repeats>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="decrement" field="points" value="10.0">
-                  <repeats/>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
@@ -45403,6 +45189,147 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
               <modifiers/>
               <constraints/>
             </entryLink>
+            <entryLink id="b80f-ceff-de1e-8aac" name="New EntryLink" hidden="false" targetId="0137-bfce-22c9-8f03" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="5">
+                  <repeats>
+                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b8f1-e2a7-0c25-1c08" repeats="1"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="decrement" field="points" value="5">
+                  <repeats>
+                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="10a134c9-dfdd-c921-6c14-17d0875f3b82" repeats="1"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="297a-ce0c-2b95-8a58" name="New EntryLink" hidden="false" targetId="edadef72-c786-ab75-6888-15d0cc090857" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="decrement" field="points" value="10">
+                  <repeats>
+                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="10a134c9-dfdd-c921-6c14-17d0875f3b82" repeats="1"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="increment" field="points" value="10">
+                  <repeats>
+                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b8f1-e2a7-0c25-1c08" repeats="1"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="95e9-4610-5f32-6c8c" name="New EntryLink" hidden="false" targetId="9fef-d14e-0e9f-1cc8" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="13fc-f4ad-e04f-3083" name="New EntryLink" hidden="false" targetId="8036-b730-d533-e31f" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="decrement" field="points" value="20">
+                  <repeats>
+                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="10a134c9-dfdd-c921-6c14-17d0875f3b82" repeats="1"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="increment" field="points" value="20">
+                  <repeats>
+                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b8f1-e2a7-0c25-1c08" repeats="1"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="bb9c-32cd-46d5-608d" name="New EntryLink" hidden="false" targetId="e5d2-e10d-1552-c5c6" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="decrement" field="points" value="5">
+                  <repeats>
+                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="10a134c9-dfdd-c921-6c14-17d0875f3b82" repeats="1"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="increment" field="points" value="5">
+                  <repeats>
+                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b8f1-e2a7-0c25-1c08" repeats="1"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="1605-4c8b-763b-a935" name="New EntryLink" hidden="false" targetId="d1c0-746f-2b39-5f17" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="10">
+                  <repeats>
+                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b8f1-e2a7-0c25-1c08" repeats="1"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="decrement" field="points" value="10">
+                  <repeats>
+                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="10a134c9-dfdd-c921-6c14-17d0875f3b82" repeats="1"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="66fe-43cf-68e9-8b6a" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="02bf-8201-bcdf-e0ae" name="New EntryLink" hidden="false" targetId="9f1b-7c69-13d6-56b5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="decrement" field="points" value="15">
+                  <repeats>
+                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="10a134c9-dfdd-c921-6c14-17d0875f3b82" repeats="1"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="increment" field="points" value="15">
+                  <repeats>
+                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b8f1-e2a7-0c25-1c08" repeats="1"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="5da0b64e-8685-481d-e23e-89e7ff3d671b" name="Entire squad may be equipped with:" hidden="false" collective="false">
@@ -45414,16 +45341,15 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
           <selectionEntries>
             <selectionEntry id="ece334f5-3017-2217-36ef-e4bac8431ab7" name="Hardened Armour" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
               <profiles/>
-              <rules>
-                <rule id="242a566c-67ef-3edc-c91e-5021e5134dd9" name="Hardened Armour" book="HH1: Betrayal" page="204" hidden="false">
+              <rules/>
+              <infoLinks>
+                <infoLink id="7fbc-6547-4aee-ef4c" hidden="false" targetId="7439f6fd-4c50-f88a-eb41-81d9b9c9eed8" type="rule">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
                   <modifiers/>
-                  <description>Hardened Armour counts as being Void Hardened.  Failed armour saves against template and blast weapons may be re-rolled.  Reduces distance rolled for charges, sweeping advances, and run moves by 1&quot;</description>
-                </rule>
-              </rules>
-              <infoLinks/>
+                </infoLink>
+              </infoLinks>
               <modifiers/>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
@@ -45435,11 +45361,11 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
                 <cost name="pts" costTypeId="points" value="25.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="9370e7dd-55d4-53d7-b907-9c687cba6a58" name="Flakk Missiles" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+            <selectionEntry id="9b43-c118-07f5-fb10" name="Flakk Missiles" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
               <profiles/>
               <rules/>
               <infoLinks>
-                <infoLink id="604b-db11-0af1-0842" name="New InfoLink" hidden="false" targetId="1182-02a7-3325-8c51" type="profile">
+                <infoLink id="4ce5-2d09-f9da-6a94" name="New InfoLink" hidden="false" targetId="1182-02a7-3325-8c51" type="profile">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -45447,23 +45373,16 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
                 </infoLink>
               </infoLinks>
               <modifiers>
-                <modifier type="set" field="maxSelections" value="1">
-                  <repeats>
-                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="cfb48ef9-5d81-0b93-3a8b-02a8533e5a84" repeats="1"/>
-                  </repeats>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
                 <modifier type="set" field="hidden" value="true">
                   <repeats/>
                   <conditions>
-                    <condition field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="cfb48ef9-5d81-0b93-3a8b-02a8533e5a84" type="equalTo"/>
+                    <condition field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bb9c-32cd-46d5-608d" type="equalTo"/>
                   </conditions>
                   <conditionGroups/>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c72a-8912-d63b-595f" type="max"/>
               </constraints>
               <selectionEntries/>
               <selectionEntryGroups/>
@@ -45482,7 +45401,7 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
               <modifiers>
                 <modifier type="increment" field="points" value="2.0">
                   <repeats>
-                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7cf102e8-d48f-92be-dc50-90c79d74d3a8" repeats="1"/>
+                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b8f1-e2a7-0c25-1c08" repeats="1"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -45563,20 +45482,20 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
                 <modifier type="set" field="hidden" value="true">
                   <repeats/>
                   <conditions>
-                    <condition field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="902a08ef-cda1-51c8-1c15-37aff66c0c1a" type="equalTo"/>
+                    <condition field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c927-9bc1-c180-b676" type="equalTo"/>
                   </conditions>
                   <conditionGroups/>
                 </modifier>
-                <modifier type="increment" field="points" value="5.0">
+                <modifier type="increment" field="points" value="5">
                   <repeats>
-                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7cf102e8-d48f-92be-dc50-90c79d74d3a8" repeats="1"/>
+                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b8f1-e2a7-0c25-1c08" repeats="1"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
                 <modifier type="decrement" field="points" value="5.0">
                   <repeats>
-                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="10a134c9-dfdd-c921-6c14-17d0875f3b82" repeats="1"/>
+                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="10a134c9-dfdd-c921-6c14-17d0875f3b82" repeats="1"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -45591,14 +45510,14 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
               <modifiers>
                 <modifier type="increment" field="points" value="5.0">
                   <repeats>
-                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7cf102e8-d48f-92be-dc50-90c79d74d3a8" repeats="1"/>
+                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b8f1-e2a7-0c25-1c08" repeats="1"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
                 <modifier type="decrement" field="points" value="5.0">
                   <repeats>
-                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="10a134c9-dfdd-c921-6c14-17d0875f3b82" repeats="1"/>
+                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="10a134c9-dfdd-c921-6c14-17d0875f3b82" repeats="1"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -45606,7 +45525,7 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
                 <modifier type="set" field="hidden" value="true">
                   <repeats/>
                   <conditions>
-                    <condition field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="cfb48ef9-5d81-0b93-3a8b-02a8533e5a84" type="equalTo"/>
+                    <condition field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bb9c-32cd-46d5-608d" type="equalTo"/>
                   </conditions>
                   <conditionGroups/>
                 </modifier>
@@ -45703,7 +45622,7 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
           <rules/>
           <infoLinks/>
           <modifiers>
-            <modifier type="increment" field="points" value="5.0">
+            <modifier type="increment" field="points" value="5">
               <repeats>
                 <repeat field="selections" scope="b9f0-57cc-d0da-4ae3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8786-8772-e209-9f59" repeats="1"/>
               </repeats>
@@ -67223,7 +67142,9 @@ Explodes results add D3&quot; to radius.  </description>
         </infoLink>
       </infoLinks>
       <modifiers/>
-      <constraints/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="367a-32fc-ce10-0bf6" type="max"/>
+      </constraints>
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks/>
@@ -68660,6 +68581,26 @@ Explodes results add D3&quot; to radius.  </description>
       <costs>
         <cost name="pts" costTypeId="points" value="55.0"/>
       </costs>
+    </selectionEntry>
+    <selectionEntry id="9f1b-7c69-13d6-56b5" name="Plasma Cannon" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="08eb-8585-d550-5c40" name="New InfoLink" hidden="false" targetId="13df-d6b0-3f33-bf9b" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a85c-2561-5a1e-1040" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs/>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -16189,233 +16189,6 @@
         <cost name="pts" costTypeId="points" value="625.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="c8a6a754-3a48-26b2-9caa-c34d2308481a" name="Legion Javelin Attack Speeder Squadron" book="HH:LACAL" page="48" hidden="false" collective="false" categoryEntryId="466173742041747461636b23232344415441232323" type="unit">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <selectionEntries>
-        <selectionEntry id="c609536d-8313-8754-4697-cd2f32b00dcc" name="Legion Javelin Attack Speeder" book="" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-          <profiles>
-            <profile id="da3a81e6-8f9f-ef49-0290-ad661ffeed9e" name="Legion Javelin Attack Speeder" book="HH:LACAL" page="48" hidden="false" profileTypeId="56656869636c6523232344415441232323">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="4"/>
-                <characteristic name="Front" characteristicTypeId="46726f6e7423232344415441232323" value="11"/>
-                <characteristic name="Side" characteristicTypeId="5369646523232344415441232323" value="11"/>
-                <characteristic name="Rear" characteristicTypeId="5265617223232344415441232323" value="10"/>
-                <characteristic name="HP" characteristicTypeId="485023232344415441232323" value="2"/>
-                <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Fast, Skimmer"/>
-              </characteristics>
-            </profile>
-          </profiles>
-          <rules>
-            <rule id="878d582e-97b6-c764-27c9-a42b01ae7440" name="Deep Strike" page="0" hidden="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </rule>
-            <rule id="f307d557-c815-5a22-8bd5-3272fea368e0" name="Outflank" page="0" hidden="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </rule>
-          </rules>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <selectionEntries/>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="d9d9b2e8-e93a-489b-5b17-ddb061776275" name="Exchange Heavy Bolter for:" hidden="false" collective="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries>
-                <selectionEntry id="2958a472-bd2d-59ad-ec47-6cd4fe30f88e" name="Heavy Flamer" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="1bd055d9-adaf-4fd4-257d-2c43ac9f982c" name="Multi-melta" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="10.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="6dd0-0a8c-da39-7147" hidden="false" targetId="2d56d45d-d276-7830-2b7d-026de64bbae8" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers>
-                    <modifier type="set" field="points" value="5.0">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                  <constraints/>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-            <selectionEntryGroup id="89845b9c-7cf4-23c5-0e42-f61a95625396" name="May take any of the following upgrades:" hidden="false" collective="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries>
-                <selectionEntry id="2b6c18c1-9c8a-ae3c-a4a9-eb54320cadb4" name="Searchlight" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="1.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="ac92ee70-460b-232a-e889-832ecd553d54" name="Hunter-killer Missiles" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="5.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups/>
-              <entryLinks/>
-            </selectionEntryGroup>
-            <selectionEntryGroup id="98d3bdfd-9172-314b-c9b3-4af7788ce589" name="Exchange Twin-linked Cyclone Missile Launcher for:" hidden="false" collective="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries>
-                <selectionEntry id="10b42223-d653-872b-337d-fbc3a3ba569e" name="Twin-linked Lascannon" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="10.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups/>
-              <entryLinks/>
-            </selectionEntryGroup>
-            <selectionEntryGroup id="64b95ace-69d3-87cb-c4be-c05c8ff46390" name="Legion-specific upgrade" hidden="false" collective="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="545d7d79-2d9b-baf6-8088-9ec114181c73" hidden="false" targetId="a15bdf56-4ffe-fe04-ff77-3d533ab99dfa" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-                <entryLink id="c9ff999d-2d32-451c-e692-bc29d1971113" hidden="false" targetId="86e70545-ed1a-7cf4-5a3d-d60662a6b3be" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-                <entryLink id="2dea74fe-a222-0a82-8fec-77d7a3c0cb8c" hidden="false" targetId="f785888f-6dfa-08f4-054f-29b1a0e4f20c" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="55.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups/>
-      <entryLinks>
-        <entryLink id="996f-3788-0550-9922" hidden="false" targetId="c487-be13-ea53-917e" type="selectionEntryGroup">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </entryLink>
-      </entryLinks>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
     <selectionEntry id="d2dd-05f4-a5dd-627f" name="Legion Mastadon Heavy Assault Transport" book="" hidden="false" collective="false" categoryEntryId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" type="model">
       <profiles>
         <profile id="b436-1cc9-3d0d-2415" name="Mastadon" book="HH6: Retribution" page="242" hidden="false" profileTypeId="56656869636c6523232344415441232323">
@@ -33030,6 +32803,13 @@ Ignores Cover special rule.</description>
           <conditionGroups/>
         </modifier>
       </modifiers>
+      <constraints/>
+    </entryLink>
+    <entryLink id="9b34-7709-6cf6-713d" name="Legion Javelin Attack Speeder Squadron" book="AL:AoDAL" page="59" hidden="false" targetId="cda4-9061-3bd8-9aff" type="selectionEntry" categoryEntryId="466173742041747461636b23232344415441232323">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <constraints/>
     </entryLink>
   </entryLinks>
@@ -62563,7 +62343,7 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
           <entryLinks/>
           <costs/>
         </selectionEntry>
-        <selectionEntry id="9589-66f8-7b84-17da" name="Additional Wargear" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="9589-66f8-7b84-17da" name="May take any of the following upgrades:" hidden="false" collective="false" type="upgrade">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -69286,6 +69066,302 @@ differently armed Sentry Guns to fire at two separate targets.</description>
         <cost name="pts" costTypeId="points" value="10.0"/>
       </costs>
     </selectionEntry>
+    <selectionEntry id="cda4-9061-3bd8-9aff" name="Legion Javelin Attack Speeder Squadron" book="AL:AoDAL" page="59" hidden="false" collective="false" categoryEntryId="466173742041747461636b23232344415441232323" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="4c16-1a4c-6d34-dd62" name="Legion Javelin Attack Speeder" book="" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles>
+            <profile id="cebc-04cc-36eb-1277" name="Legion Javelin Attack Speeder" book="AL:AoDAL" page="59" hidden="false" profileTypeId="56656869636c6523232344415441232323">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="4"/>
+                <characteristic name="Front" characteristicTypeId="46726f6e7423232344415441232323" value="11"/>
+                <characteristic name="Side" characteristicTypeId="5369646523232344415441232323" value="11"/>
+                <characteristic name="Rear" characteristicTypeId="5265617223232344415441232323" value="10"/>
+                <characteristic name="HP" characteristicTypeId="485023232344415441232323" value="2"/>
+                <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Fast, Skimmer"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks>
+            <infoLink id="d881-73ed-d28f-e38d" name="New InfoLink" hidden="false" targetId="d219-2314-4834-c054" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="1d88-cc6d-0354-2993" name="New InfoLink" hidden="false" targetId="de18-25a0-504b-74be" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="ff25-fd97-9b2d-1696" name="New InfoLink" hidden="false" targetId="7911-b951-c819-2f4f" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="3de6-23d1-26dd-7b2e" name="New InfoLink" hidden="false" targetId="5a15-1563-68c5-172c" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a06b-234b-9c0f-2e3d" type="min"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="61a4-392f-c22a-196b" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="b05c-2504-b5d4-4160" name="Exchange Heavy Bolter for:" hidden="false" collective="false" defaultSelectionEntryId="dffa-a33a-3100-df2d">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ef40-7de0-c390-6d1d" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="8532-bdad-926c-f0fd" type="min"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="12bf-5d4e-0fd0-005d" hidden="false" targetId="2d56d45d-d276-7830-2b7d-026de64bbae8" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="set" field="points" value="5.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="0ad1-3e80-8ca9-ae90" name="New EntryLink" hidden="false" targetId="9fef-d14e-0e9f-1cc8" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="f75a-b995-87e8-6171" name="New EntryLink" hidden="false" targetId="d1c0-746f-2b39-5f17" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="set" field="points" value="10">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="dffa-a33a-3100-df2d" name="New EntryLink" hidden="false" targetId="a161-76b3-9ef1-da7b" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="63ef-2644-13d6-df13" name="May take any of the following upgrades:" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="fe0e-fc1d-41d0-f31c" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="d251-6b33-e12b-0640" name="New EntryLink" hidden="false" targetId="00d9-65e8-94b2-2396" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="set" field="aa92-da0b-de00-eacc" value="2">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="f74d-7305-2560-87eb" name="New EntryLink" hidden="false" targetId="1e27e511-cf75-d55a-6807-b67be6f7474f" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="set" field="points" value="1">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                    <modifier type="set" field="minSelections" value="0.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="1dc4-577c-ae84-8ff4" name="Exchange Twin-linked Cyclone Missile Launcher for:" book="" hidden="false" collective="false" defaultSelectionEntryId="225e-68ce-35e9-a763">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="78b8-fcc0-005d-d74a" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="e2c8-1269-1151-7277" type="min"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="d046-b76a-337d-4715" name="New EntryLink" hidden="false" targetId="8b1d-77d3-74f2-9d1c" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="set" field="points" value="10">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="225e-68ce-35e9-a763" name="New EntryLink" hidden="false" targetId="b064-8530-f4f4-2fb4" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="457c-fd8c-8e3a-b89a" name="Legion-specific upgrade" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="714c-c34c-416c-b222" hidden="false" targetId="a15bdf56-4ffe-fe04-ff77-3d533ab99dfa" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="9ea1-fc42-f8b4-17c4" hidden="false" targetId="86e70545-ed1a-7cf4-5a3d-d60662a6b3be" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="4861-de54-4c11-3c20" hidden="false" targetId="f785888f-6dfa-08f4-054f-29b1a0e4f20c" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="55.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="8ab0-3e5e-68da-8312" hidden="false" targetId="c487-be13-ea53-917e" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b064-8530-f4f4-2fb4" name="Twin-linked Cyclone missile launcher" book="AL:AoDAL" page="134" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="961a-f34c-599b-9d48" name="New InfoLink" hidden="false" targetId="40e6-c95c-7c8d-cf02" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="set" field="5479706523232344415441232323" value="Heavy 2, Blast (3&quot;), Twin-linked">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="dedc-e80e-ea60-961a" name="New InfoLink" hidden="false" targetId="1e33-d8ec-f833-b584" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="set" field="5479706523232344415441232323" value="Heavy 2, Twin-linked">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="a8cf-0aee-f878-13f5" name="New InfoLink" hidden="false" targetId="10a8-8d89-0bec-3e21" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs/>
+    </selectionEntry>
+    <selectionEntry id="f6e2-4e7b-efcb-b231" name="Twin-linked Cyclone Missile Launcher" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs/>
+    </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup id="fc8ed347-6cd6-c24e-942f-bda78004e894" name="Bodyguard" hidden="false" collective="false">
@@ -72483,6 +72559,13 @@ If a unit of Automated Artillery loses an assault nothing happens, there are no 
       <modifiers/>
       <description>An Immobile Artillery piece cannot be moved after it has been deployed except by the use of a specialised vehicle, and ignores any effect which forces it to move. This only affects the platform – not any crew who are subject to all normal Artillery rules. When called upon to Fall Back, the crew must leave their guns behind and fall back; the platforms are then removed as casualties.
 Note that an Immobile unit may still have the Scout or Deep Strike special rules as these reflect redeployment or deployment during battle, rather than game movement. Only if it has the Deep Strike special rule may an Immobile unit be held in Reserve.</description>
+    </rule>
+    <rule id="5a15-1563-68c5-172c" name="Grav-backwash" book="AL:AoDAL" page="59" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>Unless the Javelin Attack Speeder has become immobilised, attackers suffer a -2 To Hit in Assault.</description>
     </rule>
   </sharedRules>
   <sharedProfiles>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -23633,50 +23633,6 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
           <modifiers/>
           <constraints/>
           <selectionEntries>
-            <selectionEntry id="adf7689a-cea4-4beb-c893-a72e5950346c" name="Chaff Launcher" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="389a1fc3-a8c0-5b43-485c-df54562c6559" hidden="false" targetId="c3bb10b0-0ad1-3d7e-5b6e-20b2f57fbaba" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="10.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="3dba6720-7491-031c-5b16-6907e1193180" name="Armoured Cockpit" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="a3407aed-3566-ac8d-c846-7ab4eac12a24" hidden="false" targetId="06710a9d-a2a8-638f-91b0-2af2fb3e95c2" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="15.0"/>
-              </costs>
-            </selectionEntry>
             <selectionEntry id="2328058f-72f6-b053-63f3-cfd04dcc3b28" name="Ramjet Diffraction Grid" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
               <profiles>
                 <profile id="37d7da24-6b99-e5bb-2c63-3b1623a0eb9c" name="Ramjet Diffraction Grid" book="HH:LACAL" page="42" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323">
@@ -23739,6 +23695,26 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                   <conditionGroups/>
                 </modifier>
               </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="4108-4e2c-5187-6380" name="New EntryLink" hidden="false" targetId="472a-3a4d-f0cf-a903" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="15">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="fbe4-46a5-bbe2-ce74" name="New EntryLink" hidden="false" targetId="1e54-cea6-bda7-8555" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
               <constraints/>
             </entryLink>
           </entryLinks>
@@ -23893,50 +23869,6 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
           <modifiers/>
           <constraints/>
           <selectionEntries>
-            <selectionEntry id="8d5ce81d-a26f-635a-9c03-e3fa68f2ecdc" name="Chaff Launcher" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="928f3a3e-6f2a-ade7-bbe9-25ef91c87348" hidden="false" targetId="c3bb10b0-0ad1-3d7e-5b6e-20b2f57fbaba" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="10.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="aa014898-a11f-378e-6d7b-db69e43c5757" name="Armoured Cockpit" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="6b2a31ab-6390-235a-0b85-3fdfb9d0ae52" hidden="false" targetId="06710a9d-a2a8-638f-91b0-2af2fb3e95c2" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="15.0"/>
-              </costs>
-            </selectionEntry>
             <selectionEntry id="e48a4c41-9311-29fd-de13-bc76b25be1e7" name="Illum Flares" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
               <profiles/>
               <rules/>
@@ -24036,6 +23968,26 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                   <conditionGroups/>
                 </modifier>
               </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="a868-479f-9153-740d" name="New EntryLink" hidden="false" targetId="472a-3a4d-f0cf-a903" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="15">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="c4f1-7570-9de2-6125" name="New EntryLink" hidden="false" targetId="1e54-cea6-bda7-8555" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
               <constraints/>
             </entryLink>
           </entryLinks>
@@ -27750,28 +27702,6 @@ Ignores Cover special rule.</description>
                   <modifiers/>
                   <constraints/>
                   <selectionEntries>
-                    <selectionEntry id="458ea46f-efff-6a01-728b-f93f5b6f44c1" name="Chaff Launcher" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="a2543057-848b-fd5f-ad73-0812f7a21279" hidden="false" targetId="c3bb10b0-0ad1-3d7e-5b6e-20b2f57fbaba" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="10.0"/>
-                      </costs>
-                    </selectionEntry>
                     <selectionEntry id="24826fd6-9789-58a5-871c-85431d77f7fe" name="Infra-red Targeting" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
                       <profiles/>
                       <rules/>
@@ -27818,7 +27748,15 @@ Ignores Cover special rule.</description>
                     </selectionEntry>
                   </selectionEntries>
                   <selectionEntryGroups/>
-                  <entryLinks/>
+                  <entryLinks>
+                    <entryLink id="d67a-3862-5af6-cc30" name="New EntryLink" hidden="false" targetId="1e54-cea6-bda7-8555" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </entryLink>
+                  </entryLinks>
                 </selectionEntryGroup>
                 <selectionEntryGroup id="9c94f2c1-f69e-1bc4-e644-8a9b44598c99" name="May equip two hardpoints with one choice of:" hidden="false" collective="false">
                   <profiles/>
@@ -39964,6 +39902,12 @@ In addtion, all units with the Legiones Astartes (Emperor&apos;s Children) rule 
       <rules/>
       <infoLinks>
         <infoLink id="e07ac9e5-7585-dff4-5fdd-f7736134dc36" hidden="false" targetId="abdf1422-184a-f8f9-9544-621c2e1c646f" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="7285-890e-7f39-4932" name="New InfoLink" hidden="false" targetId="7911-b951-c819-2f4f" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -56317,6 +56261,15 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
           </modifiers>
           <constraints/>
         </entryLink>
+        <entryLink id="d827-1281-2840-ca42" name="New EntryLink" hidden="false" targetId="8b1d-77d3-74f2-9d1c" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="de23-b4a8-624b-ac43" type="min"/>
+          </constraints>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="pts" costTypeId="points" value="135.0"/>
@@ -58169,50 +58122,6 @@ Phalanx Breacher squads and Legion Terminator squads may be taken as troops in a
               <modifiers/>
               <constraints/>
               <selectionEntries>
-                <selectionEntry id="f784-0b57-72c0-4501" name="Chaff Launcher" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="94e8-1f13-0147-29d6" hidden="false" targetId="c3bb10b0-0ad1-3d7e-5b6e-20b2f57fbaba" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="10.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="8dac-d89e-fd6e-9b27" name="Armoured Cockpit" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="b07a-f053-a73e-4f33" hidden="false" targetId="06710a9d-a2a8-638f-91b0-2af2fb3e95c2" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="15.0"/>
-                  </costs>
-                </selectionEntry>
                 <selectionEntry id="5d5c-8262-b17c-6e09" name="Ramjet Diffraction Grid" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
                   <profiles>
                     <profile id="de98-40bb-212f-c6e2" name="Ramjet Diffraction Grid" book="HH:LACAL" page="42" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323">
@@ -58275,6 +58184,26 @@ Phalanx Breacher squads and Legion Terminator squads may be taken as troops in a
                       <conditionGroups/>
                     </modifier>
                   </modifiers>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="695d-3a6b-5105-b277" name="New EntryLink" hidden="false" targetId="472a-3a4d-f0cf-a903" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="set" field="points" value="15">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="ae98-688c-111f-7d96" name="New EntryLink" hidden="false" targetId="1e54-cea6-bda7-8555" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
                   <constraints/>
                 </entryLink>
               </entryLinks>
@@ -62551,7 +62480,7 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
     </selectionEntry>
     <selectionEntry id="a040-15fd-9aa5-caf1" name="Xiphon Interceptor" book="HH5: Tempest" page="216" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
       <profiles>
-        <profile id="3222-0ffa-5bf0-29c8" name="Xiphon Interceptor" book="HH5: Tempest" page="216" hidden="false" profileTypeId="56656869636c6523232344415441232323">
+        <profile id="1c69-b4ae-1e80-5155" name="Xiphon Interceptor" book="AL:AoDAL" page="58" hidden="false" profileTypeId="56656869636c6523232344415441232323">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -62565,62 +62494,22 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
             <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Flyer"/>
           </characteristics>
         </profile>
-        <profile id="e1da-5beb-4e2c-4158" name="Xiphon Rotary Missile Launcher" book="HH5: Tempest" page="216" hidden="false" profileTypeId="576561706f6e23232344415441232323">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="60&quot;"/>
-            <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="8"/>
-            <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="2"/>
-            <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 2, Cluster Warhead, Terminal Tracking"/>
-          </characteristics>
-        </profile>
       </profiles>
-      <rules>
-        <rule id="71d3-b17d-fd68-c6b7" name="Supersonic" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </rule>
-        <rule id="fc5d-717e-51bf-ad8d" name="Deep Strike" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </rule>
-        <rule id="74ff-46c8-e018-efca" name="Agile" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <description>Increases cover save granted by Jink special rule by +1</description>
-        </rule>
-        <rule id="ea11-8da6-f09d-e0eb" name="Terminal Tracking" book="HH5: Tempest" page="216" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <description>Successful Jink and Cover saves against this weapon must be re-rolled.  </description>
-        </rule>
-        <rule id="283f-a3b6-21be-673a" name="Cluster Warhead" book="HH5: Tempest" page="216" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <description>When scoring a Penetrating Hit, roll D3 times on the Vehicle Damage table and select the highest result.  </description>
-        </rule>
-      </rules>
+      <rules/>
       <infoLinks>
-        <infoLink id="4256-7c7d-efac-36ca" hidden="false" targetId="2e87b8ca-7cd1-78b9-2116-246015e7935e" type="profile">
+        <infoLink id="8056-a01f-399d-1f32" name="New InfoLink" hidden="false" targetId="b35f-72bc-bdac-c298" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="8056-a01f-399d-1f32" name="New InfoLink" hidden="false" targetId="b35f-72bc-bdac-c298" type="rule">
+        <infoLink id="b463-dfb4-d6c7-c834" name="New InfoLink" hidden="false" targetId="d219-2314-4834-c054" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="af3a-066f-5d09-7ee5" name="New InfoLink" hidden="false" targetId="2e96-21ae-353e-8742" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -62631,63 +62520,82 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
       <constraints>
         <constraint field="selections" scope="parent" value="-1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
       </constraints>
-      <selectionEntries/>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="ccd5-706a-df2b-2761" name="May take any of the following:" hidden="false" collective="false">
+      <selectionEntries>
+        <selectionEntry id="ee91-3afa-3a21-302a" name="Xiphon Rotary Missile Launcher" book="AL:AoDAL" page="58" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="dbfd-78a7-de44-42bd" name="Xiphon Rotary Missile Launcher" book="AL:AoDAL" page="58" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="60&quot;"/>
+                <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="8"/>
+                <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="2"/>
+                <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 2, Cluster Warhead, Terminal Tracking"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="38de-84d6-3abf-ebb2" name="Cluster Warhead" book="AL:AoDAL" page="58" hidden="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <description>When scoring a Penetrating Hit, roll D3 times on the Vehicle Damage table and select the highest result.  </description>
+            </rule>
+            <rule id="574c-85e5-28f2-5c09" name="Terminal Tracking" book="AL:AoDAL" page="58" hidden="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <description>Successful Jink and Cover saves against this weapon must be re-rolled.  </description>
+            </rule>
+          </rules>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="dbc1-d5d9-3481-d631" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5575-13fe-eb89-98f4" type="min"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs/>
+        </selectionEntry>
+        <selectionEntry id="9589-66f8-7b84-17da" name="Additional Wargear" hidden="false" collective="false" type="upgrade">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <constraints/>
-          <selectionEntries>
-            <selectionEntry id="5c88-6ee4-16d3-2a2f" name="Armoured Cockpit" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="1817-a58e-6094-962d" hidden="false" targetId="06710a9d-a2a8-638f-91b0-2af2fb3e95c2" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="06fc-0657-6ea1-b8fa" name="Chaff Launcher" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="3c3e-1c01-e926-4229" hidden="false" targetId="c3bb10b0-0ad1-3d7e-5b6e-20b2f57fbaba" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2aa7-1edd-75d8-f6c9" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="36fe-06b2-17d9-4264" type="min"/>
+          </constraints>
+          <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="e175-0a49-c39b-a8fa" hidden="false" targetId="1501761c-e675-edf5-e2c5-6e51f554e377" type="selectionEntry">
+            <entryLink id="9a3b-4ce7-10dd-ef8e" name="New EntryLink" hidden="false" targetId="1e54-cea6-bda7-8555" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="5">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="a21b-1d2f-4912-76c1" name="" hidden="false" targetId="1501761c-e675-edf5-e2c5-6e51f554e377" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="9044-4f79-2e1d-faa8" name="New EntryLink" hidden="false" targetId="472a-3a4d-f0cf-a903" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -62695,9 +62603,21 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
               <constraints/>
             </entryLink>
           </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks/>
+          <costs/>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="b126-7d78-32db-e48a" name="New EntryLink" hidden="false" targetId="8b1d-77d3-74f2-9d1c" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="81bc-90de-00af-bf8a" type="min"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
       <costs>
         <cost name="pts" costTypeId="points" value="205.0"/>
       </costs>
@@ -69322,6 +69242,50 @@ differently armed Sentry Guns to fire at two separate targets.</description>
       <entryLinks/>
       <costs/>
     </selectionEntry>
+    <selectionEntry id="472a-3a4d-f0cf-a903" name="Armoured Cockpit" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="10ea-0b8a-e83f-d28c" hidden="false" targetId="b468-bcac-2a69-3a94" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="862a-297a-e863-576b" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="5.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1e54-cea6-bda7-8555" name="Chaff Launcher" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="1dcb-0c13-7fac-8ccc" hidden="false" targetId="5472-381f-30fb-637a" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c1d5-db35-2fa1-d5fa" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup id="fc8ed347-6cd6-c24e-942f-bda78004e894" name="Bodyguard" hidden="false" collective="false">
@@ -72502,6 +72466,7 @@ Kharybdis: After it has landed treat as a flyer in Hover mode. LA:AODAL P75</des
       <rules/>
       <infoLinks/>
       <modifiers/>
+      <description>Increases cover save granted by Jink special rule by +1</description>
     </rule>
     <rule id="56ad-c026-7680-1d4d" name="Automated Artillery" book="AL:AoDAL" page="122" hidden="false">
       <profiles/>
@@ -72542,7 +72507,7 @@ Note that an Immobile unit may still have the Scout or Deep Strike special rules
         <characteristic name="Description" characteristicTypeId="4465736372697074696f6e23232344415441232323" value="A vehicle with this wargear is not subject to the additional D6 armour penetration caused by weapons with the Melta special rule.  "/>
       </characteristics>
     </profile>
-    <profile id="06710a9d-a2a8-638f-91b0-2af2fb3e95c2" name="Armoured Cockpit" book="HH:LACAL" page="88" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323">
+    <profile id="b468-bcac-2a69-3a94" name="Armoured Cockpit" book="HH:LACAL" page="88" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -72653,7 +72618,7 @@ Note that an Immobile unit may still have the Scout or Deep Strike special rules
         <characteristic name="Description" characteristicTypeId="4465736372697074696f6e23232344415441232323" value="A model in Terminator armour has the Relentless and Bulky special rules, and is not able to make Sweeping Advance moves unless otherwise specified. They also may not be  transported in Rhino APCs. Terminator armour affords a 2+ armour save and a 5+ invulnerable save.   In addition to the effects and rules listed previously for Terminator armour, models in Cataphractii pattern armour cannot make Run moves or Overwatch attacks. In addition, their invulnerable save is increased to 4+. Models which join a unit in Cataphractii armour may themselves not make Run moves or Sweeping Advances while with the unit, but may make Overwatch attacks as normal for them. If a unit is joined by a model in Cataphractii armour, the unit is prevented from making Run moves or Sweeping Advances while the model is with them. "/>
       </characteristics>
     </profile>
-    <profile id="c3bb10b0-0ad1-3d7e-5b6e-20b2f57fbaba" name="Chaff/Flare Launchers" book="HH:LACAL" page="90" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323">
+    <profile id="5472-381f-30fb-637a" name="Chaff/Flare Launchers" book="HH:LACAL" page="90" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323">
       <profiles/>
       <rules/>
       <infoLinks/>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -16416,307 +16416,6 @@
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="bd1878f5-ec53-67c0-f89e-d8680dbfc32c" name="Legion Land Speeder Squadron" book="HH:LACAL" page="46" hidden="false" collective="false" categoryEntryId="466173742041747461636b23232344415441232323" type="unit">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <selectionEntries>
-        <selectionEntry id="f95c348b-9eac-8bbf-241e-4ee79ab736da" name="Legion Land Speeder" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-          <profiles>
-            <profile id="beb3a421-57cd-324b-259a-7fb172bd7183" name="Legion Land Speeder" book="HH:LACAL" page="46" hidden="false" profileTypeId="56656869636c6523232344415441232323">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="4"/>
-                <characteristic name="Front" characteristicTypeId="46726f6e7423232344415441232323" value="10"/>
-                <characteristic name="Side" characteristicTypeId="5369646523232344415441232323" value="10"/>
-                <characteristic name="Rear" characteristicTypeId="5265617223232344415441232323" value="10"/>
-                <characteristic name="HP" characteristicTypeId="485023232344415441232323" value="2"/>
-                <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Skimmer, Fast"/>
-              </characteristics>
-            </profile>
-          </profiles>
-          <rules>
-            <rule id="094035cf-627a-fb00-34b5-fb255de8c29b" name="Deep Strike" page="0" hidden="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </rule>
-          </rules>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="54323238-4406-b630-eb35-2a088626af1d" name="Hunter-killer Missiles" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="10.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="67a4d57c-2aa0-4397-0c8d-baa033a8c220" name="Replace Heavy Bolter with:" hidden="false" collective="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries>
-                <selectionEntry id="ca2b7648-8f02-ffe8-d953-37123ee0d343" name="Heavy Flamer" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="11ef07b4-9995-bf8c-fbc9-a1ea2f5c0336" name="Multi-melta" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="10.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="ae58ca90-108a-04b3-6155-74ae6db8bfa6" name="Volkite Culverin" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="4e9543fa-dd8a-fba3-3a5e-3a0a9137c04f" hidden="false" targetId="c7838603-9e18-8756-26b1-222a294c5c2c" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                    <infoLink id="fb09ce88-dd0e-aeaf-f63a-26c7837b7532" hidden="false" targetId="cbcf-5f25-f8ea-7cfd" type="rule">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="10.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="6999-4c3a-bf28-d6fc" hidden="false" targetId="2d56d45d-d276-7830-2b7d-026de64bbae8" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers>
-                    <modifier type="set" field="points" value="5.0">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                  <constraints/>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-            <selectionEntryGroup id="97c8897a-007f-4a70-f681-73ed07b21087" name="May be upgraded with one:" hidden="false" collective="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries>
-                <selectionEntry id="8fa0968e-8d6b-a241-6477-4f0ffd6e1348" name="Havoc Launcher" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="e6971d5a-dbd2-7949-d8b4-0e4eb5ee396a" hidden="false" targetId="b3ea1d32-ba66-0585-d7f7-0dc56e707736" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="15.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="0d489528-afbc-89fb-f9dd-e3e1b6631e5f" name="Heavy Bolter" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="15.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="61814dc1-8d9a-a8da-0c65-0015bf97d565" name="Plasma Cannon" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="30.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="e446d749-152e-d71c-c1a4-5a95d9badd00" name="Graviton Gun" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="322874f7-c59c-35b9-0157-205f73784e2b" hidden="false" targetId="48a06170-d952-045d-a033-bd04d1122b59" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                    <infoLink id="3749a6a2-a4ee-5b3c-77cb-5ce556354eb5" hidden="false" targetId="53a62286-f01f-a0b5-7003-7cc0c702a11a" type="rule">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="15.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="ce2fc53c-80dc-9ec8-aca2-91882cc5ffec" hidden="false" targetId="f2d4a6e5-edf4-52b2-fa15-13b163113aa5" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers>
-                    <modifier type="set" field="points" value="15.0">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                  <constraints/>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-            <selectionEntryGroup id="7e6d4476-a2c5-9684-8464-fc3419241c7a" name="Legion-specific upgrade" hidden="false" collective="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="f9e0aa5f-85cf-203b-a9e6-85190fa9e1ac" hidden="false" targetId="a15bdf56-4ffe-fe04-ff77-3d533ab99dfa" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-                <entryLink id="24a4a0f7-e573-0f3f-a42b-283ae33a7b07" hidden="false" targetId="86e70545-ed1a-7cf4-5a3d-d60662a6b3be" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-                <entryLink id="896c60b5-0dd8-50c5-debc-208d6389483f" hidden="false" targetId="f785888f-6dfa-08f4-054f-29b1a0e4f20c" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="40.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups/>
-      <entryLinks>
-        <entryLink id="6f4c-a5bc-5b7f-6e8d" hidden="false" targetId="c487-be13-ea53-917e" type="selectionEntryGroup">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </entryLink>
-      </entryLinks>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
     <selectionEntry id="d2dd-05f4-a5dd-627f" name="Legion Mastadon Heavy Assault Transport" book="" hidden="false" collective="false" categoryEntryId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" type="model">
       <profiles>
         <profile id="b436-1cc9-3d0d-2415" name="Mastadon" book="HH6: Retribution" page="242" hidden="false" profileTypeId="56656869636c6523232344415441232323">
@@ -33766,6 +33465,13 @@ Ignores Cover special rule.</description>
       </modifiers>
       <constraints/>
     </entryLink>
+    <entryLink id="328b-2809-ccac-77cb" name="New EntryLink" hidden="false" targetId="7025-def4-671f-77f3" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </entryLink>
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="a9bf-b37e-126b-a699" name="&apos;Iron Circle&apos; Domitar-Ferrum Class Battle-automata Maniple" hidden="false" collective="false" categoryEntryId="456c6974657323232344415441232323" type="unit">
@@ -40578,7 +40284,7 @@ In addtion, all units with the Legiones Astartes (Emperor&apos;s Children) rule 
         <cost name="pts" costTypeId="points" value="60.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="74337d9b-668a-a426-0ce4-a61afe69176f" name="Graviton Gun" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+    <selectionEntry id="74337d9b-668a-a426-0ce4-a61afe69176f" name="Graviton Gun (Iron Hands)" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
       <rules/>
       <infoLinks>
@@ -68909,6 +68615,273 @@ Explodes results add D3&quot; to radius.  </description>
       </entryLinks>
       <costs>
         <cost name="pts" costTypeId="points" value="400.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7025-def4-671f-77f3" name="Legion Land Speeder Squadron" book="HH:LACAL" page="46" hidden="false" collective="false" categoryEntryId="466173742041747461636b23232344415441232323" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="963b-d853-63fa-6bb1" name="New InfoLink" hidden="false" targetId="d219-2314-4834-c054" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="217b-6f6b-9587-1017" name="Legion Land Speeder" book="" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles>
+            <profile id="4321-6fbf-f8de-6b17" name="Legion Land Speeder" book="AL:AoDL" page="56" hidden="false" profileTypeId="56656869636c6523232344415441232323">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="4"/>
+                <characteristic name="Front" characteristicTypeId="46726f6e7423232344415441232323" value="10"/>
+                <characteristic name="Side" characteristicTypeId="5369646523232344415441232323" value="10"/>
+                <characteristic name="Rear" characteristicTypeId="5265617223232344415441232323" value="10"/>
+                <characteristic name="HP" characteristicTypeId="485023232344415441232323" value="2"/>
+                <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Skimmer, Fast"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7aa0-fc26-15c8-c120" type="min"/>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d852-1f66-b049-fa6c" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="a8aa-e53e-1b0f-f3c6" name="Replace Heavy Bolter with:" hidden="false" collective="false" defaultSelectionEntryId="7f36-e31f-b4c1-8e29">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0e5d-d68c-2074-8a3a" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="1f0e-623a-4e05-9124" hidden="false" targetId="2d56d45d-d276-7830-2b7d-026de64bbae8" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="set" field="points" value="5.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="aa3e-ae9c-d79b-699b" name="New EntryLink" hidden="false" targetId="edadef72-c786-ab75-6888-15d0cc090857" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="set" field="points" value="10">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="a830-cf3d-50d1-a8c3" name="New EntryLink" hidden="false" targetId="d1c0-746f-2b39-5f17" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="set" field="points" value="10">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="9f2c-7510-500d-880c" name="New EntryLink" hidden="false" targetId="9fef-d14e-0e9f-1cc8" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="7f36-e31f-b4c1-8e29" name="New EntryLink" hidden="false" targetId="a161-76b3-9ef1-da7b" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="9ba2-2f34-c3bf-f0b0" name="May be upgraded with one:" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="93ad-ea31-7978-a4ca" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="deb9-408a-8a81-656f" hidden="false" targetId="f2d4a6e5-edf4-52b2-fa15-13b163113aa5" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="set" field="points" value="15">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="f1d8-d6fc-1fd8-f986" name="New EntryLink" hidden="false" targetId="a161-76b3-9ef1-da7b" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="set" field="points" value="15">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="deca-71e3-3a33-24e7" name="New EntryLink" hidden="false" targetId="d6bf-b694-8ca0-a6c5" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="15b2-128f-b078-29db" name="New EntryLink" hidden="false" targetId="9f1b-7c69-13d6-56b5" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="set" field="points" value="30">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="c418-a0f9-d1a0-a6f1" name="New EntryLink" hidden="false" targetId="0d3c-2b57-247d-548d" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="e05b-4bbd-3b6f-1e9e" name="Legion-specific upgrade" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="b056-a3bf-8bc6-f186" hidden="false" targetId="a15bdf56-4ffe-fe04-ff77-3d533ab99dfa" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="7c5c-468d-6151-fa98" hidden="false" targetId="86e70545-ed1a-7cf4-5a3d-d60662a6b3be" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="87cb-3670-4c61-e164" hidden="false" targetId="f785888f-6dfa-08f4-054f-29b1a0e4f20c" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="6511-2fbf-010c-9892" name="New EntryLink" hidden="false" targetId="00d9-65e8-94b2-2396" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="aa92-da0b-de00-eacc" value="2">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="40.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="cbaf-6186-cce3-e4c7" hidden="false" targetId="c487-be13-ea53-917e" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0d3c-2b57-247d-548d" name="Graviton Gun" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="1923-7e22-4585-22b6" hidden="false" targetId="48a06170-d952-045d-a033-bd04d1122b59" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="dd7e-d7f3-2955-a814" hidden="false" targetId="53a62286-f01f-a0b5-7003-7cc0c702a11a" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f43b-76d7-90d0-21d4" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="15.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -30045,7 +30045,7 @@ Ignores Cover special rule.</description>
           </profiles>
           <rules/>
           <infoLinks>
-            <infoLink id="9ffa-cd6c-27fc-9d46" hidden="false" targetId="beb478f9-bf5e-772f-e627-8ea394beaa5c" type="rule">
+            <infoLink id="9ffa-cd6c-27fc-9d46" hidden="false" targetId="39b7-c66e-6b9c-8430" type="rule">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -34418,18 +34418,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
       </constraints>
       <selectionEntries/>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="3416-3086-2717-fefe" name="New SelectionEntryGroup" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
+      <selectionEntryGroups/>
       <entryLinks/>
       <costs>
         <cost name="pts" costTypeId="points" value="10.0"/>
@@ -40401,7 +40390,7 @@ In addtion, all units with the Legiones Astartes (Emperor&apos;s Children) rule 
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="c9c1-59d0-3864-e171" hidden="false" targetId="beb478f9-bf5e-772f-e627-8ea394beaa5c" type="rule">
+        <infoLink id="c9c1-59d0-3864-e171" hidden="false" targetId="39b7-c66e-6b9c-8430" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -40646,7 +40635,7 @@ In addtion, all units with the Legiones Astartes (Emperor&apos;s Children) rule 
                   <profiles/>
                   <rules/>
                   <infoLinks>
-                    <infoLink id="b4f4-e439-e7cc-47fd" hidden="false" targetId="beb478f9-bf5e-772f-e627-8ea394beaa5c" type="rule">
+                    <infoLink id="b4f4-e439-e7cc-47fd" hidden="false" targetId="39b7-c66e-6b9c-8430" type="rule">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -40705,7 +40694,7 @@ In addtion, all units with the Legiones Astartes (Emperor&apos;s Children) rule 
                   <profiles/>
                   <rules/>
                   <infoLinks>
-                    <infoLink id="7d3e-6cc6-1e9d-a1eb" hidden="false" targetId="beb478f9-bf5e-772f-e627-8ea394beaa5c" type="rule">
+                    <infoLink id="7d3e-6cc6-1e9d-a1eb" hidden="false" targetId="39b7-c66e-6b9c-8430" type="rule">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -40738,7 +40727,7 @@ In addtion, all units with the Legiones Astartes (Emperor&apos;s Children) rule 
                   <profiles/>
                   <rules/>
                   <infoLinks>
-                    <infoLink id="68b7-4764-90af-9049" hidden="false" targetId="beb478f9-bf5e-772f-e627-8ea394beaa5c" type="rule">
+                    <infoLink id="68b7-4764-90af-9049" hidden="false" targetId="39b7-c66e-6b9c-8430" type="rule">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -44664,41 +44653,10 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
                   </constraints>
-                  <selectionEntries>
-                    <selectionEntry id="31b03d30-b3d2-f035-12ce-cf3790a30f1d" name="Power Weapon" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="10.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="d02f1083-9260-502c-c584-710a9572eadb" name="Power Fist" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="15.0"/>
-                      </costs>
-                    </selectionEntry>
-                  </selectionEntries>
+                  <selectionEntries/>
                   <selectionEntryGroups/>
                   <entryLinks>
-                    <entryLink id="c95d6f31-a6a5-9a62-f1eb-50b4da91602d" hidden="false" targetId="fa1c768d-9b24-bfbd-8dea-ec7b4ff72bb2" type="selectionEntry">
+                    <entryLink id="c95d6f31-a6a5-9a62-f1eb-50b4da91602d" name="" hidden="false" targetId="fa1c768d-9b24-bfbd-8dea-ec7b4ff72bb2" type="selectionEntry">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -44770,6 +44728,20 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
                           <conditionGroups/>
                         </modifier>
                       </modifiers>
+                      <constraints/>
+                    </entryLink>
+                    <entryLink id="fe54-5453-f1ce-7898" name="New EntryLink" hidden="false" targetId="fcef-f5ac-16a3-9401" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </entryLink>
+                    <entryLink id="166f-ec2a-29e3-08a1" name="New EntryLink" hidden="false" targetId="e890-52eb-3444-c6c7" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
                       <constraints/>
                     </entryLink>
                   </entryLinks>
@@ -47027,16 +46999,17 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
         <cost name="pts" costTypeId="points" value="35.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="9fb7-a82a-11cb-fc8e" name="Legion Seeker Squad" book="HH:LACAL" page="38" hidden="false" collective="false" categoryEntryId="466173742041747461636b23232344415441232323" type="unit">
+    <selectionEntry id="9fb7-a82a-11cb-fc8e" name="Legion Seeker Squad" book="AL:AoDAL" page="48" hidden="false" collective="false" categoryEntryId="466173742041747461636b23232344415441232323" type="unit">
       <profiles/>
       <rules>
-        <rule id="3376-8a4e-a355-3135" name="Special Issue Ammunition" book="HH:LACAL" page="38" hidden="false">
+        <rule id="3376-8a4e-a355-3135" name="Special Issue Ammunition" book="AL:AoDL" page="48" hidden="false">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
+          <description>Seeker Space Marines are equipped with Kraken, Scorpius and Tempest bolt shells for their bolters (and combi-weapons where applicable), and may choose which to use each turn they fire.</description>
         </rule>
-        <rule id="8e27-703d-8305-4072" name="Marked for Death" book="HH:LACAL" page="38" hidden="false">
+        <rule id="8e27-703d-8305-4072" name="Marked for Death" book="AL:AoDL" page="48" hidden="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -47051,25 +47024,13 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="ef09-2039-1471-b398" hidden="false" targetId="dae18398-f03c-63ac-5477-470244e1e687" type="profile">
+        <infoLink id="7039-c2a2-965a-92e8" name="" hidden="false" targetId="d4ecfa6a-ed59-8dc4-6606-b62d65cc5e28" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="bad5-adad-4f39-6044" hidden="false" targetId="067e9186-0fba-6430-507f-4fbaaecd0d17" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="8224-05c0-eb21-ec50" hidden="false" targetId="345c9b22-c89e-3234-d710-9b9262a1fd38" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="7039-c2a2-965a-92e8" hidden="false" targetId="d4ecfa6a-ed59-8dc4-6606-b62d65cc5e28" type="rule">
+        <infoLink id="6da5-b3bc-7b45-09c5" name="New InfoLink" hidden="false" targetId="4771-b711-0e74-3aee" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -47081,7 +47042,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
       <selectionEntries>
         <selectionEntry id="1d99-6882-36e4-64f3" name="Legion Seeker Space Marines" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
           <profiles>
-            <profile id="91af-1293-f3b8-dd56" name="Legion Seeker Space Marine" book="HH:LACAL" page="38" hidden="false" profileTypeId="556e697423232344415441232323">
+            <profile id="91af-1293-f3b8-dd56" name="d" book="AL:AoDAL" page="48" hidden="false" profileTypeId="556e697423232344415441232323">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -47116,11 +47077,19 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
         </selectionEntry>
         <selectionEntry id="4e7b-f0a4-31c6-03d6" name="Legion Strike Leader" book="" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
           <profiles>
-            <profile id="bdfb-7544-1923-e662" name="Legion Strike Leader" book="HH:LACAL" page="38" hidden="false" profileTypeId="556e697423232344415441232323">
+            <profile id="bdfb-7544-1923-e662" name="Legion Strike Leader" book="AL:AoDAL" page="48" hidden="false" profileTypeId="556e697423232344415441232323">
               <profiles/>
               <rules/>
               <infoLinks/>
-              <modifiers/>
+              <modifiers>
+                <modifier type="set" field="5361766523232344415441232323" value="2+">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="4e7b-f0a4-31c6-03d6" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="082f-f5f5-1e92-dd7f" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" characteristicTypeId="556e6974205479706523232344415441232323" value="Infantry (Character)"/>
                 <characteristic name="WS" characteristicTypeId="575323232344415441232323" value="4"/>
@@ -47142,38 +47111,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
-          <selectionEntries>
-            <selectionEntry id="2a88-79d9-61bd-6ec5" name="Artificer Armour" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="10.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="af6e-6ffc-db7e-cc14" name="Melta Bombs" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
+          <selectionEntries/>
           <selectionEntryGroups>
             <selectionEntryGroup id="42a0-3147-d3bc-2563" name="May take one of the following:" hidden="false" collective="false">
               <profiles/>
@@ -47183,38 +47121,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
-              <selectionEntries>
-                <selectionEntry id="dd45-7eb7-22da-2fd1" name="Power Weapon" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="10.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="f69d-f40a-563b-5e1f" name="Power Fist" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="15.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
+              <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks>
                 <entryLink id="bed6-37a1-6cdc-04d1" hidden="false" targetId="30834ca2-20b0-cb5a-c7db-f76092533a64" type="selectionEntry">
@@ -47271,6 +47178,33 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
                   <modifiers/>
                   <constraints/>
                 </entryLink>
+                <entryLink id="58f5-4c5b-a91e-b9ee" name="New EntryLink" hidden="false" targetId="26db-484d-3757-03c8" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="set" field="name" value="Single Lighting Claw">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="3580-a478-acf2-f225" name="New EntryLink" hidden="false" targetId="e890-52eb-3444-c6c7" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="17b0-4dbf-df5f-23ef" name="New EntryLink" hidden="false" targetId="fcef-f5ac-16a3-9401" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="08c0-90c1-c542-4f10" name="Exchange Bolter and special issue ammunition for:" hidden="false" collective="false">
@@ -47279,26 +47213,30 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
               <infoLinks/>
               <modifiers/>
               <constraints/>
-              <selectionEntries>
-                <selectionEntry id="81f6-b0dc-8d63-cc03" name="Plasma Pistol" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="cb4a-6f0e-6eec-8582" name="New EntryLink" hidden="false" targetId="b7f52347-4a1b-6d9e-3f3c-0b80e0a2cafe" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
                   <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="10.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="1f27-a240-a286-877f" hidden="false" targetId="82d4-9768-236a-2ea1" type="selectionEntry">
+                  <constraints/>
+                </entryLink>
+                <entryLink id="a619-4be1-f7a8-055e" name="New EntryLink" hidden="false" targetId="f832-f4b2-6aaf-ad83" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="set" field="points" value="10">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="5290-7446-3557-64cd" name="" hidden="false" targetId="82d4-9768-236a-2ea1" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -47316,16 +47254,97 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
               <modifiers/>
               <constraints/>
             </entryLink>
+            <entryLink id="082f-f5f5-1e92-dd7f" name="New EntryLink" hidden="false" targetId="dd74-ccdb-9bc6-7069" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="42f6-aebd-0f4a-d659" name="New EntryLink" hidden="false" targetId="4c62-8983-4a1b-d1c6" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
           </entryLinks>
           <costs>
             <cost name="pts" costTypeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="72a4-0de6-e6ca-1b4d" name="Nuncio-Vox" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+        <selectionEntry id="9e30-f3e0-1731-b5d3" name="Additional Wargear" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ce2e-8bec-8f20-6288" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="876e-ca0f-397b-6467" type="min"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="0678-f7f3-84ce-660c" name="Any Seeker may exchange their Bolter for:" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="6be0-39b9-7e1c-d4e3" value="1">
+                  <repeats>
+                    <repeat field="selections" scope="9fb7-a82a-11cb-fc8e" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1d99-6882-36e4-64f3" repeats="1"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6be0-39b9-7e1c-d4e3" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="2151-bee6-2c3b-17b7" name="New EntryLink" hidden="false" targetId="a329-9d2f-3a3d-d9eb" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d420-eb98-8b74-6e66" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="0cd6-6034-9e61-0bb5" name="New EntryLink" hidden="false" targetId="b4ea-a586-86a9-02eb" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="5ed0-e46a-6cb3-0cd4" name="Standard Wargear" hidden="false" collective="false" type="upgrade">
           <profiles/>
           <rules/>
           <infoLinks>
-            <infoLink id="45b5-0856-a4c6-1acb" hidden="false" targetId="9a458a3c-a9b5-db5e-a218-2041a3a49004" type="profile">
+            <infoLink id="9048-9d32-d918-ad66" hidden="false" targetId="dae18398-f03c-63ac-5477-470244e1e687" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="26ea-8ced-523b-bd16" name="" hidden="false" targetId="067e9186-0fba-6430-507f-4fbaaecd0d17" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="ef65-1128-b04a-c053" hidden="false" targetId="345c9b22-c89e-3234-d710-9b9262a1fd38" type="profile">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -47334,13 +47353,43 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
           </infoLinks>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1000-07cf-9b7a-a71b" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e073-6cbc-004d-a033" type="min"/>
           </constraints>
           <selectionEntries/>
           <selectionEntryGroups/>
-          <entryLinks/>
+          <entryLinks>
+            <entryLink id="7a64-0047-460d-ce0e" name="New EntryLink" hidden="false" targetId="0a96-04b6-7340-91a4" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="2901-bf05-9d77-6f33" name="New EntryLink" hidden="false" targetId="0a53-b471-df87-7b83" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="2a2c-ce39-4a26-1205" name="New EntryLink" hidden="false" targetId="fe8d-1baa-d58d-00bc" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="9cf2-82a2-911f-34af" name="New EntryLink" hidden="false" targetId="ac90-ce47-65c6-f5f3" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
           <costs>
-            <cost name="pts" costTypeId="points" value="10.0"/>
+            <cost name="pts" costTypeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -47480,86 +47529,6 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="cd57-154d-b4d4-a61d" name="Any Seeker may exchange their Bolter for:" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="increment" field="maxSelections" value="1.0">
-              <repeats>
-                <repeat field="selections" scope="9fb7-a82a-11cb-fc8e" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1d99-6882-36e4-64f3" repeats="1"/>
-              </repeats>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="4b01-bbe8-cc54-a256" name="Combi-weapon" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="10.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups/>
-          <entryLinks/>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="2f1e-c1ba-e240-73d2" name="Exchange Scorpios ammunition for:" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <repeats/>
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="822d-fa53-3053-1d7d" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="496f-2a80-5340-df01" type="equalTo"/>
-              </conditions>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="-1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="e0ab-9217-335a-81e8" name="Banestrike Bolter Shells" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="ab1b-01dd-d664-e15f" hidden="false" targetId="239e677c-9ec8-69cf-7923-7a344b33711f" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups/>
-          <entryLinks/>
-        </selectionEntryGroup>
         <selectionEntryGroup id="1672-1bf4-2810-feba" name="Legion-specific upgrade:" hidden="false" collective="false">
           <profiles/>
           <rules/>
@@ -47567,7 +47536,28 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
           <modifiers/>
           <constraints/>
           <selectionEntries/>
-          <selectionEntryGroups/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="27c5-2f46-9fb4-ed70" name="Exchange Scorpios ammunition for:" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="-1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ddcb-276c-2823-ca02" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="b9d8-914a-c06e-77aa" name="New EntryLink" book="AL" page="&amp; 125" hidden="false" targetId="832a-b660-e975-94b3" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
           <entryLinks>
             <entryLink id="12e0-d818-1079-58ba" hidden="false" targetId="86e70545-ed1a-7cf4-5a3d-d60662a6b3be" type="selectionEntry">
               <profiles/>
@@ -68909,7 +68899,46 @@ Explodes results add D3&quot; to radius.  </description>
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="832a-b660-e975-94b3" name="Banestrike Bolter Shells" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="cb00-b1d5-76f4-ac57" hidden="false" targetId="239e677c-9ec8-69cf-7923-7a344b33711f" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="ef3c-2fb8-4cf1-1a32" name="New InfoLink" hidden="false" targetId="39b7-c66e-6b9c-8430" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <repeats/>
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="822d-fa53-3053-1d7d" type="equalTo"/>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="496f-2a80-5340-df01" type="equalTo"/>
+          </conditions>
+          <conditionGroups/>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="70fb-6183-2d2e-6f19" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
@@ -71464,7 +71493,7 @@ Phalanx Warders</description>
       <modifiers/>
       <description>May be included as a HQ choice in a Legion army whose Legiones Astartes rule he does not share.  Where this is the case, he does not gain any benefits from the different Legiones Astartes rules nor does he negate those rules.  When his Leadership value is used to make tests for the unit, his special rules rather than any for the unit are used.  In the case of a Legion Command Squad, these must use the Legiones Astartes special rules from the detachment he is a part of, rather than his own.  </description>
     </rule>
-    <rule id="beb478f9-bf5e-772f-e627-8ea394beaa5c" name="Banestrike" book="HH:LAICL" page="9" hidden="false">
+    <rule id="39b7-c66e-6b9c-8430" name="Banestrike" book="AL:AoDL" page="81 &amp; 125" hidden="false">
       <profiles/>
       <rules/>
       <infoLinks/>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -46959,7 +46959,13 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
               <profiles/>
               <rules/>
               <infoLinks/>
-              <modifiers/>
+              <modifiers>
+                <modifier type="set" field="points" value="25">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
               <constraints/>
             </entryLink>
             <entryLink id="aa43-0a0c-e92a-b375" name="New EntryLink" hidden="false" targetId="a0a4-4e61-7118-fcff" type="selectionEntry">
@@ -65522,7 +65528,13 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
               <profiles/>
               <rules/>
               <infoLinks/>
-              <modifiers/>
+              <modifiers>
+                <modifier type="set" field="points" value="25">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
               <constraints/>
             </entryLink>
           </entryLinks>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -48202,9 +48202,9 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
         <cost name="pts" costTypeId="points" value="305.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="bd2ad8ef-8033-0a45-7ee5-ebcf07f1f117" name="Legion Storm Eagle Assault Gunship" book="HH:LACAL" page="47" hidden="false" collective="false" categoryEntryId="466173742041747461636b23232344415441232323" type="unit">
+    <selectionEntry id="bd2ad8ef-8033-0a45-7ee5-ebcf07f1f117" name="Legion Storm Eagle Assault Gunship" book="AL:AoDL" page="57" hidden="false" collective="false" categoryEntryId="466173742041747461636b23232344415441232323" type="unit">
       <profiles>
-        <profile id="06b6c2cc-e892-38ce-c0da-f6acb128bf13" name="Legion Storm Eagle Assault Gunship" book="HH1: Betrayal" page="215" hidden="false" profileTypeId="56656869636c6523232344415441232323">
+        <profile id="06b6c2cc-e892-38ce-c0da-f6acb128bf13" name="Legion Storm Eagle Assault Gunship" book="AL:AoDL" page="57" hidden="false" profileTypeId="56656869636c6523232344415441232323">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -48218,55 +48218,33 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
             <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Flyer, Hover, Transport"/>
           </characteristics>
         </profile>
-        <profile id="498e3a5d-70ac-6e0a-7406-7ab522c719d5" name="Vengeance Launcher" book="HH1: Betrayal" page="215" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+        <profile id="9a61-b48d-f326-39c5" name="Legion Storm Eagle Assault Gunship (Transport)" book="AL:AoDL" page="57" hidden="false" profileTypeId="307d-047f-ca13-706b" profileTypeName="Transport">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="48&quot;"/>
-            <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="5"/>
-            <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="4"/>
-            <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 2, Large Blast"/>
-          </characteristics>
-        </profile>
-        <profile id="92f964a9-0461-9d5f-1740-70ff8fd5743e" name="Tempest Rockets" book="HH1: Betrayal" page="215" hidden="false" profileTypeId="576561706f6e23232344415441232323">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <repeats/>
-              <conditions>
-                <condition field="selections" scope="bd2ad8ef-8033-0a45-7ee5-ebcf07f1f117" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1a862e4c-315a-e2d3-b5ba-7ca7362ad0b6" type="equalTo"/>
-              </conditions>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <characteristics>
-            <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="60&quot;"/>
-            <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="6"/>
-            <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="4"/>
-            <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 1, Sunder, One-shot"/>
+            <characteristic name="Capacity" characteristicTypeId="8285-4205-b6cd-8473" value="20"/>
+            <characteristic name="Fire Points" characteristicTypeId="b270-a7f9-22b2-3702" value="None"/>
+            <characteristic name="Access Points" characteristicTypeId="d17b-0342-b1dc-b8e7" value="4. One on each side and ramps at the front and rear"/>
           </characteristics>
         </profile>
       </profiles>
-      <rules>
-        <rule id="d14dcd5f-d89e-1c54-7c45-37014d7a343b" name="Deep Strike" page="0" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </rule>
-        <rule id="4246f565-b5ac-732b-78a0-c3cf1674161b" name="Assault Vehicle" page="0" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </rule>
-      </rules>
+      <rules/>
       <infoLinks>
         <infoLink id="f37d592d-e099-647e-dc8b-53f01e9527a9" hidden="false" targetId="3a93202e-ac23-5508-2dda-248efcc8ff3d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="73d7-462d-4ec5-48db" name="New InfoLink" hidden="false" targetId="d219-2314-4834-c054" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="329d-ba42-9f6c-dcd4" name="New InfoLink" hidden="false" targetId="45cf-653a-4ff6-f22d" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -48285,64 +48263,44 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
           <infoLinks/>
           <modifiers/>
           <constraints/>
-          <selectionEntries>
-            <selectionEntry id="38e965fe-8c67-33cb-1feb-a242f0e92a96" name="Armoured Ceramite" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="7e429bb1-0529-b3af-31b0-9cfb8283b2f3" hidden="false" targetId="2e87b8ca-7cd1-78b9-2116-246015e7935e" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="20.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="fed8c5be-be76-c917-af00-59b0cd4bcf5e" name="Searchlight" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="1.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="7ec9a61c-0a13-ad2a-3ad3-606d20d80018" name="Extra Armour" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="10.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
+          <selectionEntries/>
           <selectionEntryGroups/>
-          <entryLinks/>
+          <entryLinks>
+            <entryLink id="55c7-85c5-eb62-c8bb" name="New EntryLink" hidden="false" targetId="f888-a294-fcff-8391" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="2b66-20e9-6943-2b62" name="New EntryLink" hidden="false" targetId="1e27e511-cf75-d55a-6807-b67be6f7474f" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="1">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="set" field="minSelections" value="0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="230f-5965-b3ec-fa1a" name="New EntryLink" hidden="false" targetId="a6cd-f04b-711e-c083" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="b3dd14bf-b391-0fab-8d4c-f8c40fbc6764" name="Exchange Twin-linked Heavy Bolter for:" hidden="false" collective="false">
+        <selectionEntryGroup id="b3dd14bf-b391-0fab-8d4c-f8c40fbc6764" name="Hull Mounted:" hidden="false" collective="false" defaultSelectionEntryId="0c21-109a-f46b-c7c2">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -48350,42 +48308,45 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
-          <selectionEntries>
-            <selectionEntry id="ae682b96-cdd9-c88c-4fdf-1b06a449546a" name="Twin-linked Multi-melta" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="15.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="ff3af780-0db5-5e8d-567c-867dc25d4309" name="Single Missile Launcher" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
+          <selectionEntries/>
           <selectionEntryGroups/>
-          <entryLinks/>
+          <entryLinks>
+            <entryLink id="0c21-109a-f46b-c7c2" name="New EntryLink" hidden="false" targetId="aa78-540d-996f-52ff" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="8d55-32e0-7093-a183" name="New EntryLink" hidden="false" targetId="16b8-350f-f3ad-2af6" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="15">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="7011-3095-5101-094e" name="New EntryLink" hidden="false" targetId="e5d2-e10d-1552-c5c6" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="5">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="1a862e4c-315a-e2d3-b5ba-7ca7362ad0b6" name="Exchange all four Tempest Rockets for:" hidden="false" collective="false">
+        <selectionEntryGroup id="1a862e4c-315a-e2d3-b5ba-7ca7362ad0b6" name="Wing Mounted:" hidden="false" collective="false" defaultSelectionEntryId="cc05-456d-c344-104e">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -48393,40 +48354,59 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
-          <selectionEntries>
-            <selectionEntry id="77cd69ad-f4f0-a183-35ff-a16ef0022655" name="Four Hellfire Missiles" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="20.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="eec66739-1421-275d-a3ab-8066ed225712" name="Two Twin-linked Lascannons" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="40.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
+          <selectionEntries/>
           <selectionEntryGroups/>
-          <entryLinks/>
+          <entryLinks>
+            <entryLink id="cc05-456d-c344-104e" name="New EntryLink" hidden="false" targetId="688b-8c27-2579-ffdd" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="append" field="name" value="x 4">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="43fd-1a2f-2ef4-d56d" name="New EntryLink" hidden="false" targetId="8b1d-77d3-74f2-9d1c" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="40">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="append" field="name" value="x 2">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="8079-72b6-c296-ecff" name="New EntryLink" hidden="false" targetId="7a6c-699b-f816-764d" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="append" field="name" value="x 4">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="set" field="points" value="20">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="c80dd9ba-802e-7145-d4a0-64f7bb5420a4" name="Legion-specific upgrade" hidden="false" collective="false">
           <profiles/>
@@ -48445,6 +48425,27 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
               <constraints/>
             </entryLink>
             <entryLink id="37b3e657-ace3-d1cd-6513-c42861bfa08e" hidden="false" targetId="f785888f-6dfa-08f4-054f-29b1a0e4f20c" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="7d16-e24d-fd51-11d0" name="Hull Mounted Vengeance Launcher:" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="79c5-5394-1de8-e246" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9711-71d0-584e-1bb0" type="min"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="3d3b-330b-d381-2882" name="New EntryLink" hidden="false" targetId="9166-533e-dc72-7d5d" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -68617,7 +68618,7 @@ Explodes results add D3&quot; to radius.  </description>
         <cost name="pts" costTypeId="points" value="400.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="7025-def4-671f-77f3" name="Legion Land Speeder Squadron" book="HH:LACAL" page="46" hidden="false" collective="false" categoryEntryId="466173742041747461636b23232344415441232323" type="unit">
+    <selectionEntry id="7025-def4-671f-77f3" name="Legion Land Speeder Squadron" book="AL:AoDL" page="56" hidden="false" collective="false" categoryEntryId="466173742041747461636b23232344415441232323" type="unit">
       <profiles/>
       <rules/>
       <infoLinks>
@@ -68883,6 +68884,32 @@ Explodes results add D3&quot; to radius.  </description>
       <costs>
         <cost name="pts" costTypeId="points" value="15.0"/>
       </costs>
+    </selectionEntry>
+    <selectionEntry id="9166-533e-dc72-7d5d" name="Vengeance Launcher" book="AL:AoDL" page="57" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="e38f-c7ad-ec7f-1665" name="Vengeance Launcher" book="AL:AoDL" page="57" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="48&quot;"/>
+            <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="5"/>
+            <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="4"/>
+            <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 2, Large Blast"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2834-99f6-804f-b399" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs/>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -14901,7 +14901,7 @@
                   <infoLinks/>
                   <modifiers/>
                 </infoLink>
-                <infoLink id="3aa92f7c-831c-f3ad-bdc0-f5996e5ac086" hidden="false" targetId="3c82221c-a8de-fa0e-845e-225e326822d8" type="rule">
+                <infoLink id="daa3-5216-5263-16b4" hidden="false" targetId="eefe-09e4-17aa-deb2" type="rule">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -56274,33 +56274,27 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
           </characteristics>
         </profile>
       </profiles>
-      <rules>
-        <rule id="cffcd34f-852b-1bde-627c-e4cfa8836a3b" name="Agile" page="0" hidden="false">
+      <rules/>
+      <infoLinks>
+        <infoLink id="30c1-76fc-84e5-849c" name="New InfoLink" hidden="false" targetId="d219-2314-4834-c054" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-        </rule>
-        <rule id="48010ccf-7be7-26fe-1dbc-16f8f220c877" name="Deep Strike" page="0" hidden="false">
+        </infoLink>
+        <infoLink id="e883-776b-6754-423a" name="New InfoLink" hidden="false" targetId="2e96-21ae-353e-8742" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-        </rule>
-        <rule id="a0df08b3-2989-b980-9af2-9ac7b55260f6" name="Supersonic" page="0" hidden="false">
+        </infoLink>
+        <infoLink id="5e74-171b-c8f9-8985" name="New InfoLink" hidden="false" targetId="b35f-72bc-bdac-c298" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-        </rule>
-        <rule id="0fffc88a-a660-7868-e09c-603bb4a25ed6" name="Missile Barrage" page="0" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </rule>
-      </rules>
-      <infoLinks/>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
       <constraints>
         <constraint field="selections" scope="parent" value="-1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
@@ -56351,6 +56345,12 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
                   <infoLinks/>
                   <modifiers/>
                 </infoLink>
+                <infoLink id="32f6-16fa-e2da-2b4e" name="New InfoLink" hidden="false" targetId="5d88-bcf6-e410-6e01" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
               </infoLinks>
               <modifiers/>
               <constraints>
@@ -56373,6 +56373,12 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
                   <infoLinks/>
                   <modifiers/>
                 </infoLink>
+                <infoLink id="7fa6-5be4-8c24-2c5e" name="New InfoLink" hidden="false" targetId="7911-b951-c819-2f4f" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
               </infoLinks>
               <modifiers/>
               <constraints>
@@ -56389,141 +56395,18 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
           <selectionEntryGroups/>
           <entryLinks/>
         </selectionEntryGroup>
-        <selectionEntryGroup id="24ee567f-e8fc-b847-ed0a-e94b9872fd04" name="d" hidden="false" collective="false">
+        <selectionEntryGroup id="24ee567f-e8fc-b847-ed0a-e94b9872fd04" name="Three dual hardpoint mounts equiped with" book="AL:AoDAL" page="52" hidden="false" collective="false">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="459b8c01-6e5b-0734-c9b2-b249861211e1" name="Twin-linked Autocannon" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="20.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="156f0b68-9b21-a39f-f982-cb40789b8eba" name="Twin-linked Multi-laser" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="20.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="fa6e3ed8-d747-1fc0-3735-edd6ec9fbe66" name="Twin-linked Missile Launcher" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="25.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="c0c3a3a9-e25b-3740-4cc4-0d4e8c1c69a0" name="Twin-linked Missile Launcher with Rad Missiles" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="7b7ae765-cd4d-7a62-985b-51c6d096046b" hidden="false" targetId="042efe45-dff8-3d5f-bb7f-f84c2a09a4b7" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="40.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="a62aadce-4547-3220-f246-dc7b16223473" name="Two Sunfury heavy missiles" book="HH:LACAL" page="43" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+            <selectionEntry id="9a039e01-e570-b463-6a03-1cacb922679f" name="Phosphex bomb cluster" book="AL:AoDAL" page="43" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
               <profiles>
-                <profile id="587b63ad-11bb-77da-5423-9fa3d808313d" name="Sunfury heavy missile" book="HH:LACAL" page="43" hidden="false" profileTypeId="576561706f6e23232344415441232323">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <characteristics>
-                    <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="36&quot;"/>
-                    <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="6"/>
-                    <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="3"/>
-                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 1, Missile, Large Blast, Blind, Gets Hot, One Use"/>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="25.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="64d925e2-9c6b-1a84-dc25-1b729eac9566" name="Two Kraken penetrator heavy missiles" book="HH:LACAL" page="43" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles>
-                <profile id="d5d063c9-95f6-a6bf-9fb3-3fbb0b117881" name="Kraken penetrator heavy missile" book="HH:LACAL" page="43" hidden="false" profileTypeId="576561706f6e23232344415441232323">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <characteristics>
-                    <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="36&quot;"/>
-                    <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="8"/>
-                    <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="1"/>
-                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 1, Missile, Armourbane, One Use"/>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="35.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="9a039e01-e570-b463-6a03-1cacb922679f" name="Phosphex bomb cluster" book="HH:LACAL" page="43" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles>
-                <profile id="35338ae9-f2aa-e021-f90e-df70554ec74c" name="Phosphex bomb cluster" book="HH:LACAL" page="43" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+                <profile id="35338ae9-f2aa-e021-f90e-df70554ec74c" name="Phosphex bomb cluster" book="AL:AoDAL" page="53" hidden="false" profileTypeId="576561706f6e23232344415441232323">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -56532,12 +56415,12 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
                     <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="Bomb"/>
                     <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="5"/>
                     <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="2"/>
-                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 2, Barrage, Bomb Cluster, Blast, Poisoned (3+), Crawling Fire, Lingering Death, Deadly Cargo, One Use"/>
+                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Bomb 2, Barrage, Blast, Poisoned (3+), Crawling Fire, Lingering Death, Deadly Cargo, One Use"/>
                   </characteristics>
                 </profile>
               </profiles>
               <rules>
-                <rule id="570f1b33-7c24-2f6a-a32a-502ea2c61deb" name="Deadly Cargo" book="HH:LACAL" page="43" hidden="false">
+                <rule id="570f1b33-7c24-2f6a-a32a-502ea2c61deb" name="Deadly Cargo" book="AL:AoDAL" page="53" hidden="false">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -56546,13 +56429,13 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
                 </rule>
               </rules>
               <infoLinks>
-                <infoLink id="0b409a23-0742-c7c7-22cd-beff9d45b918" hidden="false" targetId="c05245e1-0c49-a3e4-30d9-f6006c256839" type="rule">
+                <infoLink id="0b409a23-0742-c7c7-22cd-beff9d45b918" book="AL:AoDAL" page="126" hidden="false" targetId="c05245e1-0c49-a3e4-30d9-f6006c256839" type="rule">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
                   <modifiers/>
                 </infoLink>
-                <infoLink id="7b5b2242-12d5-8339-c859-d17090d557df" hidden="false" targetId="395c911d-e7ca-b2cc-c4e9-1e5d807187f1" type="rule">
+                <infoLink id="7b5b2242-12d5-8339-c859-d17090d557df" book="AL:AoDAL" page="126" hidden="false" targetId="395c911d-e7ca-b2cc-c4e9-1e5d807187f1" type="rule">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -56570,9 +56453,9 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
                 <cost name="pts" costTypeId="points" value="15.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="d744728f-a9ff-0108-b97a-bf9100346ba3" name="Two Electromagnetic storm charges" book="HH:LACAL" page="43" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+            <selectionEntry id="d744728f-a9ff-0108-b97a-bf9100346ba3" name="Two Electromagnetic storm charges" book="AL:AoDAL" page="53" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
               <profiles>
-                <profile id="6518d073-d1f0-867d-3478-499f18d6b0f1" name="Electromagnetic storm charges" book="HH:LACAL" page="43" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+                <profile id="6518d073-d1f0-867d-3478-499f18d6b0f1" name="Electromagnetic storm charges" book="AL:AoDAL" page="53" hidden="false" profileTypeId="576561706f6e23232344415441232323">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -56581,12 +56464,25 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
                     <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="Bomb"/>
                     <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="3"/>
                     <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="4"/>
-                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 1, Bomb, Large Blast, Haywire, Concussive, One Use"/>
+                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Bomb 1, Large Blast, Haywire, Concussive, One Use"/>
                   </characteristics>
                 </profile>
               </profiles>
               <rules/>
-              <infoLinks/>
+              <infoLinks>
+                <infoLink id="eb97-01e1-d35c-47fc" name="New InfoLink" hidden="false" targetId="6970-1bf3-b33e-5dce" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="fa0b-0f29-3089-69f9" name="New InfoLink" hidden="false" targetId="9d85-46f7-f5e6-a5f7" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
               <modifiers/>
               <constraints>
                 <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
@@ -56598,9 +56494,171 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
                 <cost name="pts" costTypeId="points" value="10.0"/>
               </costs>
             </selectionEntry>
+            <selectionEntry id="9f66-1e81-2fb8-aa98" name="Twin-linked Missile Launcher" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="7a30-f025-a492-fa09" name="New InfoLink" hidden="false" targetId="40e6-c95c-7c8d-cf02" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="8a15-caa8-289c-d41f" name="New InfoLink" hidden="false" targetId="1e33-d8ec-f833-b584" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="ad95-b032-17c8-1f6b" name="New InfoLink" hidden="false" targetId="10a8-8d89-0bec-3e21" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers>
+                <modifier type="set" field="points" value="25">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f755-06f2-8f38-e178" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="25.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="c6c4-91ac-3f9a-9346" name="Twin-linked Missile Launcher with Rad Missiles" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="c93d-6a10-1a04-1f98" name="New InfoLink" hidden="false" targetId="1e33-d8ec-f833-b584" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="f4c9-7be4-5910-d8dc" name="New InfoLink" hidden="false" targetId="40e6-c95c-7c8d-cf02" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="754b-1010-06cc-dcb0" name="New InfoLink" hidden="false" targetId="042efe45-dff8-3d5f-bb7f-f84c2a09a4b7" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="c86e-da6c-ccaf-8abf" name="New InfoLink" hidden="false" targetId="eefe-09e4-17aa-deb2" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="5928-7958-647b-6d41" name="New InfoLink" hidden="false" targetId="4575-0a0a-caaf-e4bf" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="e770-fa91-d725-f8a9" name="New InfoLink" hidden="false" targetId="10a8-8d89-0bec-3e21" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers>
+                <modifier type="set" field="points" value="40">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6a5d-28e4-53fd-b6eb" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="25.0"/>
+              </costs>
+            </selectionEntry>
           </selectionEntries>
           <selectionEntryGroups/>
-          <entryLinks/>
+          <entryLinks>
+            <entryLink id="0e62-c054-8f5e-375d" name="New EntryLink" hidden="false" targetId="62a9-03fb-a823-fc57" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="54ca-6fde-31e6-5fb9" value="3">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="set" field="points" value="20">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="ff1f-a212-85aa-ff7b" name="New EntryLink" hidden="false" targetId="b39c-9db2-30da-b1b1" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="d312-96b4-9edf-a726" value="3">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="3d2e-0f83-2397-c836" name="New EntryLink" hidden="false" targetId="6ca3-7a72-861e-cda5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="cfea-386d-5b38-3278" name="New EntryLink" hidden="false" targetId="63e4-8299-4cd1-bc7d" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="97e9-8fc9-ae01-9e70" name="New EntryLink" hidden="false" targetId="3b01-3691-b570-475d" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="6ba8-e169-8861-44c6" value="3">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="set" field="points" value="40">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="0b9aa5e4-c1e1-6773-93cd-2fd317a407cd" name="Legion-specific upgrade" hidden="false" collective="false">
           <profiles/>
@@ -62071,7 +62129,7 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
       </constraints>
       <selectionEntries/>
       <selectionEntryGroups/>
@@ -68940,6 +68998,232 @@ Explodes results add D3&quot; to radius.  </description>
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
+    <selectionEntry id="62a9-03fb-a823-fc57" name="Twin-linked Autocannon" book="BRB 7th" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="7e66-5b2e-0349-280a" name="New InfoLink" hidden="false" targetId="5e91-9a0b-0ea0-3fcc" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="append" field="5479706523232344415441232323" value=", Twin-Linked">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="set" field="name" value="Twin-Linked Autocannon">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="54ca-6fde-31e6-5fb9" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs/>
+    </selectionEntry>
+    <selectionEntry id="3b01-3691-b570-475d" name="Twin-linked Missile Launcher" book="BRB 7th" page="" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="74f1-9927-b4f0-7f1f" name="New InfoLink" hidden="false" targetId="40e6-c95c-7c8d-cf02" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="append" field="5479706523232344415441232323" value=", Twin-Linked">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="bed8-4e56-bb33-0aef" name="New InfoLink" hidden="false" targetId="1e33-d8ec-f833-b584" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="append" field="5479706523232344415441232323" value=", Twin-Linked">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6ba8-e169-8861-44c6" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="25.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b39c-9db2-30da-b1b1" name="Twin-linked Multi-laser" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="f35e-4dc5-6eeb-3ef1" name="New InfoLink" hidden="false" targetId="414f-a5cc-e6de-fd78" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="set" field="name" value="Twin-Linked Multi-laser">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="append" field="5479706523232344415441232323" value=", Twin-Linked">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d312-96b4-9edf-a726" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6ca3-7a72-861e-cda5" name="Two Sunfury heavy missiles" book="AL:AoDAL" page="53" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="747a-3abe-19ad-e1d8" name="Sunfury heavy missile" book="AL:AoDAL" page="43" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="36&quot;"/>
+            <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="6"/>
+            <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="3"/>
+            <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 1, Missile, Large Blast, Blind, Gets Hot, One Use"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="8a55-448a-7512-ba79" name="New InfoLink" hidden="false" targetId="7dae-4d12-baba-e529" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="1c73-94d2-8619-87dd" name="New InfoLink" hidden="false" targetId="f4fd-d519-4769-5510" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="ce95-ac99-26d5-fb84" name="New InfoLink" hidden="false" targetId="2fd3-2f63-8d89-e7d9" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="646e-2303-036f-c335" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="25.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="63e4-8299-4cd1-bc7d" name="Kraken Penetrator Heavy missile" book="AD:AoDAL" page="53" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="06de-a181-1a69-cbf7" name="Kraken penetrator heavy missile" book="AL:AoDAL" page="53" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="36&quot;"/>
+            <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="8"/>
+            <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="1"/>
+            <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 1, Missile, Armourbane, One Use"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="75ad-f9b5-2dbb-36b0" name="New InfoLink" hidden="false" targetId="e182-50cd-0867-9a8d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="2409-e0de-df1c-5fa5" name="New InfoLink" hidden="false" targetId="2fd3-2f63-8d89-e7d9" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e3a9-5079-95ff-0a69" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="35.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2902-349c-e3c9-78a3" name="Rad Missiles" book="AL:AoDAL" page="127" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="f563-1e29-452e-b38c" name="New InfoLink" hidden="false" targetId="042efe45-dff8-3d5f-bb7f-f84c2a09a4b7" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="28b5-766e-2851-89c6" name="New InfoLink" hidden="false" targetId="4575-0a0a-caaf-e4bf" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="eb75-ab71-db0c-1a25" name="New InfoLink" hidden="false" targetId="eefe-09e4-17aa-deb2" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8677-e628-8ab1-2b3c" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="15.0"/>
+      </costs>
+    </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup id="fc8ed347-6cd6-c24e-942f-bda78004e894" name="Bodyguard" hidden="false" collective="false">
@@ -71564,7 +71848,7 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
 Ignore the effects of Crew Shaken results on a roll of a 4+.
 When the entire squadron fires at a single target within 24&quot;, the squadron gains the Tank Hunters and Monster Hunter rules.</description>
     </rule>
-    <rule id="395c911d-e7ca-b2cc-c4e9-1e5d807187f1" name="Crawling Fire" book="HH:LACAL" page="84" hidden="false">
+    <rule id="395c911d-e7ca-b2cc-c4e9-1e5d807187f1" name="Crawling Fire" book="AL:AoDAL" page="126" hidden="false">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -71786,7 +72070,7 @@ Available to Traitor faction Apothecaries and Primus Medicae models with the Leg
       <modifiers/>
       <description>If a unit fires one or more weapons with this special rule in the Shooting phase, roll 2D6.  If the roll result is less than the number of Deathlock shots fired by the unit in that phase, that unit suffers a wound with no armour saves on a model selected by its owning player.  Do not roll for Lethal Exposure in the case of Overwatch fire.  </description>
     </rule>
-    <rule id="c05245e1-0c49-a3e4-30d9-f6006c256839" name="Lingering Death" book="HH:LACAL" page="84" hidden="false">
+    <rule id="c05245e1-0c49-a3e4-30d9-f6006c256839" name="Lingering Death" book="AL:AoDAL" page="126" hidden="false">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -71880,13 +72164,6 @@ King Slayer (3 Victory points): If the opposing army includes a Primarch, this m
 - Target Priority: If enemy models are within 12&quot; and line of sight during their shooting phase, the unit must fire all its weapons against the closest enemy unit it is able to harm.  If this is not the case, they are free to select targets as normal.
 - Onslaught: If enemy units are within 12&quot; during their Assault phase, them must attempt to charge the closest enemy unit.  May still only charge a unit fired upon.  If consolidating, must consolidate towards the closest enemy if within 12&quot;
 - Fire Protocols: May fire up to three weapons in the shooting phase against the same target. </description>
-    </rule>
-    <rule id="3c82221c-a8de-fa0e-845e-225e326822d8" name="Rad-phage" book="HH:LACAL" page="84" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>A model which loses one or more wounds to an attack with this rule and survives suffers a -1 penalty to its Toughness value for the rest of the battle.  </description>
     </rule>
     <rule id="408442df-d483-ac91-8be3-2948d61ec87c" name="Reactor Blast" book="HH3: Extermination" page="207" hidden="false">
       <profiles/>
@@ -72115,6 +72392,18 @@ Kharybdis: After it has landed treat as a flyer in Hover mode. LA:AODAL P75</des
       <infoLinks/>
       <modifiers/>
       <description>Any vehicle, including super-heavies, that suffers a penetrating hit may only fire snap shots on the following game turn.  </description>
+    </rule>
+    <rule id="2fd3-2f63-8d89-e7d9" name="Missile" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+    </rule>
+    <rule id="b35f-72bc-bdac-c298" name="Agile" book="" page="0" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
     </rule>
   </sharedRules>
   <sharedProfiles>
@@ -73030,7 +73319,7 @@ Kharybdis: After it has landed treat as a flyer in Hover mode. LA:AODAL P75</des
         <characteristic name="Description" characteristicTypeId="4465736372697074696f6e23232344415441232323" value="During a turn in which a unit equipped with Rad Grenades assaults or is assaulted, the enemy unit(s) suffer a -1 penalty to the Toughness until the end of the Assault Phase.  This does affect the victim&apos;s Instant Death thresholds.  "/>
       </characteristics>
     </profile>
-    <profile id="042efe45-dff8-3d5f-bb7f-f84c2a09a4b7" name="Rad Missiles" book="HH:LACAL" page="85" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+    <profile id="042efe45-dff8-3d5f-bb7f-f84c2a09a4b7" name="Rad Missiles" book="AL:AoDAL" page="127" hidden="false" profileTypeId="576561706f6e23232344415441232323">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -73508,6 +73797,18 @@ Kharybdis: After it has landed treat as a flyer in Hover mode. LA:AODAL P75</des
         <characteristic name="A" characteristicTypeId="4123232344415441232323" value="2"/>
         <characteristic name="LD" characteristicTypeId="4c4423232344415441232323" value="9"/>
         <characteristic name="Save" characteristicTypeId="5361766523232344415441232323" value="2+"/>
+      </characteristics>
+    </profile>
+    <profile id="414f-a5cc-e6de-fd78" name="Multi-laser" book="BRB 7th" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="36&quot;"/>
+        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="6"/>
+        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="6"/>
+        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 3"/>
       </characteristics>
     </profile>
   </sharedProfiles>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -45309,16 +45309,15 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
     </selectionEntry>
     <selectionEntry id="517b-d4ca-d6ee-ef8c" name="Legion Outrider Squad" book="HH:LACAL" page="39" hidden="false" collective="false" categoryEntryId="466173742041747461636b23232344415441232323" type="unit">
       <profiles/>
-      <rules>
-        <rule id="5028-56d6-d69a-d364" name="Scout" page="0" hidden="false">
+      <rules/>
+      <infoLinks>
+        <infoLink id="38c9-91d2-12ee-66e5" hidden="false" targetId="d4a1a878-9ad4-6ae0-a864-08f58264c4a5" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-        </rule>
-      </rules>
-      <infoLinks>
-        <infoLink id="38c9-91d2-12ee-66e5" hidden="false" targetId="d4a1a878-9ad4-6ae0-a864-08f58264c4a5" type="rule">
+        </infoLink>
+        <infoLink id="a3e8-a689-1deb-3b1f" name="New InfoLink" hidden="false" targetId="9b30-1da3-eb8d-ce7a" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -45825,7 +45824,15 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
             </selectionEntry>
           </selectionEntries>
           <selectionEntryGroups/>
-          <entryLinks/>
+          <entryLinks>
+            <entryLink id="bd4b-0556-5d06-cb0e" name="New EntryLink" hidden="false" targetId="30c2c848-c1d3-e61f-6632-a91bcee1fdc4" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="8b4a-54aa-d3c0-0485" name="Legion-specific upgrade:" hidden="false" collective="false">
           <profiles/>

--- a/The Horus Heresy.gst
+++ b/The Horus Heresy.gst
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<gameSystem id="ca571888-56a9-c58e-ddaf-54f4713538bc" name="Warhammer 30,000 - The Horus Heresy" book="Forgeworld Horus Heresy Series" revision="43" battleScribeVersion="2.00" authorName="Millicant" authorContact="Please submit any bugs to the website below" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
+<gameSystem id="ca571888-56a9-c58e-ddaf-54f4713538bc" name="Warhammer 30,000 - The Horus Heresy" book="Forgeworld Horus Heresy Series" revision="44" battleScribeVersion="2.00" authorName="Millicant" authorContact="Please submit any bugs to the website below" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
   <profiles/>
   <rules/>
   <infoLinks/>
@@ -12918,6 +12918,87 @@ D6 - Result
       <infoLinks/>
       <modifiers/>
       <description>A flare shield operates against shooting attacks that strike the vehicle&apos;s front arc.  It reduces the strength of attacks by weapons with the Templae or Blast type by -2, and other shooting attacks by -1.  A flare shield has no effect on attacks from close combat or with the Destroyer rule.</description>
+    </rule>
+    <rule id="a080-af1b-fb2e-4860" name="Precision Strikes" book="BRB 7th" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>If a model with this special rule rolls a 6 To Hit with a Melee weapon, that hit is a ‘Precision Strike’.
+Wounds from Precision Strikes are allocated against an engaged model (or models) of your choice in the unit you are attacking, rather than following the normal rules for Wound allocation. If a Precision Strike Wound is allocated to a character, they can still make their Look Out, Sir roll.</description>
+    </rule>
+    <rule id="4771-b711-0e74-3aee" name="Precision Shots" book="BRB 7th" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>If a model with this special rule rolls a 6 To Hit with a shooting weapon, that shot is a ‘Precision Shot’.
+Wounds from Precision Shots are allocated against a model (or models) of your choice in the target unit, as long as it is in range and line of sight of the firer, rather than following the normal rules for Wound allocation. A character that has a Precision Shot Wound allocated to it can still make a Look Out, Sir roll.
+Note that Snap Shots and shots from weapons that scatter, or do not roll To Hit, can never be Precision Shots.</description>
+    </rule>
+    <rule id="0122-421f-88f2-9c68" name="Psyker" book="BRB 7th" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>A model with this special rule is a Psyker. This rule is typically presented with a Mastery Level, shown in brackets – if no Mastery Level is shown then that model has a Mastery Level of 1. </description>
+    </rule>
+    <rule id="cf90-39d9-c923-f6bf" name="Repel the Enemy" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>Models disembarking from Access Points on a building can charge on the turn they do so, even on a turn the building was destroyed.</description>
+    </rule>
+    <rule id="9f71-25a6-08e5-f088" name="Sentry Defence System" book="BRB 7th" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>A building with this special rule can use automated fire against enemy units, even if it is unoccupied. In addition, enemy units can shoot at and charge a building with this special rule, even if it is unoccupied.</description>
+    </rule>
+    <rule id="4608-a89f-8d54-2fe4" name="Slow and Purposeful" book="BRB 7th" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>A unit that contains at least one model with this special rule cannot Run, Turbo-boost, move Flat Out, perform Sweeping Advances or fire Overwatch. However, they can shoot with Heavy, Salvo and Ordnance weapons, counting as stationary even if they moved in the previous Movement phase. They are also allowed to charge in the same turn they fire Heavy, Ordnance, Rapid Fire or Salvo weapons.</description>
+    </rule>
+    <rule id="38ff-a919-70c4-aec4" name="Split Fire" book="BRB 7th" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>When a unit that contains at least one model with this special rule shoots, one model in the unit can shoot at a different target to the rest of his unit. Once this shooting attack has been resolved, resolve the shooting attacks made by the rest of the unit. These must be at a different target, which cannot be a unit forced to disembark as a result of the Split Firing unit’s initial shooting attack.</description>
+    </rule>
+    <rule id="0d66-14c9-d2f4-708b" name="Stealth" book="BRB 7th" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>A unit that contains at least one model with this special rule counts its cover saves as being 1 point better than normal. Note that this means that a model with the Stealth special rule always has a cover save of at least 6+, even if it is in the open. This rule is often presented as Stealth (X) where X indicates a specific type of terrain, such as Stealth (Woods) or Stealth (Ruins). If this is the case, the unit only gains the benefit whilst it is in terrain of the specified type.
+Cover save bonuses from the Shrouded and Stealth special rules are cumulative (to a maximum of a 2+ cover save).</description>
+    </rule>
+    <rule id="7911-b951-c819-2f4f" name="Strafing Run" book="BRB 7th" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>When shooting Assault, Heavy, Rapid Fire or Salvo weapons at Artillery, Beasts, Bikes, Cavalry, Infantry, Monstrous Creatures and vehicles without the Flyer or Skimmer type, this vehicle has +1 Ballistic Skill.</description>
+    </rule>
+    <rule id="2e96-21ae-353e-8742" name="Supersonic" book="BRB 7th" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>A Supersonic vehicle that moves Flat Out must move at least 18&quot; and can move up to 36&quot;.</description>
+    </rule>
+    <rule id="3e0b-be9f-b7eb-8c5e" name="Eternal Warrior" book="BRB 7th" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>If a model with this special rule suffers an unsaved Wound from an attack that inflicts Instant Death, it only reduces its Wounds by 1, instead of automatically reducing its Wounds to 0.</description>
     </rule>
   </sharedRules>
   <sharedProfiles>


### PR DESCRIPTION
Remaining heavy support unit bugs, 
Added missing command squad for Shadrak
Added Leman Russell, Russ' tamer cousin who uses "Get you by" rules
Updated Fast Attack units (fixing points, missing profile, missing options and missing rules)

Updated units in the fast attack slot, corrections and optimisations for BS2.

BS2 optimisation still needst to be done for Outriders, Attack bikes, Jetbikes and Anvillus.