### PR TITLE
Fixes astarte fastattack2

### DIFF
--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -44566,8 +44566,8 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
           <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <selectionEntries/>
           <selectionEntryGroups/>
@@ -44601,74 +44601,20 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
           <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
-          <selectionEntries>
-            <selectionEntry id="1b68-b38f-c34e-9cb9" name="Melta Bombs" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="set" field="hidden" value="true">
-                  <repeats/>
-                  <conditions>
-                    <condition field="selections" scope="517b-d4ca-d6ee-ef8c" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3399-be06-a734-dd9e" type="equalTo"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
+          <selectionEntries/>
           <selectionEntryGroups>
-            <selectionEntryGroup id="ef43-05dc-69e7-c936" name="Exchange Bolt Pistol for:" hidden="false" collective="false">
+            <selectionEntryGroup id="ef43-05dc-69e7-c936" name="Exchange Bolt Pistol for:" hidden="false" collective="false" defaultSelectionEntryId="d252-7c06-1fd8-0f0a">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxSelections" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="936a-ee6d-e3da-5f12" type="min"/>
               </constraints>
-              <selectionEntries>
-                <selectionEntry id="dbdb-fd97-4b5e-a566" name="Hand Flamer" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="10.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="f57a-72ea-213b-d40d" name="Plasma Pistol" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="15.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
+              <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks>
                 <entryLink id="1a40-3140-ada8-9af5" hidden="false" targetId="82d4-9768-236a-2ea1" type="selectionEntry">
@@ -44678,63 +44624,45 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
                   <modifiers/>
                   <constraints/>
                 </entryLink>
+                <entryLink id="d252-7c06-1fd8-0f0a" name="New EntryLink" hidden="false" targetId="c3db-f1a4-194f-835e" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="07c8-5a97-30a1-4334" name="New EntryLink" hidden="false" targetId="f832-f4b2-6aaf-ad83" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="c3ac-3581-baa9-c08a" name="New EntryLink" hidden="false" targetId="5eb2-7950-9270-ceb5" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="set" field="points" value="10">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
               </entryLinks>
             </selectionEntryGroup>
-            <selectionEntryGroup id="399d-36be-a389-73f3" name="Exchange Chainsword/Combat Blade for:" hidden="false" collective="false">
+            <selectionEntryGroup id="399d-36be-a389-73f3" name="Exchange Chainsword/Combat Blade for:" hidden="false" collective="false" defaultSelectionEntryId="6d53-767a-36e3-9448">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxSelections" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="04ba-03ae-e72e-5bb7" type="min"/>
               </constraints>
-              <selectionEntries>
-                <selectionEntry id="e0b1-fae7-0cd5-7841" name="Power Weapon" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="10.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="aa65-f3f5-ee7a-d006" name="Power Fist" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="15.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="3c04-f353-078b-6cae" name="Single Lightning Claw" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="15.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
+              <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks>
                 <entryLink id="0689-f7d6-86e0-c958" hidden="false" targetId="30834ca2-20b0-cb5a-c7db-f76092533a64" type="selectionEntry">
@@ -44811,6 +44739,34 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
                   <modifiers/>
                   <constraints/>
                 </entryLink>
+                <entryLink id="1bf0-2a9a-8a13-39db" name="New EntryLink" hidden="false" targetId="fcef-f5ac-16a3-9401" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="d514-71e9-2bed-8074" name="New EntryLink" hidden="false" targetId="e890-52eb-3444-c6c7" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="da0a-6e55-af57-b2b3" name="New EntryLink" hidden="false" targetId="26db-484d-3757-03c8" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="6d53-767a-36e3-9448" name="New EntryLink" hidden="false" targetId="10e739aa-3153-9348-3458-738dd5938617" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
@@ -44822,30 +44778,104 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
               <modifiers/>
               <constraints/>
             </entryLink>
+            <entryLink id="644c-64ff-bf45-d6f4" name="New EntryLink" hidden="false" targetId="4c62-8983-4a1b-d1c6" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="517b-d4ca-d6ee-ef8c" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c96c-6117-917f-2ad2" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
           </entryLinks>
           <costs>
             <cost name="pts" costTypeId="points" value="15.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="3399-be06-a734-dd9e" name="Melta Bombs" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+        <selectionEntry id="8dbc-dac2-ffa8-ae8c" name="Additional Wargear" hidden="false" collective="false" type="upgrade">
           <profiles/>
           <rules/>
           <infoLinks/>
-          <modifiers>
-            <modifier type="increment" field="points" value="5.0">
-              <repeats>
-                <repeat field="selections" scope="517b-d4ca-d6ee-ef8c" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="94a7-5e77-7a91-1e94" repeats="1" roundUp="false"/>
-              </repeats>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
+          <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="91f6-4c3d-a6f6-eefa" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="40cf-e38c-404d-d282" type="min"/>
           </constraints>
           <selectionEntries/>
           <selectionEntryGroups/>
-          <entryLinks/>
+          <entryLinks>
+            <entryLink id="c96c-6117-917f-2ad2" name="New EntryLink" hidden="false" targetId="4c62-8983-4a1b-d1c6" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="5">
+                  <repeats>
+                    <repeat field="selections" scope="517b-d4ca-d6ee-ef8c" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2b9f-bf3a-4286-3fec" repeats="1" roundUp="false"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs/>
+        </selectionEntry>
+        <selectionEntry id="b979-2c08-c89c-1fd5" name="Standard Wargear" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="560e-3c23-d0e1-ce7e" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8fe6-9431-5c31-370c" type="min"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="0cd1-ce7e-868f-4732" name="New EntryLink" hidden="false" targetId="0a96-04b6-7340-91a4" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="3e5a-d8b7-136d-576d" name="New EntryLink" hidden="false" targetId="0a53-b471-df87-7b83" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="cd79-f27d-6ec8-ab8a" name="New EntryLink" hidden="false" targetId="fe8d-1baa-d58d-00bc" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="01c9-b009-c49b-1620" name="New EntryLink" hidden="false" targetId="10e739aa-3153-9348-3458-738dd5938617" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="f3f3-e322-94a2-f828" name="New EntryLink" hidden="false" targetId="30c2c848-c1d3-e61f-6632-a91bcee1fdc4" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
           <costs>
             <cost name="pts" costTypeId="points" value="0.0"/>
           </costs>
@@ -44866,7 +44896,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <selectionEntries/>
           <selectionEntryGroups>
@@ -44875,69 +44905,32 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
               <rules/>
               <infoLinks/>
               <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries>
-                <selectionEntry id="2ede-d035-2d6a-6239" name="Power Weapon" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <constraints/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="9f3c-44aa-4bf8-cf2a" name="New EntryLink" hidden="false" targetId="e890-52eb-3444-c6c7" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="10.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups/>
-              <entryLinks/>
+                  <modifiers>
+                    <modifier type="set" field="0783-9ec4-693a-3532" value="3">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="7242-e3e8-37cc-8638" name="Exchange Bolt Pistol for:" hidden="false" collective="false">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries>
-                <selectionEntry id="565f-5ec4-cb93-6b21" name="Hand Flamer" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="10.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="733b-3e6e-b882-1f34" name="Plasma Pistol" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="15.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
+              <constraints/>
+              <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks>
                 <entryLink id="fb7d-589b-8cdd-cf23" hidden="false" targetId="82d4-9768-236a-2ea1" type="selectionEntry">
@@ -44946,6 +44939,34 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
                   <infoLinks/>
                   <modifiers>
                     <modifier type="set" field="4195-9053-3cfd-daf9" value="3">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="a255-e09d-3008-782d" name="New EntryLink" hidden="false" targetId="5eb2-7950-9270-ceb5" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="set" field="points" value="10">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="834e-ce82-9486-659d" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="6525-f9d2-a4aa-25ca" name="New EntryLink" hidden="false" targetId="f832-f4b2-6aaf-ad83" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="set" field="190e-3e42-ee0a-f3e6" value="3">
                       <repeats/>
                       <conditions/>
                       <conditionGroups/>
@@ -44962,88 +44983,64 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
           <profiles/>
           <rules/>
           <infoLinks/>
-          <modifiers/>
+          <modifiers>
+            <modifier type="increment" field="maxSelections" value="1">
+              <repeats>
+                <repeat field="selections" scope="517b-d4ca-d6ee-ef8c" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="94a7-5e77-7a91-1e94" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
-          <selectionEntries>
-            <selectionEntry id="1549-e7f6-6d53-2066" name="Twin-linked Flamer" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="increment" field="points" value="15.0">
-                  <repeats>
-                    <repeat field="selections" scope="517b-d4ca-d6ee-ef8c" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="94a7-5e77-7a91-1e94" repeats="1" roundUp="false"/>
-                  </repeats>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="212a-b72e-cfa6-8fd6" name="Twin-linked Melta Gun" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="increment" field="points" value="25.0">
-                  <repeats>
-                    <repeat field="selections" scope="517b-d4ca-d6ee-ef8c" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="94a7-5e77-7a91-1e94" repeats="1" roundUp="false"/>
-                  </repeats>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="3d4f-b128-5626-ea45" name="Twin-linked Plasma Gun" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="increment" field="points" value="25.0">
-                  <repeats>
-                    <repeat field="selections" scope="517b-d4ca-d6ee-ef8c" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="94a7-5e77-7a91-1e94" repeats="1" roundUp="false"/>
-                  </repeats>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
+          <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="bd4b-0556-5d06-cb0e" name="New EntryLink" hidden="false" targetId="30c2c848-c1d3-e61f-6632-a91bcee1fdc4" type="selectionEntry">
+            <entryLink id="897a-d6d8-4e0e-7cfa" name="New EntryLink" hidden="false" targetId="4bdd-efdd-0dab-3931" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
-              <modifiers/>
+              <modifiers>
+                <modifier type="increment" field="points" value="25">
+                  <repeats>
+                    <repeat field="selections" scope="517b-d4ca-d6ee-ef8c" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="94a7-5e77-7a91-1e94" repeats="1" roundUp="false"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="6546-e658-1285-6d7e" name="New EntryLink" hidden="false" targetId="5373-63f9-e430-9043" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="15">
+                  <repeats>
+                    <repeat field="selections" scope="517b-d4ca-d6ee-ef8c" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="94a7-5e77-7a91-1e94" repeats="1" roundUp="false"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="9eea-8008-c56b-ce1d" name="New EntryLink" hidden="false" targetId="e22c-8213-f142-f2fe" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="25">
+                  <repeats>
+                    <repeat field="selections" scope="517b-d4ca-d6ee-ef8c" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="94a7-5e77-7a91-1e94" repeats="1" roundUp="false"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
               <constraints/>
             </entryLink>
           </entryLinks>
@@ -49076,7 +49073,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="a826-80cb-d2f3-43fd" hidden="false" targetId="1720-1fb3-a76f-c0fd" type="selectionEntry">
+                <entryLink id="a826-80cb-d2f3-43fd" name="" hidden="false" targetId="1720-1fb3-a76f-c0fd" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -68599,19 +68596,6 @@ differently armed Sentry Guns to fire at two separate targets.</description>
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="f6e2-4e7b-efcb-b231" name="Twin-linked Cyclone Missile Launcher" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
     <selectionEntry id="52d1-4d3f-902a-4ca8" name="Legion Tactical Support Squad" book="HH:LACAL" page="33" hidden="false" collective="false" categoryEntryId="54726f6f707323232344415441232323" type="upgrade">
       <profiles/>
       <rules>
@@ -69106,7 +69090,7 @@ differently armed Sentry Guns to fire at two separate targets.</description>
           <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b99a-c74e-2bed-f30c" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b99a-c74e-2bed-f30c" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e82c-78b7-01bc-efca" type="min"/>
           </constraints>
           <selectionEntries>
@@ -69544,6 +69528,93 @@ differently armed Sentry Guns to fire at two separate targets.</description>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b347-509e-dea1-aa87" type="max"/>
         <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="cd9e-3857-b7d6-58e5" type="min"/>
       </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs/>
+    </selectionEntry>
+    <selectionEntry id="5373-63f9-e430-9043" name="Twin-linked Flamer" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="ddfc-d4c2-18aa-c45a" name="New InfoLink" hidden="false" targetId="3a71-7de1-1948-3655" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="append" field="5479706523232344415441232323" value=", Twin-Linked">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="set" field="name" value="Twin-Linked Flamer">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs/>
+    </selectionEntry>
+    <selectionEntry id="4bdd-efdd-0dab-3931" name="Twin-linked Meltagun" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="6564-8022-0fc6-2ee3" name="New InfoLink" hidden="false" targetId="8ae4-74e5-7700-3804" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="set" field="name" value="Twin-Linked Meltagun">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="append" field="5479706523232344415441232323" value=", Twin-Linked">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs/>
+    </selectionEntry>
+    <selectionEntry id="e22c-8213-f142-f2fe" name="Twin-linked Plasma gun" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="3a14-341c-ecdc-12fc" name="New InfoLink" hidden="false" targetId="87c7-bd37-70f7-1933" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="set" field="name" value="Twin-Linked Plasma Gun">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="append" field="5479706523232344415441232323" value=", Twin-Linked">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks/>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -54645,7 +54645,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
       </constraints>
       <selectionEntries/>
       <selectionEntryGroups/>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -43250,18 +43250,18 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
               <rules/>
               <infoLinks/>
               <modifiers>
-                <modifier type="increment" field="points" value="5.0">
+                <modifier type="increment" field="points" value="5">
                   <repeats>
                     <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b8f1-e2a7-0c25-1c08" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
-                <modifier type="decrement" field="points" value="5">
-                  <repeats>
-                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e989-a995-d544-1b6f" repeats="1" roundUp="false"/>
-                  </repeats>
-                  <conditions/>
+                <modifier type="increment" field="points" value="5">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e989-a995-d544-1b6f" type="equalTo"/>
+                  </conditions>
                   <conditionGroups/>
                 </modifier>
               </modifiers>
@@ -43301,11 +43301,11 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
               <rules/>
               <infoLinks/>
               <modifiers>
-                <modifier type="decrement" field="points" value="10">
-                  <repeats>
-                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e989-a995-d544-1b6f" repeats="1" roundUp="false"/>
-                  </repeats>
-                  <conditions/>
+                <modifier type="increment" field="points" value="10">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e989-a995-d544-1b6f" type="equalTo"/>
+                  </conditions>
                   <conditionGroups/>
                 </modifier>
                 <modifier type="increment" field="points" value="10">
@@ -43330,11 +43330,11 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
               <rules/>
               <infoLinks/>
               <modifiers>
-                <modifier type="decrement" field="points" value="20">
-                  <repeats>
-                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e989-a995-d544-1b6f" repeats="1" roundUp="false"/>
-                  </repeats>
-                  <conditions/>
+                <modifier type="increment" field="points" value="20">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e989-a995-d544-1b6f" type="equalTo"/>
+                  </conditions>
                   <conditionGroups/>
                 </modifier>
                 <modifier type="increment" field="points" value="20">
@@ -43352,11 +43352,11 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
               <rules/>
               <infoLinks/>
               <modifiers>
-                <modifier type="decrement" field="points" value="5">
-                  <repeats>
-                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e989-a995-d544-1b6f" repeats="1" roundUp="false"/>
-                  </repeats>
-                  <conditions/>
+                <modifier type="increment" field="points" value="5">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e989-a995-d544-1b6f" type="equalTo"/>
+                  </conditions>
                   <conditionGroups/>
                 </modifier>
                 <modifier type="increment" field="points" value="5">
@@ -43381,11 +43381,11 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
-                <modifier type="decrement" field="points" value="10">
-                  <repeats>
-                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e989-a995-d544-1b6f" repeats="1" roundUp="false"/>
-                  </repeats>
-                  <conditions/>
+                <modifier type="increment" field="points" value="10">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e989-a995-d544-1b6f" type="equalTo"/>
+                  </conditions>
                   <conditionGroups/>
                 </modifier>
               </modifiers>
@@ -43398,11 +43398,11 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
               <rules/>
               <infoLinks/>
               <modifiers>
-                <modifier type="decrement" field="points" value="15">
-                  <repeats>
-                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e989-a995-d544-1b6f" repeats="1" roundUp="false"/>
-                  </repeats>
-                  <conditions/>
+                <modifier type="increment" field="points" value="15">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e989-a995-d544-1b6f" type="equalTo"/>
+                  </conditions>
                   <conditionGroups/>
                 </modifier>
                 <modifier type="increment" field="points" value="15">

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="839b6f2a-4041-398b-fc2d-dc6a31d5f75e" name="Legiones Astartes: Age of Darkness Army List" book="Forgeworld Horus Heresy Series" revision="206" battleScribeVersion="2.00" authorName="Millicant" authorContact="Please submit any bugs to the website below" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="20" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="839b6f2a-4041-398b-fc2d-dc6a31d5f75e" name="Legiones Astartes: Age of Darkness Army List" book="Forgeworld Horus Heresy Series" revision="207" battleScribeVersion="2.00" authorName="Millicant" authorContact="Please submit any bugs to the website below" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="20" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules/>
   <infoLinks/>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -53563,8 +53563,8 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
       <infoLinks/>
       <modifiers/>
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
       </constraints>
       <selectionEntries/>
       <selectionEntryGroups/>
@@ -53631,7 +53631,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
       </constraints>
       <selectionEntries/>
       <selectionEntryGroups/>
@@ -53706,7 +53706,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
       </constraints>
       <selectionEntries/>
       <selectionEntryGroups/>
@@ -53782,8 +53782,8 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
           <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <selectionEntries/>
           <selectionEntryGroups/>
@@ -53798,7 +53798,15 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
               <profiles/>
               <rules/>
               <infoLinks/>
-              <modifiers/>
+              <modifiers>
+                <modifier type="set" field="5361766523232344415441232323" value="2+">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="55ed332e-e48b-a282-5011-37b0d8b65d36" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f2a9-c21d-faca-6f7b" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" characteristicTypeId="556e6974205479706523232344415441232323" value="Infantry (Character)"/>
                 <characteristic name="WS" characteristicTypeId="575323232344415441232323" value="4"/>
@@ -53817,118 +53825,138 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
           <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
-          <selectionEntries>
-            <selectionEntry id="2adcad91-d87a-f3ad-9616-93cc9a0cd97c" name="Melta Bombs" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="ec097a76-99fc-923a-2e5c-f7b57541fdd2" name="Artificer Armour" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="10.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
+          <selectionEntries/>
           <selectionEntryGroups>
-            <selectionEntryGroup id="cd331e53-5482-00dd-b763-1e8107257e65" name="May exchange Bolt Pistol for:" hidden="false" collective="false">
+            <selectionEntryGroup id="cd331e53-5482-00dd-b763-1e8107257e65" name="May exchange Bolt Pistol for:" hidden="false" collective="false" defaultSelectionEntryId="f7e8-2d1d-0d0d-8f74">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
-              <selectionEntries>
-                <selectionEntry id="2db0655f-98f1-6a42-2790-483564b8853f" name="Power Weapon" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="10.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="b5865739-f25d-e561-b38a-38b5cd1c75ca" name="Power Fist" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="15.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="07894795-5fc1-a6c5-e98f-f3a8e0913d5e" name="Plasma Pistol" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="15.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="886e83e1-32bc-9ed4-81d2-b566dc72b0ca" name="Thunder Hammer" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="20.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
+              <selectionEntries/>
               <selectionEntryGroups/>
-              <entryLinks/>
+              <entryLinks>
+                <entryLink id="7ec2-0d56-fb30-831a" name="New EntryLink" hidden="false" targetId="e890-52eb-3444-c6c7" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="f7e8-2d1d-0d0d-8f74" name="New EntryLink" hidden="false" targetId="c3db-f1a4-194f-835e" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="5eb7-8f48-9f3c-57fd" name="New EntryLink" hidden="false" targetId="2767-2afe-31ac-5cca" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="6528-fa82-d4d2-e4ff" name="New EntryLink" hidden="false" targetId="fcef-f5ac-16a3-9401" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="756b-fa84-0973-9e68" name="New EntryLink" hidden="false" targetId="f832-f4b2-6aaf-ad83" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="c086-07c7-024d-1c3a" name="New EntryLink" hidden="false" targetId="925c-50d4-0101-e0e7" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="9ae9-17c2-78f2-7ff8" name="May exchange Bolter for:" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3c3a-fa0f-a2c2-d0e6" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="64fd-23bd-b645-1175" name="New EntryLink" hidden="false" targetId="e890-52eb-3444-c6c7" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="fdb0-830a-574c-2c57" name="New EntryLink" hidden="false" targetId="75906716-f8ed-ecdd-0d25-57cf99a189c8" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="dfc2-ad9e-dc7e-6f0c" name="New EntryLink" hidden="false" targetId="2767-2afe-31ac-5cca" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="3dd5-202c-0c1b-f7f9" name="New EntryLink" hidden="false" targetId="fcef-f5ac-16a3-9401" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="3ba8-04f2-e681-f947" name="New EntryLink" hidden="false" targetId="f832-f4b2-6aaf-ad83" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="159e-f1e1-e1e3-cf00" name="New EntryLink" hidden="false" targetId="925c-50d4-0101-e0e7" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks>
-            <entryLink id="1678-3c64-4ae6-185f" hidden="false" targetId="bb7961b5-6a23-9806-bb17-f30335c66389" type="selectionEntry">
+            <entryLink id="1678-3c64-4ae6-185f" name="" book="" hidden="false" targetId="bb7961b5-6a23-9806-bb17-f30335c66389" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="f2a9-c21d-faca-6f7b" name="New EntryLink" hidden="false" targetId="dd74-ccdb-9bc6-7069" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="19b0-8068-06a1-3a74" name="New EntryLink" hidden="false" targetId="4c62-8983-4a1b-d1c6" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -53971,38 +53999,24 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
                 <cost name="pts" costTypeId="points" value="15.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="c5158c24-4be3-98c1-9522-ff885ab2717f" name="Nuncio-vox" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="1381bc8c-0176-503b-f325-c469e2411790" hidden="false" targetId="9a458a3c-a9b5-db5e-a218-2041a3a49004" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="10.0"/>
-              </costs>
-            </selectionEntry>
           </selectionEntries>
           <selectionEntryGroups/>
-          <entryLinks/>
+          <entryLinks>
+            <entryLink id="d460-15cb-7a53-c10a" name="New EntryLink" hidden="false" targetId="b4ea-a586-86a9-02eb" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="d218927b-bb45-65fc-9c45-bd98da01a088" name="Weapons" hidden="false" collective="false">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers>
-            <modifier type="increment" field="maxSelections" value="1.0">
+            <modifier type="increment" field="maxSelections" value="1">
               <repeats>
                 <repeat field="selections" scope="08851922-b3de-b46f-ff8d-9fefaa58141f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="934d7fd6-6542-9ae3-dcc6-f51869b2afff" repeats="1" roundUp="false"/>
               </repeats>
@@ -54011,7 +54025,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <selectionEntries/>
           <selectionEntryGroups>
@@ -54028,7 +54042,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
                   <infoLinks/>
                   <modifiers/>
                   <constraints>
-                    <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                    <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
                   </constraints>
                   <selectionEntries/>
                   <selectionEntryGroups/>
@@ -54053,7 +54067,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
                   </conditions>
                   <conditionGroups/>
                 </modifier>
-                <modifier type="increment" field="maxSelections" value="1.0">
+                <modifier type="increment" field="maxSelections" value="1">
                   <repeats/>
                   <conditions>
                     <condition field="selections" scope="08851922-b3de-b46f-ff8d-9fefaa58141f" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="934d7fd6-6542-9ae3-dcc6-f51869b2afff" type="atLeast"/>
@@ -54062,31 +54076,16 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <selectionEntries>
-                <selectionEntry id="9642bd11-25ee-808c-e6bb-232d50c7a2b5" name="Combi-weapon" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="5.0"/>
-                  </costs>
-                </selectionEntry>
                 <selectionEntry id="a504546c-2715-8282-9660-f1f4cc639343" name="Flamer" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
                   <modifiers/>
                   <constraints>
-                    <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                    <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
                   </constraints>
                   <selectionEntries/>
                   <selectionEntryGroups/>
@@ -54108,7 +54107,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
                   </infoLinks>
                   <modifiers/>
                   <constraints>
-                    <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                    <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
                   </constraints>
                   <selectionEntries/>
                   <selectionEntryGroups/>
@@ -54123,7 +54122,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
                   <infoLinks/>
                   <modifiers/>
                   <constraints>
-                    <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                    <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
                   </constraints>
                   <selectionEntries/>
                   <selectionEntryGroups/>
@@ -54138,7 +54137,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
                   <infoLinks/>
                   <modifiers/>
                   <constraints>
-                    <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                    <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
                   </constraints>
                   <selectionEntries/>
                   <selectionEntryGroups/>
@@ -54153,7 +54152,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
                   <infoLinks/>
                   <modifiers/>
                   <constraints>
-                    <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                    <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6132-5581-89db-4df9" type="max"/>
                   </constraints>
                   <selectionEntries/>
                   <selectionEntryGroups/>
@@ -54164,7 +54163,17 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
                 </selectionEntry>
               </selectionEntries>
               <selectionEntryGroups/>
-              <entryLinks/>
+              <entryLinks>
+                <entryLink id="d324-89d2-bd8f-15b4" name="New EntryLink" hidden="false" targetId="a329-9d2f-3a3d-d9eb" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="dbc1-3371-9d55-b3f1" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks/>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -7940,260 +7940,6 @@
         <cost name="pts" costTypeId="points" value="58.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="cc96f9e9-632a-8e4d-c4ac-5c8c5b93101b" name="Legion Attack Bike Squadron" book="HH:LACAL" page="40" hidden="false" collective="false" categoryEntryId="466173742041747461636b23232344415441232323" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="b49bda9f-a060-6f3b-1796-19f30a7c47a2" hidden="false" targetId="d4a1a878-9ad4-6ae0-a864-08f58264c4a5" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <selectionEntries>
-        <selectionEntry id="683a840a-e0a1-1f83-c149-7fa7b35411ef" name="Legion Attack Bike" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-          <profiles>
-            <profile id="d93f0684-f1e0-167e-550c-8ad6d9c03022" name="Legion Attack Bike" book="HH:LACAL" page="40" hidden="false" profileTypeId="556e697423232344415441232323">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="Unit Type" characteristicTypeId="556e6974205479706523232344415441232323" value="Bike"/>
-                <characteristic name="WS" characteristicTypeId="575323232344415441232323" value="4"/>
-                <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="4"/>
-                <characteristic name="S" characteristicTypeId="5323232344415441232323" value="4"/>
-                <characteristic name="T" characteristicTypeId="5423232344415441232323" value="5"/>
-                <characteristic name="W" characteristicTypeId="5723232344415441232323" value="2"/>
-                <characteristic name="I" characteristicTypeId="4923232344415441232323" value="4"/>
-                <characteristic name="A" characteristicTypeId="4123232344415441232323" value="2"/>
-                <characteristic name="LD" characteristicTypeId="4c4423232344415441232323" value="8"/>
-                <characteristic name="Save" characteristicTypeId="5361766523232344415441232323" value="3+"/>
-              </characteristics>
-            </profile>
-          </profiles>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="40.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="49213749-9a8f-ad8d-71a1-2b97ca0fa1c8" name="Melta Bombs" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="increment" field="points" value="5.0">
-              <repeats>
-                <repeat field="selections" scope="cc96f9e9-632a-8e4d-c4ac-5c8c5b93101b" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="683a840a-e0a1-1f83-c149-7fa7b35411ef" repeats="1" roundUp="false"/>
-              </repeats>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="8eb84e90-f36a-5186-31ad-4811bad70cb9" name="Any Attack Bike may exchange their Heavy Bolter for:" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="increment" field="maxSelections" value="1.0">
-              <repeats>
-                <repeat field="selections" scope="cc96f9e9-632a-8e4d-c4ac-5c8c5b93101b" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="683a840a-e0a1-1f83-c149-7fa7b35411ef" repeats="1" roundUp="false"/>
-              </repeats>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="4027a209-2825-d18f-3f70-15ef09ec14ad" name="Heavy Flamer" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="e54037af-27a8-1b7e-be3c-cb6ad546af1f" name="Autocannon" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="fdfd447c-b331-0bc5-56d4-9a113f2d9fde" name="Multi-Melta" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="10.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="1ef1-85e0-35e3-3159" hidden="false" targetId="2d56d45d-d276-7830-2b7d-026de64bbae8" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="set" field="points" value="5.0">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="set" field="maxSelections" value="5.0">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="ac6fa8df-1cfe-7dd4-9fd0-860f81cc25ea" hidden="false" targetId="86e70545-ed1a-7cf4-5a3d-d60662a6b3be" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </entryLink>
-        <entryLink id="e4ce29f1-80b8-83ed-8785-93c4c7232b92" hidden="false" targetId="f785888f-6dfa-08f4-054f-29b1a0e4f20c" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </entryLink>
-        <entryLink id="6fcf-0163-45d6-3426" hidden="false" targetId="d8f4-1501-66fd-0477" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="increment" field="points" value="2.0">
-              <repeats>
-                <repeat field="selections" scope="cc96f9e9-632a-8e4d-c4ac-5c8c5b93101b" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="683a840a-e0a1-1f83-c149-7fa7b35411ef" repeats="1" roundUp="false"/>
-              </repeats>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="decrement" field="points" value="2.0">
-              <repeats/>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints/>
-        </entryLink>
-        <entryLink id="f3ad-c495-3876-cdeb" hidden="false" targetId="cea6be0e-460b-ce44-90f4-b1b0159ee33c" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="set" field="points" value="25.0">
-              <repeats/>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="set" field="hidden" value="true">
-              <repeats/>
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d3a3-3f65-2193-bc1b" type="equalTo"/>
-              </conditions>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints/>
-        </entryLink>
-        <entryLink id="278a-f149-4296-b2ab" hidden="false" targetId="413a-6252-82be-9f41" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="decrement" field="points" value="5.0">
-              <repeats/>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="5.0">
-              <repeats>
-                <repeat field="selections" scope="cc96f9e9-632a-8e4d-c4ac-5c8c5b93101b" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="683a840a-e0a1-1f83-c149-7fa7b35411ef" repeats="1" roundUp="false"/>
-              </repeats>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="decrement" field="points" value="5.0">
-              <repeats>
-                <repeat field="selections" scope="cc96f9e9-632a-8e4d-c4ac-5c8c5b93101b" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8eb84e90-f36a-5186-31ad-4811bad70cb9" repeats="1" roundUp="false"/>
-              </repeats>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints/>
-        </entryLink>
-        <entryLink id="fe1f-4ef1-d4ff-3a43" hidden="false" targetId="c487-be13-ea53-917e" type="selectionEntryGroup">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </entryLink>
-      </entryLinks>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
     <selectionEntry id="997365b1-87a9-ca8e-e534-f5adecaef20f" name="Legion Breacher Siege Squad" book="HH:LACAL" page="32" hidden="false" collective="false" categoryEntryId="54726f6f707323232344415441232323" type="unit">
       <profiles/>
       <rules/>
@@ -30092,7 +29838,7 @@ Ignores Cover special rule.</description>
       <modifiers/>
       <constraints/>
     </entryLink>
-    <entryLink id="ac2ec963-7643-b51f-531d-3d3d1067efda" hidden="false" targetId="ba9221f1-7a8a-4d55-0c30-ca4c502fab8d" type="selectionEntry" categoryEntryId="466173742041747461636b23232344415441232323">
+    <entryLink id="ac2ec963-7643-b51f-531d-3d3d1067efda" name="" hidden="false" targetId="ba9221f1-7a8a-4d55-0c30-ca4c502fab8d" type="selectionEntry" categoryEntryId="466173742041747461636b23232344415441232323">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -31888,7 +31634,7 @@ Ignores Cover special rule.</description>
       <modifiers/>
       <constraints/>
     </entryLink>
-    <entryLink id="b22d-6356-a2b3-695f" name="New EntryLink" hidden="false" targetId="57e7-980d-f042-f566" type="selectionEntry">
+    <entryLink id="b22d-6356-a2b3-695f" name="New EntryLink" hidden="false" targetId="57e7-980d-f042-f566" type="selectionEntry" categoryEntryId="486561767920537570706f727423232344415441232323">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -32024,6 +31770,13 @@ Ignores Cover special rule.</description>
           <conditionGroups/>
         </modifier>
       </modifiers>
+      <constraints/>
+    </entryLink>
+    <entryLink id="3329-6cb8-16b8-ae78" name="Legion Attack Bike Squadron" hidden="false" targetId="f19e-c9b0-dc39-21ef" type="selectionEntry" categoryEntryId="466173742041747461636b23232344415441232323">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <constraints/>
     </entryLink>
   </entryLinks>
@@ -69658,6 +69411,306 @@ differently armed Sentry Guns to fire at two separate targets.</description>
       <selectionEntryGroups/>
       <entryLinks/>
       <costs/>
+    </selectionEntry>
+    <selectionEntry id="f19e-c9b0-dc39-21ef" name="Legion Attack Bike Squadron" book="HH:LACAL" page="40" hidden="false" collective="false" categoryEntryId="466173742041747461636b23232344415441232323" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="c902-fadf-fd01-b693" hidden="false" targetId="d4a1a878-9ad4-6ae0-a864-08f58264c4a5" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="3662-d407-072d-e69b" name="Legion Attack Bike" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles>
+            <profile id="60e9-57a8-99ae-ac35" name="Legion Attack Bike" book="HH:LACAL" page="40" hidden="false" profileTypeId="556e697423232344415441232323">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Unit Type" characteristicTypeId="556e6974205479706523232344415441232323" value="Bike"/>
+                <characteristic name="WS" characteristicTypeId="575323232344415441232323" value="4"/>
+                <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="4"/>
+                <characteristic name="S" characteristicTypeId="5323232344415441232323" value="4"/>
+                <characteristic name="T" characteristicTypeId="5423232344415441232323" value="5"/>
+                <characteristic name="W" characteristicTypeId="5723232344415441232323" value="2"/>
+                <characteristic name="I" characteristicTypeId="4923232344415441232323" value="4"/>
+                <characteristic name="A" characteristicTypeId="4123232344415441232323" value="2"/>
+                <characteristic name="LD" characteristicTypeId="4c4423232344415441232323" value="8"/>
+                <characteristic name="Save" characteristicTypeId="5361766523232344415441232323" value="3+"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3d75-9c16-ba8a-ebe8" type="min"/>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bde3-c1be-d014-0a04" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="40.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="57c2-180a-50f5-8819" name="Standard Wargear" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d34f-c493-12ef-5c9b" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bc28-ba59-4d3a-4b0c" type="min"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="8e21-e9c5-3c8b-c5a1" name="New EntryLink" hidden="false" targetId="0a96-04b6-7340-91a4" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="80fa-c4ca-1f2d-db93" name="New EntryLink" hidden="false" targetId="0a53-b471-df87-7b83" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="f1ce-1a93-6ed5-6c36" name="New EntryLink" hidden="false" targetId="fe8d-1baa-d58d-00bc" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="25c1-4581-48f4-a079" name="New EntryLink" hidden="false" targetId="10e739aa-3153-9348-3458-738dd5938617" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="8fc9-18b7-5e05-c772" name="Any Attack Bike may be equiped with:" hidden="false" collective="false" defaultSelectionEntryId="e8d3-e4d9-7307-e8f2">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="1906-81b4-1ebb-ac59" value="1">
+              <repeats>
+                <repeat field="selections" scope="f19e-c9b0-dc39-21ef" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3662-d407-072d-e69b" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="c434-442d-c93f-4ee3" value="1">
+              <repeats>
+                <repeat field="selections" scope="f19e-c9b0-dc39-21ef" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3662-d407-072d-e69b" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1906-81b4-1ebb-ac59" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c434-442d-c93f-4ee3" type="min"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="9c55-ec51-d57f-0c81" hidden="false" targetId="2d56d45d-d276-7830-2b7d-026de64bbae8" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="5.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="set" field="maxSelections" value="5.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="4dff-719f-61b0-6296" name="New EntryLink" hidden="false" targetId="0137-bfce-22c9-8f03" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="5">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="set" field="55c3-237d-0dfe-345d" value="5">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="4b31-7349-c99c-a6e9" name="New EntryLink" hidden="false" targetId="9fef-d14e-0e9f-1cc8" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="367a-32fc-ce10-0bf6" value="5">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="e9e4-4a29-029a-a394" name="New EntryLink" hidden="false" targetId="c380-04b3-db69-3e09" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="10">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="e8d3-e4d9-7307-e8f2" name="New EntryLink" hidden="false" targetId="a161-76b3-9ef1-da7b" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="4358-956c-b1d3-3b9c" name="Legion-specific upgrade:" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="9663-5695-0078-a679" hidden="false" targetId="86e70545-ed1a-7cf4-5a3d-d60662a6b3be" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="1d7c-4f35-699c-80c8" hidden="false" targetId="413a-6252-82be-9f41" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="decrement" field="points" value="5">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="increment" field="points" value="5">
+                  <repeats>
+                    <repeat field="selections" scope="f19e-c9b0-dc39-21ef" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3662-d407-072d-e69b" repeats="1" roundUp="false"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="decrement" field="points" value="5">
+                  <repeats>
+                    <repeat field="selections" scope="f19e-c9b0-dc39-21ef" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8fc9-18b7-5e05-c772" repeats="1" roundUp="false"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="ac1e-33c3-0068-0bf4" hidden="false" targetId="f785888f-6dfa-08f4-054f-29b1a0e4f20c" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="7e89-c4a7-0db8-3fc1" hidden="false" targetId="cea6be0e-460b-ce44-90f4-b1b0159ee33c" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="25.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d3a3-3f65-2193-bc1b" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="f5a3-bbee-f423-7ed5" hidden="false" targetId="d8f4-1501-66fd-0477" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="2">
+                  <repeats>
+                    <repeat field="selections" scope="f19e-c9b0-dc39-21ef" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3662-d407-072d-e69b" repeats="1" roundUp="false"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="decrement" field="points" value="2">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="e7a1-7f1a-7b23-af79" hidden="false" targetId="c487-be13-ea53-917e" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -42949,7 +42949,7 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="10a134c9-dfdd-c921-6c14-17d0875f3b82" name="Exchange heavy weapon for a Nuncio-vox and Chainsword/Combat Blade" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+            <selectionEntry id="e989-a995-d544-1b6f" name="Exchange heavy weapon for a Nuncio-vox and Chainsword/Combat Blade" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
               <profiles/>
               <rules/>
               <infoLinks>
@@ -43239,8 +43239,8 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
           <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6558-6cc9-025a-ab66" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6558-6cc9-025a-ab66" type="min"/>
           </constraints>
           <selectionEntries/>
           <selectionEntryGroups/>
@@ -43259,7 +43259,7 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
                 </modifier>
                 <modifier type="decrement" field="points" value="5">
                   <repeats>
-                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="10a134c9-dfdd-c921-6c14-17d0875f3b82" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e989-a995-d544-1b6f" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -43286,11 +43286,11 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
-                <modifier type="decrement" field="points" value="5">
-                  <repeats>
-                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="10a134c9-dfdd-c921-6c14-17d0875f3b82" repeats="1" roundUp="false"/>
-                  </repeats>
-                  <conditions/>
+                <modifier type="increment" field="points" value="5">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e989-a995-d544-1b6f" type="equalTo"/>
+                  </conditions>
                   <conditionGroups/>
                 </modifier>
               </modifiers>
@@ -43303,7 +43303,7 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
               <modifiers>
                 <modifier type="decrement" field="points" value="10">
                   <repeats>
-                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="10a134c9-dfdd-c921-6c14-17d0875f3b82" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e989-a995-d544-1b6f" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -43332,7 +43332,7 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
               <modifiers>
                 <modifier type="decrement" field="points" value="20">
                   <repeats>
-                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="10a134c9-dfdd-c921-6c14-17d0875f3b82" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e989-a995-d544-1b6f" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -43354,7 +43354,7 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
               <modifiers>
                 <modifier type="decrement" field="points" value="5">
                   <repeats>
-                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="10a134c9-dfdd-c921-6c14-17d0875f3b82" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e989-a995-d544-1b6f" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -43383,7 +43383,7 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
                 </modifier>
                 <modifier type="decrement" field="points" value="10">
                   <repeats>
-                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="10a134c9-dfdd-c921-6c14-17d0875f3b82" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e989-a995-d544-1b6f" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -43400,7 +43400,7 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
               <modifiers>
                 <modifier type="decrement" field="points" value="15">
                   <repeats>
-                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="10a134c9-dfdd-c921-6c14-17d0875f3b82" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e989-a995-d544-1b6f" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -43580,7 +43580,7 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
                 </modifier>
                 <modifier type="decrement" field="points" value="5.0">
                   <repeats>
-                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="10a134c9-dfdd-c921-6c14-17d0875f3b82" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e989-a995-d544-1b6f" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -43593,7 +43593,7 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
               <rules/>
               <infoLinks/>
               <modifiers>
-                <modifier type="increment" field="points" value="5.0">
+                <modifier type="increment" field="points" value="5">
                   <repeats>
                     <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b8f1-e2a7-0c25-1c08" repeats="1" roundUp="false"/>
                   </repeats>
@@ -43602,7 +43602,7 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
                 </modifier>
                 <modifier type="decrement" field="points" value="5.0">
                   <repeats>
-                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="10a134c9-dfdd-c921-6c14-17d0875f3b82" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e989-a995-d544-1b6f" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -43669,7 +43669,7 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
       <selectionEntries>
         <selectionEntry id="8786-8772-e209-9f59" name="Space Marine Sky Hunters" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
           <profiles>
-            <profile id="e83a-816b-05a3-06c7" name="Legion Space Marine Sky Hunter" book="HH:LACAL" page="41" hidden="false" profileTypeId="556e697423232344415441232323">
+            <profile id="e83a-816b-05a3-06c7" name="Legion Space Marine Sky Hunter" book="AL:AoDAL" page="51" hidden="false" profileTypeId="556e697423232344415441232323">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -43692,8 +43692,8 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
           <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <selectionEntries/>
           <selectionEntryGroups/>
@@ -43702,30 +43702,7 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
             <cost name="pts" costTypeId="points" value="35.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="7aaa-6a16-689f-b69a" name="Melta Bombs" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="increment" field="points" value="5">
-              <repeats>
-                <repeat field="selections" scope="b9f0-57cc-d0da-4ae3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8786-8772-e209-9f59" repeats="1" roundUp="false"/>
-              </repeats>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="9740-9beb-39a0-3203" name="Sky Hunter Sergeant" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+        <selectionEntry id="9740-9beb-39a0-3203" name="Sky Slayer Sergeant Upgrade" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
           <profiles/>
           <rules/>
           <infoLinks>
@@ -43738,145 +43715,71 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
           </infoLinks>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
-          <selectionEntries>
-            <selectionEntry id="ecc3-beeb-b584-aaf0" name="Melta Bombs" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="set" field="hidden" value="true">
-                  <repeats>
-                    <repeat field="selections" scope="b9f0-57cc-d0da-4ae3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7aaa-6a16-689f-b69a" repeats="1" roundUp="false"/>
-                  </repeats>
-                  <conditions>
-                    <condition field="selections" scope="b9f0-57cc-d0da-4ae3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7aaa-6a16-689f-b69a" type="equalTo"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
+          <selectionEntries/>
           <selectionEntryGroups>
-            <selectionEntryGroup id="af0d-54fc-d7bc-2e02" name="Exchange Bolt Pistol for:" hidden="false" collective="false">
+            <selectionEntryGroup id="987d-332e-57bb-9d40" name="Exchange Bolt Pistol for:" hidden="false" collective="false" defaultSelectionEntryId="4260-9608-d640-e90d">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="98d9-0fdd-1832-cb00" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9b43-fa55-aae6-36cf" type="min"/>
               </constraints>
-              <selectionEntries>
-                <selectionEntry id="92a6-f0ee-db77-2b69" name="Hand Flamer" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="10.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="65b8-e377-ce7a-5dbb" name="Plasma Pistol" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="15.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
+              <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="93df-8315-00cd-f3d7" hidden="false" targetId="82d4-9768-236a-2ea1" type="selectionEntry">
+                <entryLink id="708d-b497-ca18-60e2" hidden="false" targetId="82d4-9768-236a-2ea1" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
                   <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="4260-9608-d640-e90d" name="New EntryLink" hidden="false" targetId="c3db-f1a4-194f-835e" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="b1e7-4bef-2e6b-4796" name="New EntryLink" hidden="false" targetId="f832-f4b2-6aaf-ad83" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="4dd5-2a23-fd27-1f0c" name="New EntryLink" hidden="false" targetId="5eb2-7950-9270-ceb5" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="set" field="points" value="10">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
                   <constraints/>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
-            <selectionEntryGroup id="ca44-b45a-7272-0855" name="Exchange Chainsword/Combat Blade for:" hidden="false" collective="false">
+            <selectionEntryGroup id="5107-a1be-05cc-614d" name="Exchange Chainsword/Combat Blade for:" hidden="false" collective="false" defaultSelectionEntryId="5719-a9d9-9d0b-1f05">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0ede-dc9a-387f-a612" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b458-0285-030f-84ef" type="min"/>
               </constraints>
-              <selectionEntries>
-                <selectionEntry id="bb13-4573-ebca-27d7" name="Power Weapon" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="10.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="5684-7423-ea8f-0446" name="Power Fist" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="15.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="d301-5f69-4eb8-8d93" name="Single Lightning Claw" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="15.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
+              <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="6116-a771-dc50-dd9a" hidden="false" targetId="30834ca2-20b0-cb5a-c7db-f76092533a64" type="selectionEntry">
+                <entryLink id="5323-5202-8148-8b14" hidden="false" targetId="30834ca2-20b0-cb5a-c7db-f76092533a64" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -43889,14 +43792,14 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
                   </modifiers>
                   <constraints/>
                 </entryLink>
-                <entryLink id="31fe-6de0-7389-9426" hidden="false" targetId="fa1c768d-9b24-bfbd-8dea-ec7b4ff72bb2" type="selectionEntry">
+                <entryLink id="68fc-cf07-253f-7562" hidden="false" targetId="fa1c768d-9b24-bfbd-8dea-ec7b4ff72bb2" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
                   <modifiers/>
                   <constraints/>
                 </entryLink>
-                <entryLink id="83ee-c014-db7e-0e51" hidden="false" targetId="479f576b-b28d-801e-b928-d82431d554b9" type="selectionEntry">
+                <entryLink id="0763-bfd9-ff83-dccc" hidden="false" targetId="479f576b-b28d-801e-b928-d82431d554b9" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -43909,7 +43812,7 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
                   </modifiers>
                   <constraints/>
                 </entryLink>
-                <entryLink id="24db-12de-4834-f9a7" hidden="false" targetId="6435afdc-d8b1-09a1-a82a-9d4d7af1c869" type="selectionEntry">
+                <entryLink id="50ba-c049-0c2f-1d18" hidden="false" targetId="6435afdc-d8b1-09a1-a82a-9d4d7af1c869" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -43922,28 +43825,56 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
                   </modifiers>
                   <constraints/>
                 </entryLink>
-                <entryLink id="6f1c-5ddb-5617-0c0b" hidden="false" targetId="c31253d0-d1b9-35ac-6435-f1a06611e356" type="selectionEntry">
+                <entryLink id="7e40-af26-6d0b-3f89" hidden="false" targetId="c31253d0-d1b9-35ac-6435-f1a06611e356" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
                   <modifiers/>
                   <constraints/>
                 </entryLink>
-                <entryLink id="4195-f9e3-160c-9531" hidden="false" targetId="2acd15a3-57b3-6c4e-1199-0fa706a5b3d8" type="selectionEntry">
+                <entryLink id="004f-c62c-1e63-63a6" hidden="false" targetId="2acd15a3-57b3-6c4e-1199-0fa706a5b3d8" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
                   <modifiers/>
                   <constraints/>
                 </entryLink>
-                <entryLink id="136c-539e-12f7-f70e" hidden="false" targetId="2767-2afe-31ac-5cca" type="selectionEntry">
+                <entryLink id="5e41-8353-dc15-fb32" hidden="false" targetId="2767-2afe-31ac-5cca" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
                   <modifiers/>
                   <constraints/>
                 </entryLink>
-                <entryLink id="2530-ac62-2a91-165f" hidden="false" targetId="5beb-0cde-90c1-0f88" type="selectionEntry">
+                <entryLink id="3f4e-b823-bb1d-2275" hidden="false" targetId="5beb-0cde-90c1-0f88" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="d842-ba48-998c-0f1e" name="New EntryLink" hidden="false" targetId="fcef-f5ac-16a3-9401" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="dce0-c4b6-5fed-94d5" name="New EntryLink" hidden="false" targetId="e890-52eb-3444-c6c7" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="edd4-a43a-137f-e2a4" name="New EntryLink" hidden="false" targetId="26db-484d-3757-03c8" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="5719-a9d9-9d0b-1f05" name="New EntryLink" hidden="false" targetId="10e739aa-3153-9348-3458-738dd5938617" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -43961,10 +43892,105 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
               <modifiers/>
               <constraints/>
             </entryLink>
+            <entryLink id="aea6-a4ce-42fa-4dd1" name="New EntryLink" hidden="false" targetId="4c62-8983-4a1b-d1c6" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="b9f0-57cc-d0da-4ae3" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="aea6-a4ce-42fa-4dd1" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
           </entryLinks>
           <costs>
             <cost name="pts" costTypeId="points" value="15.0"/>
           </costs>
+        </selectionEntry>
+        <selectionEntry id="3e74-4a42-fb99-0006" name="Standard Wargear" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4add-aadc-7998-69d0" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="df33-643f-388a-7318" type="min"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="09a3-9302-0311-f16b" name="New EntryLink" hidden="false" targetId="0a96-04b6-7340-91a4" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="4180-d7f3-fc67-927a" name="New EntryLink" hidden="false" targetId="0a53-b471-df87-7b83" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="9627-f61a-ae53-c511" name="New EntryLink" hidden="false" targetId="fe8d-1baa-d58d-00bc" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="ffea-e06a-d873-c412" name="New EntryLink" hidden="false" targetId="10e739aa-3153-9348-3458-738dd5938617" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="78ef-2eac-5155-c0ba" name="Additional Wargear" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1bc7-9761-3edf-e190" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dd2f-0a8b-5cff-d364" type="min"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="e96e-2a65-3071-16f3" name="New EntryLink" hidden="false" targetId="4c62-8983-4a1b-d1c6" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="5">
+                  <repeats>
+                    <repeat field="selections" scope="b9f0-57cc-d0da-4ae3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8786-8772-e209-9f59" repeats="1" roundUp="false"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="decrement" field="points" value="5">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs/>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -43982,70 +44008,61 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
-          <selectionEntries>
-            <selectionEntry id="e889-fbc3-7aca-24d9" name="Multi-Melta" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="10.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="0c87-e8ba-5d6e-4fc8" name="Plasma Cannon" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="15.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="7303-8edd-7a9a-9b94" name="Volkite Culverin" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="c179-a48b-24a9-7c08" hidden="false" targetId="c7838603-9e18-8756-26b1-222a294c5c2c" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="b1b1-d2a4-ec71-da31" hidden="false" targetId="cbcf-5f25-f8ea-7cfd" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="10.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
+          <selectionEntries/>
           <selectionEntryGroups/>
-          <entryLinks/>
+          <entryLinks>
+            <entryLink id="4507-b87a-5e45-67d3" name="New EntryLink" hidden="false" targetId="9f1b-7c69-13d6-56b5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="a85c-2561-5a1e-1040" value="3">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="set" field="points" value="15">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="b0fc-c780-98d8-2633" name="Multi-Metla" hidden="false" targetId="d1c0-746f-2b39-5f17" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="10">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="5390-9fc3-dc82-305d" name="Volkite Culverin" hidden="false" targetId="edadef72-c786-ab75-6888-15d0cc090857" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="10">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="set" field="maxSelections" value="3">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="aeea-d44a-968a-36ca" name="Legion-specific upgrades:" hidden="false" collective="false">
           <profiles/>
@@ -44107,9 +44124,9 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
-                <modifier type="decrement" field="points" value="5.0">
+                <modifier type="decrement" field="points" value="5">
                   <repeats>
-                    <repeat field="selections" scope="b9f0-57cc-d0da-4ae3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7dbb-e4ea-5a70-ce24" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="b9f0-57cc-d0da-4ae3" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7dbb-e4ea-5a70-ce24" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -44119,7 +44136,7 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="d8a3-c49e-ff81-a97a" name="Exchange Heavy Bolter for:" hidden="false" collective="false">
+        <selectionEntryGroup id="d8a3-c49e-ff81-a97a" name="Exchange Heavy Bolters for:" hidden="false" collective="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -45635,8 +45652,8 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
           <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ce2e-8bec-8f20-6288" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="876e-ca0f-397b-6467" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ce2e-8bec-8f20-6288" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="876e-ca0f-397b-6467" type="min"/>
           </constraints>
           <selectionEntries/>
           <selectionEntryGroups>
@@ -66107,7 +66124,7 @@ Explodes results add D3&quot; to radius.  </description>
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="9b0f-fe11-248c-953f" name="Legion Jetbike Sky Slayer Support Squadron" book="HH:LACAL" page="41" hidden="false" collective="false" categoryEntryId="466173742041747461636b23232344415441232323" type="unit">
+    <selectionEntry id="9b0f-fe11-248c-953f" name="Legion Jetbike Sky Slayer Support Squadron" book="AL:AoDAL" page="60" hidden="false" collective="false" categoryEntryId="466173742041747461636b23232344415441232323" type="unit">
       <profiles/>
       <rules/>
       <infoLinks>
@@ -66129,7 +66146,7 @@ Explodes results add D3&quot; to radius.  </description>
       <selectionEntries>
         <selectionEntry id="6112-73ef-3754-6518" name="Space Marine Sky Slayers" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
           <profiles>
-            <profile id="6c77-1427-5e74-d1b1" name="Legion Space Marine Sky Hunter" book="HH:LACAL" page="41" hidden="false" profileTypeId="556e697423232344415441232323">
+            <profile id="6c77-1427-5e74-d1b1" name="Legion Space Marine Sky Hunter" book="AL:AoDAL" page="51" hidden="false" profileTypeId="556e697423232344415441232323">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -66152,8 +66169,8 @@ Explodes results add D3&quot; to radius.  </description>
           <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="02f8-fc1d-4e34-8fed" type="min"/>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d7dc-e9ce-0517-a31f" type="max"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="02f8-fc1d-4e34-8fed" type="min"/>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d7dc-e9ce-0517-a31f" type="max"/>
           </constraints>
           <selectionEntries/>
           <selectionEntryGroups/>
@@ -66175,108 +66192,71 @@ Explodes results add D3&quot; to radius.  </description>
           </infoLinks>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7032-5d71-ff7e-b264" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7032-5d71-ff7e-b264" type="max"/>
           </constraints>
-          <selectionEntries>
-            <selectionEntry id="f277-623d-d1b1-78e3" name="Melta Bombs" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="set" field="hidden" value="true">
-                  <repeats>
-                    <repeat field="selections" scope="9b0f-fe11-248c-953f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c1ee-dbf0-ab40-bad2" repeats="1" roundUp="false"/>
-                  </repeats>
-                  <conditions>
-                    <condition field="selections" scope="9b0f-fe11-248c-953f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c1ee-dbf0-ab40-bad2" type="equalTo"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4423-30e0-2b24-1c2e" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
+          <selectionEntries/>
           <selectionEntryGroups>
-            <selectionEntryGroup id="f48f-a1f7-a042-aeb5" name="Exchange Bolt Pistol for:" hidden="false" collective="false" defaultSelectionEntryId="cd94-bf4b-6814-4a16">
+            <selectionEntryGroup id="24b2-4542-f053-6ee5" name="Exchange Bolt Pistol for:" hidden="false" collective="false">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7478-6ace-0d76-8bd4" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="db54-fadc-a850-88a0" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ffc3-97bd-e31a-8744" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="cb59-f947-22b2-c872" type="min"/>
               </constraints>
-              <selectionEntries>
-                <selectionEntry id="6325-4f82-d8be-26f2" name="Hand Flamer" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="e951-3b8d-e190-8cf6" hidden="false" targetId="21b6-668e-d5ef-a8da" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1e4d-6ceb-59a2-311f" type="max"/>
-                    <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a084-0c43-a2dd-a8fb" type="min"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="10.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
+              <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="2dcd-9a62-a033-ed10" name="" hidden="false" targetId="82d4-9768-236a-2ea1" type="selectionEntry">
+                <entryLink id="a275-2f34-a35b-68eb" hidden="false" targetId="82d4-9768-236a-2ea1" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
                   <modifiers/>
                   <constraints/>
                 </entryLink>
-                <entryLink id="ec39-da28-d8be-b117" name="New EntryLink" hidden="false" targetId="f832-f4b2-6aaf-ad83" type="selectionEntry">
+                <entryLink id="4ef0-b7ec-9055-c749" name="New EntryLink" hidden="false" targetId="c3db-f1a4-194f-835e" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
                   <modifiers/>
                   <constraints/>
                 </entryLink>
-                <entryLink id="cd94-bf4b-6814-4a16" name="New EntryLink" hidden="false" targetId="6026-d507-935a-7200" type="selectionEntry">
+                <entryLink id="ad6a-15b8-1b9b-65d0" name="New EntryLink" hidden="false" targetId="f832-f4b2-6aaf-ad83" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
                   <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="f05d-432e-d7f6-fdc1" name="New EntryLink" hidden="false" targetId="5eb2-7950-9270-ceb5" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="set" field="points" value="10">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
                   <constraints/>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
-            <selectionEntryGroup id="822b-f167-7c1f-7868" name="Exchange Chainsword/Combat Blade for:" hidden="false" collective="false" defaultSelectionEntryId="4951-c155-d8da-91e0">
+            <selectionEntryGroup id="74bc-41c1-c633-51db" name="Exchange Chainsword/Combat Blade for:" hidden="false" collective="false">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="489e-92ce-7532-3403" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8b3c-c021-defa-531b" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a4d8-56bc-ca03-a161" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6a64-acb4-6d24-54e5" type="min"/>
               </constraints>
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="cba3-c446-505b-b001" hidden="false" targetId="30834ca2-20b0-cb5a-c7db-f76092533a64" type="selectionEntry">
+                <entryLink id="28c4-fc91-1492-e3c1" hidden="false" targetId="30834ca2-20b0-cb5a-c7db-f76092533a64" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -66289,14 +66269,14 @@ Explodes results add D3&quot; to radius.  </description>
                   </modifiers>
                   <constraints/>
                 </entryLink>
-                <entryLink id="d3e5-ca6e-d3ab-d4bc" hidden="false" targetId="fa1c768d-9b24-bfbd-8dea-ec7b4ff72bb2" type="selectionEntry">
+                <entryLink id="c36e-7b16-7b41-e729" hidden="false" targetId="fa1c768d-9b24-bfbd-8dea-ec7b4ff72bb2" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
                   <modifiers/>
                   <constraints/>
                 </entryLink>
-                <entryLink id="6fa1-dd19-8317-eeec" hidden="false" targetId="479f576b-b28d-801e-b928-d82431d554b9" type="selectionEntry">
+                <entryLink id="138d-4338-154c-ae20" hidden="false" targetId="479f576b-b28d-801e-b928-d82431d554b9" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -66309,7 +66289,7 @@ Explodes results add D3&quot; to radius.  </description>
                   </modifiers>
                   <constraints/>
                 </entryLink>
-                <entryLink id="5e4d-db81-5512-c28b" hidden="false" targetId="6435afdc-d8b1-09a1-a82a-9d4d7af1c869" type="selectionEntry">
+                <entryLink id="8a3e-9c3f-1d1d-76bc" hidden="false" targetId="6435afdc-d8b1-09a1-a82a-9d4d7af1c869" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -66322,62 +66302,56 @@ Explodes results add D3&quot; to radius.  </description>
                   </modifiers>
                   <constraints/>
                 </entryLink>
-                <entryLink id="340a-be68-1179-2cd7" hidden="false" targetId="c31253d0-d1b9-35ac-6435-f1a06611e356" type="selectionEntry">
+                <entryLink id="dc1c-e9a8-6eca-352e" hidden="false" targetId="c31253d0-d1b9-35ac-6435-f1a06611e356" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
                   <modifiers/>
                   <constraints/>
                 </entryLink>
-                <entryLink id="fbd3-810f-6138-a9dd" hidden="false" targetId="2acd15a3-57b3-6c4e-1199-0fa706a5b3d8" type="selectionEntry">
+                <entryLink id="2591-7b0f-f424-ba46" hidden="false" targetId="2acd15a3-57b3-6c4e-1199-0fa706a5b3d8" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
                   <modifiers/>
                   <constraints/>
                 </entryLink>
-                <entryLink id="843b-8687-0329-e627" hidden="false" targetId="2767-2afe-31ac-5cca" type="selectionEntry">
+                <entryLink id="4fc7-59fa-7b10-41e9" hidden="false" targetId="2767-2afe-31ac-5cca" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
                   <modifiers/>
                   <constraints/>
                 </entryLink>
-                <entryLink id="02ff-6808-477c-8485" hidden="false" targetId="5beb-0cde-90c1-0f88" type="selectionEntry">
+                <entryLink id="d248-329b-1ed0-5059" hidden="false" targetId="5beb-0cde-90c1-0f88" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
                   <modifiers/>
                   <constraints/>
                 </entryLink>
-                <entryLink id="491d-2d89-749c-9bd0" name="New EntryLink" hidden="false" targetId="e890-52eb-3444-c6c7" type="selectionEntry">
+                <entryLink id="97e8-796b-791c-1b81" name="New EntryLink" hidden="false" targetId="fcef-f5ac-16a3-9401" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
                   <modifiers/>
                   <constraints/>
                 </entryLink>
-                <entryLink id="6d9a-21d2-3195-9b9e" name="New EntryLink" hidden="false" targetId="26db-484d-3757-03c8" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers>
-                    <modifier type="set" field="name" value="Single Lighting Claw">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                  <constraints/>
-                </entryLink>
-                <entryLink id="19d0-ee3b-3a56-d0b9" name="New EntryLink" hidden="false" targetId="fcef-f5ac-16a3-9401" type="selectionEntry">
+                <entryLink id="8c3a-7adb-2100-0e1e" name="New EntryLink" hidden="false" targetId="e890-52eb-3444-c6c7" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
                   <modifiers/>
                   <constraints/>
                 </entryLink>
-                <entryLink id="4951-c155-d8da-91e0" name="New EntryLink" hidden="false" targetId="4b1e-680b-1d39-e4f1" type="selectionEntry">
+                <entryLink id="8c6b-6969-5fb6-b59b" name="New EntryLink" hidden="false" targetId="26db-484d-3757-03c8" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="6890-2ab5-c7c1-4b2e" name="New EntryLink" hidden="false" targetId="10e739aa-3153-9348-3458-738dd5938617" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -66395,6 +66369,21 @@ Explodes results add D3&quot; to radius.  </description>
               <modifiers/>
               <constraints/>
             </entryLink>
+            <entryLink id="3d56-02b4-a445-5ca0" name="New EntryLink" hidden="false" targetId="4c62-8983-4a1b-d1c6" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="9b0f-fe11-248c-953f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3d56-02b4-a445-5ca0" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
           </entryLinks>
           <costs>
             <cost name="pts" costTypeId="points" value="15.0"/>
@@ -66406,8 +66395,8 @@ Explodes results add D3&quot; to radius.  </description>
           <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="bc7f-dd68-2479-f0a3" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f2cb-17ff-0323-9f4b" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bc7f-dd68-2479-f0a3" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f2cb-17ff-0323-9f4b" type="min"/>
           </constraints>
           <selectionEntries/>
           <selectionEntryGroups/>
@@ -66433,6 +66422,13 @@ Explodes results add D3&quot; to radius.  </description>
               <modifiers/>
               <constraints/>
             </entryLink>
+            <entryLink id="7272-be08-7c21-8bda" name="New EntryLink" hidden="false" targetId="10e739aa-3153-9348-3458-738dd5938617" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
           </entryLinks>
           <costs>
             <cost name="pts" costTypeId="points" value="0.0"/>
@@ -66446,47 +66442,10 @@ Explodes results add D3&quot; to radius.  </description>
           <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="724c-4d3e-b127-eabc" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6f2e-a1e7-987b-3078" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="724c-4d3e-b127-eabc" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6f2e-a1e7-987b-3078" type="min"/>
           </constraints>
-          <selectionEntries>
-            <selectionEntry id="5f2a-eb96-e759-e022" name="Plasma Cannon" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="b54b-5211-53d9-acc7" name="New InfoLink" hidden="false" targetId="13df-d6b0-3f33-bf9b" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="de0a-fb40-528a-063c" name="New InfoLink" hidden="false" targetId="f4fd-d519-4769-5510" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers>
-                <modifier type="increment" field="points" value="15">
-                  <repeats>
-                    <repeat field="selections" scope="9b0f-fe11-248c-953f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6112-73ef-3754-6518" repeats="1" roundUp="false"/>
-                  </repeats>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e201-972b-14f9-e6c5" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="15.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
+          <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
             <entryLink id="cc49-468e-d126-ca37" name="Multi-Metla" hidden="false" targetId="d1c0-746f-2b39-5f17" type="selectionEntry">
@@ -66502,6 +66461,21 @@ Explodes results add D3&quot; to radius.  </description>
               <infoLinks/>
               <modifiers>
                 <modifier type="increment" field="points" value="10">
+                  <repeats>
+                    <repeat field="selections" scope="9b0f-fe11-248c-953f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6112-73ef-3754-6518" repeats="1" roundUp="false"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="bc0a-52ab-93fa-257a" name="New EntryLink" hidden="false" targetId="9f1b-7c69-13d6-56b5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="15">
                   <repeats>
                     <repeat field="selections" scope="9b0f-fe11-248c-953f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6112-73ef-3754-6518" repeats="1" roundUp="false"/>
                   </repeats>
@@ -66562,6 +66536,11 @@ Explodes results add D3&quot; to radius.  </description>
               <repeats>
                 <repeat field="selections" scope="9b0f-fe11-248c-953f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6112-73ef-3754-6518" repeats="1" roundUp="false"/>
               </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="decrement" field="points" value="5">
+              <repeats/>
               <conditions/>
               <conditionGroups/>
             </modifier>
@@ -74260,7 +74239,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
         <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Ordnance 1, Large Blast"/>
       </characteristics>
     </profile>
-    <profile id="7d40-c47e-9fcc-7cb4" name="Legion Jetbike Sergeant" book="HH:LACAL" page="41" hidden="false" profileTypeId="556e697423232344415441232323">
+    <profile id="7d40-c47e-9fcc-7cb4" name="Legion Jetbike Sergeant" book="AL:AoDAL" page="51" hidden="false" profileTypeId="556e697423232344415441232323">
       <profiles/>
       <rules/>
       <infoLinks/>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -32402,7 +32402,7 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
     </selectionEntry>
     <selectionEntry id="ba9221f1-7a8a-4d55-0c30-ca4c502fab8d" name="Anvillus Pattern Dreadclaw Drop Pod" book="HH:LACAL" page="45" hidden="false" collective="false" categoryEntryId="466173742041747461636b23232344415441232323" type="model">
       <profiles>
-        <profile id="78e2cfcb-9ba5-32ad-69ac-3f11fb92335f" name="Anvillus Pattern Dreadclaw Drop Pod" book="HH:LACAL" page="45" hidden="false" profileTypeId="56656869636c6523232344415441232323">
+        <profile id="78e2cfcb-9ba5-32ad-69ac-3f11fb92335f" name="Anvillus Pattern Dreadclaw Drop Pod" book="AL:AoDAL" page="55" hidden="false" profileTypeId="56656869636c6523232344415441232323">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -32416,42 +32416,68 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
             <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Flyer, Hover, Transport"/>
           </characteristics>
         </profile>
+        <profile id="81ed-d66c-ef26-0744" name="Anvillus Pattern Dreadclaw Drop Pod (Transport)" book="AL:AoDAL" page="55" hidden="false" profileTypeId="307d-047f-ca13-706b" profileTypeName="Transport">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Capacity" characteristicTypeId="8285-4205-b6cd-8473" value="10 or a single Dreadnought *see Dreadclaw Transport Capacity rule"/>
+            <characteristic name="Fire Points" characteristicTypeId="b270-a7f9-22b2-3702" value="None"/>
+            <characteristic name="Access Points" characteristicTypeId="d17b-0342-b1dc-b8e7" value="One access hatch beneath the hull. Passengers can disembark at ground level within 2&quot; of the hull."/>
+          </characteristics>
+        </profile>
       </profiles>
       <rules>
-        <rule id="e22e1971-f89c-ce36-ca85-2adf7eb0c2cd" name="Assault Vehicle" page="0" hidden="false">
+        <rule id="8a85-2ac6-c4b3-8d46" name="Dreadclaw Transport Capacity" book="AL:AoDAL" page="55" hidden="false">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-        </rule>
-        <rule id="b460cb6b-bde8-c63c-ce79-0f3f0437e1cc" name="Deep Strike" page="0" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </rule>
-        <rule id="7844451a-533b-1140-1643-9ed0b89ca3a1" name="Drop Pod Assault" page="0" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </rule>
-        <rule id="aa996e78-21fb-2dc9-9be2-78e14a1dff21" name="Heat Blast" book="HH:LACAL" page="45" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <description>May be used when the model arrives from Deep strike or later when operating in Hover mode.  No models may embark or disembark on the turn this attack is used.  
+          <description>The Dreadclaw has a transport capacity of 10 or can be used to transport a single Dreadnought from the following list:
 
-Heat Blast (Deep Strike): Immediately after deploying, measure a radius of 3+D3&quot; horizontally from the main hull.  Any model caught in the blast suffers a S6 AP5 hit with no cover saves.  Vehicles are struck on their weakest armour value.  This counts as a flamer based attack.  
-
-Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit with no cover saves.  Vehicles are struck on their weakest armour value.  This counts as a flamer based attack.  Unit being hit determines wound allocation.  On a D6 of 1, the Drop Pod suffers a penetrating hit.  </description>
+Legion Dreadnought
+Legion Mortis Dreadnought
+Contemptor Dreadnought
+Contemptor Mortis
+Contemptor-Cortus</description>
         </rule>
       </rules>
-      <infoLinks/>
+      <infoLinks>
+        <infoLink id="3cc4-a70d-315e-64c8" name="New InfoLink" hidden="false" targetId="d219-2314-4834-c054" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="cf1b-fc4a-8ac3-3959" name="New InfoLink" hidden="false" targetId="9bc2-f58b-4edd-8673" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="1d99-c24e-6112-f26f" name="New InfoLink" hidden="false" targetId="45cf-653a-4ff6-f22d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="b2ee-e63f-ac20-712f" name="New InfoLink" hidden="false" targetId="abbb-19db-a983-dc47" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="7a98-813b-5f3b-ab15" name="New InfoLink" hidden="false" targetId="502e-1950-cef4-540b" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
       </constraints>
       <selectionEntries/>
       <selectionEntryGroups>
@@ -32472,6 +32498,24 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
               <constraints/>
             </entryLink>
             <entryLink id="5c1d99a5-599c-db7d-e5e1-9bed73b6b57a" hidden="false" targetId="86e70545-ed1a-7cf4-5a3d-d60662a6b3be" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="bcb4-4b98-aa14-1f78" name="Standard Wargear" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="a4ed-fde6-124e-2d2c" name="New EntryLink" hidden="false" targetId="eca0-004a-24f2-e2e9" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -44418,17 +44462,6 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
         </profile>
       </profiles>
       <rules>
-        <rule id="86f1-39c0-5841-0b59" name="Heat Blast" book="LA:AoDAL" page="75" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <description>May be used when the model arrives from Deep strike or later when operating in Hover mode.  No models may embark or disembark on the turn this attack is used.  
-
-Heat Blast (Deep Strike): Immediately after deploying, measure a radius of 3+D3&quot; horizontally from the main hull.  Any model caught in the blast suffers a S6 AP5 hit with no cover saves.  Vehicles are struck on their weakest armour value.  This counts as a flamer based attack.  
-
-Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit with no cover saves.  Vehicles are struck on their weakest armour value.  This counts as a flamer based attack.  Unit being hit determines wound allocation.  On a D6 of 1, the Drop Pod suffers a penetrating hit.  </description>
-        </rule>
         <rule id="01df-0b7b-2948-524c" name="Melta-ram" book="LA:AoDAL" page="75" hidden="false">
           <profiles/>
           <rules/>
@@ -44457,6 +44490,12 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
           <modifiers/>
         </infoLink>
         <infoLink id="8a71-cfb1-f253-0f15" name="New InfoLink" hidden="false" targetId="45cf-653a-4ff6-f22d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="dd09-8f9e-359d-6513" name="New InfoLink" hidden="false" targetId="abbb-19db-a983-dc47" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -44521,7 +44560,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
         <cost name="pts" costTypeId="points" value="235.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="517b-d4ca-d6ee-ef8c" name="Legion Outrider Squad" book="HH:LACAL" page="39" hidden="false" collective="false" categoryEntryId="466173742041747461636b23232344415441232323" type="unit">
+    <selectionEntry id="517b-d4ca-d6ee-ef8c" name="Legion Outrider Squad" book="AL:AoDAL" page="49" hidden="false" collective="false" categoryEntryId="466173742041747461636b23232344415441232323" type="unit">
       <profiles/>
       <rules/>
       <infoLinks>
@@ -44543,7 +44582,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
       <selectionEntries>
         <selectionEntry id="94a7-5e77-7a91-1e94" name="Legion Space Marine Outrider" book="" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
           <profiles>
-            <profile id="3a90-2a76-b8fd-195d" name="Legion Space Marine Outrider" book="HH:LACAL" page="39" hidden="false" profileTypeId="556e697423232344415441232323">
+            <profile id="3a90-2a76-b8fd-195d" name="Legion Space Marine Outrider" book="AL:AoDAL" page="49" hidden="false" profileTypeId="556e697423232344415441232323">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -44578,7 +44617,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
         </selectionEntry>
         <selectionEntry id="2b9f-bf3a-4286-3fec" name="Outrider Sergeant" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
           <profiles>
-            <profile id="2829-aa53-0480-c7f3" name="Legion Outrider Sergeant" book="HH:LACAL" page="39" hidden="false" profileTypeId="556e697423232344415441232323">
+            <profile id="2829-aa53-0480-c7f3" name="Legion Outrider Sergeant" book="AL:AoDAL" page="49" hidden="false" profileTypeId="556e697423232344415441232323">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -72824,6 +72863,17 @@ Note that an Immobile unit may still have the Scout or Deep Strike special rules
       <infoLinks/>
       <modifiers/>
       <description>Unless the Javelin Attack Speeder has become immobilised, attackers suffer a -2 To Hit in Assault.</description>
+    </rule>
+    <rule id="abbb-19db-a983-dc47" name="Heat Blast" book="LA:AoDAL" page="75" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>May be used when the model arrives from Deep strike or later when operating in Hover mode.  No models may embark or disembark on the turn this attack is used.  
+
+Heat Blast (Deep Strike): Immediately after deploying, measure a radius of 3+D3&quot; horizontally from the main hull.  Any model caught in the blast suffers a S6 AP5 hit with no cover saves.  Vehicles are struck on their weakest armour value.  This counts as a flamer based attack.  
+
+Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit with no cover saves.  Vehicles are struck on their weakest armour value.  This counts as a flamer based attack.  Unit being hit determines wound allocation.  On a D6 of 1, the Drop Pod suffers a penetrating hit.  </description>
     </rule>
   </sharedRules>
   <sharedProfiles>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -1131,14 +1131,14 @@
           <modifiers>
             <modifier type="increment" field="maxSelections" value="1.0">
               <repeats>
-                <repeat field="selections" scope="b265-40da-ae16-1f42" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9025-251e-d04e-c8f5" repeats="1"/>
+                <repeat field="selections" scope="b265-40da-ae16-1f42" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9025-251e-d04e-c8f5" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
             </modifier>
             <modifier type="decrement" field="maxSelections" value="1.0">
               <repeats>
-                <repeat field="selections" scope="b265-40da-ae16-1f42" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8cb0-edfb-9dbb-5739" repeats="1"/>
+                <repeat field="selections" scope="b265-40da-ae16-1f42" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8cb0-edfb-9dbb-5739" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -2399,7 +2399,7 @@
           <modifiers>
             <modifier type="set" field="maxSelections" value="1.0">
               <repeats>
-                <repeat field="selections" scope="1fed-73d2-551b-00db" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="164b-8f50-3a2e-636a" repeats="1"/>
+                <repeat field="selections" scope="1fed-73d2-551b-00db" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="164b-8f50-3a2e-636a" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -2868,7 +2868,7 @@
           <modifiers>
             <modifier type="set" field="maxSelections" value="1.0">
               <repeats>
-                <repeat field="selections" scope="02cc-4855-9274-5f03" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="308b-5a2b-1b3d-b8b6" repeats="1"/>
+                <repeat field="selections" scope="02cc-4855-9274-5f03" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="308b-5a2b-1b3d-b8b6" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -7778,7 +7778,7 @@
               <modifiers>
                 <modifier type="increment" field="points" value="5">
                   <repeats>
-                    <repeat field="selections" scope="e2bbc832-2c59-80ad-5a6f-6c8daeda79e2" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" childId="2da1da8f-d005-c9d5-fafd-cf4912a1e3a5" repeats="1"/>
+                    <repeat field="selections" scope="e2bbc832-2c59-80ad-5a6f-6c8daeda79e2" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" childId="2da1da8f-d005-c9d5-fafd-cf4912a1e3a5" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -7803,7 +7803,7 @@
                 </modifier>
                 <modifier type="increment" field="points" value="3">
                   <repeats>
-                    <repeat field="selections" scope="e2bbc832-2c59-80ad-5a6f-6c8daeda79e2" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2da1da8f-d005-c9d5-fafd-cf4912a1e3a5" repeats="1"/>
+                    <repeat field="selections" scope="e2bbc832-2c59-80ad-5a6f-6c8daeda79e2" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2da1da8f-d005-c9d5-fafd-cf4912a1e3a5" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -7916,7 +7916,7 @@
               <modifiers>
                 <modifier type="increment" field="points" value="2.0">
                   <repeats>
-                    <repeat field="selections" scope="e2bbc832-2c59-80ad-5a6f-6c8daeda79e2" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2da1da8f-d005-c9d5-fafd-cf4912a1e3a5" repeats="1"/>
+                    <repeat field="selections" scope="e2bbc832-2c59-80ad-5a6f-6c8daeda79e2" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2da1da8f-d005-c9d5-fafd-cf4912a1e3a5" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -7996,7 +7996,7 @@
           <modifiers>
             <modifier type="increment" field="points" value="5.0">
               <repeats>
-                <repeat field="selections" scope="cc96f9e9-632a-8e4d-c4ac-5c8c5b93101b" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="683a840a-e0a1-1f83-c149-7fa7b35411ef" repeats="1"/>
+                <repeat field="selections" scope="cc96f9e9-632a-8e4d-c4ac-5c8c5b93101b" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="683a840a-e0a1-1f83-c149-7fa7b35411ef" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -8021,7 +8021,7 @@
           <modifiers>
             <modifier type="increment" field="maxSelections" value="1.0">
               <repeats>
-                <repeat field="selections" scope="cc96f9e9-632a-8e4d-c4ac-5c8c5b93101b" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="683a840a-e0a1-1f83-c149-7fa7b35411ef" repeats="1"/>
+                <repeat field="selections" scope="cc96f9e9-632a-8e4d-c4ac-5c8c5b93101b" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="683a840a-e0a1-1f83-c149-7fa7b35411ef" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -8122,7 +8122,7 @@
           <modifiers>
             <modifier type="increment" field="points" value="2.0">
               <repeats>
-                <repeat field="selections" scope="cc96f9e9-632a-8e4d-c4ac-5c8c5b93101b" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="683a840a-e0a1-1f83-c149-7fa7b35411ef" repeats="1"/>
+                <repeat field="selections" scope="cc96f9e9-632a-8e4d-c4ac-5c8c5b93101b" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="683a840a-e0a1-1f83-c149-7fa7b35411ef" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -8167,14 +8167,14 @@
             </modifier>
             <modifier type="increment" field="points" value="5.0">
               <repeats>
-                <repeat field="selections" scope="cc96f9e9-632a-8e4d-c4ac-5c8c5b93101b" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="683a840a-e0a1-1f83-c149-7fa7b35411ef" repeats="1"/>
+                <repeat field="selections" scope="cc96f9e9-632a-8e4d-c4ac-5c8c5b93101b" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="683a840a-e0a1-1f83-c149-7fa7b35411ef" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
             </modifier>
             <modifier type="decrement" field="points" value="5.0">
               <repeats>
-                <repeat field="selections" scope="cc96f9e9-632a-8e4d-c4ac-5c8c5b93101b" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8eb84e90-f36a-5186-31ad-4811bad70cb9" repeats="1"/>
+                <repeat field="selections" scope="cc96f9e9-632a-8e4d-c4ac-5c8c5b93101b" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8eb84e90-f36a-5186-31ad-4811bad70cb9" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -8631,7 +8631,7 @@
                   <modifiers>
                     <modifier type="increment" field="0783-9ec4-693a-3532" value="1">
                       <repeats>
-                        <repeat field="selections" scope="997365b1-87a9-ca8e-e534-f5adecaef20f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f7b6b462-5fdd-9962-078a-f11ea75dfb50" repeats="1"/>
+                        <repeat field="selections" scope="997365b1-87a9-ca8e-e534-f5adecaef20f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f7b6b462-5fdd-9962-078a-f11ea75dfb50" repeats="1" roundUp="false"/>
                       </repeats>
                       <conditions/>
                       <conditionGroups/>
@@ -8773,7 +8773,7 @@
               <modifiers>
                 <modifier type="increment" field="points" value="5">
                   <repeats>
-                    <repeat field="selections" scope="997365b1-87a9-ca8e-e534-f5adecaef20f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f7b6b462-5fdd-9962-078a-f11ea75dfb50" repeats="1"/>
+                    <repeat field="selections" scope="997365b1-87a9-ca8e-e534-f5adecaef20f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f7b6b462-5fdd-9962-078a-f11ea75dfb50" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -8968,7 +8968,7 @@
               <modifiers>
                 <modifier type="increment" field="points" value="2.0">
                   <repeats>
-                    <repeat field="selections" scope="997365b1-87a9-ca8e-e534-f5adecaef20f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f7b6b462-5fdd-9962-078a-f11ea75dfb50" repeats="1"/>
+                    <repeat field="selections" scope="997365b1-87a9-ca8e-e534-f5adecaef20f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f7b6b462-5fdd-9962-078a-f11ea75dfb50" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -9142,7 +9142,7 @@
               <modifiers>
                 <modifier type="set" field="maxSelections" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="f4d182d9-0e3e-80e8-cd54-de9c84bf9abb" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4aca9ef4-865d-64b5-cff4-9b6f2211b8d2" repeats="1"/>
+                    <repeat field="selections" scope="f4d182d9-0e3e-80e8-cd54-de9c84bf9abb" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4aca9ef4-865d-64b5-cff4-9b6f2211b8d2" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -9256,7 +9256,7 @@
               <modifiers>
                 <modifier type="increment" field="points" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="5fab84ab-ab50-ecc0-a170-bb2ebc0059ad" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f4d182d9-0e3e-80e8-cd54-de9c84bf9abb" repeats="1"/>
+                    <repeat field="selections" scope="5fab84ab-ab50-ecc0-a170-bb2ebc0059ad" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f4d182d9-0e3e-80e8-cd54-de9c84bf9abb" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -9286,7 +9286,7 @@
               <modifiers>
                 <modifier type="increment" field="points" value="5.0">
                   <repeats>
-                    <repeat field="selections" scope="5fab84ab-ab50-ecc0-a170-bb2ebc0059ad" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f4d182d9-0e3e-80e8-cd54-de9c84bf9abb" repeats="1"/>
+                    <repeat field="selections" scope="5fab84ab-ab50-ecc0-a170-bb2ebc0059ad" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f4d182d9-0e3e-80e8-cd54-de9c84bf9abb" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -9309,7 +9309,7 @@
               <modifiers>
                 <modifier type="increment" field="points" value="5.0">
                   <repeats>
-                    <repeat field="selections" scope="5fab84ab-ab50-ecc0-a170-bb2ebc0059ad" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f4d182d9-0e3e-80e8-cd54-de9c84bf9abb" repeats="1"/>
+                    <repeat field="selections" scope="5fab84ab-ab50-ecc0-a170-bb2ebc0059ad" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f4d182d9-0e3e-80e8-cd54-de9c84bf9abb" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -9339,7 +9339,7 @@
               <modifiers>
                 <modifier type="increment" field="points" value="15.0">
                   <repeats>
-                    <repeat field="selections" scope="5fab84ab-ab50-ecc0-a170-bb2ebc0059ad" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f4d182d9-0e3e-80e8-cd54-de9c84bf9abb" repeats="1"/>
+                    <repeat field="selections" scope="5fab84ab-ab50-ecc0-a170-bb2ebc0059ad" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f4d182d9-0e3e-80e8-cd54-de9c84bf9abb" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -11058,7 +11058,7 @@
                 </modifier>
                 <modifier type="set" field="points" value="5.0">
                   <repeats>
-                    <repeat field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0df0a0f1-9ddf-f57b-cada-26dce57443ec" repeats="1"/>
+                    <repeat field="selections" scope="7c08f7c0-32a3-8221-052f-48ea9e5c82d4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0df0a0f1-9ddf-f57b-cada-26dce57443ec" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -11361,7 +11361,7 @@
           <modifiers>
             <modifier type="set" field="maxSelections" value="1.0">
               <repeats>
-                <repeat field="selections" scope="edffeedf-00ac-372c-6bad-56657d6ae827" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="87a33892-e6f6-ae80-a548-03c3eac81ca4" repeats="1"/>
+                <repeat field="selections" scope="edffeedf-00ac-372c-6bad-56657d6ae827" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="87a33892-e6f6-ae80-a548-03c3eac81ca4" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -12264,7 +12264,7 @@
           <modifiers>
             <modifier type="set" field="maxSelections" value="1.0">
               <repeats>
-                <repeat field="selections" scope="8a497b01-a54a-9a91-a2f3-f25c16658570" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1c27ff10-2756-1d36-1d80-8738db27d2d2" repeats="1"/>
+                <repeat field="selections" scope="8a497b01-a54a-9a91-a2f3-f25c16658570" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1c27ff10-2756-1d36-1d80-8738db27d2d2" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -12760,7 +12760,7 @@
                   <modifiers>
                     <modifier type="increment" field="maxSelections" value="1.0">
                       <repeats>
-                        <repeat field="selections" scope="ac85dde6-190f-04ca-0c50-1dfabb2bb4ed" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="da10206a-bfd7-972c-6dba-43d6fdb71a6c" repeats="1"/>
+                        <repeat field="selections" scope="ac85dde6-190f-04ca-0c50-1dfabb2bb4ed" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="da10206a-bfd7-972c-6dba-43d6fdb71a6c" repeats="1" roundUp="false"/>
                       </repeats>
                       <conditions/>
                       <conditionGroups/>
@@ -13730,7 +13730,7 @@
                   <modifiers>
                     <modifier type="increment" field="maxSelections" value="1.0">
                       <repeats>
-                        <repeat field="selections" scope="e06a-659f-1f19-e93d" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2ab1-3a80-7aec-3303" repeats="1"/>
+                        <repeat field="selections" scope="e06a-659f-1f19-e93d" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2ab1-3a80-7aec-3303" repeats="1" roundUp="false"/>
                       </repeats>
                       <conditions/>
                       <conditionGroups/>
@@ -13766,7 +13766,7 @@
                   <modifiers>
                     <modifier type="increment" field="maxSelections" value="2.0">
                       <repeats>
-                        <repeat field="selections" scope="e06a-659f-1f19-e93d" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2ab1-3a80-7aec-3303" repeats="1"/>
+                        <repeat field="selections" scope="e06a-659f-1f19-e93d" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2ab1-3a80-7aec-3303" repeats="1" roundUp="false"/>
                       </repeats>
                       <conditions/>
                       <conditionGroups/>
@@ -13784,7 +13784,7 @@
                       <modifiers>
                         <modifier type="increment" field="maxSelections" value="1.0">
                           <repeats>
-                            <repeat field="selections" scope="e06a-659f-1f19-e93d" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2ab1-3a80-7aec-3303" repeats="1"/>
+                            <repeat field="selections" scope="e06a-659f-1f19-e93d" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2ab1-3a80-7aec-3303" repeats="1" roundUp="false"/>
                           </repeats>
                           <conditions/>
                           <conditionGroups/>
@@ -13929,7 +13929,7 @@
                       <modifiers>
                         <modifier type="increment" field="maxSelections" value="1.0">
                           <repeats>
-                            <repeat field="selections" scope="e06a-659f-1f19-e93d" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2ab1-3a80-7aec-3303" repeats="1"/>
+                            <repeat field="selections" scope="e06a-659f-1f19-e93d" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2ab1-3a80-7aec-3303" repeats="1" roundUp="false"/>
                           </repeats>
                           <conditions/>
                           <conditionGroups/>
@@ -14003,7 +14003,7 @@
                       <modifiers>
                         <modifier type="increment" field="points" value="15.0">
                           <repeats>
-                            <repeat field="selections" scope="e06a-659f-1f19-e93d" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2ab1-3a80-7aec-3303" repeats="1"/>
+                            <repeat field="selections" scope="e06a-659f-1f19-e93d" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2ab1-3a80-7aec-3303" repeats="1" roundUp="false"/>
                           </repeats>
                           <conditions/>
                           <conditionGroups/>
@@ -14033,7 +14033,7 @@
                       <modifiers>
                         <modifier type="increment" field="points" value="20.0">
                           <repeats>
-                            <repeat field="selections" scope="e06a-659f-1f19-e93d" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2ab1-3a80-7aec-3303" repeats="1"/>
+                            <repeat field="selections" scope="e06a-659f-1f19-e93d" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2ab1-3a80-7aec-3303" repeats="1" roundUp="false"/>
                           </repeats>
                           <conditions/>
                           <conditionGroups/>
@@ -14063,7 +14063,7 @@
                       <modifiers>
                         <modifier type="increment" field="points" value="35.0">
                           <repeats>
-                            <repeat field="selections" scope="e06a-659f-1f19-e93d" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2ab1-3a80-7aec-3303" repeats="1"/>
+                            <repeat field="selections" scope="e06a-659f-1f19-e93d" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2ab1-3a80-7aec-3303" repeats="1" roundUp="false"/>
                           </repeats>
                           <conditions/>
                           <conditionGroups/>
@@ -14111,7 +14111,7 @@
                       <modifiers>
                         <modifier type="increment" field="points" value="2.0">
                           <repeats>
-                            <repeat field="selections" scope="e06a-659f-1f19-e93d" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2ab1-3a80-7aec-3303" repeats="1"/>
+                            <repeat field="selections" scope="e06a-659f-1f19-e93d" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2ab1-3a80-7aec-3303" repeats="1" roundUp="false"/>
                           </repeats>
                           <conditions/>
                           <conditionGroups/>
@@ -14171,7 +14171,7 @@
                         </modifier>
                         <modifier type="increment" field="points" value="5.0">
                           <repeats>
-                            <repeat field="selections" scope="e06a-659f-1f19-e93d" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2ab1-3a80-7aec-3303" repeats="1"/>
+                            <repeat field="selections" scope="e06a-659f-1f19-e93d" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2ab1-3a80-7aec-3303" repeats="1" roundUp="false"/>
                           </repeats>
                           <conditions/>
                           <conditionGroups/>
@@ -14609,7 +14609,7 @@
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <repeats>
-                <repeat field="selections" scope="957bd47c-1513-0f25-6950-611bced0c302" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="236d7c53-16fe-0e18-d58a-13f98003e166" repeats="1"/>
+                <repeat field="selections" scope="957bd47c-1513-0f25-6950-611bced0c302" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="236d7c53-16fe-0e18-d58a-13f98003e166" repeats="1" roundUp="false"/>
               </repeats>
               <conditions>
                 <condition field="selections" scope="957bd47c-1513-0f25-6950-611bced0c302" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="236d7c53-16fe-0e18-d58a-13f98003e166" type="equalTo"/>
@@ -15162,7 +15162,7 @@
               <modifiers>
                 <modifier type="increment" field="points" value="2.0">
                   <repeats>
-                    <repeat field="selections" scope="957bd47c-1513-0f25-6950-611bced0c302" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a1b4e6ca-5f80-fa2e-2b7e-0d2d490d2fcb" repeats="1"/>
+                    <repeat field="selections" scope="957bd47c-1513-0f25-6950-611bced0c302" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a1b4e6ca-5f80-fa2e-2b7e-0d2d490d2fcb" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -16645,7 +16645,7 @@
               <modifiers>
                 <modifier type="set" field="maxSelections" value="0.0">
                   <repeats>
-                    <repeat field="selections" scope="ec7e911b-a55c-b944-8a2a-cdc6b6cda36e" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="998d20f8-4ec3-217a-f648-a36b217ab711" repeats="1"/>
+                    <repeat field="selections" scope="ec7e911b-a55c-b944-8a2a-cdc6b6cda36e" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="998d20f8-4ec3-217a-f648-a36b217ab711" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -17040,7 +17040,7 @@
                   <modifiers>
                     <modifier type="increment" field="maxSelections" value="1.0">
                       <repeats>
-                        <repeat field="selections" scope="07c5673f-c52f-5bd7-a6c2-1b4648313bfa" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="04ebeeee-7a49-c2be-ca3d-63bb74c434cb" repeats="1"/>
+                        <repeat field="selections" scope="07c5673f-c52f-5bd7-a6c2-1b4648313bfa" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="04ebeeee-7a49-c2be-ca3d-63bb74c434cb" repeats="1" roundUp="false"/>
                       </repeats>
                       <conditions/>
                       <conditionGroups/>
@@ -17076,7 +17076,7 @@
                   <modifiers>
                     <modifier type="increment" field="maxSelections" value="2.0">
                       <repeats>
-                        <repeat field="selections" scope="07c5673f-c52f-5bd7-a6c2-1b4648313bfa" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="04ebeeee-7a49-c2be-ca3d-63bb74c434cb" repeats="1"/>
+                        <repeat field="selections" scope="07c5673f-c52f-5bd7-a6c2-1b4648313bfa" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="04ebeeee-7a49-c2be-ca3d-63bb74c434cb" repeats="1" roundUp="false"/>
                       </repeats>
                       <conditions/>
                       <conditionGroups/>
@@ -17094,7 +17094,7 @@
                       <modifiers>
                         <modifier type="increment" field="maxSelections" value="1.0">
                           <repeats>
-                            <repeat field="selections" scope="07c5673f-c52f-5bd7-a6c2-1b4648313bfa" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="04ebeeee-7a49-c2be-ca3d-63bb74c434cb" repeats="1"/>
+                            <repeat field="selections" scope="07c5673f-c52f-5bd7-a6c2-1b4648313bfa" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="04ebeeee-7a49-c2be-ca3d-63bb74c434cb" repeats="1" roundUp="false"/>
                           </repeats>
                           <conditions/>
                           <conditionGroups/>
@@ -17239,7 +17239,7 @@
                       <modifiers>
                         <modifier type="increment" field="maxSelections" value="1.0">
                           <repeats>
-                            <repeat field="selections" scope="07c5673f-c52f-5bd7-a6c2-1b4648313bfa" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="04ebeeee-7a49-c2be-ca3d-63bb74c434cb" repeats="1"/>
+                            <repeat field="selections" scope="07c5673f-c52f-5bd7-a6c2-1b4648313bfa" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="04ebeeee-7a49-c2be-ca3d-63bb74c434cb" repeats="1" roundUp="false"/>
                           </repeats>
                           <conditions/>
                           <conditionGroups/>
@@ -17313,7 +17313,7 @@
                       <modifiers>
                         <modifier type="increment" field="points" value="15.0">
                           <repeats>
-                            <repeat field="selections" scope="07c5673f-c52f-5bd7-a6c2-1b4648313bfa" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="04ebeeee-7a49-c2be-ca3d-63bb74c434cb" repeats="1"/>
+                            <repeat field="selections" scope="07c5673f-c52f-5bd7-a6c2-1b4648313bfa" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="04ebeeee-7a49-c2be-ca3d-63bb74c434cb" repeats="1" roundUp="false"/>
                           </repeats>
                           <conditions/>
                           <conditionGroups/>
@@ -17343,7 +17343,7 @@
                       <modifiers>
                         <modifier type="increment" field="points" value="20.0">
                           <repeats>
-                            <repeat field="selections" scope="07c5673f-c52f-5bd7-a6c2-1b4648313bfa" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="04ebeeee-7a49-c2be-ca3d-63bb74c434cb" repeats="1"/>
+                            <repeat field="selections" scope="07c5673f-c52f-5bd7-a6c2-1b4648313bfa" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="04ebeeee-7a49-c2be-ca3d-63bb74c434cb" repeats="1" roundUp="false"/>
                           </repeats>
                           <conditions/>
                           <conditionGroups/>
@@ -17373,7 +17373,7 @@
                       <modifiers>
                         <modifier type="increment" field="points" value="35.0">
                           <repeats>
-                            <repeat field="selections" scope="07c5673f-c52f-5bd7-a6c2-1b4648313bfa" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="04ebeeee-7a49-c2be-ca3d-63bb74c434cb" repeats="1"/>
+                            <repeat field="selections" scope="07c5673f-c52f-5bd7-a6c2-1b4648313bfa" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="04ebeeee-7a49-c2be-ca3d-63bb74c434cb" repeats="1" roundUp="false"/>
                           </repeats>
                           <conditions/>
                           <conditionGroups/>
@@ -17421,7 +17421,7 @@
                       <modifiers>
                         <modifier type="increment" field="points" value="2.0">
                           <repeats>
-                            <repeat field="selections" scope="07c5673f-c52f-5bd7-a6c2-1b4648313bfa" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="04ebeeee-7a49-c2be-ca3d-63bb74c434cb" repeats="1"/>
+                            <repeat field="selections" scope="07c5673f-c52f-5bd7-a6c2-1b4648313bfa" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="04ebeeee-7a49-c2be-ca3d-63bb74c434cb" repeats="1" roundUp="false"/>
                           </repeats>
                           <conditions/>
                           <conditionGroups/>
@@ -17481,7 +17481,7 @@
                         </modifier>
                         <modifier type="increment" field="points" value="5.0">
                           <repeats>
-                            <repeat field="selections" scope="07c5673f-c52f-5bd7-a6c2-1b4648313bfa" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="04ebeeee-7a49-c2be-ca3d-63bb74c434cb" repeats="1"/>
+                            <repeat field="selections" scope="07c5673f-c52f-5bd7-a6c2-1b4648313bfa" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="04ebeeee-7a49-c2be-ca3d-63bb74c434cb" repeats="1" roundUp="false"/>
                           </repeats>
                           <conditions/>
                           <conditionGroups/>
@@ -18458,7 +18458,7 @@
           <modifiers>
             <modifier type="set" field="maxSelections" value="1.0">
               <repeats>
-                <repeat field="selections" scope="f5a8a6ef-124c-5164-37f2-12682bbb2e5e" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="79895595-6e3d-af5a-dd02-0d5874944046" repeats="1"/>
+                <repeat field="selections" scope="f5a8a6ef-124c-5164-37f2-12682bbb2e5e" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="79895595-6e3d-af5a-dd02-0d5874944046" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -19195,7 +19195,7 @@
           <modifiers>
             <modifier type="set" field="maxSelections" value="1.0">
               <repeats>
-                <repeat field="selections" scope="8e75af35-a8e6-05cf-2d6e-3d03c4fc7cfb" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0b3db2ed-3f0d-87b5-75c2-c1a8a610d5c4" repeats="1"/>
+                <repeat field="selections" scope="8e75af35-a8e6-05cf-2d6e-3d03c4fc7cfb" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0b3db2ed-3f0d-87b5-75c2-c1a8a610d5c4" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -19713,7 +19713,7 @@
               <modifiers>
                 <modifier type="increment" field="points" value="5.0">
                   <repeats>
-                    <repeat field="selections" scope="18b7-59fb-f5cc-b856" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="232e-5584-d249-0835" repeats="1"/>
+                    <repeat field="selections" scope="18b7-59fb-f5cc-b856" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="232e-5584-d249-0835" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -19756,7 +19756,7 @@
               <modifiers>
                 <modifier type="increment" field="points" value="10.0">
                   <repeats>
-                    <repeat field="selections" scope="18b7-59fb-f5cc-b856" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="232e-5584-d249-0835" repeats="1"/>
+                    <repeat field="selections" scope="18b7-59fb-f5cc-b856" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="232e-5584-d249-0835" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -19792,7 +19792,7 @@
               <modifiers>
                 <modifier type="increment" field="points" value="10.0">
                   <repeats>
-                    <repeat field="selections" scope="18b7-59fb-f5cc-b856" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="232e-5584-d249-0835" repeats="1"/>
+                    <repeat field="selections" scope="18b7-59fb-f5cc-b856" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="232e-5584-d249-0835" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -19841,7 +19841,7 @@
               <modifiers>
                 <modifier type="increment" field="points" value="20.0">
                   <repeats>
-                    <repeat field="selections" scope="18b7-59fb-f5cc-b856" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="232e-5584-d249-0835" repeats="1"/>
+                    <repeat field="selections" scope="18b7-59fb-f5cc-b856" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="232e-5584-d249-0835" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -19894,7 +19894,7 @@
                 </modifier>
                 <modifier type="increment" field="maxSelections" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="18b7-59fb-f5cc-b856" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="232e-5584-d249-0835" repeats="1"/>
+                    <repeat field="selections" scope="18b7-59fb-f5cc-b856" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="232e-5584-d249-0835" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -20755,7 +20755,7 @@
           <modifiers>
             <modifier type="increment" field="points" value="5.0">
               <repeats>
-                <repeat field="selections" scope="4a2532cc-ee27-1a58-dd34-4e78263770a3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="368cc40f-06e4-7e2c-39cb-fac756956908" repeats="1"/>
+                <repeat field="selections" scope="4a2532cc-ee27-1a58-dd34-4e78263770a3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="368cc40f-06e4-7e2c-39cb-fac756956908" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -20813,7 +20813,7 @@
           <modifiers>
             <modifier type="increment" field="points" value="5.0">
               <repeats>
-                <repeat field="selections" scope="4a2532cc-ee27-1a58-dd34-4e78263770a3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="368cc40f-06e4-7e2c-39cb-fac756956908" repeats="1"/>
+                <repeat field="selections" scope="4a2532cc-ee27-1a58-dd34-4e78263770a3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="368cc40f-06e4-7e2c-39cb-fac756956908" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -20838,7 +20838,7 @@
           <modifiers>
             <modifier type="increment" field="maxSelections" value="1.0">
               <repeats>
-                <repeat field="selections" scope="4a2532cc-ee27-1a58-dd34-4e78263770a3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="368cc40f-06e4-7e2c-39cb-fac756956908" repeats="1"/>
+                <repeat field="selections" scope="4a2532cc-ee27-1a58-dd34-4e78263770a3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="368cc40f-06e4-7e2c-39cb-fac756956908" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -21123,7 +21123,7 @@
                 </modifier>
                 <modifier type="increment" field="points" value="2.0">
                   <repeats>
-                    <repeat field="selections" scope="4a2532cc-ee27-1a58-dd34-4e78263770a3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="368cc40f-06e4-7e2c-39cb-fac756956908" repeats="1"/>
+                    <repeat field="selections" scope="4a2532cc-ee27-1a58-dd34-4e78263770a3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="368cc40f-06e4-7e2c-39cb-fac756956908" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -21263,7 +21263,7 @@
           <modifiers>
             <modifier type="increment" field="maxSelections" value="1.0">
               <repeats>
-                <repeat field="selections" scope="3a43ab18-4bef-179b-8619-09cf049d00c0" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8be192da-eb5a-9d50-64f5-86d62a169ecf" repeats="1"/>
+                <repeat field="selections" scope="3a43ab18-4bef-179b-8619-09cf049d00c0" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8be192da-eb5a-9d50-64f5-86d62a169ecf" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -21645,7 +21645,7 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
         </modifier>
         <modifier type="increment" field="6e24-6484-a8a5-ffd4" value="1">
           <repeats>
-            <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5e9c6a5f-b807-27ae-8a84-90129437976b" repeats="1"/>
+            <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5e9c6a5f-b807-27ae-8a84-90129437976b" repeats="1" roundUp="false"/>
           </repeats>
           <conditions>
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a901-f10d-4c89-caca" type="equalTo"/>
@@ -22163,7 +22163,7 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                 </modifier>
                 <modifier type="increment" field="points" value="2">
                   <repeats>
-                    <repeat field="selections" scope="da40e015-a22c-ecc4-c9b8-0add9ff5d50f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="cdc44304-100a-25d6-01d5-4be1eb3b32b7" repeats="1"/>
+                    <repeat field="selections" scope="da40e015-a22c-ecc4-c9b8-0add9ff5d50f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="cdc44304-100a-25d6-01d5-4be1eb3b32b7" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -22483,7 +22483,7 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
               <modifiers>
                 <modifier type="increment" field="points" value="2.0">
                   <repeats>
-                    <repeat field="selections" scope="da40e015-a22c-ecc4-c9b8-0add9ff5d50f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="cdc44304-100a-25d6-01d5-4be1eb3b32b7" repeats="1"/>
+                    <repeat field="selections" scope="da40e015-a22c-ecc4-c9b8-0add9ff5d50f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="cdc44304-100a-25d6-01d5-4be1eb3b32b7" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -22930,7 +22930,7 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
           <modifiers>
             <modifier type="increment" field="points" value="2">
               <repeats>
-                <repeat field="selections" scope="d744f750-8ad0-c8f0-fb8d-81608f361be3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="70f738ac-f22d-9e10-c395-781534c8cb2a" repeats="1"/>
+                <repeat field="selections" scope="d744f750-8ad0-c8f0-fb8d-81608f361be3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="70f738ac-f22d-9e10-c395-781534c8cb2a" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -22986,7 +22986,7 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
               <modifiers>
                 <modifier type="increment" field="points" value="15.0">
                   <repeats>
-                    <repeat field="selections" scope="d744f750-8ad0-c8f0-fb8d-81608f361be3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="70f738ac-f22d-9e10-c395-781534c8cb2a" repeats="1"/>
+                    <repeat field="selections" scope="d744f750-8ad0-c8f0-fb8d-81608f361be3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="70f738ac-f22d-9e10-c395-781534c8cb2a" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -23029,7 +23029,7 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
               <modifiers>
                 <modifier type="increment" field="points" value="5.0">
                   <repeats>
-                    <repeat field="selections" scope="d744f750-8ad0-c8f0-fb8d-81608f361be3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="70f738ac-f22d-9e10-c395-781534c8cb2a" repeats="1"/>
+                    <repeat field="selections" scope="d744f750-8ad0-c8f0-fb8d-81608f361be3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="70f738ac-f22d-9e10-c395-781534c8cb2a" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -23059,7 +23059,7 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
               <modifiers>
                 <modifier type="increment" field="points" value="15.0">
                   <repeats>
-                    <repeat field="selections" scope="d744f750-8ad0-c8f0-fb8d-81608f361be3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="70f738ac-f22d-9e10-c395-781534c8cb2a" repeats="1"/>
+                    <repeat field="selections" scope="d744f750-8ad0-c8f0-fb8d-81608f361be3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="70f738ac-f22d-9e10-c395-781534c8cb2a" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -23117,7 +23117,7 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
               <modifiers>
                 <modifier type="increment" field="points" value="10.0">
                   <repeats>
-                    <repeat field="selections" scope="d744f750-8ad0-c8f0-fb8d-81608f361be3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="70f738ac-f22d-9e10-c395-781534c8cb2a" repeats="1"/>
+                    <repeat field="selections" scope="d744f750-8ad0-c8f0-fb8d-81608f361be3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="70f738ac-f22d-9e10-c395-781534c8cb2a" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -23168,7 +23168,7 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                 </modifier>
                 <modifier type="increment" field="points" value="20.0">
                   <repeats>
-                    <repeat field="selections" scope="d744f750-8ad0-c8f0-fb8d-81608f361be3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="70f738ac-f22d-9e10-c395-781534c8cb2a" repeats="1"/>
+                    <repeat field="selections" scope="d744f750-8ad0-c8f0-fb8d-81608f361be3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="70f738ac-f22d-9e10-c395-781534c8cb2a" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -23261,7 +23261,7 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
               <modifiers>
                 <modifier type="increment" field="points" value="2.0">
                   <repeats>
-                    <repeat field="selections" scope="d744f750-8ad0-c8f0-fb8d-81608f361be3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="70f738ac-f22d-9e10-c395-781534c8cb2a" repeats="1"/>
+                    <repeat field="selections" scope="d744f750-8ad0-c8f0-fb8d-81608f361be3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="70f738ac-f22d-9e10-c395-781534c8cb2a" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -24329,7 +24329,7 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                       <modifiers>
                         <modifier type="increment" field="maxSelections" value="1.0">
                           <repeats>
-                            <repeat field="selections" scope="caa2-53e4-f317-e065" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a170-c6b9-7389-e057" repeats="1"/>
+                            <repeat field="selections" scope="caa2-53e4-f317-e065" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a170-c6b9-7389-e057" repeats="1" roundUp="false"/>
                           </repeats>
                           <conditions/>
                           <conditionGroups/>
@@ -24385,7 +24385,7 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                         </modifier>
                         <modifier type="increment" field="points" value="15.0">
                           <repeats>
-                            <repeat field="selections" scope="caa2-53e4-f317-e065" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a170-c6b9-7389-e057" repeats="1"/>
+                            <repeat field="selections" scope="caa2-53e4-f317-e065" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a170-c6b9-7389-e057" repeats="1" roundUp="false"/>
                           </repeats>
                           <conditions/>
                           <conditionGroups/>
@@ -24421,7 +24421,7 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                       <modifiers>
                         <modifier type="increment" field="maxSelections" value="1.0">
                           <repeats>
-                            <repeat field="selections" scope="caa2-53e4-f317-e065" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a170-c6b9-7389-e057" repeats="1"/>
+                            <repeat field="selections" scope="caa2-53e4-f317-e065" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a170-c6b9-7389-e057" repeats="1" roundUp="false"/>
                           </repeats>
                           <conditions/>
                           <conditionGroups/>
@@ -24571,7 +24571,7 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                       <modifiers>
                         <modifier type="increment" field="maxSelections" value="1.0">
                           <repeats>
-                            <repeat field="selections" scope="caa2-53e4-f317-e065" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a170-c6b9-7389-e057" repeats="1"/>
+                            <repeat field="selections" scope="caa2-53e4-f317-e065" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a170-c6b9-7389-e057" repeats="1" roundUp="false"/>
                           </repeats>
                           <conditions/>
                           <conditionGroups/>
@@ -28064,7 +28064,7 @@ Ignores Cover special rule.</description>
                   <modifiers>
                     <modifier type="increment" field="maxSelections" value="1.0">
                       <repeats>
-                        <repeat field="selections" scope="143cf6a9-db92-be55-968f-8310a7fa1f12" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="189a7a82-7a39-089d-5270-d5d88941fcaf" repeats="1"/>
+                        <repeat field="selections" scope="143cf6a9-db92-be55-968f-8310a7fa1f12" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="189a7a82-7a39-089d-5270-d5d88941fcaf" repeats="1" roundUp="false"/>
                       </repeats>
                       <conditions/>
                       <conditionGroups/>
@@ -28302,7 +28302,7 @@ Ignores Cover special rule.</description>
             </modifier>
             <modifier type="increment" field="points" value="2.0">
               <repeats>
-                <repeat field="selections" scope="12d746d3-ae08-8959-c298-0d748159d672" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b6478115-0e71-bdea-3245-7070e04f7105" repeats="1"/>
+                <repeat field="selections" scope="12d746d3-ae08-8959-c298-0d748159d672" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b6478115-0e71-bdea-3245-7070e04f7105" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -28413,7 +28413,7 @@ Ignores Cover special rule.</description>
           <modifiers>
             <modifier type="increment" field="points" value="5.0">
               <repeats>
-                <repeat field="selections" scope="80ade231-979a-a454-9621-efc840ec8e94" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="240759e4-f5d3-d95c-7017-37352f28bbe4" repeats="1"/>
+                <repeat field="selections" scope="80ade231-979a-a454-9621-efc840ec8e94" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="240759e4-f5d3-d95c-7017-37352f28bbe4" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -28438,7 +28438,7 @@ Ignores Cover special rule.</description>
           <modifiers>
             <modifier type="increment" field="maxSelections" value="1.0">
               <repeats>
-                <repeat field="selections" scope="80ade231-979a-a454-9621-efc840ec8e94" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="240759e4-f5d3-d95c-7017-37352f28bbe4" repeats="1"/>
+                <repeat field="selections" scope="80ade231-979a-a454-9621-efc840ec8e94" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="240759e4-f5d3-d95c-7017-37352f28bbe4" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -28555,7 +28555,7 @@ Ignores Cover special rule.</description>
           <modifiers>
             <modifier type="increment" field="maxSelections" value="1.0">
               <repeats>
-                <repeat field="selections" scope="80ade231-979a-a454-9621-efc840ec8e94" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="240759e4-f5d3-d95c-7017-37352f28bbe4" repeats="1"/>
+                <repeat field="selections" scope="80ade231-979a-a454-9621-efc840ec8e94" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="240759e4-f5d3-d95c-7017-37352f28bbe4" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -32349,7 +32349,7 @@ Ignores Cover special rule.</description>
       </modifiers>
       <constraints/>
     </entryLink>
-    <entryLink id="0d8c-bcf7-51cf-c36d" hidden="false" targetId="5ea9-06d0-d880-86f1" type="selectionEntry" categoryEntryId="456c6974657323232344415441232323">
+    <entryLink id="0d8c-bcf7-51cf-c36d" name="" hidden="false" targetId="5ea9-06d0-d880-86f1" type="selectionEntry" categoryEntryId="456c6974657323232344415441232323">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -34206,21 +34206,21 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
               <modifiers>
                 <modifier type="decrement" field="maxSelections" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="48c8-5bb4-3541-bc91" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6ca5-3205-c2d8-2ece" repeats="1"/>
+                    <repeat field="selections" scope="48c8-5bb4-3541-bc91" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6ca5-3205-c2d8-2ece" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
                 <modifier type="increment" field="maxSelections" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="48c8-5bb4-3541-bc91" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8ecb-fbf8-d0fb-e949" repeats="1"/>
+                    <repeat field="selections" scope="48c8-5bb4-3541-bc91" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8ecb-fbf8-d0fb-e949" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
                 <modifier type="increment" field="maxSelections" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="48c8-5bb4-3541-bc91" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="adcb-3917-e888-9929" repeats="1"/>
+                    <repeat field="selections" scope="48c8-5bb4-3541-bc91" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="adcb-3917-e888-9929" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -34972,28 +34972,28 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
               <modifiers>
                 <modifier type="decrement" field="maxSelections" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="5c66-d84f-3746-91cb" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d2fd-ad6a-9dd4-5ca0" repeats="1"/>
+                    <repeat field="selections" scope="5c66-d84f-3746-91cb" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d2fd-ad6a-9dd4-5ca0" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
                 <modifier type="increment" field="maxSelections" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="5c66-d84f-3746-91cb" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="07dd-bfc7-2126-2666" repeats="1"/>
+                    <repeat field="selections" scope="5c66-d84f-3746-91cb" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="07dd-bfc7-2126-2666" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
                 <modifier type="increment" field="maxSelections" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="5c66-d84f-3746-91cb" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1157-0992-2a1c-e5ec" repeats="1"/>
+                    <repeat field="selections" scope="5c66-d84f-3746-91cb" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1157-0992-2a1c-e5ec" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
                 <modifier type="increment" field="maxSelections" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="5c66-d84f-3746-91cb" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5487-0d6e-9399-c454" repeats="1"/>
+                    <repeat field="selections" scope="5c66-d84f-3746-91cb" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5487-0d6e-9399-c454" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -35207,14 +35207,14 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
           <modifiers>
             <modifier type="decrement" field="5723232344415441232323" value="1">
               <repeats>
-                <repeat field="selections" scope="9952-2552-faf2-3ec9" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5276-c612-1442-cd74" repeats="1"/>
+                <repeat field="selections" scope="9952-2552-faf2-3ec9" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5276-c612-1442-cd74" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
             </modifier>
             <modifier type="decrement" field="4123232344415441232323" value="1">
               <repeats>
-                <repeat field="selections" scope="9952-2552-faf2-3ec9" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5276-c612-1442-cd74" repeats="1"/>
+                <repeat field="selections" scope="9952-2552-faf2-3ec9" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5276-c612-1442-cd74" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -35349,7 +35349,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
         </modifier>
         <modifier type="decrement" field="points" value="100.0">
           <repeats>
-            <repeat field="selections" scope="9952-2552-faf2-3ec9" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5276-c612-1442-cd74" repeats="1"/>
+            <repeat field="selections" scope="9952-2552-faf2-3ec9" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5276-c612-1442-cd74" repeats="1" roundUp="false"/>
           </repeats>
           <conditions/>
           <conditionGroups/>
@@ -35564,7 +35564,7 @@ Token representing the Cyber-hawk plays no other role in the game and may not be
         </modifier>
         <modifier type="increment" field="maxInForce" value="3.0">
           <repeats>
-            <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b76-5e02-0970-7b40" repeats="1"/>
+            <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b76-5e02-0970-7b40" repeats="1" roundUp="false"/>
           </repeats>
           <conditions>
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a955-3b63-2411-3e8e" type="equalTo"/>
@@ -36263,7 +36263,7 @@ Token representing the Cyber-hawk plays no other role in the game and may not be
               <modifiers>
                 <modifier type="increment" field="points" value="5.0">
                   <repeats>
-                    <repeat field="selections" scope="59dc2f80-3991-a6ca-84d7-7e4299c755ad" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="faffe0f0-aee5-4d6b-60d0-4ece9dd625fc" repeats="1"/>
+                    <repeat field="selections" scope="59dc2f80-3991-a6ca-84d7-7e4299c755ad" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="faffe0f0-aee5-4d6b-60d0-4ece9dd625fc" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -36297,7 +36297,7 @@ Token representing the Cyber-hawk plays no other role in the game and may not be
             </modifier>
             <modifier type="increment" field="maxSelections" value="1.0">
               <repeats>
-                <repeat field="selections" scope="59dc2f80-3991-a6ca-84d7-7e4299c755ad" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="faffe0f0-aee5-4d6b-60d0-4ece9dd625fc" repeats="1"/>
+                <repeat field="selections" scope="59dc2f80-3991-a6ca-84d7-7e4299c755ad" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="faffe0f0-aee5-4d6b-60d0-4ece9dd625fc" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -37042,7 +37042,7 @@ All models in an army with Ferrus Manus with Legions Astartes (Iron Hands) gain 
         </modifier>
         <modifier type="set" field="points" value="415.0">
           <repeats>
-            <repeat field="selections" scope="efce-53fa-8dbe-2769" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="dacf-bb26-4d6f-ea0c" repeats="1"/>
+            <repeat field="selections" scope="efce-53fa-8dbe-2769" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="dacf-bb26-4d6f-ea0c" repeats="1" roundUp="false"/>
           </repeats>
           <conditions/>
           <conditionGroups/>
@@ -37448,7 +37448,7 @@ All models in an army with Ferrus Manus with Legions Astartes (Iron Hands) gain 
           <modifiers>
             <modifier type="increment" field="maxSelections" value="2.0">
               <repeats>
-                <repeat field="selections" scope="b14a9d49-fb08-e3f5-8e39-6dedfc0a69c1" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c7553117-133b-e169-22bf-fe775a0927da" repeats="1"/>
+                <repeat field="selections" scope="b14a9d49-fb08-e3f5-8e39-6dedfc0a69c1" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c7553117-133b-e169-22bf-fe775a0927da" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -37466,7 +37466,7 @@ All models in an army with Ferrus Manus with Legions Astartes (Iron Hands) gain 
               <modifiers>
                 <modifier type="increment" field="maxSelections" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="b14a9d49-fb08-e3f5-8e39-6dedfc0a69c1" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c7553117-133b-e169-22bf-fe775a0927da" repeats="1"/>
+                    <repeat field="selections" scope="b14a9d49-fb08-e3f5-8e39-6dedfc0a69c1" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c7553117-133b-e169-22bf-fe775a0927da" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -37532,14 +37532,14 @@ All models in an army with Ferrus Manus with Legions Astartes (Iron Hands) gain 
               <modifiers>
                 <modifier type="increment" field="maxSelections" value="1">
                   <repeats>
-                    <repeat field="selections" scope="b14a9d49-fb08-e3f5-8e39-6dedfc0a69c1" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c7553117-133b-e169-22bf-fe775a0927da" repeats="1"/>
+                    <repeat field="selections" scope="b14a9d49-fb08-e3f5-8e39-6dedfc0a69c1" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c7553117-133b-e169-22bf-fe775a0927da" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
                 <modifier type="decrement" field="maxSelections" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="abdd6965-36c9-058f-ffb2-1a20c25b9b2d" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8d43989a-e67a-61a4-c7de-f61846864596" repeats="1"/>
+                    <repeat field="selections" scope="abdd6965-36c9-058f-ffb2-1a20c25b9b2d" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8d43989a-e67a-61a4-c7de-f61846864596" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -38153,7 +38153,7 @@ In addtion, all units with the Legiones Astartes (Emperor&apos;s Children) rule 
           <modifiers>
             <modifier type="increment" field="maxSelections" value="1.0">
               <repeats>
-                <repeat field="selections" scope="fea8-bbb6-fe4d-2892" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9c9a-fc65-224d-37b1" repeats="1"/>
+                <repeat field="selections" scope="fea8-bbb6-fe4d-2892" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9c9a-fc65-224d-37b1" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -38237,7 +38237,7 @@ In addtion, all units with the Legiones Astartes (Emperor&apos;s Children) rule 
               <modifiers>
                 <modifier type="increment" field="points" value="5.0">
                   <repeats>
-                    <repeat field="selections" scope="fea8-bbb6-fe4d-2892" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9c9a-fc65-224d-37b1" repeats="1"/>
+                    <repeat field="selections" scope="fea8-bbb6-fe4d-2892" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9c9a-fc65-224d-37b1" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -38260,7 +38260,7 @@ In addtion, all units with the Legiones Astartes (Emperor&apos;s Children) rule 
               <modifiers>
                 <modifier type="increment" field="points" value="20.0">
                   <repeats>
-                    <repeat field="selections" scope="fea8-bbb6-fe4d-2892" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9c9a-fc65-224d-37b1" repeats="1"/>
+                    <repeat field="selections" scope="fea8-bbb6-fe4d-2892" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9c9a-fc65-224d-37b1" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -38305,7 +38305,7 @@ In addtion, all units with the Legiones Astartes (Emperor&apos;s Children) rule 
               <modifiers>
                 <modifier type="increment" field="points" value="30.0">
                   <repeats>
-                    <repeat field="selections" scope="fea8-bbb6-fe4d-2892" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9c9a-fc65-224d-37b1" repeats="1"/>
+                    <repeat field="selections" scope="fea8-bbb6-fe4d-2892" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9c9a-fc65-224d-37b1" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -38645,7 +38645,7 @@ In addtion, all units with the Legiones Astartes (Emperor&apos;s Children) rule 
           <modifiers>
             <modifier type="increment" field="maxSelections" value="1.0">
               <repeats>
-                <repeat field="selections" scope="59e98276-476f-0169-0950-56b0dd13b937" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e95d5122-73a8-c030-68e0-9ac11967cdbc" repeats="1"/>
+                <repeat field="selections" scope="59e98276-476f-0169-0950-56b0dd13b937" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e95d5122-73a8-c030-68e0-9ac11967cdbc" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -39043,14 +39043,14 @@ In addtion, all units with the Legiones Astartes (Emperor&apos;s Children) rule 
           <modifiers>
             <modifier type="increment" field="maxSelections" value="2.0">
               <repeats>
-                <repeat field="selections" scope="38de9d1a-135a-55d2-32e0-575f2726d753" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f02afe03-f2a4-e126-8587-5210111ad1e7" repeats="1"/>
+                <repeat field="selections" scope="38de9d1a-135a-55d2-32e0-575f2726d753" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f02afe03-f2a4-e126-8587-5210111ad1e7" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
             </modifier>
             <modifier type="decrement" field="maxSelections" value="1.0">
               <repeats>
-                <repeat field="selections" scope="28198ac7-1281-470a-964a-0bb69354de8d" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="45ca9f81-3e92-f0a4-ee28-b7b75a52f7f7" repeats="1"/>
+                <repeat field="selections" scope="28198ac7-1281-470a-964a-0bb69354de8d" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="45ca9f81-3e92-f0a4-ee28-b7b75a52f7f7" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -39068,14 +39068,14 @@ In addtion, all units with the Legiones Astartes (Emperor&apos;s Children) rule 
               <modifiers>
                 <modifier type="decrement" field="maxSelections" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="28198ac7-1281-470a-964a-0bb69354de8d" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="45ca9f81-3e92-f0a4-ee28-b7b75a52f7f7" repeats="1"/>
+                    <repeat field="selections" scope="28198ac7-1281-470a-964a-0bb69354de8d" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="45ca9f81-3e92-f0a4-ee28-b7b75a52f7f7" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
                 <modifier type="increment" field="maxSelections" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="38de9d1a-135a-55d2-32e0-575f2726d753" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f02afe03-f2a4-e126-8587-5210111ad1e7" repeats="1"/>
+                    <repeat field="selections" scope="38de9d1a-135a-55d2-32e0-575f2726d753" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f02afe03-f2a4-e126-8587-5210111ad1e7" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -39141,7 +39141,7 @@ In addtion, all units with the Legiones Astartes (Emperor&apos;s Children) rule 
               <modifiers>
                 <modifier type="increment" field="maxSelections" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="38de9d1a-135a-55d2-32e0-575f2726d753" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f02afe03-f2a4-e126-8587-5210111ad1e7" repeats="1"/>
+                    <repeat field="selections" scope="38de9d1a-135a-55d2-32e0-575f2726d753" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f02afe03-f2a4-e126-8587-5210111ad1e7" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -39477,7 +39477,7 @@ In addtion, all units with the Legiones Astartes (Emperor&apos;s Children) rule 
           <modifiers>
             <modifier type="increment" field="maxSelections" value="1.0">
               <repeats>
-                <repeat field="selections" scope="c23a1644-8684-27a2-7028-975fab8a0ccf" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c30ecda4-4475-31e1-fc7f-1b5f61637cfe" repeats="1"/>
+                <repeat field="selections" scope="c23a1644-8684-27a2-7028-975fab8a0ccf" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c30ecda4-4475-31e1-fc7f-1b5f61637cfe" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -40018,7 +40018,7 @@ In addtion, all units with the Legiones Astartes (Emperor&apos;s Children) rule 
           <modifiers>
             <modifier type="increment" field="maxSelections" value="1.0">
               <repeats>
-                <repeat field="selections" scope="a6acb50f-ff30-33bd-8355-5369362eb242" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="aca17c4f-9352-74be-fdc6-edfa0ebf2a22" repeats="1"/>
+                <repeat field="selections" scope="a6acb50f-ff30-33bd-8355-5369362eb242" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="aca17c4f-9352-74be-fdc6-edfa0ebf2a22" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -40675,7 +40675,7 @@ In addtion, all units with the Legiones Astartes (Emperor&apos;s Children) rule 
               <modifiers>
                 <modifier type="increment" field="maxSelections" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="ef1d-f7d5-2c48-0bba" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="15cf-f909-d1df-8fb8" repeats="1"/>
+                    <repeat field="selections" scope="ef1d-f7d5-2c48-0bba" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="15cf-f909-d1df-8fb8" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -40709,7 +40709,7 @@ In addtion, all units with the Legiones Astartes (Emperor&apos;s Children) rule 
               <modifiers>
                 <modifier type="increment" field="maxSelections" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="ef1d-f7d5-2c48-0bba" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="15cf-f909-d1df-8fb8" repeats="1"/>
+                    <repeat field="selections" scope="ef1d-f7d5-2c48-0bba" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="15cf-f909-d1df-8fb8" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -41168,7 +41168,7 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
           <modifiers>
             <modifier type="increment" field="maxSelections" value="1.0">
               <repeats>
-                <repeat field="selections" scope="d2668403-0cc0-a0c2-c2d8-c120e3a61437" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="48025648-f4c5-ca05-f8f0-b40608d97582" repeats="1"/>
+                <repeat field="selections" scope="d2668403-0cc0-a0c2-c2d8-c120e3a61437" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="48025648-f4c5-ca05-f8f0-b40608d97582" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -41355,14 +41355,14 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
           <modifiers>
             <modifier type="increment" field="maxSelections" value="2.0">
               <repeats>
-                <repeat field="selections" scope="b4ae8f2a-ef96-0289-5600-4634a00a4c9f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="fdeebcc5-c383-d154-7bba-87f3cdb1e68d" repeats="1"/>
+                <repeat field="selections" scope="b4ae8f2a-ef96-0289-5600-4634a00a4c9f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="fdeebcc5-c383-d154-7bba-87f3cdb1e68d" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
             </modifier>
             <modifier type="decrement" field="maxSelections" value="1.0">
               <repeats>
-                <repeat field="selections" scope="b4ae8f2a-ef96-0289-5600-4634a00a4c9f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c63479b3-4683-d680-94b6-7ecbd93ed1f7" repeats="1"/>
+                <repeat field="selections" scope="b4ae8f2a-ef96-0289-5600-4634a00a4c9f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c63479b3-4683-d680-94b6-7ecbd93ed1f7" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -41380,21 +41380,21 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
               <modifiers>
                 <modifier type="decrement" field="maxSelections" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="3d3f61a1-18b5-956c-4acb-4123f8e06940" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c63479b3-4683-d680-94b6-7ecbd93ed1f7" repeats="1"/>
+                    <repeat field="selections" scope="3d3f61a1-18b5-956c-4acb-4123f8e06940" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c63479b3-4683-d680-94b6-7ecbd93ed1f7" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
                 <modifier type="decrement" field="maxSelections" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="3d3f61a1-18b5-956c-4acb-4123f8e06940" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5aa7d12f-4f2e-ab82-5355-d85768b242d1" repeats="1"/>
+                    <repeat field="selections" scope="3d3f61a1-18b5-956c-4acb-4123f8e06940" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5aa7d12f-4f2e-ab82-5355-d85768b242d1" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
                 <modifier type="increment" field="maxSelections" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="b4ae8f2a-ef96-0289-5600-4634a00a4c9f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="fdeebcc5-c383-d154-7bba-87f3cdb1e68d" repeats="1"/>
+                    <repeat field="selections" scope="b4ae8f2a-ef96-0289-5600-4634a00a4c9f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="fdeebcc5-c383-d154-7bba-87f3cdb1e68d" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -41430,14 +41430,14 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
               <modifiers>
                 <modifier type="decrement" field="maxSelections" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="3d3f61a1-18b5-956c-4acb-4123f8e06940" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c63479b3-4683-d680-94b6-7ecbd93ed1f7" repeats="1"/>
+                    <repeat field="selections" scope="3d3f61a1-18b5-956c-4acb-4123f8e06940" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c63479b3-4683-d680-94b6-7ecbd93ed1f7" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
                 <modifier type="increment" field="maxSelections" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="b4ae8f2a-ef96-0289-5600-4634a00a4c9f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="fdeebcc5-c383-d154-7bba-87f3cdb1e68d" repeats="1"/>
+                    <repeat field="selections" scope="b4ae8f2a-ef96-0289-5600-4634a00a4c9f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="fdeebcc5-c383-d154-7bba-87f3cdb1e68d" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -41503,7 +41503,7 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
               <modifiers>
                 <modifier type="increment" field="maxSelections" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="b4ae8f2a-ef96-0289-5600-4634a00a4c9f" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="fdeebcc5-c383-d154-7bba-87f3cdb1e68d" repeats="1"/>
+                    <repeat field="selections" scope="b4ae8f2a-ef96-0289-5600-4634a00a4c9f" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="fdeebcc5-c383-d154-7bba-87f3cdb1e68d" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -42575,7 +42575,7 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
               <modifiers>
                 <modifier type="increment" field="maxSelections" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="cba7eacc-627d-ad1f-3c72-70e35c15fd9f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="cb131561-fcb0-4264-1a6f-16e60bfc847a" repeats="1"/>
+                    <repeat field="selections" scope="cba7eacc-627d-ad1f-3c72-70e35c15fd9f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="cb131561-fcb0-4264-1a6f-16e60bfc847a" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -42627,7 +42627,7 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
               <modifiers>
                 <modifier type="increment" field="points" value="2.0">
                   <repeats>
-                    <repeat field="selections" scope="cba7eacc-627d-ad1f-3c72-70e35c15fd9f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="cb131561-fcb0-4264-1a6f-16e60bfc847a" repeats="1"/>
+                    <repeat field="selections" scope="cba7eacc-627d-ad1f-3c72-70e35c15fd9f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="cb131561-fcb0-4264-1a6f-16e60bfc847a" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -42652,7 +42652,7 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
               <modifiers>
                 <modifier type="increment" field="maxSelections" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="cba7eacc-627d-ad1f-3c72-70e35c15fd9f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="cb131561-fcb0-4264-1a6f-16e60bfc847a" repeats="1"/>
+                    <repeat field="selections" scope="cba7eacc-627d-ad1f-3c72-70e35c15fd9f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="cb131561-fcb0-4264-1a6f-16e60bfc847a" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -42815,7 +42815,7 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
               <modifiers>
                 <modifier type="increment" field="maxSelections" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="cba7eacc-627d-ad1f-3c72-70e35c15fd9f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="cb131561-fcb0-4264-1a6f-16e60bfc847a" repeats="1"/>
+                    <repeat field="selections" scope="cba7eacc-627d-ad1f-3c72-70e35c15fd9f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="cb131561-fcb0-4264-1a6f-16e60bfc847a" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -44241,14 +44241,14 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
               <modifiers>
                 <modifier type="increment" field="points" value="5.0">
                   <repeats>
-                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b8f1-e2a7-0c25-1c08" repeats="1"/>
+                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b8f1-e2a7-0c25-1c08" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
                 <modifier type="decrement" field="points" value="5">
                   <repeats>
-                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="10a134c9-dfdd-c921-6c14-17d0875f3b82" repeats="1"/>
+                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="10a134c9-dfdd-c921-6c14-17d0875f3b82" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -44270,14 +44270,14 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
               <modifiers>
                 <modifier type="increment" field="points" value="5">
                   <repeats>
-                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b8f1-e2a7-0c25-1c08" repeats="1"/>
+                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b8f1-e2a7-0c25-1c08" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
                 <modifier type="decrement" field="points" value="5">
                   <repeats>
-                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="10a134c9-dfdd-c921-6c14-17d0875f3b82" repeats="1"/>
+                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="10a134c9-dfdd-c921-6c14-17d0875f3b82" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -44292,14 +44292,14 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
               <modifiers>
                 <modifier type="decrement" field="points" value="10">
                   <repeats>
-                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="10a134c9-dfdd-c921-6c14-17d0875f3b82" repeats="1"/>
+                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="10a134c9-dfdd-c921-6c14-17d0875f3b82" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
                 <modifier type="increment" field="points" value="10">
                   <repeats>
-                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b8f1-e2a7-0c25-1c08" repeats="1"/>
+                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b8f1-e2a7-0c25-1c08" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -44321,14 +44321,14 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
               <modifiers>
                 <modifier type="decrement" field="points" value="20">
                   <repeats>
-                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="10a134c9-dfdd-c921-6c14-17d0875f3b82" repeats="1"/>
+                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="10a134c9-dfdd-c921-6c14-17d0875f3b82" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
                 <modifier type="increment" field="points" value="20">
                   <repeats>
-                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b8f1-e2a7-0c25-1c08" repeats="1"/>
+                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b8f1-e2a7-0c25-1c08" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -44343,14 +44343,14 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
               <modifiers>
                 <modifier type="decrement" field="points" value="5">
                   <repeats>
-                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="10a134c9-dfdd-c921-6c14-17d0875f3b82" repeats="1"/>
+                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="10a134c9-dfdd-c921-6c14-17d0875f3b82" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
                 <modifier type="increment" field="points" value="5">
                   <repeats>
-                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b8f1-e2a7-0c25-1c08" repeats="1"/>
+                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b8f1-e2a7-0c25-1c08" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -44365,14 +44365,14 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
               <modifiers>
                 <modifier type="increment" field="points" value="10">
                   <repeats>
-                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b8f1-e2a7-0c25-1c08" repeats="1"/>
+                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b8f1-e2a7-0c25-1c08" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
                 <modifier type="decrement" field="points" value="10">
                   <repeats>
-                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="10a134c9-dfdd-c921-6c14-17d0875f3b82" repeats="1"/>
+                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="10a134c9-dfdd-c921-6c14-17d0875f3b82" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -44389,14 +44389,14 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
               <modifiers>
                 <modifier type="decrement" field="points" value="15">
                   <repeats>
-                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="10a134c9-dfdd-c921-6c14-17d0875f3b82" repeats="1"/>
+                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="10a134c9-dfdd-c921-6c14-17d0875f3b82" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
                 <modifier type="increment" field="points" value="15">
                   <repeats>
-                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b8f1-e2a7-0c25-1c08" repeats="1"/>
+                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b8f1-e2a7-0c25-1c08" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -44475,7 +44475,7 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
               <modifiers>
                 <modifier type="increment" field="points" value="2.0">
                   <repeats>
-                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b8f1-e2a7-0c25-1c08" repeats="1"/>
+                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b8f1-e2a7-0c25-1c08" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -44562,14 +44562,14 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
                 </modifier>
                 <modifier type="increment" field="points" value="5">
                   <repeats>
-                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b8f1-e2a7-0c25-1c08" repeats="1"/>
+                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b8f1-e2a7-0c25-1c08" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
                 <modifier type="decrement" field="points" value="5.0">
                   <repeats>
-                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="10a134c9-dfdd-c921-6c14-17d0875f3b82" repeats="1"/>
+                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="10a134c9-dfdd-c921-6c14-17d0875f3b82" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -44584,14 +44584,14 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
               <modifiers>
                 <modifier type="increment" field="points" value="5.0">
                   <repeats>
-                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b8f1-e2a7-0c25-1c08" repeats="1"/>
+                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b8f1-e2a7-0c25-1c08" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
                 <modifier type="decrement" field="points" value="5.0">
                   <repeats>
-                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="10a134c9-dfdd-c921-6c14-17d0875f3b82" repeats="1"/>
+                    <repeat field="selections" scope="aa571dbd-da68-5e74-3593-7fda3e713898" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="10a134c9-dfdd-c921-6c14-17d0875f3b82" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -44698,7 +44698,7 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
           <modifiers>
             <modifier type="increment" field="points" value="5">
               <repeats>
-                <repeat field="selections" scope="b9f0-57cc-d0da-4ae3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8786-8772-e209-9f59" repeats="1"/>
+                <repeat field="selections" scope="b9f0-57cc-d0da-4ae3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8786-8772-e209-9f59" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -44737,7 +44737,7 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <repeats>
-                    <repeat field="selections" scope="b9f0-57cc-d0da-4ae3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7aaa-6a16-689f-b69a" repeats="1"/>
+                    <repeat field="selections" scope="b9f0-57cc-d0da-4ae3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7aaa-6a16-689f-b69a" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions>
                     <condition field="selections" scope="b9f0-57cc-d0da-4ae3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7aaa-6a16-689f-b69a" type="equalTo"/>
@@ -44964,7 +44964,7 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
           <modifiers>
             <modifier type="increment" field="maxSelections" value="1.0">
               <repeats>
-                <repeat field="selections" scope="b9f0-57cc-d0da-4ae3" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8786-8772-e209-9f59" repeats="1"/>
+                <repeat field="selections" scope="b9f0-57cc-d0da-4ae3" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8786-8772-e209-9f59" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -45091,14 +45091,14 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
                 </modifier>
                 <modifier type="increment" field="points" value="5.0">
                   <repeats>
-                    <repeat field="selections" scope="b9f0-57cc-d0da-4ae3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8786-8772-e209-9f59" repeats="1"/>
+                    <repeat field="selections" scope="b9f0-57cc-d0da-4ae3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8786-8772-e209-9f59" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
                 <modifier type="decrement" field="points" value="5.0">
                   <repeats>
-                    <repeat field="selections" scope="b9f0-57cc-d0da-4ae3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7dbb-e4ea-5a70-ce24" repeats="1"/>
+                    <repeat field="selections" scope="b9f0-57cc-d0da-4ae3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7dbb-e4ea-5a70-ce24" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -45139,7 +45139,7 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
                 </modifier>
                 <modifier type="increment" field="maxSelections" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="b9f0-57cc-d0da-4ae3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8786-8772-e209-9f59" repeats="1"/>
+                    <repeat field="selections" scope="b9f0-57cc-d0da-4ae3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8786-8772-e209-9f59" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -45620,7 +45620,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
           <modifiers>
             <modifier type="increment" field="points" value="5.0">
               <repeats>
-                <repeat field="selections" scope="517b-d4ca-d6ee-ef8c" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="94a7-5e77-7a91-1e94" repeats="1"/>
+                <repeat field="selections" scope="517b-d4ca-d6ee-ef8c" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="94a7-5e77-7a91-1e94" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -45645,7 +45645,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
           <modifiers>
             <modifier type="increment" field="maxSelections" value="1.0">
               <repeats>
-                <repeat field="selections" scope="517b-d4ca-d6ee-ef8c" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="94a7-5e77-7a91-1e94" repeats="1"/>
+                <repeat field="selections" scope="517b-d4ca-d6ee-ef8c" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="94a7-5e77-7a91-1e94" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -45760,7 +45760,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
               <modifiers>
                 <modifier type="increment" field="points" value="15.0">
                   <repeats>
-                    <repeat field="selections" scope="517b-d4ca-d6ee-ef8c" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="94a7-5e77-7a91-1e94" repeats="1"/>
+                    <repeat field="selections" scope="517b-d4ca-d6ee-ef8c" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="94a7-5e77-7a91-1e94" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -45783,7 +45783,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
               <modifiers>
                 <modifier type="increment" field="points" value="25.0">
                   <repeats>
-                    <repeat field="selections" scope="517b-d4ca-d6ee-ef8c" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="94a7-5e77-7a91-1e94" repeats="1"/>
+                    <repeat field="selections" scope="517b-d4ca-d6ee-ef8c" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="94a7-5e77-7a91-1e94" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -45806,7 +45806,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
               <modifiers>
                 <modifier type="increment" field="points" value="25.0">
                   <repeats>
-                    <repeat field="selections" scope="517b-d4ca-d6ee-ef8c" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="94a7-5e77-7a91-1e94" repeats="1"/>
+                    <repeat field="selections" scope="517b-d4ca-d6ee-ef8c" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="94a7-5e77-7a91-1e94" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -46644,7 +46644,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
               <modifiers>
                 <modifier type="increment" field="6be0-39b9-7e1c-d4e3" value="1">
                   <repeats>
-                    <repeat field="selections" scope="9fb7-a82a-11cb-fc8e" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1d99-6882-36e4-64f3" repeats="1"/>
+                    <repeat field="selections" scope="9fb7-a82a-11cb-fc8e" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1d99-6882-36e4-64f3" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -46973,7 +46973,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
               <modifiers>
                 <modifier type="increment" field="points" value="2.0">
                   <repeats>
-                    <repeat field="selections" scope="9fb7-a82a-11cb-fc8e" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1d99-6882-36e4-64f3" repeats="1"/>
+                    <repeat field="selections" scope="9fb7-a82a-11cb-fc8e" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1d99-6882-36e4-64f3" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -47950,7 +47950,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
               <modifiers>
                 <modifier type="increment" field="points" value="15.0">
                   <repeats>
-                    <repeat field="selections" scope="0af4be1b-e2a3-c1dd-c49d-18c53e1088f8" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="fe7bf3e4-6d84-89a3-463f-14ce40b4f7f0" repeats="1"/>
+                    <repeat field="selections" scope="0af4be1b-e2a3-c1dd-c49d-18c53e1088f8" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="fe7bf3e4-6d84-89a3-463f-14ce40b4f7f0" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -47980,7 +47980,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
               <modifiers>
                 <modifier type="increment" field="points" value="15.0">
                   <repeats>
-                    <repeat field="selections" scope="0af4be1b-e2a3-c1dd-c49d-18c53e1088f8" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="fe7bf3e4-6d84-89a3-463f-14ce40b4f7f0" repeats="1"/>
+                    <repeat field="selections" scope="0af4be1b-e2a3-c1dd-c49d-18c53e1088f8" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="fe7bf3e4-6d84-89a3-463f-14ce40b4f7f0" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -48007,14 +48007,14 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
           <modifiers>
             <modifier type="increment" field="maxSelections" value="2">
               <repeats>
-                <repeat field="selections" scope="0af4be1b-e2a3-c1dd-c49d-18c53e1088f8" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="fe7bf3e4-6d84-89a3-463f-14ce40b4f7f0" repeats="1"/>
+                <repeat field="selections" scope="0af4be1b-e2a3-c1dd-c49d-18c53e1088f8" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="fe7bf3e4-6d84-89a3-463f-14ce40b4f7f0" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
             </modifier>
             <modifier type="decrement" field="maxSelections" value="1.0">
               <repeats>
-                <repeat field="selections" scope="8ba1e3bb-e056-eb36-e8a2-0bb1a8bfb9e9" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="33754c95-e4e8-2965-ee43-7f2a7f8bac86" repeats="1"/>
+                <repeat field="selections" scope="8ba1e3bb-e056-eb36-e8a2-0bb1a8bfb9e9" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="33754c95-e4e8-2965-ee43-7f2a7f8bac86" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -48032,21 +48032,21 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
               <modifiers>
                 <modifier type="increment" field="maxSelections" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="0af4be1b-e2a3-c1dd-c49d-18c53e1088f8" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="fe7bf3e4-6d84-89a3-463f-14ce40b4f7f0" repeats="1"/>
+                    <repeat field="selections" scope="0af4be1b-e2a3-c1dd-c49d-18c53e1088f8" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="fe7bf3e4-6d84-89a3-463f-14ce40b4f7f0" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
                 <modifier type="decrement" field="maxSelections" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="8ba1e3bb-e056-eb36-e8a2-0bb1a8bfb9e9" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="33754c95-e4e8-2965-ee43-7f2a7f8bac86" repeats="1"/>
+                    <repeat field="selections" scope="8ba1e3bb-e056-eb36-e8a2-0bb1a8bfb9e9" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="33754c95-e4e8-2965-ee43-7f2a7f8bac86" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
                 <modifier type="decrement" field="maxSelections" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="8ba1e3bb-e056-eb36-e8a2-0bb1a8bfb9e9" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="70498dec-1f1f-fd3b-06c8-9982222af13f" repeats="1"/>
+                    <repeat field="selections" scope="8ba1e3bb-e056-eb36-e8a2-0bb1a8bfb9e9" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="70498dec-1f1f-fd3b-06c8-9982222af13f" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -48144,14 +48144,14 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
               <modifiers>
                 <modifier type="increment" field="maxSelections" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="0af4be1b-e2a3-c1dd-c49d-18c53e1088f8" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="fe7bf3e4-6d84-89a3-463f-14ce40b4f7f0" repeats="1"/>
+                    <repeat field="selections" scope="0af4be1b-e2a3-c1dd-c49d-18c53e1088f8" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="fe7bf3e4-6d84-89a3-463f-14ce40b4f7f0" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
                 <modifier type="decrement" field="maxSelections" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="8ba1e3bb-e056-eb36-e8a2-0bb1a8bfb9e9" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="33754c95-e4e8-2965-ee43-7f2a7f8bac86" repeats="1"/>
+                    <repeat field="selections" scope="8ba1e3bb-e056-eb36-e8a2-0bb1a8bfb9e9" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="33754c95-e4e8-2965-ee43-7f2a7f8bac86" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -48627,7 +48627,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
               <modifiers>
                 <modifier type="set" field="maxSelections" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="a2ea5ece-6fe2-e355-4039-b728dc9df581" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="782c9504-39ca-4c28-7141-971be719716b" repeats="1"/>
+                    <repeat field="selections" scope="a2ea5ece-6fe2-e355-4039-b728dc9df581" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="782c9504-39ca-4c28-7141-971be719716b" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -48950,14 +48950,14 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
           <modifiers>
             <modifier type="increment" field="maxSelections" value="2.0">
               <repeats>
-                <repeat field="selections" scope="3bd8064e-91eb-24e0-b07f-555fceb5f674" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="91e33f36-7917-a2d4-7a87-c83355bbb592" repeats="1"/>
+                <repeat field="selections" scope="3bd8064e-91eb-24e0-b07f-555fceb5f674" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="91e33f36-7917-a2d4-7a87-c83355bbb592" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
             </modifier>
             <modifier type="decrement" field="maxSelections" value="1.0">
               <repeats>
-                <repeat field="selections" scope="3bd8064e-91eb-24e0-b07f-555fceb5f674" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3e2b7502-ec89-4482-681a-7ea96b441b61" repeats="1"/>
+                <repeat field="selections" scope="3bd8064e-91eb-24e0-b07f-555fceb5f674" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3e2b7502-ec89-4482-681a-7ea96b441b61" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -48975,21 +48975,21 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
               <modifiers>
                 <modifier type="decrement" field="maxSelections" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="c727c2d5-8402-5390-89bd-5c6b3c856eb8" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3a090e7f-1ef3-cfec-26ac-c2ce78a58849" repeats="1"/>
+                    <repeat field="selections" scope="c727c2d5-8402-5390-89bd-5c6b3c856eb8" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3a090e7f-1ef3-cfec-26ac-c2ce78a58849" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
                 <modifier type="decrement" field="maxSelections" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="c727c2d5-8402-5390-89bd-5c6b3c856eb8" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3e2b7502-ec89-4482-681a-7ea96b441b61" repeats="1"/>
+                    <repeat field="selections" scope="c727c2d5-8402-5390-89bd-5c6b3c856eb8" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3e2b7502-ec89-4482-681a-7ea96b441b61" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
                 <modifier type="increment" field="maxSelections" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="3bd8064e-91eb-24e0-b07f-555fceb5f674" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="91e33f36-7917-a2d4-7a87-c83355bbb592" repeats="1"/>
+                    <repeat field="selections" scope="3bd8064e-91eb-24e0-b07f-555fceb5f674" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="91e33f36-7917-a2d4-7a87-c83355bbb592" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -49052,7 +49052,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
                   <modifiers>
                     <modifier type="increment" field="maxSelections" value="1.0">
                       <repeats>
-                        <repeat field="selections" scope="3bd8064e-91eb-24e0-b07f-555fceb5f674" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="91e33f36-7917-a2d4-7a87-c83355bbb592" repeats="1"/>
+                        <repeat field="selections" scope="3bd8064e-91eb-24e0-b07f-555fceb5f674" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="91e33f36-7917-a2d4-7a87-c83355bbb592" repeats="1" roundUp="false"/>
                       </repeats>
                       <conditions/>
                       <conditionGroups/>
@@ -49107,14 +49107,14 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
               <modifiers>
                 <modifier type="decrement" field="maxSelections" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="c727c2d5-8402-5390-89bd-5c6b3c856eb8" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3e2b7502-ec89-4482-681a-7ea96b441b61" repeats="1"/>
+                    <repeat field="selections" scope="c727c2d5-8402-5390-89bd-5c6b3c856eb8" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3e2b7502-ec89-4482-681a-7ea96b441b61" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
                 <modifier type="increment" field="maxSelections" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="3bd8064e-91eb-24e0-b07f-555fceb5f674" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="91e33f36-7917-a2d4-7a87-c83355bbb592" repeats="1"/>
+                    <repeat field="selections" scope="3bd8064e-91eb-24e0-b07f-555fceb5f674" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="91e33f36-7917-a2d4-7a87-c83355bbb592" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -49214,7 +49214,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
               <modifiers>
                 <modifier type="increment" field="maxSelections" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="3bd8064e-91eb-24e0-b07f-555fceb5f674" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="91e33f36-7917-a2d4-7a87-c83355bbb592" repeats="1"/>
+                    <repeat field="selections" scope="3bd8064e-91eb-24e0-b07f-555fceb5f674" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="91e33f36-7917-a2d4-7a87-c83355bbb592" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -49315,7 +49315,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
               <modifiers>
                 <modifier type="increment" field="maxSelections" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="3bd8064e-91eb-24e0-b07f-555fceb5f674" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="91e33f36-7917-a2d4-7a87-c83355bbb592" repeats="1"/>
+                    <repeat field="selections" scope="3bd8064e-91eb-24e0-b07f-555fceb5f674" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="91e33f36-7917-a2d4-7a87-c83355bbb592" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -49959,7 +49959,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
               <modifiers>
                 <modifier type="increment" field="9982-ae20-2eca-be75" value="1">
                   <repeats>
-                    <repeat field="selections" scope="5e9c6a5f-b807-27ae-8a84-90129437976b" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dd02066d-5458-c38d-990a-b6fdad016494" repeats="1"/>
+                    <repeat field="selections" scope="5e9c6a5f-b807-27ae-8a84-90129437976b" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dd02066d-5458-c38d-990a-b6fdad016494" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -50009,7 +50009,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
               <modifiers>
                 <modifier type="increment" field="cf98-3f59-d8e2-e1c5" value="1">
                   <repeats>
-                    <repeat field="selections" scope="5e9c6a5f-b807-27ae-8a84-90129437976b" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="dd02066d-5458-c38d-990a-b6fdad016494" repeats="1"/>
+                    <repeat field="selections" scope="5e9c6a5f-b807-27ae-8a84-90129437976b" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="dd02066d-5458-c38d-990a-b6fdad016494" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -50043,7 +50043,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
               <modifiers>
                 <modifier type="increment" field="7170-4a6d-e55f-7f87" value="1">
                   <repeats>
-                    <repeat field="selections" scope="5e9c6a5f-b807-27ae-8a84-90129437976b" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="dd02066d-5458-c38d-990a-b6fdad016494" repeats="1"/>
+                    <repeat field="selections" scope="5e9c6a5f-b807-27ae-8a84-90129437976b" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="dd02066d-5458-c38d-990a-b6fdad016494" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -50783,7 +50783,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
               <modifiers>
                 <modifier type="increment" field="points" value="2.0">
                   <repeats>
-                    <repeat field="selections" scope="5e9c6a5f-b807-27ae-8a84-90129437976b" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="dd02066d-5458-c38d-990a-b6fdad016494" repeats="1"/>
+                    <repeat field="selections" scope="5e9c6a5f-b807-27ae-8a84-90129437976b" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="dd02066d-5458-c38d-990a-b6fdad016494" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -51034,14 +51034,14 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
           <modifiers>
             <modifier type="increment" field="maxSelections" value="1.0">
               <repeats>
-                <repeat field="selections" scope="bfa29302-44f6-78de-d3d0-505017188013" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f2c3b20d-d915-ad46-b75f-26c3496ccdb2" repeats="1"/>
+                <repeat field="selections" scope="bfa29302-44f6-78de-d3d0-505017188013" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f2c3b20d-d915-ad46-b75f-26c3496ccdb2" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
             </modifier>
             <modifier type="increment" field="maxSelections" value="1.0">
               <repeats>
-                <repeat field="selections" scope="d689ad80-9a93-3f42-df63-2072f9fd912c" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b29a4bae-7c76-f4e7-1f26-33d2fb08dfe3" repeats="1"/>
+                <repeat field="selections" scope="d689ad80-9a93-3f42-df63-2072f9fd912c" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b29a4bae-7c76-f4e7-1f26-33d2fb08dfe3" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -51102,7 +51102,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
               <modifiers>
                 <modifier type="increment" field="maxSelections" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="bfa29302-44f6-78de-d3d0-505017188013" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f2c3b20d-d915-ad46-b75f-26c3496ccdb2" repeats="1"/>
+                    <repeat field="selections" scope="bfa29302-44f6-78de-d3d0-505017188013" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f2c3b20d-d915-ad46-b75f-26c3496ccdb2" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -51880,7 +51880,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
         </modifier>
         <modifier type="increment" field="maxInRoster" value="1">
           <repeats>
-            <repeat field="limit::points" scope="roster" value="1000.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1"/>
+            <repeat field="limit::points" scope="roster" value="1000.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
           </repeats>
           <conditions/>
           <conditionGroups/>
@@ -52285,7 +52285,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
           <modifiers>
             <modifier type="increment" field="maxSelections" value="1.0">
               <repeats>
-                <repeat field="selections" scope="56cdd068-fb04-ef20-c63b-709e3c033f7f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="42d95ca4-adcd-5ed8-2ee9-6b3207bfcf5b" repeats="1"/>
+                <repeat field="selections" scope="56cdd068-fb04-ef20-c63b-709e3c033f7f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="42d95ca4-adcd-5ed8-2ee9-6b3207bfcf5b" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -52823,14 +52823,14 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
           <modifiers>
             <modifier type="increment" field="minSelections" value="1.0">
               <repeats>
-                <repeat field="selections" scope="d3e5ece4-8862-4390-7a65-843981d7298b" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f9c02c84-8b3e-f000-7c76-b879f30647ac" repeats="1"/>
+                <repeat field="selections" scope="d3e5ece4-8862-4390-7a65-843981d7298b" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f9c02c84-8b3e-f000-7c76-b879f30647ac" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
             </modifier>
             <modifier type="increment" field="maxSelections" value="1.0">
               <repeats>
-                <repeat field="selections" scope="d3e5ece4-8862-4390-7a65-843981d7298b" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f9c02c84-8b3e-f000-7c76-b879f30647ac" repeats="1"/>
+                <repeat field="selections" scope="d3e5ece4-8862-4390-7a65-843981d7298b" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f9c02c84-8b3e-f000-7c76-b879f30647ac" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -53336,7 +53336,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
               <modifiers>
                 <modifier type="set" field="maxSelections" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="af8e431e-977e-93a0-f8f4-a2dc77e71bd0" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6726759d-aa99-f4c0-dcea-91821f44dc8e" repeats="1"/>
+                    <repeat field="selections" scope="af8e431e-977e-93a0-f8f4-a2dc77e71bd0" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6726759d-aa99-f4c0-dcea-91821f44dc8e" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -53576,14 +53576,14 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
           <modifiers>
             <modifier type="increment" field="maxSelections" value="1.0">
               <repeats>
-                <repeat field="selections" scope="9c4b5745-1a15-ed4a-0124-e6a877f2c496" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="299893b6-c606-c075-1473-0d96c1c2ac9d" repeats="1"/>
+                <repeat field="selections" scope="9c4b5745-1a15-ed4a-0124-e6a877f2c496" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="299893b6-c606-c075-1473-0d96c1c2ac9d" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
             </modifier>
             <modifier type="increment" field="maxSelections" value="1.0">
               <repeats>
-                <repeat field="selections" scope="0704f25e-9e62-4928-f129-07b85aea31ce" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="777c0269-cd84-12f6-07eb-6fb2eb198a90" repeats="1"/>
+                <repeat field="selections" scope="0704f25e-9e62-4928-f129-07b85aea31ce" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="777c0269-cd84-12f6-07eb-6fb2eb198a90" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -53601,14 +53601,14 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
               <modifiers>
                 <modifier type="increment" field="maxSelections" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="9c4b5745-1a15-ed4a-0124-e6a877f2c496" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="299893b6-c606-c075-1473-0d96c1c2ac9d" repeats="1"/>
+                    <repeat field="selections" scope="9c4b5745-1a15-ed4a-0124-e6a877f2c496" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="299893b6-c606-c075-1473-0d96c1c2ac9d" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
                 <modifier type="decrement" field="maxSelections" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="0704f25e-9e62-4928-f129-07b85aea31ce" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="777c0269-cd84-12f6-07eb-6fb2eb198a90" repeats="1"/>
+                    <repeat field="selections" scope="0704f25e-9e62-4928-f129-07b85aea31ce" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="777c0269-cd84-12f6-07eb-6fb2eb198a90" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -53644,14 +53644,14 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
               <modifiers>
                 <modifier type="increment" field="maxSelections" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="9c4b5745-1a15-ed4a-0124-e6a877f2c496" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="299893b6-c606-c075-1473-0d96c1c2ac9d" repeats="1"/>
+                    <repeat field="selections" scope="9c4b5745-1a15-ed4a-0124-e6a877f2c496" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="299893b6-c606-c075-1473-0d96c1c2ac9d" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
                 <modifier type="decrement" field="maxSelections" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="0704f25e-9e62-4928-f129-07b85aea31ce" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0d4f5452-a539-964a-e8c0-1224f9f6b3ca" repeats="1"/>
+                    <repeat field="selections" scope="0704f25e-9e62-4928-f129-07b85aea31ce" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0d4f5452-a539-964a-e8c0-1224f9f6b3ca" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -54200,7 +54200,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
               <modifiers>
                 <modifier type="increment" field="points" value="2.0">
                   <repeats>
-                    <repeat field="selections" scope="d74303db-b69f-85c7-d14c-bf9743a70ff9" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4d85bb36-8473-4768-2adf-44e497aad3c7" repeats="1"/>
+                    <repeat field="selections" scope="d74303db-b69f-85c7-d14c-bf9743a70ff9" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4d85bb36-8473-4768-2adf-44e497aad3c7" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -54223,7 +54223,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
               <modifiers>
                 <modifier type="increment" field="points" value="10.0">
                   <repeats>
-                    <repeat field="selections" scope="d74303db-b69f-85c7-d14c-bf9743a70ff9" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4d85bb36-8473-4768-2adf-44e497aad3c7" repeats="1"/>
+                    <repeat field="selections" scope="d74303db-b69f-85c7-d14c-bf9743a70ff9" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4d85bb36-8473-4768-2adf-44e497aad3c7" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -54250,7 +54250,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
           <modifiers>
             <modifier type="increment" field="maxSelections" value="1.0">
               <repeats>
-                <repeat field="selections" scope="d74303db-b69f-85c7-d14c-bf9743a70ff9" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4d85bb36-8473-4768-2adf-44e497aad3c7" repeats="1"/>
+                <repeat field="selections" scope="d74303db-b69f-85c7-d14c-bf9743a70ff9" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4d85bb36-8473-4768-2adf-44e497aad3c7" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -54790,7 +54790,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
           <modifiers>
             <modifier type="increment" field="maxSelections" value="1.0">
               <repeats>
-                <repeat field="selections" scope="08851922-b3de-b46f-ff8d-9fefaa58141f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="934d7fd6-6542-9ae3-dcc6-f51869b2afff" repeats="1"/>
+                <repeat field="selections" scope="08851922-b3de-b46f-ff8d-9fefaa58141f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="934d7fd6-6542-9ae3-dcc6-f51869b2afff" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -56483,7 +56483,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
               <modifiers>
                 <modifier type="set" field="maxSelections" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="ded5d875-ccab-e130-6137-3438431db6d5" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f12cc0ad-63fe-f446-503e-f7a6f093695a" repeats="1"/>
+                    <repeat field="selections" scope="ded5d875-ccab-e130-6137-3438431db6d5" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f12cc0ad-63fe-f446-503e-f7a6f093695a" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -56693,7 +56693,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
               <modifiers>
                 <modifier type="increment" field="points" value="10.0">
                   <repeats>
-                    <repeat field="selections" scope="bcc4b792-787e-1cff-6146-ef9c480a4538" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b8acc2c4-33dd-b805-ec03-6711060ee62e" repeats="1"/>
+                    <repeat field="selections" scope="bcc4b792-787e-1cff-6146-ef9c480a4538" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b8acc2c4-33dd-b805-ec03-6711060ee62e" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -56720,7 +56720,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
           <modifiers>
             <modifier type="increment" field="maxSelections" value="1.0">
               <repeats>
-                <repeat field="selections" scope="bcc4b792-787e-1cff-6146-ef9c480a4538" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b8acc2c4-33dd-b805-ec03-6711060ee62e" repeats="1"/>
+                <repeat field="selections" scope="bcc4b792-787e-1cff-6146-ef9c480a4538" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b8acc2c4-33dd-b805-ec03-6711060ee62e" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -57096,14 +57096,14 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
           <modifiers>
             <modifier type="increment" field="maxSelections" value="1.0">
               <repeats>
-                <repeat field="selections" scope="cb9e1c3d-8547-ecf0-0260-26720068088d" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6cef3168-998a-2e7b-d533-d5bb5fa42429" repeats="1"/>
+                <repeat field="selections" scope="cb9e1c3d-8547-ecf0-0260-26720068088d" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6cef3168-998a-2e7b-d533-d5bb5fa42429" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
             </modifier>
             <modifier type="decrement" field="maxSelections" value="1.0">
               <repeats>
-                <repeat field="selections" scope="cb9e1c3d-8547-ecf0-0260-26720068088d" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="98d20014-d666-b04d-3ceb-8b3d389e0a95" repeats="1"/>
+                <repeat field="selections" scope="cb9e1c3d-8547-ecf0-0260-26720068088d" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="98d20014-d666-b04d-3ceb-8b3d389e0a95" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -57399,7 +57399,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
           <modifiers>
             <modifier type="increment" field="maxSelections" value="1.0">
               <repeats>
-                <repeat field="selections" scope="cb9e1c3d-8547-ecf0-0260-26720068088d" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6cef3168-998a-2e7b-d533-d5bb5fa42429" repeats="1"/>
+                <repeat field="selections" scope="cb9e1c3d-8547-ecf0-0260-26720068088d" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6cef3168-998a-2e7b-d533-d5bb5fa42429" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -58779,7 +58779,7 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
               <modifiers>
                 <modifier type="increment" field="maxSelections" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="83d0ac63-e1ef-0a67-4171-472bf9f042c0" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="cb94b9e4-babc-f6b5-1711-b6f58d79c55a" repeats="1"/>
+                    <repeat field="selections" scope="83d0ac63-e1ef-0a67-4171-472bf9f042c0" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="cb94b9e4-babc-f6b5-1711-b6f58d79c55a" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -59363,7 +59363,7 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
           <modifiers>
             <modifier type="increment" field="maxSelections" value="1.0">
               <repeats>
-                <repeat field="selections" scope="e6d27859-b474-aa9d-c4bc-7a4b9b2c8737" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="418c18de-cf47-af65-0a1c-f2e0e1f1dda8" repeats="1"/>
+                <repeat field="selections" scope="e6d27859-b474-aa9d-c4bc-7a4b9b2c8737" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="418c18de-cf47-af65-0a1c-f2e0e1f1dda8" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -59853,7 +59853,7 @@ All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affec
           <modifiers>
             <modifier type="increment" field="maxSelections" value="1.0">
               <repeats>
-                <repeat field="selections" scope="a94a00ff-77c2-bc8c-1044-283e14795b55" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9a83142b-be49-90ce-290c-204906b37f1c" repeats="1"/>
+                <repeat field="selections" scope="a94a00ff-77c2-bc8c-1044-283e14795b55" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9a83142b-be49-90ce-290c-204906b37f1c" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -60559,7 +60559,7 @@ If the test is failed, the unit immediately suffers D6 wounds at AP2 with Instan
               <modifiers>
                 <modifier type="increment" field="maxSelections" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="9f0c-fbca-a387-b37c" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4faa-575c-d658-5ed9" repeats="1"/>
+                    <repeat field="selections" scope="9f0c-fbca-a387-b37c" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4faa-575c-d658-5ed9" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -60744,7 +60744,7 @@ If the test is failed, the unit immediately suffers D6 wounds at AP2 with Instan
                   <modifiers>
                     <modifier type="increment" field="maxSelections" value="1.0">
                       <repeats>
-                        <repeat field="selections" scope="9f0c-fbca-a387-b37c" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4faa-575c-d658-5ed9" repeats="1"/>
+                        <repeat field="selections" scope="9f0c-fbca-a387-b37c" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4faa-575c-d658-5ed9" repeats="1" roundUp="false"/>
                       </repeats>
                       <conditions/>
                       <conditionGroups/>
@@ -61184,7 +61184,7 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
                   <modifiers>
                     <modifier type="increment" field="maxSelections" value="1.0">
                       <repeats>
-                        <repeat field="selections" scope="fe7a81f2-4f3e-dd94-ef75-eb37a4cbefe6" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="262d02b6-69d3-b79e-c1a0-6af220bcf848" repeats="1"/>
+                        <repeat field="selections" scope="fe7a81f2-4f3e-dd94-ef75-eb37a4cbefe6" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="262d02b6-69d3-b79e-c1a0-6af220bcf848" repeats="1" roundUp="false"/>
                       </repeats>
                       <conditions/>
                       <conditionGroups/>
@@ -61269,7 +61269,7 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
           <modifiers>
             <modifier type="increment" field="maxSelections" value="1.0">
               <repeats>
-                <repeat field="selections" scope="4a689753-47b5-5897-1023-1b51b177ec61" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ef5cd1d3-ad57-d35b-684c-b5e19cd12b45" repeats="1"/>
+                <repeat field="selections" scope="4a689753-47b5-5897-1023-1b51b177ec61" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ef5cd1d3-ad57-d35b-684c-b5e19cd12b45" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -61724,7 +61724,7 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
           <modifiers>
             <modifier type="increment" field="maxSelections" value="1.0">
               <repeats>
-                <repeat field="selections" scope="ae82263c-4bad-79fd-c274-305b8f0f7ffb" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="13551365-1e8a-ec0a-0346-b084a64e3e49" repeats="1"/>
+                <repeat field="selections" scope="ae82263c-4bad-79fd-c274-305b8f0f7ffb" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="13551365-1e8a-ec0a-0346-b084a64e3e49" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -62348,7 +62348,9 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="9589-66f8-7b84-17da" name="May take any of the following upgrades:" hidden="false" collective="false" type="upgrade">
           <profiles/>
@@ -62390,7 +62392,9 @@ In addition, units of Domitar-Ferrum may be joined by a single Independent Chara
               <constraints/>
             </entryLink>
           </entryLinks>
-          <costs/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups/>
@@ -64874,7 +64878,13 @@ When conducting a Ram attack, use Strength 10, roll two dice and pick the higher
                   <profiles/>
                   <rules/>
                   <infoLinks/>
-                  <modifiers/>
+                  <modifiers>
+                    <modifier type="set" field="points" value="10">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
                   <constraints/>
                 </entryLink>
               </entryLinks>
@@ -67163,7 +67173,7 @@ Explodes results add D3&quot; to radius.  </description>
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <repeats>
-                    <repeat field="selections" scope="9b0f-fe11-248c-953f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c1ee-dbf0-ab40-bad2" repeats="1"/>
+                    <repeat field="selections" scope="9b0f-fe11-248c-953f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c1ee-dbf0-ab40-bad2" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions>
                     <condition field="selections" scope="9b0f-fe11-248c-953f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c1ee-dbf0-ab40-bad2" type="equalTo"/>
@@ -67448,7 +67458,7 @@ Explodes results add D3&quot; to radius.  </description>
               <modifiers>
                 <modifier type="increment" field="points" value="15">
                   <repeats>
-                    <repeat field="selections" scope="9b0f-fe11-248c-953f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6112-73ef-3754-6518" repeats="1"/>
+                    <repeat field="selections" scope="9b0f-fe11-248c-953f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6112-73ef-3754-6518" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -67481,7 +67491,7 @@ Explodes results add D3&quot; to radius.  </description>
               <modifiers>
                 <modifier type="increment" field="points" value="10">
                   <repeats>
-                    <repeat field="selections" scope="9b0f-fe11-248c-953f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6112-73ef-3754-6518" repeats="1"/>
+                    <repeat field="selections" scope="9b0f-fe11-248c-953f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6112-73ef-3754-6518" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -67538,7 +67548,7 @@ Explodes results add D3&quot; to radius.  </description>
           <modifiers>
             <modifier type="increment" field="points" value="5">
               <repeats>
-                <repeat field="selections" scope="9b0f-fe11-248c-953f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6112-73ef-3754-6518" repeats="1"/>
+                <repeat field="selections" scope="9b0f-fe11-248c-953f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6112-73ef-3754-6518" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -67630,7 +67640,7 @@ Explodes results add D3&quot; to radius.  </description>
         </modifier>
         <modifier type="set" field="hidden" value="true">
           <repeats>
-            <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3215-720d-8883-ab23" repeats="1"/>
+            <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3215-720d-8883-ab23" repeats="1" roundUp="false"/>
           </repeats>
           <conditions>
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1006-e22e-3aa4-f79a" type="equalTo"/>
@@ -68663,7 +68673,7 @@ differently armed Sentry Guns to fire at two separate targets.</description>
               <modifiers>
                 <modifier type="increment" field="9489-2191-9d76-96b5" value="1">
                   <repeats>
-                    <repeat field="selections" scope="7218-3d68-4761-d7fd" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fe4-e743-ab98-5e44" repeats="1"/>
+                    <repeat field="selections" scope="7218-3d68-4761-d7fd" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fe4-e743-ab98-5e44" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions>
                     <condition field="selections" scope="7218-3d68-4761-d7fd" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="edd8-6ef1-4bc3-637e" type="equalTo"/>
@@ -68672,7 +68682,7 @@ differently armed Sentry Guns to fire at two separate targets.</description>
                 </modifier>
                 <modifier type="increment" field="1228-49ef-c35c-8b88" value="1">
                   <repeats>
-                    <repeat field="selections" scope="7218-3d68-4761-d7fd" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fe4-e743-ab98-5e44" repeats="1"/>
+                    <repeat field="selections" scope="7218-3d68-4761-d7fd" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fe4-e743-ab98-5e44" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions>
                     <condition field="selections" scope="7218-3d68-4761-d7fd" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="edd8-6ef1-4bc3-637e" type="equalTo"/>
@@ -68818,7 +68828,7 @@ differently armed Sentry Guns to fire at two separate targets.</description>
                   <modifiers>
                     <modifier type="increment" field="points" value="20">
                       <repeats>
-                        <repeat field="selections" scope="7218-3d68-4761-d7fd" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fe4-e743-ab98-5e44" repeats="1"/>
+                        <repeat field="selections" scope="7218-3d68-4761-d7fd" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fe4-e743-ab98-5e44" repeats="1" roundUp="false"/>
                       </repeats>
                       <conditions/>
                       <conditionGroups/>
@@ -68942,7 +68952,9 @@ differently armed Sentry Guns to fire at two separate targets.</description>
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks/>
-              <costs/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
             </selectionEntry>
           </selectionEntries>
           <selectionEntryGroups/>
@@ -68996,7 +69008,9 @@ differently armed Sentry Guns to fire at two separate targets.</description>
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="15c1-2cf9-0fa4-6093" name="Twin-linked Rotor Cannon" hidden="false" collective="false" type="upgrade">
       <profiles/>
@@ -69027,7 +69041,9 @@ differently armed Sentry Guns to fire at two separate targets.</description>
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="472a-3a4d-f0cf-a903" name="Armoured Cockpit" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
@@ -69356,7 +69372,9 @@ differently armed Sentry Guns to fire at two separate targets.</description>
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="f6e2-4e7b-efcb-b231" name="Twin-linked Cyclone Missile Launcher" hidden="false" collective="false" type="upgrade">
       <profiles/>
@@ -69367,7 +69385,9 @@ differently armed Sentry Guns to fire at two separate targets.</description>
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
@@ -69814,7 +69834,7 @@ differently armed Sentry Guns to fire at two separate targets.</description>
                   <modifiers>
                     <modifier type="set" field="maxSelections" value="1.0">
                       <repeats>
-                        <repeat field="selections" scope="08d8-2df3-2cd1-1575" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="04b0-02f9-702c-403e" repeats="1"/>
+                        <repeat field="selections" scope="08d8-2df3-2cd1-1575" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="04b0-02f9-702c-403e" repeats="1" roundUp="false"/>
                       </repeats>
                       <conditions/>
                       <conditionGroups/>
@@ -70017,7 +70037,7 @@ differently armed Sentry Guns to fire at two separate targets.</description>
                   <modifiers>
                     <modifier type="increment" field="points" value="1.0">
                       <repeats>
-                        <repeat field="selections" scope="e18b-3079-afdc-1248" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="08d8-2df3-2cd1-1575" repeats="1"/>
+                        <repeat field="selections" scope="e18b-3079-afdc-1248" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="08d8-2df3-2cd1-1575" repeats="1" roundUp="false"/>
                       </repeats>
                       <conditions/>
                       <conditionGroups/>
@@ -70047,7 +70067,7 @@ differently armed Sentry Guns to fire at two separate targets.</description>
                   <modifiers>
                     <modifier type="increment" field="points" value="5.0">
                       <repeats>
-                        <repeat field="selections" scope="e18b-3079-afdc-1248" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="08d8-2df3-2cd1-1575" repeats="1"/>
+                        <repeat field="selections" scope="e18b-3079-afdc-1248" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="08d8-2df3-2cd1-1575" repeats="1" roundUp="false"/>
                       </repeats>
                       <conditions/>
                       <conditionGroups/>
@@ -70070,7 +70090,7 @@ differently armed Sentry Guns to fire at two separate targets.</description>
                   <modifiers>
                     <modifier type="increment" field="points" value="5.0">
                       <repeats>
-                        <repeat field="selections" scope="e18b-3079-afdc-1248" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="08d8-2df3-2cd1-1575" repeats="1"/>
+                        <repeat field="selections" scope="e18b-3079-afdc-1248" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="08d8-2df3-2cd1-1575" repeats="1" roundUp="false"/>
                       </repeats>
                       <conditions/>
                       <conditionGroups/>
@@ -70100,7 +70120,7 @@ differently armed Sentry Guns to fire at two separate targets.</description>
                   <modifiers>
                     <modifier type="increment" field="points" value="15.0">
                       <repeats>
-                        <repeat field="selections" scope="e18b-3079-afdc-1248" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="08d8-2df3-2cd1-1575" repeats="1"/>
+                        <repeat field="selections" scope="e18b-3079-afdc-1248" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="08d8-2df3-2cd1-1575" repeats="1" roundUp="false"/>
                       </repeats>
                       <conditions/>
                       <conditionGroups/>
@@ -70360,7 +70380,7 @@ differently armed Sentry Guns to fire at two separate targets.</description>
                   <modifiers>
                     <modifier type="increment" field="points" value="1.0">
                       <repeats>
-                        <repeat field="selections" scope="de51-ea6a-e075-09bf" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9894-bb40-5e25-86a6" repeats="1"/>
+                        <repeat field="selections" scope="de51-ea6a-e075-09bf" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9894-bb40-5e25-86a6" repeats="1" roundUp="false"/>
                       </repeats>
                       <conditions/>
                       <conditionGroups/>
@@ -70383,7 +70403,7 @@ differently armed Sentry Guns to fire at two separate targets.</description>
                   <modifiers>
                     <modifier type="increment" field="points" value="5.0">
                       <repeats>
-                        <repeat field="selections" scope="de51-ea6a-e075-09bf" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9894-bb40-5e25-86a6" repeats="1"/>
+                        <repeat field="selections" scope="de51-ea6a-e075-09bf" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9894-bb40-5e25-86a6" repeats="1" roundUp="false"/>
                       </repeats>
                       <conditions/>
                       <conditionGroups/>
@@ -70413,7 +70433,7 @@ differently armed Sentry Guns to fire at two separate targets.</description>
                   <modifiers>
                     <modifier type="increment" field="points" value="15.0">
                       <repeats>
-                        <repeat field="selections" scope="de51-ea6a-e075-09bf" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9894-bb40-5e25-86a6" repeats="1"/>
+                        <repeat field="selections" scope="de51-ea6a-e075-09bf" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9894-bb40-5e25-86a6" repeats="1" roundUp="false"/>
                       </repeats>
                       <conditions/>
                       <conditionGroups/>
@@ -70486,7 +70506,7 @@ differently armed Sentry Guns to fire at two separate targets.</description>
                   <modifiers>
                     <modifier type="increment" field="points" value="10.0">
                       <repeats>
-                        <repeat field="selections" scope="de51-ea6a-e075-09bf" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9894-bb40-5e25-86a6" repeats="1"/>
+                        <repeat field="selections" scope="de51-ea6a-e075-09bf" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9894-bb40-5e25-86a6" repeats="1" roundUp="false"/>
                       </repeats>
                       <conditions/>
                       <conditionGroups/>

--- a/(HH) Legiones Astartes - Crusade Army List.cat
+++ b/(HH) Legiones Astartes - Crusade Army List.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="839b6f2a-4041-398b-fc2d-dc6a31d5f75e" name="Legiones Astartes: Age of Darkness Army List" book="Forgeworld Horus Heresy Series" revision="205" battleScribeVersion="2.00" authorName="Millicant" authorContact="Please submit any bugs to the website below" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="20" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="839b6f2a-4041-398b-fc2d-dc6a31d5f75e" name="Legiones Astartes: Age of Darkness Army List" book="Forgeworld Horus Heresy Series" revision="206" battleScribeVersion="2.00" authorName="Millicant" authorContact="Please submit any bugs to the website below" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="20" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules/>
   <infoLinks/>
@@ -22547,807 +22547,6 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
         <cost name="pts" costTypeId="points" value="35.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="d744f750-8ad0-c8f0-fb8d-81608f361be3" name="Legion Tactical Support Squad" book="HH:LACAL" page="33" hidden="false" collective="false" categoryEntryId="54726f6f707323232344415441232323" type="upgrade">
-      <profiles/>
-      <rules>
-        <rule id="e8133f1e-fcc9-f0e2-da0d-7226355341ed" name="Support Squad" book="HH:LACAL" page="33" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <description>May not fill the compulsory Troops slots on a Force Organization chart.</description>
-        </rule>
-      </rules>
-      <infoLinks>
-        <infoLink id="398c5706-f269-bd8b-d54e-2db78945cd59" hidden="false" targetId="d4a1a878-9ad4-6ae0-a864-08f58264c4a5" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <repeats/>
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="96bb-b11d-87e7-5408" type="atLeast"/>
-          </conditions>
-          <conditionGroups/>
-        </modifier>
-      </modifiers>
-      <constraints>
-        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-      </constraints>
-      <selectionEntries>
-        <selectionEntry id="70f738ac-f22d-9e10-c395-781534c8cb2a" name="Legion Space Marines" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="2e92c61f-10f5-7004-f8d7-27f07232e7d9" hidden="false" targetId="fbcef7de-124c-9b95-7895-480adc6bc027" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="15.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="e7c3ea79-4429-0a8f-b6c1-5734bec17f0a" name="Legion Sergeant" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="60d5e2f0-fcc6-9899-f27f-9386697b2753" hidden="false" targetId="b8d20a55-69ff-eb96-e080-8f495bf99283" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="b243d13d-c344-fdd8-9b14-b335e2ea2010" name="Artificer Armour" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="10.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="cee4abe0-f0f6-9c5b-a5b7-b7e8bd87567c" name="Melta Bombs" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="4c3cf3a6-8d0b-1edd-fffa-3b99c5f1c9e6" name="May take any of the following instead of their special weapon:" hidden="false" collective="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries>
-                <selectionEntry id="1ea56724-8cf7-7e3c-6ebd-c097635892bf" name="Close Combat Weapon" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups>
-                    <selectionEntryGroup id="ae04bcc3-2c51-9623-41b7-68704f7dc208" name="Exchange Chainsword/Combat Blade for:" hidden="false" collective="false">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <selectionEntries>
-                        <selectionEntry id="9e3a1328-053f-a611-87eb-cfd3cdb929df" name="Power Weapon" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                          <constraints>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                          </constraints>
-                          <selectionEntries/>
-                          <selectionEntryGroups/>
-                          <entryLinks/>
-                          <costs>
-                            <cost name="pts" costTypeId="points" value="10.0"/>
-                          </costs>
-                        </selectionEntry>
-                        <selectionEntry id="3af0667d-60ad-fdb8-5781-3873bd8cb2d3" name="Power Fist" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                          <constraints>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                          </constraints>
-                          <selectionEntries/>
-                          <selectionEntryGroups/>
-                          <entryLinks/>
-                          <costs>
-                            <cost name="pts" costTypeId="points" value="15.0"/>
-                          </costs>
-                        </selectionEntry>
-                        <selectionEntry id="5b1c3486-0dcb-cf88-9d90-b7edf917e52f" name="Single Lightning Claw" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                          <constraints>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                          </constraints>
-                          <selectionEntries/>
-                          <selectionEntryGroups/>
-                          <entryLinks/>
-                          <costs>
-                            <cost name="pts" costTypeId="points" value="15.0"/>
-                          </costs>
-                        </selectionEntry>
-                        <selectionEntry id="fb413293-9b14-17da-93fb-637f20d47448" name="Heavy Chainsword" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                          <constraints>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                          </constraints>
-                          <selectionEntries/>
-                          <selectionEntryGroups/>
-                          <entryLinks/>
-                          <costs>
-                            <cost name="pts" costTypeId="points" value="5.0"/>
-                          </costs>
-                        </selectionEntry>
-                      </selectionEntries>
-                      <selectionEntryGroups/>
-                      <entryLinks>
-                        <entryLink id="ba1cfb86-7e4d-c86d-ebb4-148e0be49a8a" hidden="false" targetId="30834ca2-20b0-cb5a-c7db-f76092533a64" type="selectionEntry">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers>
-                            <modifier type="set" field="points" value="15.0">
-                              <repeats/>
-                              <conditions/>
-                              <conditionGroups/>
-                            </modifier>
-                          </modifiers>
-                          <constraints/>
-                        </entryLink>
-                        <entryLink id="41d6d38c-2155-4cb9-36fc-200fa7a0439a" hidden="false" targetId="fa1c768d-9b24-bfbd-8dea-ec7b4ff72bb2" type="selectionEntry">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                          <constraints/>
-                        </entryLink>
-                        <entryLink id="d1618833-e28f-e848-85f6-906ef3f3a8dd" hidden="false" targetId="479f576b-b28d-801e-b928-d82431d554b9" type="selectionEntry">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers>
-                            <modifier type="set" field="points" value="15.0">
-                              <repeats/>
-                              <conditions/>
-                              <conditionGroups/>
-                            </modifier>
-                          </modifiers>
-                          <constraints/>
-                        </entryLink>
-                        <entryLink id="f7cf4520-df6e-8d77-c42b-63826b0334b4" hidden="false" targetId="6435afdc-d8b1-09a1-a82a-9d4d7af1c869" type="selectionEntry">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers>
-                            <modifier type="increment" field="points" value="15.0">
-                              <repeats/>
-                              <conditions/>
-                              <conditionGroups/>
-                            </modifier>
-                          </modifiers>
-                          <constraints/>
-                        </entryLink>
-                        <entryLink id="99044d63-2979-3727-18ce-3be3389fbfff" hidden="false" targetId="2acd15a3-57b3-6c4e-1199-0fa706a5b3d8" type="selectionEntry">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                          <constraints/>
-                        </entryLink>
-                        <entryLink id="b1d10581-7042-caba-f223-bbe242df00b5" hidden="false" targetId="c31253d0-d1b9-35ac-6435-f1a06611e356" type="selectionEntry">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                          <constraints/>
-                        </entryLink>
-                        <entryLink id="827c-164d-f510-3c8d" hidden="false" targetId="2767-2afe-31ac-5cca" type="selectionEntry">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                          <constraints/>
-                        </entryLink>
-                        <entryLink id="fcd4-ff89-d8df-8e78" hidden="false" targetId="5beb-0cde-90c1-0f88" type="selectionEntry">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                          <constraints/>
-                        </entryLink>
-                      </entryLinks>
-                    </selectionEntryGroup>
-                  </selectionEntryGroups>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="1450360a-63c8-73d8-7256-4b76ace9f23f" name="Combi-weapon" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="163a9c00-74be-03c5-fd3b-a39e7adb2ee8" name="Bolter and Augury Scanner" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="1151728c-99fb-8df7-1967-ccf3051e67d5" hidden="false" targetId="52c01c37-8d2a-043b-1225-c19562a840cb" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks>
-                    <entryLink id="32e1-f333-ce21-fac7" hidden="false" targetId="10c0-d162-c4f2-33c1" type="selectionEntry">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints/>
-                    </entryLink>
-                  </entryLinks>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups/>
-              <entryLinks/>
-            </selectionEntryGroup>
-            <selectionEntryGroup id="46d11d44-8c01-ebc5-0944-2a6ec523c116" name="Exchange bolt pistol for:" hidden="false" collective="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries>
-                <selectionEntry id="3254e6d3-026c-e687-91ca-70c7cfd0ed6f" name="Plasma Pistol" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="15.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="b813cc54-dc95-6de6-df3e-faaacd3f3d2f" hidden="false" targetId="82d4-9768-236a-2ea1" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <entryLinks>
-            <entryLink id="60322763-da8d-fb36-14c4-5aab127a1931" hidden="false" targetId="8b059b74-0029-efeb-ecc0-98a21dded43a" type="selectionEntryGroup">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </entryLink>
-          </entryLinks>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="a64c-5266-1c43-79da" name="Take an additional Chainsword or Combat Blade" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="increment" field="points" value="2">
-              <repeats>
-                <repeat field="selections" scope="d744f750-8ad0-c8f0-fb8d-81608f361be3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="70f738ac-f22d-9e10-c395-781534c8cb2a" repeats="1" roundUp="false"/>
-              </repeats>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9769-320f-9a42-7807" type="max"/>
-          </constraints>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="2.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="168e4d10-469b-2f94-cbe0-955293714837" name="Entire Squad may exchange their Flamers for:" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="edcb744a-2f36-39c0-83e4-403ae2c21e3c" name="Rotor Cannons" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="66e93bf0-894d-efc8-15e2-29293812b037" hidden="false" targetId="75683330-6490-c0bf-560c-2e58617425a1" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="b6a8233e-f450-9afb-1fba-f48e523c4fa1" name="Plasma Guns" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="increment" field="points" value="15.0">
-                  <repeats>
-                    <repeat field="selections" scope="d744f750-8ad0-c8f0-fb8d-81608f361be3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="70f738ac-f22d-9e10-c395-781534c8cb2a" repeats="1" roundUp="false"/>
-                  </repeats>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="points" value="15.0">
-                  <repeats/>
-                  <conditions>
-                    <condition field="selections" scope="d744f750-8ad0-c8f0-fb8d-81608f361be3" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4c3cf3a6-8d0b-1edd-fffa-3b99c5f1c9e6" type="equalTo"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="bf26bcf3-3b98-334b-ba1e-9fa691216715" name="Volkite Calivers" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="e54ade6b-cd86-93af-0a9b-8943dec097f5" hidden="false" targetId="402babca-fc14-e4b0-c135-a078ce95d036" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="6eb1b962-eb7b-8312-edfe-e99d00dfcb80" hidden="false" targetId="cbcf-5f25-f8ea-7cfd" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers>
-                <modifier type="increment" field="points" value="5.0">
-                  <repeats>
-                    <repeat field="selections" scope="d744f750-8ad0-c8f0-fb8d-81608f361be3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="70f738ac-f22d-9e10-c395-781534c8cb2a" repeats="1" roundUp="false"/>
-                  </repeats>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="points" value="5.0">
-                  <repeats/>
-                  <conditions>
-                    <condition field="selections" scope="d744f750-8ad0-c8f0-fb8d-81608f361be3" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4c3cf3a6-8d0b-1edd-fffa-3b99c5f1c9e6" type="equalTo"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="ddeb10e5-8562-7fa6-2ef6-6bb2cf57aaf9" name="Melta Guns" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="increment" field="points" value="15.0">
-                  <repeats>
-                    <repeat field="selections" scope="d744f750-8ad0-c8f0-fb8d-81608f361be3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="70f738ac-f22d-9e10-c395-781534c8cb2a" repeats="1" roundUp="false"/>
-                  </repeats>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="points" value="15.0">
-                  <repeats/>
-                  <conditions>
-                    <condition field="selections" scope="d744f750-8ad0-c8f0-fb8d-81608f361be3" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4c3cf3a6-8d0b-1edd-fffa-3b99c5f1c9e6" type="equalTo"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="987ee193-4c7e-00bc-5bd1-ff97eedf5de4" name="Volkite Chargers" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="09652709-6875-22c3-afd8-17959c0bb364" hidden="false" targetId="9c9de857-ac5e-11ff-ead6-1df8480d3f28" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="fb978155-496a-e644-bf66-909bef4f7131" hidden="false" targetId="cbcf-5f25-f8ea-7cfd" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="551a9116-2564-98cc-247b-93023857135a" name="Graviton Gun" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="increment" field="points" value="10.0">
-                  <repeats>
-                    <repeat field="selections" scope="d744f750-8ad0-c8f0-fb8d-81608f361be3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="70f738ac-f22d-9e10-c395-781534c8cb2a" repeats="1" roundUp="false"/>
-                  </repeats>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="set" field="hidden" value="true">
-                  <repeats/>
-                  <conditions>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="453c-94b8-1de5-9543" type="equalTo"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="points" value="10.0">
-                  <repeats/>
-                  <conditions>
-                    <condition field="selections" scope="d744f750-8ad0-c8f0-fb8d-81608f361be3" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4c3cf3a6-8d0b-1edd-fffa-3b99c5f1c9e6" type="equalTo"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="91a6-0a93-a1ee-d9bd" name="Plasma Repeaters" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="4135-c168-d505-a68a" hidden="false" targetId="27df-a056-0e1c-df76" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers>
-                <modifier type="set" field="hidden" value="true">
-                  <repeats/>
-                  <conditions>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ba9-caf3-cb76-cce9" type="equalTo"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="points" value="20.0">
-                  <repeats>
-                    <repeat field="selections" scope="d744f750-8ad0-c8f0-fb8d-81608f361be3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="70f738ac-f22d-9e10-c395-781534c8cb2a" repeats="1" roundUp="false"/>
-                  </repeats>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="points" value="20.0">
-                  <repeats/>
-                  <conditions>
-                    <condition field="selections" scope="d744f750-8ad0-c8f0-fb8d-81608f361be3" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4c3cf3a6-8d0b-1edd-fffa-3b99c5f1c9e6" type="equalTo"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups/>
-          <entryLinks/>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="63cd-3419-0333-a945" name="Legion-specific upgrade:" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="858a-eeda-9d8a-6372" hidden="false" targetId="86e70545-ed1a-7cf4-5a3d-d60662a6b3be" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </entryLink>
-            <entryLink id="5c0d-f589-0bcb-430f" hidden="false" targetId="f631-f1ad-3d62-ba74" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="set" field="hidden" value="true">
-                  <repeats/>
-                  <conditions>
-                    <condition field="selections" scope="d744f750-8ad0-c8f0-fb8d-81608f361be3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="168e4d10-469b-2f94-cbe0-955293714837" type="equalTo"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints/>
-            </entryLink>
-            <entryLink id="c2d0-ff39-bbd3-14a5" hidden="false" targetId="c443-ad53-4e61-77bc" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </entryLink>
-            <entryLink id="522f-6241-5ff8-f8db" hidden="false" targetId="cea6be0e-460b-ce44-90f4-b1b0159ee33c" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="set" field="points" value="25.0">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="set" field="hidden" value="true">
-                  <repeats/>
-                  <conditions>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d3a3-3f65-2193-bc1b" type="equalTo"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints/>
-            </entryLink>
-            <entryLink id="0f50-c538-43c6-ed9f" hidden="false" targetId="d8f4-1501-66fd-0477" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="increment" field="points" value="2.0">
-                  <repeats>
-                    <repeat field="selections" scope="d744f750-8ad0-c8f0-fb8d-81608f361be3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="70f738ac-f22d-9e10-c395-781534c8cb2a" repeats="1" roundUp="false"/>
-                  </repeats>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints/>
-            </entryLink>
-            <entryLink id="3a78-2716-d3f2-fd73" hidden="false" targetId="679b7bea-d780-dcba-46a2-05fbc83cabed" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="set" field="points" value="15.0">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="set" field="hidden" value="true">
-                  <repeats/>
-                  <conditions>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="54e9-7ade-668b-8f8d" type="equalTo"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="d1b24eb8-e467-12f7-d9b7-36a4a4d7b1aa" hidden="false" targetId="571b8787-f049-c91a-f5c2-136ff022621e" type="selectionEntryGroup">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </entryLink>
-        <entryLink id="3cd80c6e-9667-5ae9-6573-f60e284d90f0" hidden="false" targetId="86e70545-ed1a-7cf4-5a3d-d60662a6b3be" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </entryLink>
-        <entryLink id="10ea-8273-193d-f2b8" hidden="false" targetId="c443-ad53-4e61-77bc" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </entryLink>
-        <entryLink id="6d94-35b4-0e43-c75d" hidden="false" targetId="f631-f1ad-3d62-ba74" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <repeats/>
-              <conditions>
-                <condition field="selections" scope="d744f750-8ad0-c8f0-fb8d-81608f361be3" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="168e4d10-469b-2f94-cbe0-955293714837" type="greaterThan"/>
-              </conditions>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints/>
-        </entryLink>
-        <entryLink id="c5b9-912f-c699-fc5e" hidden="false" targetId="c487-be13-ea53-917e" type="selectionEntryGroup">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </entryLink>
-        <entryLink id="7376-3121-5ce6-5776" name="New EntryLink" hidden="false" targetId="04c4-8239-657a-ced2" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </entryLink>
-      </entryLinks>
-      <costs>
-        <cost name="pts" costTypeId="points" value="40.0"/>
-      </costs>
-    </selectionEntry>
     <selectionEntry id="d3368d47-6e25-aa3a-6e32-0b3b0d75ccb7" name="Legion Thunderhawk Gunship" book="HH:LACAL" page="73" hidden="false" collective="false" categoryEntryId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" type="unit">
       <profiles>
         <profile id="7bb67a41-0939-273a-674f-6234fe31795f" name="Legion Thunderhawk Gunship" book="HH:LACAL" page="73" hidden="false" profileTypeId="56656869636c6523232344415441232323">
@@ -32810,6 +32009,21 @@ Ignores Cover special rule.</description>
       <rules/>
       <infoLinks/>
       <modifiers/>
+      <constraints/>
+    </entryLink>
+    <entryLink id="faff-c329-9b8c-9e43" name="Legion Tactical Support Squad" hidden="false" targetId="52d1-4d3f-902a-4ca8" type="selectionEntry" categoryEntryId="54726f6f707323232344415441232323">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <repeats/>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="96bb-b11d-87e7-5408" type="atLeast"/>
+          </conditions>
+          <conditionGroups/>
+        </modifier>
+      </modifiers>
       <constraints/>
     </entryLink>
   </entryLinks>
@@ -46395,7 +45609,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
       <selectionEntries>
         <selectionEntry id="1d99-6882-36e4-64f3" name="Legion Seeker Space Marines" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
           <profiles>
-            <profile id="91af-1293-f3b8-dd56" name="d" book="AL:AoDAL" page="48" hidden="false" profileTypeId="556e697423232344415441232323">
+            <profile id="91af-1293-f3b8-dd56" name="Legion Seeker Space Marine" book="AL:AoDAL" page="48" hidden="false" profileTypeId="556e697423232344415441232323">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -50327,8 +49541,8 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
           <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6067-df83-eb5e-7532" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2a07-adae-22df-c86c" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6067-df83-eb5e-7532" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2a07-adae-22df-c86c" type="min"/>
           </constraints>
           <selectionEntries/>
           <selectionEntryGroups/>
@@ -54461,7 +53675,7 @@ Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit wit
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
       </constraints>
       <selectionEntries/>
       <selectionEntryGroups/>
@@ -69388,6 +68602,943 @@ differently armed Sentry Guns to fire at two separate targets.</description>
       <costs>
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
+    </selectionEntry>
+    <selectionEntry id="52d1-4d3f-902a-4ca8" name="Legion Tactical Support Squad" book="HH:LACAL" page="33" hidden="false" collective="false" categoryEntryId="54726f6f707323232344415441232323" type="upgrade">
+      <profiles/>
+      <rules>
+        <rule id="c412-124c-df5b-26f0" name="Support Squad" book="HH:LACAL" page="33" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <description>May not fill the compulsory Troops slots on a Force Organization chart.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="8c88-1ea3-f7a9-07fc" hidden="false" targetId="d4a1a878-9ad4-6ae0-a864-08f58264c4a5" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1940-e10e-daf9-274f" type="min"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="4a60-31b8-7df5-7ee0" name="Legion Space Marines" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="330f-0ada-6045-0ee3" hidden="false" targetId="fbcef7de-124c-9b95-7895-480adc6bc027" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="88d6-c9cb-630d-ef7f" type="min"/>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2cd0-65f4-325f-8606" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="15.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="8811-1c6c-5bad-5054" name="Legion Sergeant" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="5551-dff1-7aa6-31d9" hidden="false" targetId="b8d20a55-69ff-eb96-e080-8f495bf99283" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="5361766523232344415441232323" value="2+">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="8811-1c6c-5bad-5054" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3b19-2f64-00f1-946e" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1641-529f-dba9-89cd" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f0ef-228b-2f0b-53ef" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="6461-6543-83d0-2012" name="Exchange Flamer for:" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="52d1-4d3f-902a-4ca8" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5ed9-249c-d3be-f4b4" type="lessThan"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c31c-e507-57db-5ff9" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="e565-2197-4381-bc4a" name="Close Combat Weapon" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="426f-8edc-b2d9-7812" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups>
+                    <selectionEntryGroup id="8845-4fe3-12c1-9b63" name="Exchange Chainsword/Combat Blade for:" hidden="false" collective="false">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="95c7-d60e-1f92-48eb" type="max"/>
+                      </constraints>
+                      <selectionEntries/>
+                      <selectionEntryGroups/>
+                      <entryLinks>
+                        <entryLink id="dde0-f355-3b6f-917f" hidden="false" targetId="30834ca2-20b0-cb5a-c7db-f76092533a64" type="selectionEntry">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers>
+                            <modifier type="set" field="points" value="15">
+                              <repeats/>
+                              <conditions/>
+                              <conditionGroups/>
+                            </modifier>
+                          </modifiers>
+                          <constraints/>
+                        </entryLink>
+                        <entryLink id="dad2-21dc-f538-3416" hidden="false" targetId="fa1c768d-9b24-bfbd-8dea-ec7b4ff72bb2" type="selectionEntry">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints/>
+                        </entryLink>
+                        <entryLink id="16d2-e1a8-91d9-71d0" hidden="false" targetId="479f576b-b28d-801e-b928-d82431d554b9" type="selectionEntry">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers>
+                            <modifier type="set" field="points" value="15.0">
+                              <repeats/>
+                              <conditions/>
+                              <conditionGroups/>
+                            </modifier>
+                          </modifiers>
+                          <constraints/>
+                        </entryLink>
+                        <entryLink id="2f5f-2aa7-935c-dff1" hidden="false" targetId="6435afdc-d8b1-09a1-a82a-9d4d7af1c869" type="selectionEntry">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers>
+                            <modifier type="increment" field="points" value="15.0">
+                              <repeats/>
+                              <conditions/>
+                              <conditionGroups/>
+                            </modifier>
+                          </modifiers>
+                          <constraints/>
+                        </entryLink>
+                        <entryLink id="ec12-590a-836c-3992" hidden="false" targetId="2acd15a3-57b3-6c4e-1199-0fa706a5b3d8" type="selectionEntry">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints/>
+                        </entryLink>
+                        <entryLink id="f96c-d2ff-ddf9-261a" hidden="false" targetId="c31253d0-d1b9-35ac-6435-f1a06611e356" type="selectionEntry">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints/>
+                        </entryLink>
+                        <entryLink id="a92d-2d51-fdac-aabe" hidden="false" targetId="2767-2afe-31ac-5cca" type="selectionEntry">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints/>
+                        </entryLink>
+                        <entryLink id="7b18-12e9-406b-f9d5" hidden="false" targetId="5beb-0cde-90c1-0f88" type="selectionEntry">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints/>
+                        </entryLink>
+                        <entryLink id="b2d6-a92e-460f-5679" name="New EntryLink" hidden="false" targetId="fcef-f5ac-16a3-9401" type="selectionEntry">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints/>
+                        </entryLink>
+                        <entryLink id="e882-f441-8618-5bbc" name="New EntryLink" hidden="false" targetId="e890-52eb-3444-c6c7" type="selectionEntry">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints/>
+                        </entryLink>
+                        <entryLink id="60b8-0c1f-8f40-4e3c" name="New EntryLink" hidden="false" targetId="26db-484d-3757-03c8" type="selectionEntry">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints/>
+                        </entryLink>
+                        <entryLink id="4e95-bbd5-7efc-e020" name="New EntryLink" hidden="false" targetId="5b38-76dd-5272-3d95" type="selectionEntry">
+                          <profiles/>
+                          <rules/>
+                          <infoLinks/>
+                          <modifiers/>
+                          <constraints/>
+                        </entryLink>
+                      </entryLinks>
+                    </selectionEntryGroup>
+                  </selectionEntryGroups>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="dfba-69bd-d626-8423" name="Bolter and Augury Scanner" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="65b1-0fb1-b923-16e5" hidden="false" targetId="52c01c37-8d2a-043b-1225-c19562a840cb" type="profile">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="91f7-f113-f3a4-debe" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="6228-8922-6e88-2a87" hidden="false" targetId="75906716-f8ed-ecdd-0d25-57cf99a189c8" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </entryLink>
+                  </entryLinks>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="4671-ebce-1d95-51c6" name="New EntryLink" hidden="false" targetId="a329-9d2f-3a3d-d9eb" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="2767-c298-8d96-6cc2" name="Exchange bolt pistol for:" hidden="false" collective="false" defaultSelectionEntryId="d20d-8d85-7fcd-968e">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5382-fc48-e9d9-bd0a" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ebca-b479-f872-6733" type="min"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="6e05-5803-2447-b5bf" name="" hidden="false" targetId="82d4-9768-236a-2ea1" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="5863-78cd-77a6-7809" name="New EntryLink" hidden="false" targetId="f832-f4b2-6aaf-ad83" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="d20d-8d85-7fcd-968e" name="New EntryLink" hidden="false" targetId="c3db-f1a4-194f-835e" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="546f-9074-0e7e-81af" name="Exchange additional Chainsword/Combat Blade for:" hidden="true" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="52d1-4d3f-902a-4ca8" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="be28-016f-9840-e483" type="greaterThan"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a9b5-057e-8d31-8682" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8331-2949-f62e-29d4" type="min"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="85c4-1272-560d-4e09" hidden="false" targetId="30834ca2-20b0-cb5a-c7db-f76092533a64" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="set" field="points" value="15">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="7a01-dc0b-9730-2bd0" hidden="false" targetId="fa1c768d-9b24-bfbd-8dea-ec7b4ff72bb2" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="ad8b-b9cd-f056-ffde" hidden="false" targetId="479f576b-b28d-801e-b928-d82431d554b9" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="set" field="points" value="15.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="5039-5965-bf7f-302b" hidden="false" targetId="6435afdc-d8b1-09a1-a82a-9d4d7af1c869" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="15.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="dd31-a768-3c70-e9d1" hidden="false" targetId="2acd15a3-57b3-6c4e-1199-0fa706a5b3d8" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="fc37-e476-6ced-71a3" hidden="false" targetId="c31253d0-d1b9-35ac-6435-f1a06611e356" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="bf8f-7c7c-4fc9-b235" hidden="false" targetId="2767-2afe-31ac-5cca" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="5a58-0ed8-ef3e-c06f" hidden="false" targetId="5beb-0cde-90c1-0f88" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="86a0-6ad3-f2f1-124f" name="New EntryLink" hidden="false" targetId="fcef-f5ac-16a3-9401" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="9d62-b938-a4a2-e519" name="New EntryLink" hidden="false" targetId="e890-52eb-3444-c6c7" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="b3b0-5b89-875a-4c0f" name="New EntryLink" hidden="false" targetId="26db-484d-3757-03c8" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="e121-4008-c4a7-85fe" name="New EntryLink" hidden="false" targetId="5b38-76dd-5272-3d95" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="6944-fbe0-c26b-831d" hidden="false" targetId="8b059b74-0029-efeb-ecc0-98a21dded43a" type="selectionEntryGroup">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="3b19-2f64-00f1-946e" name="New EntryLink" hidden="false" targetId="dd74-ccdb-9bc6-7069" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="a821-7a3c-df6c-5fc5" name="New EntryLink" hidden="false" targetId="4c62-8983-4a1b-d1c6" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="cfff-36d4-2921-6fd8" name="Standard Wargear" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0e8a-7d37-4221-c11c" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d8e4-ce72-4474-f0f3" type="min"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="6bf9-90b6-5dcf-a787" name="New EntryLink" hidden="false" targetId="0a96-04b6-7340-91a4" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="b214-fb7c-5e63-3fe5" name="New EntryLink" hidden="false" targetId="0a53-b471-df87-7b83" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="ce21-4e7c-3813-8d03" name="New EntryLink" hidden="false" targetId="fe8d-1baa-d58d-00bc" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="aab8-a521-f5fb-48ec" name="Additional Wargear" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b99a-c74e-2bed-f30c" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e82c-78b7-01bc-efca" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="be28-016f-9840-e483" name="Take an additional Chainsword or Combat Blade" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="2">
+                  <repeats>
+                    <repeat field="selections" scope="52d1-4d3f-902a-4ca8" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4a60-31b8-7df5-7ee0" repeats="1" roundUp="false"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f62-eddb-cf46-3790" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="2.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs/>
+        </selectionEntry>
+        <selectionEntry id="140a-3cfc-589a-1645" name="Entire Squad may exchange their Flamers for:" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="72d1-dc99-129c-6abc" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9e07-fd69-5799-f000" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="b83c-eaab-0a84-2ace" name="Entire Squad may exchange their Flamers for:" hidden="false" collective="false" defaultSelectionEntryId="5ed9-249c-d3be-f4b4">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d35f-9488-bc0e-42ae" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="42bb-fd84-aedd-5ed9" type="min"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="fc8c-bb50-e7d7-5b93" name="New EntryLink" hidden="false" targetId="2075c6c6-b54d-2d3e-fce9-0543efa392f8" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="21c6-10c4-f16f-009e" name="New EntryLink" hidden="false" targetId="7677dd1e-d159-6a47-ab20-ed0d7e70a0e7" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="5">
+                      <repeats>
+                        <repeat field="selections" scope="52d1-4d3f-902a-4ca8" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4a60-31b8-7df5-7ee0" repeats="1" roundUp="false"/>
+                      </repeats>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                    <modifier type="increment" field="points" value="5">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="86f3-83e0-24d8-7cb7" name="New EntryLink" hidden="false" targetId="fe75-7b06-f9a5-26bd" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="e4e0-cde1-70ea-afc0" name="New EntryLink" hidden="false" targetId="d4e8-6e08-581a-79bd" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <repeats/>
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ba9-caf3-cb76-cce9" type="equalTo"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </modifier>
+                    <modifier type="increment" field="points" value="20">
+                      <repeats>
+                        <repeat field="selections" scope="52d1-4d3f-902a-4ca8" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4a60-31b8-7df5-7ee0" repeats="1" roundUp="false"/>
+                      </repeats>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                    <modifier type="increment" field="points" value="20">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="f2fa-3bfd-69c1-26b1" name="New EntryLink" hidden="false" targetId="0d3c-2b57-247d-548d" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <repeats/>
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="453c-94b8-1de5-9543" type="equalTo"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </modifier>
+                    <modifier type="increment" field="points" value="10">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                    <modifier type="increment" field="points" value="10">
+                      <repeats>
+                        <repeat field="selections" scope="52d1-4d3f-902a-4ca8" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4a60-31b8-7df5-7ee0" repeats="1" roundUp="false"/>
+                      </repeats>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="e4bc-a545-4d48-b36d" name="New EntryLink" hidden="false" targetId="388c-90c1-e42e-940a" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="15">
+                      <repeats>
+                        <repeat field="selections" scope="52d1-4d3f-902a-4ca8" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4a60-31b8-7df5-7ee0" repeats="1" roundUp="false"/>
+                      </repeats>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                    <modifier type="increment" field="points" value="15">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="df49-3e78-1ede-9c86" name="New EntryLink" hidden="false" targetId="2ad0-a760-1091-e8dd" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="15">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                    <modifier type="increment" field="points" value="15">
+                      <repeats>
+                        <repeat field="selections" scope="52d1-4d3f-902a-4ca8" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4a60-31b8-7df5-7ee0" repeats="1" roundUp="false"/>
+                      </repeats>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="5ed9-249c-d3be-f4b4" name="New EntryLink" hidden="false" targetId="6dbf-3640-dfac-0bc1" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs/>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="299c-e1de-57de-7d39" name="Legion-specific upgrade:" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="4f65-a4d4-f146-4a0c" hidden="false" targetId="86e70545-ed1a-7cf4-5a3d-d60662a6b3be" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="a85b-4a65-0372-0a67" hidden="false" targetId="f631-f1ad-3d62-ba74" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="274a-5c0d-319b-a20d" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="a543-8b8e-f66f-dbf8" hidden="false" targetId="c443-ad53-4e61-77bc" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="d2b9-607f-3826-b401" hidden="false" targetId="cea6be0e-460b-ce44-90f4-b1b0159ee33c" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="25.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d3a3-3f65-2193-bc1b" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="9e57-aae2-6490-f333" hidden="false" targetId="d8f4-1501-66fd-0477" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="2">
+                  <repeats>
+                    <repeat field="selections" scope="52d1-4d3f-902a-4ca8" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4a60-31b8-7df5-7ee0" repeats="1" roundUp="false"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="9b2e-d238-c23a-b0b8" hidden="false" targetId="679b7bea-d780-dcba-46a2-05fbc83cabed" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="15.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="54e9-7ade-668b-8f8d" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="fc36-3105-b2ce-471f" hidden="false" targetId="571b8787-f049-c91a-f5c2-136ff022621e" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="c1c1-9315-015d-ab1e" hidden="false" targetId="c487-be13-ea53-917e" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="7c04-426d-1174-da25" name="New EntryLink" hidden="false" targetId="04c4-8239-657a-ced2" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="40.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="c3db-f1a4-194f-835e" name="Bolt Pistol" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="2d4a-b117-e83b-b52a" name="New InfoLink" hidden="false" targetId="ec83-0776-ef74-9cc2" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5c57-6712-9845-5c94" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="424b-daaf-bc0d-63b4" type="min"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5b38-76dd-5272-3d95" name="Heavy Chainsword" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="ce17-0465-7e77-16d0" name="New InfoLink" hidden="false" targetId="0fef-f304-fdfe-b082" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1081-d7bc-c52c-3722" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="5.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="388c-90c1-e42e-940a" name="Plasma gun" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="cb36-869e-bc3e-15fc" name="New InfoLink" hidden="false" targetId="f4fd-d519-4769-5510" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="9569-8960-5159-23b8" name="New InfoLink" hidden="false" targetId="87c7-bd37-70f7-1933" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9a37-0c54-e6bc-3a9a" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="15.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2ad0-a760-1091-e8dd" name="Meltagun" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="1bae-8d3c-3f4a-1b97" name="New InfoLink" hidden="false" targetId="21c0-62ff-3ed2-17a7" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="5d24-75d1-ffef-7d1e" name="New InfoLink" hidden="false" targetId="8ae4-74e5-7700-3804" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9a31-0ec5-9261-b3d2" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="15.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6dbf-3640-dfac-0bc1" name="Flamer" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="5bfd-362b-21de-6c88" name="New InfoLink" hidden="false" targetId="3a71-7de1-1948-3655" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b347-509e-dea1-aa87" type="max"/>
+        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="cd9e-3857-b7d6-58e5" type="min"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs/>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>

--- a/(HH) Mechanicum - Questoris Knight.cat
+++ b/(HH) Mechanicum - Questoris Knight.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="32d1ddc6-3187-cf6f-3bf8-9891e527a002" name="Questoris Knight Crusade Army" book="HH4: Conquest" revision="20" battleScribeVersion="2.00" authorName="Millicant" authorContact="Please submit any bugs to the website" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="27" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="32d1ddc6-3187-cf6f-3bf8-9891e527a002" name="Questoris Knight Crusade Army" book="HH4: Conquest" revision="21" battleScribeVersion="2.00" authorName="Millicant" authorContact="Please submit any bugs to the website" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="27" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules/>
   <infoLinks/>
@@ -66,24 +66,6 @@ Attacking player rolls 2D6.  If the target has a Toughness characteristic, they 
           <modifiers/>
           <description>All units with the Walker, Super-heavy Walker, or Monstrous Creature types in the same detachment as the Warlord gain +1 to their  charge distances and sweeping advance rolls.  </description>
         </rule>
-        <rule id="7981b556-07bf-b8e8-dbfa-5c906c6d60ad" name="Stubborn" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </rule>
-        <rule id="199bbd2f-d842-0d33-55d4-d9ddc2918000" name="Fear" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </rule>
-        <rule id="9dd266f6-c612-1cf9-29b9-b5481986e74e" name="Relentless" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </rule>
       </rules>
       <infoLinks>
         <infoLink id="b738b043-7e9e-cb9e-669f-d243e65c6c22" hidden="false" targetId="f4750e31-0624-912a-bf07-7a1febca222e" type="profile">
@@ -116,6 +98,24 @@ Attacking player rolls 2D6.  If the target has a Toughness characteristic, they 
           <infoLinks/>
           <modifiers/>
         </infoLink>
+        <infoLink id="f6ae-a06f-4c00-95a3" name="New InfoLink" hidden="false" targetId="52ff-4074-570b-4ea1" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="ff55-1dbc-8920-efb0" name="New InfoLink" hidden="false" targetId="7be5-30af-1a02-0a89" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="7ad7-b50a-ef3b-143f" name="New InfoLink" hidden="false" targetId="3c7d-a1fa-c68b-caad" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
       </infoLinks>
       <modifiers/>
       <constraints>
@@ -135,20 +135,7 @@ Attacking player rolls 2D6.  If the target has a Toughness characteristic, they 
           <selectionEntries>
             <selectionEntry id="10035625-80f1-4b62-0eab-047edbecd95f" name="Cyber-occularis" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
               <profiles/>
-              <rules>
-                <rule id="0fb43c07-a9a3-34ea-e227-67a4241317fc" name="Fearless" page="0" hidden="false">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </rule>
-                <rule id="70e41028-7295-b12f-af8e-c6d0a39da114" name="Stealth" page="0" hidden="false">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </rule>
-              </rules>
+              <rules/>
               <infoLinks>
                 <infoLink id="cf50fabc-e374-fb4c-f619-b479050abe2e" hidden="false" targetId="dd4fa1b2-43b4-75d6-974c-83c1a4115c07" type="profile">
                   <profiles/>
@@ -163,6 +150,18 @@ Attacking player rolls 2D6.  If the target has a Toughness characteristic, they 
                   <modifiers/>
                 </infoLink>
                 <infoLink id="2085981f-d80e-7beb-1e60-ac4c292dbba9" hidden="false" targetId="5a6e2a63-286a-a771-587c-6a41724b1e6b" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="36fd-79b6-7d4c-fb63" name="New InfoLink" hidden="false" targetId="dc70-e199-5525-e78c" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="bf23-6e7c-e7ed-e647" name="New InfoLink" hidden="false" targetId="0d66-14c9-d2f4-708b" type="rule">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -239,7 +238,7 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
       <infoLinks/>
       <modifiers/>
       <constraints>
-        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxInForce" type="max"/>
       </constraints>
       <selectionEntries/>
       <selectionEntryGroups/>
@@ -274,7 +273,7 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="7f7494d8-c89f-4fc1-3dcb-a724d4a5d78f" hidden="false" targetId="e7d545a4-223a-6760-efa4-f585181bb08a" type="rule">
+        <infoLink id="7f7494d8-c89f-4fc1-3dcb-a724d4a5d78f" hidden="false" targetId="f6c9-cdb7-c695-5b6b" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -405,7 +404,7 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
               <modifiers>
                 <modifier type="set" field="maxSelections" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="858c73cb-9b65-bde1-7ce6-bdf84b5b03e2" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c7a37b0d-67db-f4a7-4d0b-c9cbba67a349" repeats="1"/>
+                    <repeat field="selections" scope="858c73cb-9b65-bde1-7ce6-bdf84b5b03e2" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c7a37b0d-67db-f4a7-4d0b-c9cbba67a349" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -475,7 +474,7 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
                       <infoLinks/>
                       <modifiers/>
                     </infoLink>
-                    <infoLink id="e6ceba24-7630-12d3-3d83-9f73f113409c" hidden="false" targetId="283aab20-3917-4fe6-dec8-5fae4245c517" type="rule">
+                    <infoLink id="e6ceba24-7630-12d3-3d83-9f73f113409c" hidden="false" targetId="fe2f-3220-3fef-b177" type="rule">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -519,7 +518,7 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
               <modifiers>
                 <modifier type="increment" field="points" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="a6c1ae81-5a6b-c042-4e8f-b44b34b8ee05" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="858c73cb-9b65-bde1-7ce6-bdf84b5b03e2" repeats="1"/>
+                    <repeat field="selections" scope="a6c1ae81-5a6b-c042-4e8f-b44b34b8ee05" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="858c73cb-9b65-bde1-7ce6-bdf84b5b03e2" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -549,7 +548,7 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
               <modifiers>
                 <modifier type="increment" field="points" value="5.0">
                   <repeats>
-                    <repeat field="selections" scope="a6c1ae81-5a6b-c042-4e8f-b44b34b8ee05" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="858c73cb-9b65-bde1-7ce6-bdf84b5b03e2" repeats="1"/>
+                    <repeat field="selections" scope="a6c1ae81-5a6b-c042-4e8f-b44b34b8ee05" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="858c73cb-9b65-bde1-7ce6-bdf84b5b03e2" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -572,7 +571,7 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
               <modifiers>
                 <modifier type="increment" field="points" value="5.0">
                   <repeats>
-                    <repeat field="selections" scope="a6c1ae81-5a6b-c042-4e8f-b44b34b8ee05" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="858c73cb-9b65-bde1-7ce6-bdf84b5b03e2" repeats="1"/>
+                    <repeat field="selections" scope="a6c1ae81-5a6b-c042-4e8f-b44b34b8ee05" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="858c73cb-9b65-bde1-7ce6-bdf84b5b03e2" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -602,7 +601,7 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
               <modifiers>
                 <modifier type="increment" field="points" value="15.0">
                   <repeats>
-                    <repeat field="selections" scope="a6c1ae81-5a6b-c042-4e8f-b44b34b8ee05" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="858c73cb-9b65-bde1-7ce6-bdf84b5b03e2" repeats="1"/>
+                    <repeat field="selections" scope="a6c1ae81-5a6b-c042-4e8f-b44b34b8ee05" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="858c73cb-9b65-bde1-7ce6-bdf84b5b03e2" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -2621,14 +2620,15 @@ D6    Result		S	AP
           <modifiers/>
           <description>The weapons-mounts and targeting systems of a Knight Arbalester have been finely attuned by their pilot and are extremely responsive to their skills. The Knight has the Tank Hunters special rule and, in addition, so long as it has not moved in the preceding Movement phase, it may, if its controlling player wishes, count all its weapons as having the Skyfire special rule in the Shooting phase.</description>
         </rule>
-        <rule id="7145-f6e9-44f0-69b2" name="Tank Hunters" hidden="false">
+      </rules>
+      <infoLinks>
+        <infoLink id="4453-6d55-fb09-b1e2" name="New InfoLink" hidden="false" targetId="5d88-bcf6-e410-6e01" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-        </rule>
-      </rules>
-      <infoLinks/>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
       <constraints/>
       <selectionEntries/>
@@ -2675,63 +2675,63 @@ D6    Result		S	AP
       <modifiers>
         <modifier type="increment" field="maxInForce" value="1.0">
           <repeats>
-            <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5053f8a2-cc7f-f635-1044-b149aed1513e" repeats="1"/>
+            <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5053f8a2-cc7f-f635-1044-b149aed1513e" repeats="1" roundUp="false"/>
           </repeats>
           <conditions/>
           <conditionGroups/>
         </modifier>
         <modifier type="increment" field="maxInForce" value="1.0">
           <repeats>
-            <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0374f5e8-736f-e990-acd5-75cb44d303a1" repeats="1"/>
+            <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0374f5e8-736f-e990-acd5-75cb44d303a1" repeats="1" roundUp="false"/>
           </repeats>
           <conditions/>
           <conditionGroups/>
         </modifier>
         <modifier type="increment" field="maxInForce" value="1.0">
           <repeats>
-            <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5137fc47-e383-8e21-a01a-cdf4cbb73094" repeats="1"/>
+            <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5137fc47-e383-8e21-a01a-cdf4cbb73094" repeats="1" roundUp="false"/>
           </repeats>
           <conditions/>
           <conditionGroups/>
         </modifier>
         <modifier type="increment" field="maxInForce" value="1.0">
           <repeats>
-            <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c9c2bc37-7048-4ed5-80c0-fb13d224f96a" repeats="1"/>
+            <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c9c2bc37-7048-4ed5-80c0-fb13d224f96a" repeats="1" roundUp="false"/>
           </repeats>
           <conditions/>
           <conditionGroups/>
         </modifier>
         <modifier type="increment" field="maxInForce" value="1.0">
           <repeats>
-            <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="48ee846f-5f68-d83d-4f9a-e1a797dc1cd1" repeats="1"/>
+            <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="48ee846f-5f68-d83d-4f9a-e1a797dc1cd1" repeats="1" roundUp="false"/>
           </repeats>
           <conditions/>
           <conditionGroups/>
         </modifier>
         <modifier type="increment" field="maxInForce" value="1.0">
           <repeats>
-            <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="97fcca37-2121-18e9-f084-4f254332c535" repeats="1"/>
+            <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="97fcca37-2121-18e9-f084-4f254332c535" repeats="1" roundUp="false"/>
           </repeats>
           <conditions/>
           <conditionGroups/>
         </modifier>
         <modifier type="increment" field="maxInForce" value="1.0">
           <repeats>
-            <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a9b3942b-357b-159d-698d-73661a1f3bff" repeats="1"/>
+            <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a9b3942b-357b-159d-698d-73661a1f3bff" repeats="1" roundUp="false"/>
           </repeats>
           <conditions/>
           <conditionGroups/>
         </modifier>
         <modifier type="increment" field="maxInForce" value="1.0">
           <repeats>
-            <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1eb55824-68fb-ea4f-b5dd-5838cdfa3afc" repeats="1"/>
+            <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1eb55824-68fb-ea4f-b5dd-5838cdfa3afc" repeats="1" roundUp="false"/>
           </repeats>
           <conditions/>
           <conditionGroups/>
         </modifier>
         <modifier type="increment" field="maxInForce" value="1.0">
           <repeats>
-            <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="33d55e37-58db-535e-ffb4-0c9136c15e25" repeats="1"/>
+            <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="33d55e37-58db-535e-ffb4-0c9136c15e25" repeats="1" roundUp="false"/>
           </repeats>
           <conditions/>
           <conditionGroups/>
@@ -2872,12 +2872,6 @@ D6    Result		S	AP
           <modifiers/>
           <description>Scions Uhlan commonly deride long-range bombardment as a dishonorable mode of warfare unbecoming of a Scion of a Great House and, despite orders to contrary, the suffer such a mode of attack with ill-grace. Scions Uhlan may only make Snap Shots with their weapons at targets greater than 24&quot; away.</description>
         </rule>
-        <rule id="15b0-5347-1b80-8dd5" name="Scout" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </rule>
         <rule id="439b-6d0c-4981-2dd2" name="Hit and Run" hidden="false">
           <profiles/>
           <rules/>
@@ -2885,7 +2879,14 @@ D6    Result		S	AP
           <modifiers/>
         </rule>
       </rules>
-      <infoLinks/>
+      <infoLinks>
+        <infoLink id="a160-e3b7-a44b-c49f" name="New InfoLink" hidden="false" targetId="9b30-1da3-eb8d-ce7a" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
       <constraints/>
       <selectionEntries/>
@@ -2943,20 +2944,7 @@ D6    Result		S	AP
     </selectionEntry>
     <selectionEntry id="4a0b28c7-df94-5836-dd56-fef0e4f8fe70" name="Vorax Class Battle-automata Maniple" book="HH3: Extermination" page="226" hidden="false" collective="false" categoryEntryId="466173742041747461636b23232344415441232323" type="unit">
       <profiles/>
-      <rules>
-        <rule id="7be41e14-ddfb-a700-a311-131942004a8f" name="Fleet" page="0" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </rule>
-        <rule id="9cb07bd3-d966-2c0e-de69-81edf9df8eb1" name="Scout" page="0" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </rule>
-      </rules>
+      <rules/>
       <infoLinks>
         <infoLink id="30e8e454-bf8d-c1c1-fc83-1b3c64a748fe" hidden="false" targetId="9221f401-6459-1e62-00fc-cd39eb567d88" type="profile">
           <profiles/>
@@ -2982,7 +2970,19 @@ D6    Result		S	AP
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="1e4a327b-252e-7cf3-4e9a-b90c5d04c159" hidden="false" targetId="e7d545a4-223a-6760-efa4-f585181bb08a" type="rule">
+        <infoLink id="1e4a327b-252e-7cf3-4e9a-b90c5d04c159" hidden="false" targetId="f6c9-cdb7-c695-5b6b" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="1dbd-dec8-a5a0-5ce2" name="New InfoLink" hidden="false" targetId="69e5-fc02-1f9d-63c2" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="338c-d648-51cf-fd22" name="New InfoLink" hidden="false" targetId="9b30-1da3-eb8d-ce7a" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -3053,7 +3053,7 @@ D6    Result		S	AP
               <modifiers>
                 <modifier type="increment" field="points" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="4a0b28c7-df94-5836-dd56-fef0e4f8fe70" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7345cda3-55f4-46ee-eb0e-02963b4f63c3" repeats="1"/>
+                    <repeat field="selections" scope="4a0b28c7-df94-5836-dd56-fef0e4f8fe70" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7345cda3-55f4-46ee-eb0e-02963b4f63c3" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -3076,7 +3076,7 @@ D6    Result		S	AP
               <modifiers>
                 <modifier type="increment" field="points" value="5.0">
                   <repeats>
-                    <repeat field="selections" scope="4a0b28c7-df94-5836-dd56-fef0e4f8fe70" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7345cda3-55f4-46ee-eb0e-02963b4f63c3" repeats="1"/>
+                    <repeat field="selections" scope="4a0b28c7-df94-5836-dd56-fef0e4f8fe70" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7345cda3-55f4-46ee-eb0e-02963b4f63c3" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -3106,7 +3106,7 @@ D6    Result		S	AP
               <modifiers>
                 <modifier type="increment" field="points" value="15.0">
                   <repeats>
-                    <repeat field="selections" scope="4a0b28c7-df94-5836-dd56-fef0e4f8fe70" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7345cda3-55f4-46ee-eb0e-02963b4f63c3" repeats="1"/>
+                    <repeat field="selections" scope="4a0b28c7-df94-5836-dd56-fef0e4f8fe70" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7345cda3-55f4-46ee-eb0e-02963b4f63c3" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -3133,7 +3133,7 @@ D6    Result		S	AP
           <modifiers>
             <modifier type="increment" field="maxSelections" value="1.0">
               <repeats>
-                <repeat field="selections" scope="4a0b28c7-df94-5836-dd56-fef0e4f8fe70" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7345cda3-55f4-46ee-eb0e-02963b4f63c3" repeats="1"/>
+                <repeat field="selections" scope="4a0b28c7-df94-5836-dd56-fef0e4f8fe70" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7345cda3-55f4-46ee-eb0e-02963b4f63c3" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -3247,6 +3247,85 @@ D6    Result		S	AP
         <cost name="pts" costTypeId="points" value="35.0"/>
       </costs>
     </selectionEntry>
+    <selectionEntry id="348b-40f4-c774-1f9a" name="Occular Augmetics" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="3108-3d2c-0469-83c4" hidden="false" targetId="faa4ea24-e51b-8663-3e7c-1a791b55aed7" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="20e9-5be0-6d88-afd5" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1782-c86b-a434-19d8" name="Super Heavy Walker" book="" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="665d-6e62-aa12-926c" name="New InfoLink" hidden="false" targetId="52ff-4074-570b-4ea1" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="e543-687d-3cb8-e079" name="New InfoLink" hidden="false" targetId="6f66-b417-6004-0916" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="d75f-66f2-a649-e93b" name="New InfoLink" hidden="false" targetId="3c7d-a1fa-c68b-caad" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="14fa-b27e-0740-6663" name="New InfoLink" hidden="false" targetId="b5c1-4b08-5ddc-1504" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="5946-1e49-b9d9-de14" name="New InfoLink" hidden="false" targetId="6d06-5ea0-9a17-ca97" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="879b-ed11-c2f4-5782" name="New InfoLink" hidden="false" targetId="4284-18a1-9844-a0bd" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="f8f7-7026-fd60-a7ee" name="New InfoLink" hidden="false" targetId="dd83-7fb9-6f58-0c96" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="da95-f77a-2e96-2fae" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1240-ab1a-2701-5b08" type="min"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs/>
+    </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup id="dcd9f954-73a9-25ad-b7db-1a8591d65d10" name="Knight Armour" hidden="false" collective="false">
@@ -3255,14 +3334,14 @@ D6    Result		S	AP
       <infoLinks/>
       <modifiers/>
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
         <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInForce" type="min"/>
         <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
         <constraint field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInRoster" type="min"/>
         <constraint field="selections" scope="roster" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
-        <constraint field="points" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="minPoints" type="min"/>
-        <constraint field="points" scope="parent" value="-1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxPoints" type="max"/>
+        <constraint field="points" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minPoints" type="min"/>
+        <constraint field="points" scope="parent" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxPoints" type="max"/>
       </constraints>
       <selectionEntries>
         <selectionEntry id="02eb28bb-1883-8603-0af7-b8bf2b7b69c8" name="Questoris Knight Paladin" book="HH4: Conquest" page="301" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
@@ -3413,31 +3492,17 @@ D6    Result		S	AP
                     <cost name="pts" costTypeId="points" value="10.0"/>
                   </costs>
                 </selectionEntry>
-                <selectionEntry id="5aa9746d-5c76-07ec-c247-362ebd7cc8d9" name="Occular Augmetics" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="814ee810-2fb7-50ef-5d69-6a3af2256a2c" hidden="false" targetId="faa4ea24-e51b-8663-3e7c-1a791b55aed7" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="10.0"/>
-                  </costs>
-                </selectionEntry>
               </selectionEntries>
               <selectionEntryGroups/>
-              <entryLinks/>
+              <entryLinks>
+                <entryLink id="8650-f3c0-85c2-6ea7" name="New EntryLink" hidden="false" targetId="348b-40f4-c774-1f9a" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="b496-156d-b9eb-95f3" name="May take one of the following carapace weapons:" hidden="false" collective="false">
               <profiles/>
@@ -3625,31 +3690,17 @@ D6    Result		S	AP
                     <cost name="pts" costTypeId="points" value="5.0"/>
                   </costs>
                 </selectionEntry>
-                <selectionEntry id="b41d3310-f9e2-6a20-602e-d74c7ce1a5cf" name="Occular Augmetics" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="f6f9b49c-b449-a6c9-20bf-4fa4065e8586" hidden="false" targetId="faa4ea24-e51b-8663-3e7c-1a791b55aed7" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="10.0"/>
-                  </costs>
-                </selectionEntry>
               </selectionEntries>
               <selectionEntryGroups/>
-              <entryLinks/>
+              <entryLinks>
+                <entryLink id="daa4-d280-3978-ddee" name="New EntryLink" hidden="false" targetId="348b-40f4-c774-1f9a" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="161b-6e36-d2e5-516d" name="May take one of the following carapace weapons:" hidden="false" collective="false">
               <profiles/>
@@ -3832,7 +3883,7 @@ D6    Result		S	AP
                   </profiles>
                   <rules/>
                   <infoLinks>
-                    <infoLink id="d84af9b2-1522-bbaf-1464-9d36c617e3b1" hidden="false" targetId="283aab20-3917-4fe6-dec8-5fae4245c517" type="rule">
+                    <infoLink id="d84af9b2-1522-bbaf-1464-9d36c617e3b1" hidden="false" targetId="fe2f-3220-3fef-b177" type="rule">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -3844,7 +3895,7 @@ D6    Result		S	AP
                       <infoLinks/>
                       <modifiers/>
                     </infoLink>
-                    <infoLink id="04b39ae6-f0a5-686d-6285-2ac971ef9e08" hidden="false" targetId="8ab154f7-17dc-b6fc-f087-81cee64e5fd3" type="rule">
+                    <infoLink id="04b39ae6-f0a5-686d-6285-2ac971ef9e08" hidden="false" targetId="eefe-09e4-17aa-deb2" type="rule">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -3872,32 +3923,17 @@ D6    Result		S	AP
               <infoLinks/>
               <modifiers/>
               <constraints/>
-              <selectionEntries>
-                <selectionEntry id="077fa001-3a79-e729-ffe9-55898bfb37c3" name="Occular Augmetics" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="bcb5-069f-bb42-5343" name="New EntryLink" hidden="false" targetId="348b-40f4-c774-1f9a" type="selectionEntry">
                   <profiles/>
                   <rules/>
-                  <infoLinks>
-                    <infoLink id="d728ec3b-a083-fe87-c289-7a560d9251a1" hidden="false" targetId="faa4ea24-e51b-8663-3e7c-1a791b55aed7" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
+                  <infoLinks/>
                   <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="10.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups/>
-              <entryLinks/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks/>
@@ -3994,32 +4030,17 @@ D6    Result		S	AP
               <infoLinks/>
               <modifiers/>
               <constraints/>
-              <selectionEntries>
-                <selectionEntry id="504aa7df-a11a-36bd-fdd3-854d869acb2e" name="Occular Augmetics" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="11b6-982a-c832-8217" name="New EntryLink" hidden="false" targetId="348b-40f4-c774-1f9a" type="selectionEntry">
                   <profiles/>
                   <rules/>
-                  <infoLinks>
-                    <infoLink id="c2c89013-f6a6-b5eb-4cb7-6a5e56175676" hidden="false" targetId="faa4ea24-e51b-8663-3e7c-1a791b55aed7" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
+                  <infoLinks/>
                   <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="10.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups/>
-              <entryLinks/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks/>
@@ -4092,7 +4113,7 @@ D6    Result		S	AP
               <infoLinks/>
               <modifiers/>
             </infoLink>
-            <infoLink id="bc0104e8-2532-0caa-c684-57b5d8186e17" hidden="false" targetId="f1aa3b29-d09e-e8e7-d1fa-0b50253598c7" type="rule">
+            <infoLink id="bc0104e8-2532-0caa-c684-57b5d8186e17" hidden="false" targetId="cbcf-5f25-f8ea-7cfd" type="rule">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -4107,7 +4128,7 @@ D6    Result		S	AP
           </infoLinks>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <selectionEntries/>
           <selectionEntryGroups>
@@ -4135,7 +4156,7 @@ D6    Result		S	AP
                   </profiles>
                   <rules/>
                   <infoLinks>
-                    <infoLink id="9931306e-824c-db8b-12f2-c58e0e8bf9b9" hidden="false" targetId="283aab20-3917-4fe6-dec8-5fae4245c517" type="rule">
+                    <infoLink id="9931306e-824c-db8b-12f2-c58e0e8bf9b9" hidden="false" targetId="fe2f-3220-3fef-b177" type="rule">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -4147,7 +4168,7 @@ D6    Result		S	AP
                       <infoLinks/>
                       <modifiers/>
                     </infoLink>
-                    <infoLink id="3ef43818-d39f-8983-3127-1306854c69f6" hidden="false" targetId="8ab154f7-17dc-b6fc-f087-81cee64e5fd3" type="rule">
+                    <infoLink id="3ef43818-d39f-8983-3127-1306854c69f6" hidden="false" targetId="eefe-09e4-17aa-deb2" type="rule">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -4175,32 +4196,17 @@ D6    Result		S	AP
               <infoLinks/>
               <modifiers/>
               <constraints/>
-              <selectionEntries>
-                <selectionEntry id="a9686fc7-def7-bf1e-a465-b154bffdd1b4" name="Occular Augmetics" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="bfc1-c694-67ae-0457" name="New EntryLink" hidden="false" targetId="348b-40f4-c774-1f9a" type="selectionEntry">
                   <profiles/>
                   <rules/>
-                  <infoLinks>
-                    <infoLink id="2ad48b04-bf93-f3c3-d66a-8332229e5840" hidden="false" targetId="faa4ea24-e51b-8663-3e7c-1a791b55aed7" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
+                  <infoLinks/>
                   <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="10.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups/>
-              <entryLinks/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks/>
@@ -4281,7 +4287,7 @@ D6    Result		S	AP
               <infoLinks/>
               <modifiers/>
             </infoLink>
-            <infoLink id="05ccc725-4149-bbe0-d1c4-291383f7d189" hidden="false" targetId="f1aa3b29-d09e-e8e7-d1fa-0b50253598c7" type="rule">
+            <infoLink id="05ccc725-4149-bbe0-d1c4-291383f7d189" hidden="false" targetId="cbcf-5f25-f8ea-7cfd" type="rule">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -4290,7 +4296,7 @@ D6    Result		S	AP
           </infoLinks>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <selectionEntries/>
           <selectionEntryGroups>
@@ -4300,32 +4306,17 @@ D6    Result		S	AP
               <infoLinks/>
               <modifiers/>
               <constraints/>
-              <selectionEntries>
-                <selectionEntry id="60cab4fd-6658-cc1c-f0cb-03087156e54f" name="Occular Augmetics" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="97b8-c2fb-2978-945e" name="New EntryLink" hidden="false" targetId="348b-40f4-c774-1f9a" type="selectionEntry">
                   <profiles/>
                   <rules/>
-                  <infoLinks>
-                    <infoLink id="7d50e5a2-eeb7-32cb-a54f-99d5620f41b3" hidden="false" targetId="faa4ea24-e51b-8663-3e7c-1a791b55aed7" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
+                  <infoLinks/>
                   <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="10.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups/>
-              <entryLinks/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks/>
@@ -4409,7 +4400,7 @@ D6    Result		S	AP
           </infoLinks>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <selectionEntries/>
           <selectionEntryGroups>
@@ -4419,32 +4410,17 @@ D6    Result		S	AP
               <infoLinks/>
               <modifiers/>
               <constraints/>
-              <selectionEntries>
-                <selectionEntry id="f1fd7662-fed1-bcc1-610c-613ceffe777c" name="Occular Augmetics" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="d808-e275-8ba5-6f32" name="New EntryLink" hidden="false" targetId="348b-40f4-c774-1f9a" type="selectionEntry">
                   <profiles/>
                   <rules/>
-                  <infoLinks>
-                    <infoLink id="ab93f0f7-5560-6c2a-0f6f-fc070f58c367" hidden="false" targetId="faa4ea24-e51b-8663-3e7c-1a791b55aed7" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
+                  <infoLinks/>
                   <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="10.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups/>
-              <entryLinks/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks/>
@@ -4522,7 +4498,7 @@ D6    Result		S	AP
           </infoLinks>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <selectionEntries/>
           <selectionEntryGroups>
@@ -4560,8 +4536,8 @@ D6    Result		S	AP
                     </modifier>
                   </modifiers>
                   <constraints>
-                    <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                    <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
                   </constraints>
                   <selectionEntries/>
                   <selectionEntryGroups/>
@@ -4570,31 +4546,17 @@ D6    Result		S	AP
                     <cost name="pts" costTypeId="points" value="5.0"/>
                   </costs>
                 </selectionEntry>
-                <selectionEntry id="1b49-cb25-95fd-3258" name="Occular Augmetics" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="37da-4733-2594-cbfe" hidden="false" targetId="faa4ea24-e51b-8663-3e7c-1a791b55aed7" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="10.0"/>
-                  </costs>
-                </selectionEntry>
               </selectionEntries>
               <selectionEntryGroups/>
-              <entryLinks/>
+              <entryLinks>
+                <entryLink id="3b5e-0a97-6a33-f3db" name="New EntryLink" hidden="false" targetId="348b-40f4-c774-1f9a" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="7e6c-a072-4bf1-2f4b" name="May take one of the following carapace weapons:" hidden="false" collective="false">
               <profiles/>
@@ -4602,7 +4564,7 @@ D6    Result		S	AP
               <infoLinks/>
               <modifiers/>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <selectionEntries>
                 <selectionEntry id="afec-cc37-37b7-8074" name="Ironstorm missile pod" book="FAQ" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
@@ -4618,7 +4580,7 @@ D6    Result		S	AP
                   </infoLinks>
                   <modifiers/>
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
                   </constraints>
                   <selectionEntries/>
                   <selectionEntryGroups/>
@@ -4640,7 +4602,7 @@ D6    Result		S	AP
                   </infoLinks>
                   <modifiers/>
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
                   </constraints>
                   <selectionEntries/>
                   <selectionEntryGroups/>
@@ -4662,7 +4624,7 @@ D6    Result		S	AP
                   </infoLinks>
                   <modifiers/>
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
                   </constraints>
                   <selectionEntries/>
                   <selectionEntryGroups/>
@@ -4709,7 +4671,7 @@ D6    Result		S	AP
                   <infoLinks/>
                   <modifiers/>
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
                   </constraints>
                   <selectionEntries/>
                   <selectionEntryGroups/>
@@ -4735,7 +4697,7 @@ D6    Result		S	AP
                   <infoLinks/>
                   <modifiers/>
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
                   </constraints>
                   <selectionEntries/>
                   <selectionEntryGroups/>
@@ -4862,8 +4824,8 @@ D6    Result		S	AP
                     </modifier>
                   </modifiers>
                   <constraints>
-                    <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                    <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
                   </constraints>
                   <selectionEntries/>
                   <selectionEntryGroups/>
@@ -4872,31 +4834,17 @@ D6    Result		S	AP
                     <cost name="pts" costTypeId="points" value="5.0"/>
                   </costs>
                 </selectionEntry>
-                <selectionEntry id="fb68-f658-1ab7-20d9" name="Occular Augmetics" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="54ae-0c27-57a7-948c" hidden="false" targetId="faa4ea24-e51b-8663-3e7c-1a791b55aed7" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="10.0"/>
-                  </costs>
-                </selectionEntry>
               </selectionEntries>
               <selectionEntryGroups/>
-              <entryLinks/>
+              <entryLinks>
+                <entryLink id="5bb8-a7b6-80df-e61f" name="New EntryLink" hidden="false" targetId="348b-40f4-c774-1f9a" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="c583-687e-8127-66d2" name="May take one of the following carapace weapons:" hidden="false" collective="false">
               <profiles/>
@@ -5131,31 +5079,17 @@ D6    Result		S	AP
                     <cost name="pts" costTypeId="points" value="5.0"/>
                   </costs>
                 </selectionEntry>
-                <selectionEntry id="51ac-24b9-e144-24e3" name="Occular Augmetics" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="0483-70f8-6cbd-4d7a" hidden="false" targetId="faa4ea24-e51b-8663-3e7c-1a791b55aed7" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="10.0"/>
-                  </costs>
-                </selectionEntry>
               </selectionEntries>
               <selectionEntryGroups/>
-              <entryLinks/>
+              <entryLinks>
+                <entryLink id="8451-15e6-de8b-cb69" name="New EntryLink" hidden="false" targetId="348b-40f4-c774-1f9a" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="6a4c-1d50-97f2-fbb0" name="May take one of the following carapace weapons:" hidden="false" collective="false">
               <profiles/>
@@ -5250,7 +5184,7 @@ D6    Result		S	AP
                   <modifiers>
                     <modifier type="increment" field="maxSelections" value="1.0">
                       <repeats>
-                        <repeat field="selections" scope="09ee-4370-1462-2cb5" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4e60-ef5b-d3df-669d" repeats="1"/>
+                        <repeat field="selections" scope="09ee-4370-1462-2cb5" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4e60-ef5b-d3df-669d" repeats="1" roundUp="false"/>
                       </repeats>
                       <conditions/>
                       <conditionGroups/>
@@ -5315,9 +5249,9 @@ D6    Result		S	AP
             <cost name="pts" costTypeId="points" value="425.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="e007-c135-cb1d-9fe1" name="Cerastus Knight-Atrapos" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+        <selectionEntry id="baad-77d0-04c2-e05f" name="Cerastus Knight-Atrapos" book="HH6: Retribution" page="278" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
           <profiles>
-            <profile id="a407-5b4d-aa86-2ff3" name="Cerastus Knight Atrapos" book="HH6: Retribution" page="278" hidden="false" profileTypeId="57616c6b657223232344415441232323">
+            <profile id="95c1-8de7-bef1-6fa1" name="Cerastus Knight-Atrapos" book="HH4: Conquest" page="306" hidden="false" profileTypeId="57616c6b657223232344415441232323">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -5331,96 +5265,38 @@ D6    Result		S	AP
                 <characteristic name="Rear" characteristicTypeId="5265617223232344415441232323" value="12"/>
                 <characteristic name="I" characteristicTypeId="4923232344415441232323" value="4"/>
                 <characteristic name="A" characteristicTypeId="4123232344415441232323" value="4"/>
-                <characteristic name="HP" characteristicTypeId="485023232344415441232323" value="7"/>
+                <characteristic name="HP" characteristicTypeId="485023232344415441232323" value="6"/>
                 <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Super-heavy Walker"/>
               </characteristics>
             </profile>
-            <profile id="fd41-a14f-5d5c-bf4c" name="Graviton Singularity Cannon" hidden="false" profileTypeId="576561706f6e23232344415441232323">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="38&quot;"/>
-                <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="8"/>
-                <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="2"/>
-                <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 1, Large Blast, Armourbane, Concussive, Collapsing Singularity"/>
-              </characteristics>
-            </profile>
-            <profile id="d096-a630-f03c-1e46" name="Atrapos Lascutter (Beam)" hidden="false" profileTypeId="576561706f6e23232344415441232323">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="8&quot;"/>
-                <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="D"/>
-                <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="2"/>
-                <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 1"/>
-              </characteristics>
-            </profile>
-            <profile id="a6cc-195c-c814-4fdb" name="Atrapos Lascutter (Close Combat)" hidden="false" profileTypeId="576561706f6e23232344415441232323">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="-"/>
-                <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="D"/>
-                <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="1"/>
-                <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Melee, Wrecker"/>
-              </characteristics>
-            </profile>
           </profiles>
-          <rules>
-            <rule id="35c1-0608-831d-1bc7" name="Macro-extinction Targeting Protocols" hidden="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <description>When making shooting attacks against targets of the Super-heavy or Gargantuan Creature type, the Cerastus Knight-Atrapos counts its weapons as Twin-linked.</description>
-            </rule>
-            <rule id="5981-8cf3-f660-4c47" name="Catastrophic Destruction" hidden="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <description>When destroyed, the Cerastus Knight-Atrapos adds +2 to the result rolled on the Catastrophic Damage table.</description>
-            </rule>
-            <rule id="cd64-d954-f951-6f4e" name="Collapsing Singularity" hidden="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <description>Before firing the weapon, roll a D6. On a result of a 1, the firing Knight-Atrapos suffers a single Hull Point of damage with no saves of any kind before the attack is carried out. On a result of a 6, the attack is carried out with the Vortex special rule. </description>
-            </rule>
-          </rules>
+          <rules/>
           <infoLinks>
-            <infoLink id="8616-e4ee-9194-b891" hidden="false" targetId="b352ed0c-5fc2-2b26-e1ea-8bc60068af56" type="rule">
+            <infoLink id="45c0-8287-d1db-989d" name="" hidden="false" targetId="9445fd7c-5f0e-e2fd-f586-2beafd8d3b6b" type="rule">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
             </infoLink>
-            <infoLink id="364d-d85b-80bc-f3bb" hidden="false" targetId="76f43c9f-9d2b-e019-63db-3ac3082ee07c" type="profile">
+            <infoLink id="ad4c-6ac3-01fb-a54c" hidden="false" targetId="53c751ef-105f-b2a8-7a17-7812d605b9f2" type="rule">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
             </infoLink>
-            <infoLink id="d726-ad40-73cd-2e9e" hidden="false" targetId="53c751ef-105f-b2a8-7a17-7812d605b9f2" type="rule">
+            <infoLink id="7629-09d1-79f3-3f7a" name="New InfoLink" hidden="false" targetId="333c-a3b2-4353-f484" type="rule">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
             </infoLink>
-            <infoLink id="c80e-0054-9aa8-11e0" hidden="false" targetId="9445fd7c-5f0e-e2fd-f586-2beafd8d3b6b" type="rule">
+            <infoLink id="175b-ee67-d5b7-02d8" name="New InfoLink" hidden="false" targetId="8fb5-0c46-e8b4-0ef6" type="rule">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
             </infoLink>
-            <infoLink id="ab27-d09c-4646-423c" hidden="false" targetId="283aab20-3917-4fe6-dec8-5fae4245c517" type="rule">
+            <infoLink id="1895-e4dd-46a4-3b0a" name="New InfoLink" hidden="false" targetId="81fe-8580-34f6-28ae" type="rule">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -5428,32 +5304,79 @@ D6    Result		S	AP
             </infoLink>
           </infoLinks>
           <modifiers>
-            <modifier type="increment" field="maxInForce" value="1.0">
+            <modifier type="increment" field="8f86-62fb-dba4-afc4" value="1">
               <repeats>
-                <repeat field="limit::points" scope="roster" value="2000.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="no child" repeats="1"/>
+                <repeat field="points" scope="roster" value="2000.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="any" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-            <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
+            <constraint field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="8f86-62fb-dba4-afc4" type="max"/>
           </constraints>
           <selectionEntries/>
           <selectionEntryGroups>
-            <selectionEntryGroup id="c70b-bc3c-e9c8-f410" name="May be upgraded with:" hidden="false" collective="false">
+            <selectionEntryGroup id="797b-8685-04c6-72f4" name="May be upgraded with:" hidden="false" collective="false">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
               <constraints/>
-              <selectionEntries>
-                <selectionEntry id="7d66-75fc-1aaa-5529" name="Occular Augmetics" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="a890-2700-1060-bb32" name="New EntryLink" hidden="false" targetId="348b-40f4-c774-1f9a" type="selectionEntry">
                   <profiles/>
                   <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="ea91-b3c1-b65c-bdaf" name="Singularity Cannon" hidden="false" collective="false" defaultSelectionEntryId="c6cf-46ab-5358-3771">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1f91-871d-6bef-5216" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8477-2187-7951-fdb3" type="min"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="c6cf-46ab-5358-3771" name="Singularity Cannon" hidden="false" collective="false" type="upgrade">
+                  <profiles>
+                    <profile id="0483-ace3-ca6b-e55e" name="Gravaton Singularity Cannon" book="HH6: Retribution" page="279" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <characteristics>
+                        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="36&quot;"/>
+                        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="8"/>
+                        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="2"/>
+                        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 1, Large Blast (5&quot;), Armourbane, Concussive, Collapsing Singularity"/>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <rules>
+                    <rule id="3431-e056-229c-9e40" name="Collapsing Singularity" book="HH6: Retribution" page="279" hidden="false">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <description>Before firing the weapon, roll a D6. On a r, the firing Knight-Atrapos suffers a single Hull Point of damage with no saves of any kind before the attack is carried out. On a result of a 6, the attack is carried out with the Vortex special rule.</description>
+                    </rule>
+                  </rules>
                   <infoLinks>
-                    <infoLink id="973f-0c69-5262-c52d" hidden="false" targetId="faa4ea24-e51b-8663-3e7c-1a791b55aed7" type="profile">
+                    <infoLink id="73d2-c7e5-ff62-be2f" name="New InfoLink" hidden="false" targetId="e182-50cd-0867-9a8d" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                    <infoLink id="568b-52ba-ba70-631b" name="New InfoLink" hidden="false" targetId="9d85-46f7-f5e6-a5f7" type="rule">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -5461,22 +5384,83 @@ D6    Result		S	AP
                     </infoLink>
                   </infoLinks>
                   <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
+                  <constraints/>
                   <selectionEntries/>
                   <selectionEntryGroups/>
                   <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="10.0"/>
-                  </costs>
+                  <costs/>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks/>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="d520-383c-95ed-8e5f" name="Lascutter" hidden="false" collective="false" defaultSelectionEntryId="5b2d-434f-7a2d-7ad3">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2044-af1a-9add-b6dc" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2225-b3bc-9b72-de91" type="min"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="5b2d-434f-7a2d-7ad3" name="Lascutter" hidden="false" collective="false" type="upgrade">
+                  <profiles>
+                    <profile id="3825-cb38-0956-1089" name="Atrapos Lascutter (Beam)" book="HH6: Retribution" page="279" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <characteristics>
+                        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="8&quot;"/>
+                        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="D"/>
+                        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="2"/>
+                        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 1, "/>
+                      </characteristics>
+                    </profile>
+                    <profile id="24d7-a4aa-f9ff-d5d0" name="Atrapos Lascutter (Melee)" book="HH6: Retribution" page="279" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <characteristics>
+                        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="-"/>
+                        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="D"/>
+                        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="1"/>
+                        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Melee, Wrecker"/>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="c410-3217-0bbd-cbcb" name="New InfoLink" hidden="false" targetId="fe2f-3220-3fef-b177" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs/>
                 </selectionEntry>
               </selectionEntries>
               <selectionEntryGroups/>
               <entryLinks/>
             </selectionEntryGroup>
           </selectionEntryGroups>
-          <entryLinks/>
+          <entryLinks>
+            <entryLink id="5265-a680-959d-e648" name="New EntryLink" hidden="false" targetId="1782-c86b-a434-19d8" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
           <costs>
             <cost name="pts" costTypeId="points" value="435.0"/>
           </costs>
@@ -5521,20 +5505,6 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
       <modifiers/>
       <description>- Successful wounds by attacks with Poisoned or Fleshbane must be re-rolled against this model
 - In addition to any other effects, attacks with Haywire cause an additional wound on a D6 roll of 6.  </description>
-    </rule>
-    <rule id="e7d545a4-223a-6760-efa4-f585181bb08a" name="Cybernetica Cortex" book="HH3: Extermination" page="206" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Models the have Programmed Behaviour, Fearless, Cybernetic Resiliance, and Adamantium Will special rules.  </description>
-    </rule>
-    <rule id="f1aa3b29-d09e-e8e7-d1fa-0b50253598c7" name="Deflagrate" book="HH4: Conquest" page="308" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>After normal attacks by this weapon have been resolved, count the number of unsaved wounds caused on the target unit.  Immediately resolve a number of additional automatic hits on the same unit using the weapon&apos;s profile equal to the number of unsaved wounds - these can then be saved normally.  Models must still be in range in order for the additional hits to take effect.  These additional hits do not themselves cause more hits.  </description>
     </rule>
     <rule id="53c751ef-105f-b2a8-7a17-7812d605b9f2" name="Flank Speed" book="HH3: Extermination" page="231" hidden="false">
       <profiles/>
@@ -5598,13 +5568,6 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
 - Onslaught: If enemy units are within 12&quot; during their Assault phase, them must attempt to charge the closest enemy unit.  May still only charge a unit fired upon.  If consolidating, must consolidate towards the closest enemy if within 12&quot;
 - Fire Protocols: May fire up to three weapons in the shooting phase against the same target. </description>
     </rule>
-    <rule id="8ab154f7-17dc-b6fc-f087-81cee64e5fd3" name="Rad-phage" book="HH4: Conquest" page="308" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>A model which loses one or more wounds to an attack with this rule and survives suffers a -1 penalty to its Toughness value for the rest of the battle.  </description>
-    </rule>
     <rule id="304d15d2-5775-efdf-f680-aa75b73911ad" name="Reactor Blast" book="HH3: Extermination" page="207" hidden="false">
       <profiles/>
       <rules/>
@@ -5626,12 +5589,28 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
       <modifiers/>
       <description>Confers Interceptor to all friendly models within the same detachment 3&quot;</description>
     </rule>
-    <rule id="283aab20-3917-4fe6-dec8-5fae4245c517" name="Wrecker" book="HH4: Conquest" page="308" hidden="false">
+    <rule id="333c-a3b2-4353-f484" name="Macro-extinction Targeting Protocols" book="HH6: Retibution" page="279" hidden="false">
       <profiles/>
       <rules/>
       <infoLinks/>
       <modifiers/>
-      <description>Attacks with this special rule may re-roll failed armour penetration rolls against fortifications and immobile structures and add +1 to any result rolled on the Building Damage chart.  If this attack damages a bulkhead or wall section of terrain and destroys it, remove that section of terrain from play if possible.  </description>
+      <description>When making shooting attacks against targets of the Super-heavy or Gargantuan Creature type, the Cerastus Knight-Atrapos counts its weapons as Twin-linked.</description>
+    </rule>
+    <rule id="8fb5-0c46-e8b4-0ef6" name="Ionic Flare Shield" book="HH6: Retibution" page="279" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>When a Cerastus Knight-Atrapos is deployed, and subsequently at the start of each of the opposing side&apos;s Shooting phases, the Cerastus
+Knight-Atrapos&apos; controlling player must declare which facing each Cerastus Knight-Atrapos&apos; ion flare shield is covering. The choices are front, left side, right side or rear. The Knight has a 4+ invulnerable save against all hits against the shield facing and the strength of any 
+Shooting attack against the shield facing is reduced by -1, the effect increasing to -2 if the weapon has the Blast or Template special rules (note however that this strength reduction has no effect on Destroyer or Haywire attacks). Ionic flare shields are repositioned before any attacks are carried out in the Shooting phase and may not be used to make 	saving throws against close combat attacks.</description>
+    </rule>
+    <rule id="81fe-8580-34f6-28ae" name="Catastrophic Destruction" book="HH6: Retibution" page="279" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>When destroyed, the Cerastus Knight-Atrapos adds +2 to the result rolled on the Catastrophic Damage table.</description>
     </rule>
   </sharedRules>
   <sharedProfiles>

--- a/The Horus Heresy.gst
+++ b/The Horus Heresy.gst
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<gameSystem id="ca571888-56a9-c58e-ddaf-54f4713538bc" name="Warhammer 30,000 - The Horus Heresy" book="Forgeworld Horus Heresy Series" revision="44" battleScribeVersion="2.00" authorName="Millicant" authorContact="Please submit any bugs to the website below" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
+<gameSystem id="ca571888-56a9-c58e-ddaf-54f4713538bc" name="Warhammer 30,000 - The Horus Heresy" book="Forgeworld Horus Heresy Series" revision="45" battleScribeVersion="2.00" authorName="Millicant" authorContact="Please submit any bugs to the website below" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
   <profiles/>
   <rules/>
   <infoLinks/>
@@ -147,14 +147,14 @@
             </modifier>
             <modifier type="increment" field="c6eb-35af-11b1-afd0" value="1">
               <repeats>
-                <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fc8c-3f13-02b6-034e" repeats="1"/>
+                <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fc8c-3f13-02b6-034e" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
             </modifier>
             <modifier type="increment" field="c6eb-35af-11b1-afd0" value="1">
               <repeats>
-                <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c419-45b3-44e8-b390" repeats="1"/>
+                <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c419-45b3-44e8-b390" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -312,7 +312,7 @@
             </modifier>
             <modifier type="increment" field="8122-8dbd-27ea-9ab7" value="1">
               <repeats>
-                <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2ecc-1bd4-10ef-cfb1" repeats="1"/>
+                <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2ecc-1bd4-10ef-cfb1" repeats="1" roundUp="false"/>
               </repeats>
               <conditions>
                 <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a955-3b63-2411-3e8e" type="equalTo"/>
@@ -328,7 +328,7 @@
             </modifier>
             <modifier type="increment" field="c8f2-ddb2-4f55-0e8b" value="1">
               <repeats>
-                <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="54726f6f707323232344415441232323" repeats="1"/>
+                <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="54726f6f707323232344415441232323" repeats="1" roundUp="false"/>
               </repeats>
               <conditions>
                 <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8b77-4000-0985-41bc" type="equalTo"/>
@@ -510,14 +510,14 @@
             </modifier>
             <modifier type="increment" field="f007-45ee-a366-021c" value="1">
               <repeats>
-                <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="04c4-8239-657a-ced2" repeats="1"/>
+                <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="04c4-8239-657a-ced2" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
             </modifier>
             <modifier type="increment" field="f007-45ee-a366-021c" value="1">
               <repeats>
-                <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="9c8f-17f9-f7c0-1324" repeats="1"/>
+                <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="9c8f-17f9-f7c0-1324" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups>
@@ -551,7 +551,7 @@
             </modifier>
             <modifier type="increment" field="f007-45ee-a366-021c" value="1">
               <repeats>
-                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed6e-b5b9-ab42-adce" repeats="1"/>
+                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed6e-b5b9-ab42-adce" repeats="1" roundUp="false"/>
               </repeats>
               <conditions>
                 <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6b5e-6b5a-8505-f943" type="equalTo"/>
@@ -560,7 +560,7 @@
             </modifier>
             <modifier type="increment" field="f007-45ee-a366-021c" value="1">
               <repeats>
-                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e9af-7cd4-9639-eaa6" repeats="1"/>
+                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e9af-7cd4-9639-eaa6" repeats="1" roundUp="false"/>
               </repeats>
               <conditions>
                 <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6b5e-6b5a-8505-f943" type="equalTo"/>
@@ -569,14 +569,14 @@
             </modifier>
             <modifier type="increment" field="f007-45ee-a366-021c" value="1">
               <repeats>
-                <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="36c5-d6db-7224-1e47" repeats="1"/>
+                <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="36c5-d6db-7224-1e47" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
             </modifier>
             <modifier type="increment" field="f007-45ee-a366-021c" value="1">
               <repeats>
-                <repeat field="selections" scope="98db-b4ba-fbcd-3239::54726f6f707323232344415441232323" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bcb9-0d45-bc12-bb51" repeats="1"/>
+                <repeat field="selections" scope="98db-b4ba-fbcd-3239::54726f6f707323232344415441232323" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bcb9-0d45-bc12-bb51" repeats="1" roundUp="false"/>
               </repeats>
               <conditions>
                 <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe95-9a5f-9896-8f03" type="equalTo"/>
@@ -598,7 +598,7 @@
             </modifier>
             <modifier type="increment" field="f007-45ee-a366-021c" value="1">
               <repeats>
-                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="bcb9-0d45-bc12-bb51" repeats="1"/>
+                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="bcb9-0d45-bc12-bb51" repeats="1" roundUp="false"/>
               </repeats>
               <conditions>
                 <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="99e8-4840-8b4e-eb96" type="equalTo"/>
@@ -671,7 +671,7 @@
             </modifier>
             <modifier type="increment" field="de22-120d-9502-2984" value="1">
               <repeats>
-                <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="486561767920537570706f727423232344415441232323" repeats="1"/>
+                <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="486561767920537570706f727423232344415441232323" repeats="1" roundUp="false"/>
               </repeats>
               <conditions>
                 <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="da38-be72-6499-c20b" type="equalTo"/>
@@ -734,7 +734,7 @@
             </modifier>
             <modifier type="increment" field="58a5-9d39-7971-065e" value="1">
               <repeats>
-                <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2445-ec95-06bb-5c81" repeats="1"/>
+                <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2445-ec95-06bb-5c81" repeats="1" roundUp="false"/>
               </repeats>
               <conditions>
                 <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a955-3b63-2411-3e8e" type="equalTo"/>
@@ -888,7 +888,7 @@
             </modifier>
             <modifier type="increment" field="7e4d-85ba-3fc8-514b" value="1">
               <repeats>
-                <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="466173742041747461636b23232344415441232323" repeats="1"/>
+                <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="466173742041747461636b23232344415441232323" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups>
@@ -919,7 +919,7 @@
             </modifier>
             <modifier type="increment" field="7e4d-85ba-3fc8-514b" value="1">
               <repeats>
-                <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="54726f6f707323232344415441232323" repeats="1"/>
+                <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="54726f6f707323232344415441232323" repeats="1" roundUp="false"/>
               </repeats>
               <conditions>
                 <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e006-2ef7-ee40-afec" type="equalTo"/>
@@ -1022,7 +1022,7 @@
             </modifier>
             <modifier type="increment" field="7e4d-85ba-3fc8-514b" value="1">
               <repeats>
-                <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="466173742041747461636b23232344415441232323" repeats="1"/>
+                <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="466173742041747461636b23232344415441232323" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups>
@@ -1196,11 +1196,91 @@
             <constraint field="selections" scope="roster" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7aaa-383a-2d50-f80f" type="min"/>
           </constraints>
         </categoryEntry>
+        <categoryEntry id="d27d-9e9b-d8c7-afe6" name="No Force Org" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryEntry>
       </categoryEntries>
       <forceEntries/>
     </forceEntry>
   </forceEntries>
-  <selectionEntries/>
+  <selectionEntries>
+    <selectionEntry id="15c1-8d52-4488-7001" name="Patch notes" hidden="false" collective="false" categoryEntryId="d27d-9e9b-d8c7-afe6" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="2d18-149a-0fdc-2aa7" name="New InfoLink" hidden="false" targetId="cc3d-bc60-3f55-768a" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs/>
+    </selectionEntry>
+    <selectionEntry id="96b2-9c32-e025-befd" name="Adding a LoW" hidden="false" collective="false" categoryEntryId="d27d-9e9b-d8c7-afe6" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="c48c-6e59-36dc-d7e7" name="New InfoLink" hidden="false" targetId="990f-5ddd-0286-5219" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs/>
+    </selectionEntry>
+    <selectionEntry id="f45a-74c6-05f5-48dd" name="Selecting a Rite of War" hidden="false" collective="false" categoryEntryId="d27d-9e9b-d8c7-afe6" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="e97b-f0cd-7a15-29d4" name="New InfoLink" hidden="false" targetId="5664-f3db-c205-6bb1" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs/>
+    </selectionEntry>
+    <selectionEntry id="f41e-f8fb-4665-5718" name="Existing issues" hidden="false" collective="false" categoryEntryId="d27d-9e9b-d8c7-afe6" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="c580-c50b-2e98-6231" name="New InfoLink" hidden="false" targetId="ed53-ae11-0216-187b" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs/>
+    </selectionEntry>
+  </selectionEntries>
   <entryLinks/>
   <sharedSelectionEntries>
     <selectionEntry id="5a28-b426-b67c-3dab" name="Allied Detachment" hidden="false" collective="false" type="upgrade">
@@ -4577,7 +4657,7 @@ D6    Result		S	AP
         </modifier>
         <modifier type="increment" field="503f-794f-8ddd-c6dd" value="3">
           <repeats>
-            <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b76-5e02-0970-7b40" repeats="1"/>
+            <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b76-5e02-0970-7b40" repeats="1" roundUp="false"/>
           </repeats>
           <conditions>
             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a955-3b63-2411-3e8e" type="equalTo"/>
@@ -4991,7 +5071,7 @@ D6    Result		S	AP
               <modifiers>
                 <modifier type="increment" field="points" value="1">
                   <repeats>
-                    <repeat field="selections" scope="94d7-495e-e0a7-3f8e" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2190-0968-a3a0-ec11" repeats="1"/>
+                    <repeat field="selections" scope="94d7-495e-e0a7-3f8e" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2190-0968-a3a0-ec11" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -5027,7 +5107,7 @@ D6    Result		S	AP
               <modifiers>
                 <modifier type="increment" field="points" value="5">
                   <repeats>
-                    <repeat field="selections" scope="94d7-495e-e0a7-3f8e" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2190-0968-a3a0-ec11" repeats="1"/>
+                    <repeat field="selections" scope="94d7-495e-e0a7-3f8e" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2190-0968-a3a0-ec11" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -5063,7 +5143,7 @@ D6    Result		S	AP
               <modifiers>
                 <modifier type="increment" field="points" value="5.0">
                   <repeats>
-                    <repeat field="selections" scope="94d7-495e-e0a7-3f8e" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2190-0968-a3a0-ec11" repeats="1"/>
+                    <repeat field="selections" scope="94d7-495e-e0a7-3f8e" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2190-0968-a3a0-ec11" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -5093,7 +5173,7 @@ D6    Result		S	AP
               <modifiers>
                 <modifier type="increment" field="points" value="15">
                   <repeats>
-                    <repeat field="selections" scope="94d7-495e-e0a7-3f8e" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2190-0968-a3a0-ec11" repeats="1"/>
+                    <repeat field="selections" scope="94d7-495e-e0a7-3f8e" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2190-0968-a3a0-ec11" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -5426,7 +5506,7 @@ D6    Result		S	AP
               <modifiers>
                 <modifier type="increment" field="points" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="2445-ec95-06bb-5c81" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c30a-7aa1-baed-9047" repeats="1"/>
+                    <repeat field="selections" scope="2445-ec95-06bb-5c81" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c30a-7aa1-baed-9047" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -5462,7 +5542,7 @@ D6    Result		S	AP
               <modifiers>
                 <modifier type="increment" field="points" value="5.0">
                   <repeats>
-                    <repeat field="selections" scope="2445-ec95-06bb-5c81" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c30a-7aa1-baed-9047" repeats="1"/>
+                    <repeat field="selections" scope="2445-ec95-06bb-5c81" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c30a-7aa1-baed-9047" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -5492,7 +5572,7 @@ D6    Result		S	AP
               <modifiers>
                 <modifier type="increment" field="points" value="15">
                   <repeats>
-                    <repeat field="selections" scope="2445-ec95-06bb-5c81" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c30a-7aa1-baed-9047" repeats="1"/>
+                    <repeat field="selections" scope="2445-ec95-06bb-5c81" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c30a-7aa1-baed-9047" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -5526,7 +5606,7 @@ D6    Result		S	AP
               <modifiers>
                 <modifier type="increment" field="points" value="10.0">
                   <repeats>
-                    <repeat field="selections" scope="2445-ec95-06bb-5c81" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c30a-7aa1-baed-9047" repeats="1"/>
+                    <repeat field="selections" scope="2445-ec95-06bb-5c81" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c30a-7aa1-baed-9047" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -5734,7 +5814,7 @@ D6    Result		S	AP
               <modifiers>
                 <modifier type="increment" field="points" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="2ecc-1bd4-10ef-cfb1" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1838-01e3-dcf6-a3b4" repeats="1"/>
+                    <repeat field="selections" scope="2ecc-1bd4-10ef-cfb1" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1838-01e3-dcf6-a3b4" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -5770,7 +5850,7 @@ D6    Result		S	AP
               <modifiers>
                 <modifier type="increment" field="points" value="5.0">
                   <repeats>
-                    <repeat field="selections" scope="2ecc-1bd4-10ef-cfb1" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1838-01e3-dcf6-a3b4" repeats="1"/>
+                    <repeat field="selections" scope="2ecc-1bd4-10ef-cfb1" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1838-01e3-dcf6-a3b4" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -5806,7 +5886,7 @@ D6    Result		S	AP
               <modifiers>
                 <modifier type="increment" field="points" value="5.0">
                   <repeats>
-                    <repeat field="selections" scope="2ecc-1bd4-10ef-cfb1" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1838-01e3-dcf6-a3b4" repeats="1"/>
+                    <repeat field="selections" scope="2ecc-1bd4-10ef-cfb1" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1838-01e3-dcf6-a3b4" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -12999,6 +13079,167 @@ Cover save bonuses from the Shrouded and Stealth special rules are cumulative (t
       <infoLinks/>
       <modifiers/>
       <description>If a model with this special rule suffers an unsaved Wound from an attack that inflicts Instant Death, it only reduces its Wounds by 1, instead of automatically reducing its Wounds to 0.</description>
+    </rule>
+    <rule id="5664-f3db-c205-6bb1" name="Instruction: Rite of War" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>Rite of War has moved from the unit entry.
+
+Add in your master of the legion and then scroll down to the Legion section and hit the + you&apos;ll have a Rite of War entry there now.
+
+We are aware of the issues using a Primarch (LoW and HQ) as a Master of the Legion and are working on a solution, please bear with us as it may take some time to implement this properly.</description>
+    </rule>
+    <rule id="990f-5ddd-0286-5219" name="Instruction: Lord of War" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>Adding a Lord of War, currently you must add a new detachment and select the appropriate Force Org chart.
+
+Once you add a new detachment
+Add a new Force Org
+Touch it for options
+Touch the Force Org Chart selection (the text, not the radio button!)
+Change to Lord of War
+Go back to the main roster
+Add in your Lord of War in a seperate detachment
+
+This isn&apos;t a great method and is a very roundabout way of adding one but it will allow you to do it. Primarchs added this way will not count as Master of the Legion for rites of war. We will be looking in to changing this to a more suitable </description>
+    </rule>
+    <rule id="cc3d-bc60-3f55-768a" name="Instruction: Patch notes" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>If you have discovered a bug, points costs are wrong or have a suggestion please report them here or the github page https://github.com/BSData/horus-heresy/issues or the appspot page http://battlescribedata.appspot.com/#/repo/horus-heresy via report a bug for the catalogue in question.
+
+Forum posts and facebook posts are not actively monitored so may not be seen and tracked. Logging an issue using the above methods garuntees the problem/bug/request will be looked at. Unfortunatly we have a large list of issues to review and work through so they may take some time to fix.
+
+This data set is maintained by an open-source community and is not linked in any way with the Battlescribe Development team.
+
+
+Change log
+----------
+7.1.5
+Astarte/Legions
+Fixed and optimised choices for the Legion Tactical support squad. (Thanks Alaric (Invision boards))
+Optimised:
+Legion Sky Hunter squad
+Legion Attack bikes
+Anvillus Drop Pod
+Legion Outrider squad
+Phalanx Warder Squad
+Updated some minor entries for BS2 features.
+Fixed Heavy Support squad weapon cost error (Thanks Cannibal Kuchen (Facebook))
+Fixed Ceastus Assault Ram missile launcher, it was free when it should have a cost. (Thanks Matt Waite (Facebook))
+
+Questoris Knights
+Fixed roster limitation for the Atrapos. (Thanks fedratsailor (Github))
+
+----------
+7.1.4 - Fast attack fixes and updates. Remaining Heavy support update. Minor fixes and added Leman Russ (Get you by)
+Remaining heavy support unit bugs, 
+Added missing command squad for Shadrak
+Added Leman Russell, Russ&apos; tamer cousin who uses &quot;Get you by&quot; rules
+Updated Fast Attack units (fixing points, missing profile, missing options and missing rules)
+
+Updated units in the fast attack slot, corrections and optimisations for BS2.
+
+BS2 optimisation still needst to be done for Outriders, Attack bikes, Jetbikes and Anvillus.
+
+----------
+7.1.3 - Taghmata Updates
+Numerous small fixes.
+
+Primarily adding basic weapon entries for most of the units.
+Added profiles to many weapons and unit entries.
+Added text to many rules.
+Updated costs on many entries.
+
+----------
+7.1.2 - Minor Heavy Support, Militia and catalogue updates/corrections
+Astarte changes and fixes:
+Added: Predator Plasma Executioner turret
+Correction: Predator heavy conversion Beamer has no cost.
+Fixed: Sicaran battle tank missing optional pintle-mount.
+Fixed: Phosphex Grenades had no cost.
+Fixed: Deathstorm not showing in Orbital RoW as a fast attack choice.
+Fixed: Deathstorm showing in Stone Gauntlet as no deep strike is allowed by that RoW.
+
+Cults and Militia Changes:
+Arvus Lighter available as fast attack choice.
+
+Misc:
+The main GST catalogue wasn&apos;t incremented, this would have caused some errors when files were pulled in by the app. It wouldn&apos;t update the GST file. Deleting files and refreshing them would fix it but this shouldn&apos;t be needed.
+
+----------
+7.1.1 - Heavy suppor and Consul fixes/updates
+Heavy Support slot has been updated to the Red Book, some entries require more work. If there are any mistakes or omissions please report them and they will be fixed. This is the biggest part of this update. If you have any current lists please export/save them before updating your datafiles as this required quite a few changes.
+
+This means the Sky-Slayer and Malcador units are now available for use.
+
+Units that are functional but require futher work are
+Sky Slayer Support (Could be better layed out)
+Legion Heavey Support squad (missing heavy weapon profiles)
+
+Other units could do with some work but it&apos;ll be purely cosmetic.
+
+Updated Command tank condition, the Vinidcator has this option available now and other squadron tanks will have it displayed correctly when three tanks are taken.
+
+-HQ
+
+Re-added Praetor Tribune
+
+Consul
+Fixed Libarian mastery levels. They&apos;ll be selectable now.
+Fixed Bots for Praevian. They can be added now but I haven&apos;t checked the loadout for the bots, please review this and let me know of any mistakes or changes needed.
+Fixed Scout Armour for Vigilator. It can be selected now
+Fixed bodyguard/command squad for Delegatus and some other consul types. It can be added and modified now.
+Fixed Phosphex bombs for Siege Breaker.
+Fixed many more issue, options where avaiable when they should not have (terminator armour for the Moritat for example)
+
+Misc
+
+Updated Pintle-mount weapon costs and missing options. Now standard across Astarte vehicles except for Super-Heavies.
+Updated Vehicle wargear across vehicles. Please report any that are incorrect and we&apos;ll update them.
+Updated Droppod rules and profiles.
+Updated Kharybdis so it&apos;s not limited to 1.
+
+Legions
+Cleaned up Pheonix Terminator Squad so the Champion is more visable.
+Removed Unwieldy from Deathshroud Scythes.
+Added in Hand Flamer for Legion Veteran squad for Blood Angels.
+
+Mechanicum
+Added Vultarax unit to Tagmata list</description>
+    </rule>
+    <rule id="ed53-ae11-0216-187b" name="Instruction: Existing issues" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>This is a list of exisiting issues we are aware of and are actively looking at, some may take a while to implement so please bear with us.
+
+If you have discovered a bug, points costs are wrong or have a suggestion please report them here or the github page https://github.com/BSData/horus-heresy/issues or the appspot page http://battlescribedata.appspot.com/#/repo/horus-heresy via report a bug for the catalogue in question.
+
+--------- Current Focus
+Profile/Points corrections - Simple to implement but with the amount of books to review this can take awhile to get to. If you spot a mistake or a correction is required please submit an issue. As long as the unit doesn&apos;t require a complete overhaul it will be fixed in a release or two. Please  read of the current issues outlined below to prevent dupliate issues.
+General bug fixes - Some slightly more complicated issues but similar to the above. Please submit an issue for any errors you spot but have a read of the current issues outlined below.
+Updating basic legion units to Battlescribe 2 standards and bringing them fully up to date with the red books.
+Heavy Support, Dedicated Transports and Fast attack entries have been complete. Please submit any errors with these entries and they will be fixed within a release or two.
+Legion specific units and wargear will be looked at after we complete the basic units.
+
+
+--------- Current issues
+Lords of War not available - working on changing the current method - See Instructions: Lord of War for the current method.
+Rites of War not working: Multiple rites of war are not working or do not function fully. We&apos;ll be reviewing them all as
+Primarchs Chosen not working properly - You need to add a different Master of the Legion to enable the Rite of War option (see Instructions: Rite of War), chose Primarchs Chosen. Your Primarch will now appear as a HQ choice. Build your list as required and then remove the Master of the Legion unit you added. You will have validate errors at the end and some Primarchs that change units to a Troops selections currently do not work.
+Fortifications missing/to be added - We&apos;ll be copying the current list from the 40k files, as they&apos;re exactly the same. The fortification slot has the same problems as the LoW slot, needs to be added as a detachment. Once it&apos;s reviewed and a fix is in place we&apos;ll be adding all the fortifications.
+Knights Errant not available as HQ choice for loyalist armies
+Taghmata Army list cannot select Matrix of Ruin force org
+</description>
     </rule>
   </sharedRules>
   <sharedProfiles>


### PR DESCRIPTION
Astarte/Legions
Fixed and optimised choices for the Legion Tactical support squad. (Thanks Alaric (Invision boards))
Optimised:
  Legion Sky Hunter squad
  Legion Attack bikes
  Anvillus Drop Pod
  Legion Outrider squad
  Phalanx Warder Squad
Updated some minor entries for BS2 features.
Fixed Heavy Support squad weapon cost error (Thanks Cannibal Kuchen (Facebook))
Fixed Ceastus Assault Ram missile launcher, it was free when it should have a cost. (Thanks Matt Waite (Facebook))

Questoris Knights
Fixed roster limitation for the Atrapos. (Thanks fedratsailor (Github))

General
Added No Force Org slot for patch notes and general info.