### PR TITLE
Rules clean up and some fixes

### DIFF
--- a/(HH) Imperialis Militia and Cults Army List.cat
+++ b/(HH) Imperialis Militia and Cults Army List.cat
@@ -5211,7 +5211,7 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
               <profiles/>
               <rules/>
               <infoLinks>
-                <infoLink id="6d51-e250-1d16-2206" hidden="false" targetId="c32e-0d1a-f6db-2007" type="profile">
+                <infoLink id="6d51-e250-1d16-2206" hidden="false" targetId="871025a3-7729-f97d-378d-804c3571cdf3" type="profile">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -8322,7 +8322,7 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
               </profiles>
               <rules/>
               <infoLinks>
-                <infoLink id="f661-886f-a458-32ed" hidden="false" targetId="c32e-0d1a-f6db-2007" type="profile">
+                <infoLink id="f661-886f-a458-32ed" hidden="false" targetId="871025a3-7729-f97d-378d-804c3571cdf3" type="profile">
                   <profiles/>
                   <rules/>
                   <infoLinks/>

--- a/(HH) Mechanicum - Questoris Knight.cat
+++ b/(HH) Mechanicum - Questoris Knight.cat
@@ -229,7 +229,7 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="57b9a887-a8c9-33dd-4c0f-da8f1a329a48" hidden="false" targetId="1a39d585-c6e2-729c-4c0b-6de16ab9ee49" type="rule">
+        <infoLink id="57b9a887-a8c9-33dd-4c0f-da8f1a329a48" hidden="false" targetId="4764-48d9-da41-afaa" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -286,7 +286,7 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
           <conditions/>
           <conditionGroups/>
         </modifier>
-        <modifier type="increment" field="maxInForce" value="1.0">
+        <modifier type="increment" field="maxInForce" value="1">
           <repeats>
             <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2f44-17e9-3707-22f2" repeats="1" roundUp="false"/>
           </repeats>
@@ -395,7 +395,7 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
       <profiles/>
       <rules/>
       <infoLinks>
-        <infoLink id="f46d7af6-d9cf-a52c-39b3-d6569197ff0f" hidden="false" targetId="1a39d585-c6e2-729c-4c0b-6de16ab9ee49" type="rule">
+        <infoLink id="f46d7af6-d9cf-a52c-39b3-d6569197ff0f" hidden="false" targetId="4764-48d9-da41-afaa" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>

--- a/(HH) Mechanicum - Taghmata Army List.cat
+++ b/(HH) Mechanicum - Taghmata Army List.cat
@@ -14579,7 +14579,7 @@ Reduces transport capacity to 8.  </description>
       <profiles/>
       <rules/>
       <infoLinks>
-        <infoLink id="58cb4118-ab44-5153-4cbc-554e93a81fba" hidden="false" targetId="32d5-9382-d290-b026" type="profile">
+        <infoLink id="58cb4118-ab44-5153-4cbc-554e93a81fba" hidden="false" targetId="51100eb8-f6e6-7048-df0a-84f0163a38bd" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>

--- a/(HH) Mechanicum - Taghmata Army List.cat
+++ b/(HH) Mechanicum - Taghmata Army List.cat
@@ -1573,922 +1573,6 @@ Attacking player rolls 2D6.  If the target has a Toughness characteristic, they 
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="6d6a-894d-6fb4-4e1c" name="Crusade Fleet Arvus Lighter Orbital Shuttle" book="" hidden="false" collective="false" categoryEntryId="466173742041747461636b23232344415441232323" type="unit">
-      <profiles>
-        <profile id="2426-7e1f-ab25-9bbc" name="Arvus Lighter Orbital Shuttle" book="HH:MT" page="50" hidden="false" profileTypeId="56656869636c6523232344415441232323">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="3"/>
-            <characteristic name="Front" characteristicTypeId="46726f6e7423232344415441232323" value="11"/>
-            <characteristic name="Side" characteristicTypeId="5369646523232344415441232323" value="11"/>
-            <characteristic name="Rear" characteristicTypeId="5265617223232344415441232323" value="10"/>
-            <characteristic name="HP" characteristicTypeId="485023232344415441232323" value="3"/>
-            <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Flyer (Hover)"/>
-          </characteristics>
-        </profile>
-      </profiles>
-      <rules/>
-      <infoLinks>
-        <infoLink id="fb00-b33b-499e-7e93" name="New InfoLink" hidden="false" targetId="d219-2314-4834-c054" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <selectionEntries/>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="e3cd-b456-57a2-33b8" name="May take one of the following:" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="1a19-ab80-0a87-7d6a" name="Multi-laser" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="14dc-4a54-082e-34d2" hidden="false" targetId="c812-a8fe-2b49-75a5" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="10.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="d898-ee78-3e27-da03" name="Autocannon" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="10.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="88cc-0b36-9941-077d" name="Lascannon" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="20.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="11c2-7f15-e5ee-9b9f" name="Twin-linked Multi-laser" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="6ec6-aae3-0513-cdc7" hidden="false" targetId="c812-a8fe-2b49-75a5" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="15.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="49c1-a2b9-9aac-21a6" name="Twin-linked Lascannon" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="25.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="baf9-6375-8ca1-f4a9" name="Twin-linked Autocannon" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="15.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups/>
-          <entryLinks/>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="5cc0-7bba-77b7-89cb" name="May take any of the following:" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <selectionEntries>
-            <selectionEntry id="3ac5-f6ea-f645-5c63" name="Chaff launcher" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="df52-23dd-0097-55aa" hidden="false" targetId="c3bb10b0-0ad1-3d7e-5b6e-20b2f57fbaba" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="10.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="8614-d972-2d94-abe0" name="Armoured Cockpit" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="e190-e84c-9b75-7c56" hidden="false" targetId="06710a9d-a2a8-638f-91b0-2af2fb3e95c2" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="15.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="dc77-e8a0-bbf4-8057" name="Illum Flares" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="f291-b697-a668-d76a" hidden="false" targetId="b4c9d27d-b3cf-28bd-3367-b1bfddd5c401" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="eda4-20b3-aa38-dda0" name="Searchlight" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="1.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="8e01-a6a3-d268-eb54" name="Flare Shield" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="82a3-89e4-bce1-bf97" hidden="false" targetId="a7069849-cdd7-ffb1-8088-8300704afcae" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="20.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="a4d9-5274-341d-38b7" name="Modified to carry Battle-automata" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules>
-                <rule id="8ff4-754a-a23c-429d" name="Modified to carry Battle-automata" book="Taghmata Army List" page="50" hidden="false">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <description>May carry 1 Castellax or two Voray, but is no longer able to transport other troops</description>
-                </rule>
-              </rules>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="20.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="690b-4b4d-0bba-4a9c" name="New EntryLink" hidden="false" targetId="d00f-81d6-1749-9499" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="set" field="points" value="10">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="75.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="1ea3-73a3-7731-6d8a" name="Crusade Fleet Avenger Strike Fighter" book="HH:MT" page="47" hidden="false" collective="false" categoryEntryId="466173742041747461636b23232344415441232323" type="unit">
-      <profiles>
-        <profile id="b8ce-d745-2f16-d397" name="Avenger Bolt-cannon" book="HH1: Betrayal" page="272" hidden="false" profileTypeId="576561706f6e23232344415441232323">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="36&quot;"/>
-            <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="6"/>
-            <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="3"/>
-            <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 7"/>
-          </characteristics>
-        </profile>
-        <profile id="ce89-f9d2-d393-7aab" name="Defensive Heavy Stubber" book="HH1: Betrayal" page="272" hidden="false" profileTypeId="576561706f6e23232344415441232323">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="36&quot;"/>
-            <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="4"/>
-            <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="6"/>
-            <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy  3, Skyfire"/>
-          </characteristics>
-        </profile>
-        <profile id="afe3-b241-4ea9-2e34" name="Crusade Fleet Avenger Strike Fighter" book="HH: MT" page="47" hidden="false" profileTypeId="56656869636c6523232344415441232323">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="3"/>
-            <characteristic name="Front" characteristicTypeId="46726f6e7423232344415441232323" value="12"/>
-            <characteristic name="Side" characteristicTypeId="5369646523232344415441232323" value="10"/>
-            <characteristic name="Rear" characteristicTypeId="5265617223232344415441232323" value="10"/>
-            <characteristic name="HP" characteristicTypeId="485023232344415441232323" value="2"/>
-            <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Flyer"/>
-          </characteristics>
-        </profile>
-      </profiles>
-      <rules/>
-      <infoLinks>
-        <infoLink id="f0cf-5ed0-d4fb-5743" hidden="false" targetId="06710a9d-a2a8-638f-91b0-2af2fb3e95c2" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="69ed-61e5-da67-0044" name="New InfoLink" hidden="false" targetId="d219-2314-4834-c054" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="8b9b-f15c-b5ae-e28a" name="New InfoLink" hidden="false" targetId="2e96-21ae-353e-8742" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="cb33-7932-6ee0-0f11" name="New InfoLink" hidden="false" targetId="7911-b951-c819-2f4f" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <selectionEntries/>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="e014-25cc-4010-c060" name="May be equipped with:" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <selectionEntries>
-            <selectionEntry id="aecc-9680-83f4-8c6e" name="Chaff Launcher" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="bfac-8e39-6e9a-ff32" hidden="false" targetId="c3bb10b0-0ad1-3d7e-5b6e-20b2f57fbaba" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="10.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="e3bf-b321-0021-aaad" name="Infra-red Targeting" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="286a-2425-792a-1bc1" hidden="false" targetId="4fedc0e6-5d69-1ecd-9624-441e0ea99565" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="7a35-2936-424d-65b3" name="Battle Servitor Control" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="eef4-1fec-1242-97c8" hidden="false" targetId="74effb54-87f7-8481-9e5f-86d9e3ed37c2" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="15.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups/>
-          <entryLinks/>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="f20d-649b-7321-64f9" name="May equip two hardpoints with one choice of:" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="5187-f08e-9df6-2256" name="Two Autocannons" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="20.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="e10f-3b50-5b7f-1d3b" name="Two Multi-lasers" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="20.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="eaca-9e62-ccf6-c11a" name="Two Missile Launchers" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="20.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="21c8-cd0e-bf07-13c8" name="Six Tactical Bombs" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="0085-ad7e-3742-58b8" hidden="false" targetId="0e9bdcf2-a925-e661-dbb5-755ee50c4967" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="40.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="0443-10b1-004b-b66b" name="Two Kraken penetrator heavy missiles" book="HH:LACAL" page="43" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles>
-                <profile id="b57e-fd23-fe5b-2ed2" name="Kraken penetrator heavy missile" book="HH:LACAL" page="43" hidden="false" profileTypeId="576561706f6e23232344415441232323">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <characteristics>
-                    <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="36&quot;"/>
-                    <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="8"/>
-                    <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="1"/>
-                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 1, Missile, Armourbane, One Use"/>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="25.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups/>
-          <entryLinks/>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="150.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="6449-adbd-04c1-7a7d" name="Crusade Fleet Primaris-Lightning Strike Fighter" book="Taghmata Army List" page="47" hidden="false" collective="false" categoryEntryId="466173742041747461636b23232344415441232323" type="unit">
-      <profiles>
-        <profile id="4da8-c421-3ab1-5ecc" name="Crusade Fleet Primaris-Lightning Strike Fighter" book="HH:MT" page="48" hidden="false" profileTypeId="56656869636c6523232344415441232323">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="4"/>
-            <characteristic name="Front" characteristicTypeId="46726f6e7423232344415441232323" value="11"/>
-            <characteristic name="Side" characteristicTypeId="5369646523232344415441232323" value="11"/>
-            <characteristic name="Rear" characteristicTypeId="5265617223232344415441232323" value="10"/>
-            <characteristic name="HP" characteristicTypeId="485023232344415441232323" value="2"/>
-            <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Flyer"/>
-          </characteristics>
-        </profile>
-        <profile id="59ad-52bb-a827-356a" name="Chaff/Flare Launchers" book="HH:LACAL" page="90" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Description" characteristicTypeId="4465736372697074696f6e23232344415441232323" value="Gains 4++ invulnerable against damage caused by missile weapons. "/>
-          </characteristics>
-        </profile>
-      </profiles>
-      <rules>
-        <rule id="904f-fe49-0cc3-a20e" name="Agile" page="0" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </rule>
-        <rule id="e492-8197-c4c1-a96f" name="Missile Barrage" page="0" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </rule>
-      </rules>
-      <infoLinks>
-        <infoLink id="c1a7-b2a6-996d-377e" hidden="false" targetId="06710a9d-a2a8-638f-91b0-2af2fb3e95c2" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="68ed-2c9c-2464-b6db" name="New InfoLink" hidden="false" targetId="d219-2314-4834-c054" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="146d-6cc6-4cad-30d1" name="New InfoLink" hidden="false" targetId="2e96-21ae-353e-8742" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <selectionEntries/>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="5fbf-d605-cf5d-64f8" name="May take any of the following:" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="6dd9-3155-2d5c-55c7" name="Ramjet Diffraction Grid" book="HH:LACAL" page="43" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles>
-                <profile id="619e-f161-a7d5-d1f5" name="Ramjet Diffraction Grid" book="HH:LACAL" page="42" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <characteristics>
-                    <characteristic name="Description" characteristicTypeId="4465736372697074696f6e23232344415441232323" value="Reduces Strength value of incoming shooting attacks from side and rear armour by -1 but may never benefit from cover saves due to Night Fighting.  "/>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="20.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="8e23-d8ae-4a68-5cc5" name="Battle Servitor Control" book="HH:LACAL" page="43" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="beaa-ed74-8fb4-4cc7" hidden="false" targetId="74effb54-87f7-8481-9e5f-86d9e3ed37c2" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="15.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="00f2-1ff2-5fcd-74d6" name="Ground-tracking Auguries" book="HH:LACAL" page="43" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="623f-207e-f8e1-4fe5" hidden="false" targetId="abdf1422-184a-f8f9-9544-621c2e1c646f" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="10.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups/>
-          <entryLinks/>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="7bea-34ce-d211-bad1" name="May equip three dual hardpoints:" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="4697-5e61-85a6-bbce" name="Twin-linked Autocannon" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="20.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="17bf-a822-d7e6-5f61" name="Twin-linked Multi-laser" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="20.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="d230-ed5b-5c09-d018" name="Twin-linked Missile Launcher" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="25.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="641e-4e0a-5841-0033" name="Two Sunfury heavy missiles" book="HH:LACAL" page="43" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles>
-                <profile id="4c77-462c-692e-f360" name="Sunfury heavy missile" book="HH:LACAL" page="43" hidden="false" profileTypeId="576561706f6e23232344415441232323">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <characteristics>
-                    <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="36&quot;"/>
-                    <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="6"/>
-                    <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="3"/>
-                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 1, Missile, Large Blast, Blind, Gets Hot, One Use"/>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="15.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="87cc-f9dd-9367-0d07" name="Two Kraken penetrator heavy missiles" book="HH:LACAL" page="43" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles>
-                <profile id="bdad-6fe8-54e7-bed9" name="Kraken penetrator heavy missile" book="HH:LACAL" page="43" hidden="false" profileTypeId="576561706f6e23232344415441232323">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <characteristics>
-                    <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="36&quot;"/>
-                    <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="8"/>
-                    <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="1"/>
-                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 1, Missile, Armourbane, One Use"/>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="25.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="3381-1e9e-89bc-2ce6" name="Phosphex bomb cluster" book="HH:LACAL" page="43" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles>
-                <profile id="0df0-e8a1-2e02-cf5e" name="Phosphex bomb cluster" book="HH:LACAL" page="43" hidden="false" profileTypeId="576561706f6e23232344415441232323">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <characteristics>
-                    <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="Bomb"/>
-                    <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="5"/>
-                    <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="2"/>
-                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 2, Barrage, Bomb Cluster, Blast, Poisoned (3+), Crawling Fire, Lingering Death, Deadly Cargo, One Use"/>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <rules>
-                <rule id="aa23-dd9f-18b5-faf5" name="Deadly Cargo" book="HH:LACAL" page="43" hidden="false">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <description>If a flyer carring a weapon with this special rule takes hull damage but is not destroyed, roll a D6.  On a 6, the flyer suffers and explodes result.  </description>
-                </rule>
-              </rules>
-              <infoLinks>
-                <infoLink id="e987-4a86-4e23-1e5f" hidden="false" targetId="c05245e1-0c49-a3e4-30d9-f6006c256839" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="19d1-9f6c-df0c-1866" hidden="false" targetId="395c911d-e7ca-b2cc-c4e9-1e5d807187f1" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="25.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="b7ed-ae8b-c3e3-ac4c" name="Two Electromagnetic storm charges" book="HH:LACAL" page="43" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles>
-                <profile id="9715-341e-6ed2-6930" name="Electromagnetic storm charges" book="HH:LACAL" page="43" hidden="false" profileTypeId="576561706f6e23232344415441232323">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <characteristics>
-                    <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="Bomb"/>
-                    <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="3"/>
-                    <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="4"/>
-                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 1, Bomb, Large Blast, Haywire, Concussive, One Use"/>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="20.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups/>
-          <entryLinks/>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="135.0"/>
-      </costs>
-    </selectionEntry>
     <selectionEntry id="1a57-bff0-745f-25ab" name="Domitar Class Battle-automata Maniple" hidden="false" collective="false" categoryEntryId="456c6974657323232344415441232323" type="unit">
       <profiles>
         <profile id="a7ac-a09c-4dcb-c0a9" name="Graviton Hammer" book="HH5: Tempest" page="227" hidden="false" profileTypeId="576561706f6e23232344415441232323">
@@ -13658,6 +12742,27 @@ Use at the start of the controlling player’s turn. Until the beginning of thei
       <modifiers/>
       <constraints/>
     </entryLink>
+    <entryLink id="a8be-c5b3-71f2-beee" name="New EntryLink" hidden="false" targetId="7b0f-7bfb-ca1f-e761" type="selectionEntry" categoryEntryId="466173742041747461636b23232344415441232323">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </entryLink>
+    <entryLink id="eb49-9c86-cc4d-9897" name="New EntryLink" hidden="false" targetId="11c8-2e78-8328-31e4" type="selectionEntry" categoryEntryId="466173742041747461636b23232344415441232323">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </entryLink>
+    <entryLink id="6168-b447-65bb-476a" name="New EntryLink" hidden="false" targetId="5d68-1fb8-1f66-af3a" type="selectionEntry" categoryEntryId="466173742041747461636b23232344415441232323">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </entryLink>
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="00cf-20ab-1b17-aad1" name="Archmagos" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
@@ -18602,6 +17707,916 @@ Buildings and Fortifications                                          D
       <entryLinks/>
       <costs>
         <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7b0f-7bfb-ca1f-e761" name="Crusade Fleet Arvus Lighter Orbital Shuttle" book="" hidden="false" collective="false" categoryEntryId="466173742041747461636b23232344415441232323" type="unit">
+      <profiles>
+        <profile id="44e0-2678-2bb6-c576" name="Arvus Lighter Orbital Shuttle" book="HH:MT" page="50" hidden="false" profileTypeId="56656869636c6523232344415441232323">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="3"/>
+            <characteristic name="Front" characteristicTypeId="46726f6e7423232344415441232323" value="11"/>
+            <characteristic name="Side" characteristicTypeId="5369646523232344415441232323" value="11"/>
+            <characteristic name="Rear" characteristicTypeId="5265617223232344415441232323" value="10"/>
+            <characteristic name="HP" characteristicTypeId="485023232344415441232323" value="3"/>
+            <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Flyer (Hover)"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="d37e-768b-11f0-2a52" name="New InfoLink" hidden="false" targetId="d219-2314-4834-c054" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="6ad6-9dd7-4994-60f9" name="May take one of the following:" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e42e-6e0a-e91c-9090" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="b706-2690-0d23-a459" name="Multi-laser" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="4af4-18f5-946b-0625" hidden="false" targetId="c812-a8fe-2b49-75a5" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="40fc-ca9f-c53d-92aa" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="8a60-4b61-343b-2089" name="Autocannon" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5eef-b141-6620-2f34" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="c6aa-acfa-4986-7818" name="Lascannon" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c428-b32a-4925-8bd7" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="20.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="f835-7925-5e93-fd6e" name="Twin-linked Multi-laser" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="ca3a-db81-b97f-f9a4" hidden="false" targetId="c812-a8fe-2b49-75a5" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d624-5d0d-8464-1908" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="15.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="15fb-87cf-554f-0132" name="Twin-linked Lascannon" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="15b1-acad-7ca5-3eb0" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="25.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="80ac-f243-b45a-0e9f" name="Twin-linked Autocannon" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="acc4-d5ce-8470-7538" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="15.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="fc2a-42d9-ddfd-9063" name="May take any of the following:" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries>
+            <selectionEntry id="38cf-1d32-10ba-1a5b" name="Chaff launcher" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="7f16-7d4a-f821-4357" hidden="false" targetId="c3bb10b0-0ad1-3d7e-5b6e-20b2f57fbaba" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="24f9-3f6e-7141-99c1" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="e43f-c2d6-414e-89af" name="Armoured Cockpit" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="ad07-841b-3b33-e57a" hidden="false" targetId="06710a9d-a2a8-638f-91b0-2af2fb3e95c2" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0ecd-6844-d82f-f5b4" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="15.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="64a1-2f6d-910e-3d72" name="Illum Flares" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="92f6-51b7-0b0f-a488" hidden="false" targetId="b4c9d27d-b3cf-28bd-3367-b1bfddd5c401" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7ccb-035a-d956-3ab0" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="9935-df2f-ea28-a043" name="Searchlight" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9bcf-aed7-3a21-2262" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="1.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="b049-75c7-9fda-441d" name="Flare Shield" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="bdd7-9edb-3ba8-3c08" hidden="false" targetId="a7069849-cdd7-ffb1-8088-8300704afcae" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c881-5b1e-a213-889b" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="20.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="3ef4-a228-484c-453c" name="Modified to carry Battle-automata" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules>
+                <rule id="a115-2971-287b-30d1" name="Modified to carry Battle-automata" book="Taghmata Army List" page="50" hidden="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <description>May carry 1 Castellax or two Voray, but is no longer able to transport other troops</description>
+                </rule>
+              </rules>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e16c-3610-5cc4-24f6" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="20.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="868a-9c49-7340-0d35" name="New EntryLink" hidden="false" targetId="d00f-81d6-1749-9499" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="10">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="75.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5d68-1fb8-1f66-af3a" name="Crusade Fleet Primaris-Lightning Strike Fighter" book="Taghmata Army List" page="47" hidden="false" collective="false" categoryEntryId="466173742041747461636b23232344415441232323" type="unit">
+      <profiles>
+        <profile id="5f6b-d6dd-568b-ebad" name="Crusade Fleet Primaris-Lightning Strike Fighter" book="HH:MT" page="48" hidden="false" profileTypeId="56656869636c6523232344415441232323">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="4"/>
+            <characteristic name="Front" characteristicTypeId="46726f6e7423232344415441232323" value="11"/>
+            <characteristic name="Side" characteristicTypeId="5369646523232344415441232323" value="11"/>
+            <characteristic name="Rear" characteristicTypeId="5265617223232344415441232323" value="10"/>
+            <characteristic name="HP" characteristicTypeId="485023232344415441232323" value="2"/>
+            <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Flyer"/>
+          </characteristics>
+        </profile>
+        <profile id="c974-2a86-c1b9-a191" name="Chaff/Flare Launchers" book="HH:LACAL" page="90" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Description" characteristicTypeId="4465736372697074696f6e23232344415441232323" value="Gains 4++ invulnerable against damage caused by missile weapons. "/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="aad0-8e73-2eee-57b4" name="Agile" page="0" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </rule>
+        <rule id="f562-81c1-83cb-ffd2" name="Missile Barrage" page="0" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="427f-b465-db63-00cc" hidden="false" targetId="06710a9d-a2a8-638f-91b0-2af2fb3e95c2" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="a382-2094-6cee-9ff8" name="New InfoLink" hidden="false" targetId="d219-2314-4834-c054" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="689f-54a5-99b3-78a6" name="New InfoLink" hidden="false" targetId="2e96-21ae-353e-8742" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="e744-5ed2-aa42-fdaa" name="May take any of the following:" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="cab8-871b-8c83-90f3" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="ce59-f93f-70ae-31ba" name="Ramjet Diffraction Grid" book="HH:LACAL" page="43" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles>
+                <profile id="6264-e4a4-5d99-e9fb" name="Ramjet Diffraction Grid" book="HH:LACAL" page="42" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Description" characteristicTypeId="4465736372697074696f6e23232344415441232323" value="Reduces Strength value of incoming shooting attacks from side and rear armour by -1 but may never benefit from cover saves due to Night Fighting.  "/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="aaa0-ce7e-5ebe-f07a" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="20.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="3196-d362-cd3e-4cc5" name="Battle Servitor Control" book="HH:LACAL" page="43" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="e6dc-7f58-5779-f362" hidden="false" targetId="74effb54-87f7-8481-9e5f-86d9e3ed37c2" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0111-958f-0306-f8c0" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="15.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="664c-0439-607c-9563" name="Ground-tracking Auguries" book="HH:LACAL" page="43" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="14a2-9df8-7afa-1135" hidden="false" targetId="abdf1422-184a-f8f9-9544-621c2e1c646f" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4e18-5278-67dc-d2f2" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="10.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="d22a-2025-30e2-c1d6" name="May equip three dual hardpoints:" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6157-0b0f-9d25-96b6" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="f705-0db7-d791-4dc1" name="Twin-linked Autocannon" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="49c2-519f-5c4c-7e30" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="20.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="13f8-7378-f624-40e0" name="Twin-linked Multi-laser" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a54c-2bd9-f1a5-8519" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="20.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="29f8-3dd3-515d-3316" name="Twin-linked Missile Launcher" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b729-f2a6-8e29-7154" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="25.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="6c7b-e9b5-db9d-6ba5" name="Two Sunfury heavy missiles" book="HH:LACAL" page="43" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles>
+                <profile id="28fb-6fa9-9baa-6ca1" name="Sunfury heavy missile" book="HH:LACAL" page="43" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="36&quot;"/>
+                    <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="6"/>
+                    <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="3"/>
+                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 1, Missile, Large Blast, Blind, Gets Hot, One Use"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6027-8c03-8225-3aaa" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="15.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="5f35-3af3-40bc-f481" name="Two Kraken penetrator heavy missiles" book="HH:LACAL" page="43" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles>
+                <profile id="c713-e734-928d-0dae" name="Kraken penetrator heavy missile" book="HH:LACAL" page="43" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="36&quot;"/>
+                    <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="8"/>
+                    <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="1"/>
+                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 1, Missile, Armourbane, One Use"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="81e7-ce06-4c69-2be7" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="25.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="0dea-fbb6-1fa7-1b98" name="Phosphex bomb cluster" book="HH:LACAL" page="43" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles>
+                <profile id="8185-8a7e-f203-a5b2" name="Phosphex bomb cluster" book="HH:LACAL" page="43" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="Bomb"/>
+                    <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="5"/>
+                    <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="2"/>
+                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 2, Barrage, Bomb Cluster, Blast, Poisoned (3+), Crawling Fire, Lingering Death, Deadly Cargo, One Use"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules>
+                <rule id="3798-9d1f-c145-0393" name="Deadly Cargo" book="HH:LACAL" page="43" hidden="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <description>If a flyer carring a weapon with this special rule takes hull damage but is not destroyed, roll a D6.  On a 6, the flyer suffers and explodes result.  </description>
+                </rule>
+              </rules>
+              <infoLinks>
+                <infoLink id="0d5a-a3fb-b5a7-f209" hidden="false" targetId="c05245e1-0c49-a3e4-30d9-f6006c256839" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="976c-1b66-468e-e1a5" hidden="false" targetId="395c911d-e7ca-b2cc-c4e9-1e5d807187f1" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a7b6-762a-aa3a-9415" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="25.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="03c6-fca2-76cd-2b06" name="Two Electromagnetic storm charges" book="HH:LACAL" page="43" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles>
+                <profile id="c218-50fd-aa05-88aa" name="Electromagnetic storm charges" book="HH:LACAL" page="43" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="Bomb"/>
+                    <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="3"/>
+                    <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="4"/>
+                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 1, Bomb, Large Blast, Haywire, Concussive, One Use"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8db3-18f7-c901-1b85" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="20.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="135.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="11c8-2e78-8328-31e4" name="Crusade Fleet Avenger Strike Fighter" book="HH:MT" page="47" hidden="false" collective="false" categoryEntryId="466173742041747461636b23232344415441232323" type="unit">
+      <profiles>
+        <profile id="341f-27c1-0e88-9c83" name="Avenger Bolt-cannon" book="HH1: Betrayal" page="272" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="36&quot;"/>
+            <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="6"/>
+            <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="3"/>
+            <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 7"/>
+          </characteristics>
+        </profile>
+        <profile id="1bbc-16a5-2991-4ed6" name="Defensive Heavy Stubber" book="HH1: Betrayal" page="272" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="36&quot;"/>
+            <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="4"/>
+            <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="6"/>
+            <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy  3, Skyfire"/>
+          </characteristics>
+        </profile>
+        <profile id="7b84-f22b-69a7-5547" name="Crusade Fleet Avenger Strike Fighter" book="HH: MT" page="47" hidden="false" profileTypeId="56656869636c6523232344415441232323">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="3"/>
+            <characteristic name="Front" characteristicTypeId="46726f6e7423232344415441232323" value="12"/>
+            <characteristic name="Side" characteristicTypeId="5369646523232344415441232323" value="10"/>
+            <characteristic name="Rear" characteristicTypeId="5265617223232344415441232323" value="10"/>
+            <characteristic name="HP" characteristicTypeId="485023232344415441232323" value="2"/>
+            <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Flyer"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="4cac-2f89-e033-a1a8" hidden="false" targetId="06710a9d-a2a8-638f-91b0-2af2fb3e95c2" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="4d22-ecaf-8cdf-03c1" name="New InfoLink" hidden="false" targetId="d219-2314-4834-c054" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="d0b5-983b-f39b-09ed" name="New InfoLink" hidden="false" targetId="2e96-21ae-353e-8742" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="033c-ee32-2c36-53fe" name="New InfoLink" hidden="false" targetId="7911-b951-c819-2f4f" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="11ed-18c7-bdf5-2bd4" name="May be equipped with:" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries>
+            <selectionEntry id="43e8-9718-76cb-f171" name="Chaff Launcher" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="4e7a-cd40-2485-c79e" hidden="false" targetId="c3bb10b0-0ad1-3d7e-5b6e-20b2f57fbaba" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5fa2-bfe5-5219-aa9d" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="7145-b013-9f58-13fd" name="Infra-red Targeting" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="e2f4-c8da-3882-9ad3" hidden="false" targetId="4fedc0e6-5d69-1ecd-9624-441e0ea99565" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="10be-5b46-6d21-6803" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="7f2b-783b-7539-d64a" name="Battle Servitor Control" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="fdfc-5665-ddb6-2233" hidden="false" targetId="74effb54-87f7-8481-9e5f-86d9e3ed37c2" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e220-e46d-0c76-aa31" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="15.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="9ddc-52b1-2e67-b23c" name="May equip two hardpoints with one choice of:" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e289-7cb9-8e7e-e3a2" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="93c1-770a-6f9f-4863" name="Two Autocannons" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="06e6-42e9-b59a-6d02" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="20.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="d563-bc4b-df21-bafb" name="Two Multi-lasers" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="527e-483e-7b4a-4cc8" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="20.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="094c-f80e-963c-315d" name="Two Missile Launchers" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7229-b13f-c945-c3c4" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="20.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="e3da-3922-27aa-cb42" name="Six Tactical Bombs" page="0" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="18fb-9d40-2b1f-2462" hidden="false" targetId="0e9bdcf2-a925-e661-dbb5-755ee50c4967" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="10f9-8610-cd1b-ca78" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="40.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="9b03-4fc5-ed9e-ff8b" name="Two Kraken penetrator heavy missiles" book="HH:LACAL" page="43" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles>
+                <profile id="1aea-e38e-108f-bc42" name="Kraken penetrator heavy missile" book="HH:LACAL" page="43" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="36&quot;"/>
+                    <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="8"/>
+                    <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="1"/>
+                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 1, Missile, Armourbane, One Use"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9aa3-e313-e912-6f07" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="25.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="150.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>

--- a/(HH) Solar Auxilia - Crusade Army List.cat
+++ b/(HH) Solar Auxilia - Crusade Army List.cat
@@ -5289,7 +5289,7 @@ but the tank loses the Fast special rule.</description>
                       <profiles/>
                       <rules/>
                       <infoLinks>
-                        <infoLink id="eb71-36b2-e94b-206c" hidden="false" targetId="c32e-0d1a-f6db-2007" type="profile">
+                        <infoLink id="eb71-36b2-e94b-206c" hidden="false" targetId="871025a3-7729-f97d-378d-804c3571cdf3" type="profile">
                           <profiles/>
                           <rules/>
                           <infoLinks/>
@@ -6350,7 +6350,7 @@ Precision Shots</description>
               <profiles/>
               <rules/>
               <infoLinks>
-                <infoLink id="a557-353e-a895-3c9c" hidden="false" targetId="c32e-0d1a-f6db-2007" type="profile">
+                <infoLink id="a557-353e-a895-3c9c" hidden="false" targetId="871025a3-7729-f97d-378d-804c3571cdf3" type="profile">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -8713,7 +8713,7 @@ Use at the start of the controlling player’s turn. Until the beginning of thei
               <profiles/>
               <rules/>
               <infoLinks>
-                <infoLink id="f16d-d10a-44d0-25c5" hidden="false" targetId="c32e-0d1a-f6db-2007" type="profile">
+                <infoLink id="f16d-d10a-44d0-25c5" hidden="false" targetId="871025a3-7729-f97d-378d-804c3571cdf3" type="profile">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -11165,7 +11165,7 @@ Use at the start of the controlling player’s turn. Until the beginning of thei
                   <profiles/>
                   <rules/>
                   <infoLinks>
-                    <infoLink id="2500-4d30-f013-bdc9" name="New InfoLink" hidden="false" targetId="c32e-0d1a-f6db-2007" type="profile">
+                    <infoLink id="2500-4d30-f013-bdc9" name="New InfoLink" hidden="false" targetId="871025a3-7729-f97d-378d-804c3571cdf3" type="profile">
                       <profiles/>
                       <rules/>
                       <infoLinks/>

--- a/The Horus Heresy.gst
+++ b/The Horus Heresy.gst
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<gameSystem id="ca571888-56a9-c58e-ddaf-54f4713538bc" name="Warhammer 30,000 - The Horus Heresy" book="Forgeworld Horus Heresy Series" revision="67" battleScribeVersion="2.00" authorName="Millicant" authorContact="Please submit any bugs to the website below" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
+<gameSystem id="ca571888-56a9-c58e-ddaf-54f4713538bc" name="Warhammer 30,000 - The Horus Heresy" book="Forgeworld Horus Heresy Series" revision="68" battleScribeVersion="2.00" authorName="Millicant" authorContact="Please submit any bugs to the website below" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
   <profiles/>
   <rules/>
   <infoLinks/>

--- a/The Horus Heresy.gst
+++ b/The Horus Heresy.gst
@@ -1327,13 +1327,13 @@ Use at the start of the controlling player’s turn. Until the beginning of thei
                   <infoLinks/>
                   <modifiers/>
                 </infoLink>
-                <infoLink id="6018-217b-c5bc-7f05" name="New InfoLink" hidden="false" targetId="39e9-832d-44e8-426f" type="profile">
+                <infoLink id="6018-217b-c5bc-7f05" name="New InfoLink" hidden="false" targetId="d0f5-09ae-4c91-8764" type="profile">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
                   <modifiers/>
                 </infoLink>
-                <infoLink id="98e4-7116-f4b0-13d4" name="New InfoLink" hidden="false" targetId="d44e-3ae0-bac4-23f9" type="profile">
+                <infoLink id="98e4-7116-f4b0-13d4" name="507b-2215-7be8-61d7" hidden="false" targetId="507b-2215-7be8-61d7" type="profile">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -1459,13 +1459,13 @@ Use at the start of the controlling player’s turn. Until the beginning of thei
                   <infoLinks/>
                   <modifiers/>
                 </infoLink>
-                <infoLink id="40cf-7127-6cd3-1831" name="New InfoLink" hidden="false" targetId="39e9-832d-44e8-426f" type="profile">
+                <infoLink id="40cf-7127-6cd3-1831" name="New InfoLink" hidden="false" targetId="d0f5-09ae-4c91-8764" type="profile">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
                   <modifiers/>
                 </infoLink>
-                <infoLink id="a979-9fd0-837a-f48f" name="New InfoLink" hidden="false" targetId="d44e-3ae0-bac4-23f9" type="profile">
+                <infoLink id="a979-9fd0-837a-f48f" name="New InfoLink" hidden="false" targetId="507b-2215-7be8-61d7" type="profile">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -1762,13 +1762,13 @@ Use at the start of the controlling player’s turn. Until the beginning of thei
                   <infoLinks/>
                   <modifiers/>
                 </infoLink>
-                <infoLink id="284a-5bf3-7f0f-8a72" name="New InfoLink" hidden="false" targetId="39e9-832d-44e8-426f" type="profile">
+                <infoLink id="284a-5bf3-7f0f-8a72" name="New InfoLink" hidden="false" targetId="d0f5-09ae-4c91-8764" type="profile">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
                   <modifiers/>
                 </infoLink>
-                <infoLink id="5a89-968a-ae1c-2a61" name="New InfoLink" hidden="false" targetId="d44e-3ae0-bac4-23f9" type="profile">
+                <infoLink id="5a89-968a-ae1c-2a61" name="New InfoLink" hidden="false" targetId="507b-2215-7be8-61d7" type="profile">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -2623,13 +2623,13 @@ D6    Result		S	AP
                   <infoLinks/>
                   <modifiers/>
                 </infoLink>
-                <infoLink id="d790-cd99-e0f1-cba9" name="New InfoLink" hidden="false" targetId="39e9-832d-44e8-426f" type="profile">
+                <infoLink id="d790-cd99-e0f1-cba9" name="New InfoLink" hidden="false" targetId="d0f5-09ae-4c91-8764" type="profile">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
                   <modifiers/>
                 </infoLink>
-                <infoLink id="3167-6a34-ea42-d324" name="New InfoLink" hidden="false" targetId="d44e-3ae0-bac4-23f9" type="profile">
+                <infoLink id="3167-6a34-ea42-d324" name="New InfoLink" hidden="false" targetId="507b-2215-7be8-61d7" type="profile">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -3296,7 +3296,7 @@ D6    Result		S	AP
               <profiles/>
               <rules/>
               <infoLinks>
-                <infoLink id="7536-fa3d-9d94-c7b4" name="New InfoLink" hidden="false" targetId="c32e-0d1a-f6db-2007" type="profile">
+                <infoLink id="7536-fa3d-9d94-c7b4" name="New InfoLink" hidden="false" targetId="871025a3-7729-f97d-378d-804c3571cdf3" type="profile">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -3943,7 +3943,7 @@ D6    Result		S	AP
                   <profiles/>
                   <rules/>
                   <infoLinks>
-                    <infoLink id="4080-b42f-51a4-6c9a" hidden="false" targetId="32d5-9382-d290-b026" type="profile">
+                    <infoLink id="4080-b42f-51a4-6c9a" hidden="false" targetId="51100eb8-f6e6-7048-df0a-84f0163a38bd" type="profile">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -12325,7 +12325,7 @@ Attacking player rolls 2D6.  If the target has a Toughness characteristic, they 
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="92d83f8e-f566-62f0-7a31-6644bab4b00c" hidden="false" targetId="9244539c-1242-7e6e-bb3c-0773cfe85e51" type="profile">
+        <infoLink id="92d83f8e-f566-62f0-7a31-6644bab4b00c" hidden="false" targetId="e135-8b23-7190-9f2c" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -16585,30 +16585,6 @@ Shooting attack against the shield facing is reduced by -1, the effect increasin
         <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Primary Weapon 1"/>
       </characteristics>
     </profile>
-    <profile id="39e9-832d-44e8-426f" name="Plasma Blastgun (Overload)" book="HH5: Tempest" page="264" hidden="false" profileTypeId="576561706f6e23232344415441232323">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="96&quot;"/>
-        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="10"/>
-        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="2"/>
-        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Primary Weapon 1, Apocalyptic Blast"/>
-      </characteristics>
-    </profile>
-    <profile id="d44e-3ae0-bac4-23f9" name="Plasma Blastgun (Rapid)" book="HH5: Tempest" page="264" hidden="false" profileTypeId="576561706f6e23232344415441232323">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="72&quot;"/>
-        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="8"/>
-        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="2"/>
-        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Primary Weapon 2, Massive Blast"/>
-      </characteristics>
-    </profile>
     <profile id="3b45-b564-4fce-e3d8" name="Vulcan Mega-bolter" book="HH5: Tempest" page="264" hidden="false" profileTypeId="576561706f6e23232344415441232323">
       <profiles/>
       <rules/>
@@ -16843,18 +16819,6 @@ Shooting attack against the shield facing is reduced by -1, the effect increasin
         <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Melee, Rending, Paired Weapons"/>
       </characteristics>
     </profile>
-    <profile id="32d5-9382-d290-b026" name="Siege Wrecker" book="HH:MT" page="115" hidden="false" profileTypeId="576561706f6e23232344415441232323">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="-"/>
-        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="10"/>
-        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="2"/>
-        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Melee, Concussive, Wrecker, Specialist Weapon"/>
-      </characteristics>
-    </profile>
     <profile id="13e0-4939-5232-8d85" name="Atomantic Shielding" book="HH:MT" page="110" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323">
       <profiles/>
       <rules/>
@@ -16901,18 +16865,6 @@ Shooting attack against the shield facing is reduced by -1, the effect increasin
         <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="3"/>
         <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="-"/>
         <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Assault 1, Blast"/>
-      </characteristics>
-    </profile>
-    <profile id="c32e-0d1a-f6db-2007" name="Rotor Cannon" book="HH:MT" page="115" hidden="false" profileTypeId="576561706f6e23232344415441232323">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="30&quot;"/>
-        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="3"/>
-        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="6"/>
-        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Salvo 3/4"/>
       </characteristics>
     </profile>
     <profile id="d1ac-3bb0-0a9d-e48f" name="Rotor Cannon (Bio-corrosive rounds)" book="HH:MT" page="115" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
@@ -18280,36 +18232,6 @@ Shooting attack against the shield facing is reduced by -1, the effect increasin
         <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 1, Skyfire, Interceptor, Heat Seeker"/>
       </characteristics>
     </profile>
-    <profile id="6368-f4e8-1e75-8ea4" name="Apocalypse Launcher" book="HH1: Betrayal" page="274" hidden="false" profileTypeId="576561706f6e23232344415441232323">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="24&quot; - 360&quot;"/>
-        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="7"/>
-        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="3"/>
-        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Apocalyptic Barrage 5"/>
-      </characteristics>
-    </profile>
-    <profile id="25e70aa3-867c-af48-6c22-1dbb7460be4c" name="Atomantic Shielding" book="HH3: Extermination" page="207" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Description" characteristicTypeId="4465736372697074696f6e23232344415441232323" value="Gains 5++ Invulnerable save from shooting attacks and explosions, and a 6++ Invulnerable save in close combat.  In addition, add +1 to the range of explosions from the Reactor Blast rule.  "/>
-      </characteristics>
-    </profile>
-    <profile id="9244539c-1242-7e6e-bb3c-0773cfe85e51" name="Cortex Controller" book="HH:LACAL" page="89" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Description" characteristicTypeId="4465736372697074696f6e23232344415441232323" value="Presence of a Cortex Controller within 12&quot; of a unit of friendly models with the Programmed Behaviour special rule at the start of any phase means that special rule is negated for that phase and their controlling player is free to use them as any other unit.  "/>
-      </characteristics>
-    </profile>
     <profile id="dd4fa1b2-43b4-75d6-974c-83c1a4115c07" name="Cyber-occularis" book="HH3: Extermination" page="207" hidden="false" profileTypeId="556e697423232344415441232323">
       <profiles/>
       <rules/>
@@ -18338,39 +18260,6 @@ Shooting attack against the shield facing is reduced by -1, the effect increasin
         <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="7"/>
         <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="2"/>
         <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 2, Lance, Blind, Gets Hot"/>
-      </characteristics>
-    </profile>
-    <profile id="d1d0-42b3-d48b-1348" name="Double-barrelled Turbo-laser Destructor" book="HH1: Betrayal" page="274" hidden="false" profileTypeId="576561706f6e23232344415441232323">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="96&quot;"/>
-        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="D"/>
-        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="2"/>
-        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 2, Large Blast"/>
-      </characteristics>
-    </profile>
-    <profile id="6253dfdd-8f74-faf6-de17-9a6b52b97abc" name="Enhanced Targeting Array" book="HH3: Extermination" page="207" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Description" characteristicTypeId="4465736372697074696f6e23232344415441232323" value="A model with this upgrade increases its BS by +1 and reduces enemy cover saves by -1. "/>
-      </characteristics>
-    </profile>
-    <profile id="f6c1-d78d-16f5-4209" name="Gatling Blaster" book="HH1: Betrayal" page="274" hidden="false" profileTypeId="576561706f6e23232344415441232323">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="72&quot;"/>
-        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="8"/>
-        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="3"/>
-        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 6, Large Blast"/>
       </characteristics>
     </profile>
     <profile id="481b32ee-2904-c9e0-8612-35ff2bcab65a" name="Graviton Gun" book="HH4: Conquest" page="308" hidden="false" profileTypeId="576561706f6e23232344415441232323">
@@ -18407,15 +18296,6 @@ Shooting attack against the shield facing is reduced by -1, the effect increasin
         <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="7"/>
         <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="3"/>
         <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 1"/>
-      </characteristics>
-    </profile>
-    <profile id="9221f401-6459-1e62-00fc-cd39eb567d88" name="Infravisor" book="HH3: Extermination" page="208" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Description" characteristicTypeId="4465736372697074696f6e23232344415441232323" value="Confers Night Vision, but counts as I1 for blind tests.  "/>
       </characteristics>
     </profile>
     <profile id="342d5e83-9f9b-42c0-cecb-e6c9c197ab9d" name="Ion Shield" book="HH4: Conquest" page="301" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323">
@@ -18458,18 +18338,6 @@ Shooting attack against the shield facing is reduced by -1, the effect increasin
         <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="5"/>
         <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="4"/>
         <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 1, Large Blast, Barrage "/>
-      </characteristics>
-    </profile>
-    <profile id="ad9f-da38-7e2c-13bf" name="Laser Blaster" book="HH1: Betrayal" page="274" hidden="false" profileTypeId="576561706f6e23232344415441232323">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="96&quot;"/>
-        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="D"/>
-        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="2"/>
-        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 3, Large Blast"/>
       </characteristics>
     </profile>
     <profile id="418fbfed-277a-7376-dfd3-7d5a95fae9f5" name="Lightning Cannon" book="HH4: Conquest" page="308" hidden="false" profileTypeId="576561706f6e23232344415441232323">
@@ -18517,18 +18385,6 @@ Shooting attack against the shield facing is reduced by -1, the effect increasin
         <characteristic name="Description" characteristicTypeId="4465736372697074696f6e23232344415441232323" value="Provides 4++ Invulnerable save"/>
       </characteristics>
     </profile>
-    <profile id="60bb-5aa9-2642-06f5" name="Melta Cannon" book="HH1: Betrayal" page="274" hidden="false" profileTypeId="576561706f6e23232344415441232323">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="72&quot;"/>
-        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="10"/>
-        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="2"/>
-        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Ordnance 1, Apocalyptic Blast (10&quot;)"/>
-      </characteristics>
-    </profile>
     <profile id="faa4ea24-e51b-8663-3e7c-1a791b55aed7" name="Occular Augmetics" book="CI:AL" page="109" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323">
       <profiles/>
       <rules/>
@@ -18572,18 +18428,6 @@ Shooting attack against the shield facing is reduced by -1, the effect increasin
         <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="8"/>
         <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="2"/>
         <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Primary Weapon 2, Massive Blast (7&quot;)"/>
-      </characteristics>
-    </profile>
-    <profile id="8d53b674-e240-cff6-bd05-4822a2783b6e" name="Power Blades" book="HH3: Extermination" page="208" hidden="false" profileTypeId="576561706f6e23232344415441232323">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="-"/>
-        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="User"/>
-        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="2"/>
-        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Melee, Rending"/>
       </characteristics>
     </profile>
     <profile id="3c77a0e2-2b38-0fff-5d7d-8f63f811bbdf" name="Rad cleanser" book="HH4: Conquest" page="308" hidden="false" profileTypeId="576561706f6e23232344415441232323">
@@ -18670,18 +18514,6 @@ Shooting attack against the shield facing is reduced by -1, the effect increasin
         <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 2, Interceptor, Skyfire, Twin-linked"/>
       </characteristics>
     </profile>
-    <profile id="dfa9-60b6-4028-e0ef" name="Volcano Cannon" book="HH1: Betrayal" page="274" hidden="false" profileTypeId="576561706f6e23232344415441232323">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="180&quot;"/>
-        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="D"/>
-        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="2"/>
-        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Ordnance 1, Massive Blast (7&quot;)"/>
-      </characteristics>
-    </profile>
     <profile id="8f57-fa37-5c5c-e7cb" name="Vortex Missile" book="HH1: Betrayal" page="274" hidden="false" profileTypeId="576561706f6e23232344415441232323">
       <profiles/>
       <rules/>
@@ -18692,18 +18524,6 @@ Shooting attack against the shield facing is reduced by -1, the effect increasin
         <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="*"/>
         <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="*"/>
         <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Ordnance 1, Apocalyptic Blast (10&quot;), One Shot"/>
-      </characteristics>
-    </profile>
-    <profile id="1ef4-b456-8ae5-800f" name="Vulcan Mega-bolter" book="HH1: Betrayal" page="274" hidden="false" profileTypeId="576561706f6e23232344415441232323">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="60&quot;"/>
-        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="6"/>
-        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="3"/>
-        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 15"/>
       </characteristics>
     </profile>
     <profile id="9170-c4db-7a4c-87fb" name="Ironstorm Missiles" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">

--- a/The Horus Heresy.gst
+++ b/The Horus Heresy.gst
@@ -10096,7 +10096,7 @@ The Bunkers of the Castellum Stronghold have a 5+ invulnerable save against shoo
       </profiles>
       <rules/>
       <infoLinks>
-        <infoLink id="a0d42172-1a16-82ae-561a-98218604c374" hidden="false" targetId="b352ed0c-5fc2-2b26-e1ea-8bc60068af56" type="rule">
+        <infoLink id="a0d42172-1a16-82ae-561a-98218604c374" hidden="false" targetId="6ce7-5e83-a2dd-571e" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -10399,7 +10399,7 @@ The Bunkers of the Castellum Stronghold have a 5+ invulnerable save against shoo
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="42d3d4f7-1fbe-6440-1bf2-22ee91ed7d0d" hidden="false" targetId="b352ed0c-5fc2-2b26-e1ea-8bc60068af56" type="rule">
+        <infoLink id="42d3d4f7-1fbe-6440-1bf2-22ee91ed7d0d" hidden="false" targetId="6ce7-5e83-a2dd-571e" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -10417,7 +10417,7 @@ The Bunkers of the Castellum Stronghold have a 5+ invulnerable save against shoo
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="828f4a19-02bb-40b8-0974-6dc4cbf24e62" hidden="false" targetId="0aa87e3d-7cb4-d681-0280-017ebea94c1f" type="rule">
+        <infoLink id="828f4a19-02bb-40b8-0974-6dc4cbf24e62" hidden="false" targetId="2d57-8425-0ec0-a9cf" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -12020,7 +12020,7 @@ The Bunkers of the Castellum Stronghold have a 5+ invulnerable save against shoo
       <profiles/>
       <rules/>
       <infoLinks>
-        <infoLink id="f24656bf-c677-271e-8c55-71099c7ff534" hidden="false" targetId="5345cd77-a0ed-7c00-c236-7fca4f3bdeeb" type="rule">
+        <infoLink id="f24656bf-c677-271e-8c55-71099c7ff534" hidden="false" targetId="cb2c-171e-df0f-2bec" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -15212,12 +15212,12 @@ Full details in BRB. Rule too long to copy verbatim.</description>
       <modifiers/>
       <description>This rule is often presented as Hatred (X) where X identifies a specific type of foe. If the special rule does not specify a type of foe, then the unit has Hatred against everyone. This can refer to a Faction, or a specific unit. For example, Hatred (Orks) means any model with the Ork Faction, whilst Hatred (Big Meks) means only Big Meks. A model striking a hated foe in close combat re-rolls all failed To Hit rolls during the first round of each close combat.</description>
     </rule>
-    <rule id="6ce7-5e83-a2dd-571e" name="Blessed Autosimulacra" book="HH3: Extermination" page="206" hidden="false">
+    <rule id="6ce7-5e83-a2dd-571e" name="Blessed Autosimulacra" book="HH:MTAL" page="113" hidden="false">
       <profiles/>
       <rules/>
       <infoLinks/>
       <modifiers/>
-      <description>If the vehicle has lost a hull point, at the end of the controlling players turn roll a D6. On a result of a 6 one lost hull point is restored.  </description>
+      <description>If the vehicle has suffered hull point damage, at the end of the controlling players turn roll a D6. On a result of a 6 one lost hull point is restored.  </description>
     </rule>
     <rule id="33ab-99bc-5c24-3cdf" name="Night Fighting" book="BRB 7th" hidden="false">
       <profiles/>
@@ -15315,7 +15315,7 @@ If, when charged, the unit was already locked in combat, the Counter-attack spec
       <modifiers/>
       <description>At the end of each of your turns, roll a D6 for each of your models with this special rule that has less than its starting number of Wounds or Hull Points, but has not been removed as a casualty or destroyed. On a roll of 5+, that model regains a Wound, or Hull Point, lost earlier in the game.</description>
     </rule>
-    <rule id="666f-e93b-4f0b-ae40" name="God-Engine" book="HH1: Betrayal" page="273" hidden="false">
+    <rule id="666f-e93b-4f0b-ae40" name="God-Engine" book="HH:MTAL" page="91" hidden="false">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -15329,7 +15329,7 @@ If, when charged, the unit was already locked in combat, the Counter-attack spec
       <modifiers/>
       <description>A model shooting a Primary weapon shoots the number of times indicated on its profile – whether or not the bearer has moved. A model carrying a Primary weapon can fire it in the Shooting phase and still charge into close combat in the Assault phase. In addition, when you roll for armour penetration with hits caused by a Primary weapon, roll two dice instead of one and pick the highest result. If the weapon rolls 2D6 for armour penetration (because of the Armourbane special rule, for example), roll three dice instead of two and pick the two highest results.</description>
     </rule>
-    <rule id="ca57-5483-64d5-ad52" name="Reactor Meltdown" book="HH5: Tempest" page="260" hidden="false">
+    <rule id="ca57-5483-64d5-ad52" name="Reactor Meltdown" book="HH:MTAL" page="90" hidden="false">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -15451,7 +15451,7 @@ Fast vehicles that moved at Combat Speed in the preceding Movement phase can fir
       <modifiers/>
       <description>Units made up of models with a Cyberntica Cortex can never count as Scoring units, regardless of the Force Organization Chart being used or the rules for the mission being played.  They do count as Denial units.  </description>
     </rule>
-    <rule id="3ebf-b52d-5006-2426" name="Cybernetic Resiliance" book="HH:MT" page="110" hidden="false">
+    <rule id="3ebf-b52d-5006-2426" name="Cybernetic Resiliance" book="HH:MTAL" page="110" hidden="false">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -15733,7 +15733,7 @@ Jump units have the Bulky and Deep Strike special rules.</description>
       <rules/>
       <infoLinks/>
       <modifiers/>
-      <description>Instead of rolling To Wound normally with this weapon, any model caught in its blast must instead roll equal to or under their Strength on a D6 or suffer a wound (a roll of ‘6’ always counts as a failure). After the graviton pulse weapon has been fired, leave the Blast marker in place. This area now counts as both difficult terrain and dangerous terrain for the next turn thanks to the gravity flux.</description>
+      <description>Instead of rolling To Wound normally with this weapon, any model caught in its blast must instead roll equal to or under their Strength on a D6 or suffer a wound (a roll of ‘6’ always counts as a failure). After the graviton pulse weapon has been fired, leave the Blast marker in place. This area now counts as both difficult terrain and dangerous terrain for the next turn.</description>
     </rule>
     <rule id="6970-1bf3-b33e-5dce" name="Haywire" book="BRB 7th" hidden="false">
       <profiles/>
@@ -16437,12 +16437,12 @@ At the beginning of every subsequent player turn, the marker scatters 2D6&quot; 
       <modifiers/>
       <description> Battle-automata power blades are paired weapons and so add +1 to the model’s attacks and count as being Two-handed.</description>
     </rule>
-    <rule id="aa779861-a8af-fa95-4150-ba94585d1aff" name="Augur-sweep" book="HH3: Extermination" page="207" hidden="false">
+    <rule id="aa779861-a8af-fa95-4150-ba94585d1aff" name="Augur-sweep" book="HH:MTAL" page="111" hidden="false">
       <profiles/>
       <rules/>
       <infoLinks/>
       <modifiers/>
-      <description>Enemy units within 12&quot; reduce their cover saves by -1 when fired at by all units in the same detachment as the Cyber-occularis</description>
+      <description>Enemy units within 12&quot; reduce their cover saves by -1 when fired at by units in the same detachment as the Cyber-occularis</description>
     </rule>
     <rule id="9edbc777-7d2b-011b-7488-335b14870be5" name="Battlesmith" book="HH:LACAL" page="81" hidden="false">
       <profiles/>
@@ -16457,41 +16457,12 @@ At the beginning of every subsequent player turn, the marker scatters 2D6&quot; 
 
 If a Weapon Destroyed result is repaired, that weapon may be fired in the following shooting phase.  The Battlesmith cannot use this ability if he has gone to ground or is falling back.  </description>
     </rule>
-    <rule id="b352ed0c-5fc2-2b26-e1ea-8bc60068af56" name="Blessed Autosimulacra" book="HH4: Conquest" page="303" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>If the vehicle has suffered damage, roll a D6 at the end of the owning players turn.  On a 6, restore one lost hull point.  </description>
-    </rule>
-    <rule id="eff0316a-36cf-2c59-1cec-25a58cb78986" name="Cybernetic Resiliance" book="HH3: Extermination" page="206" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>- Successful wounds by attacks with Poisoned or Fleshbane must be re-rolled against this model
-- In addition to any other effects, attacks with Haywire cause an additional wound on a D6 roll of 6.  </description>
-    </rule>
     <rule id="53c751ef-105f-b2a8-7a17-7812d605b9f2" name="Flank Speed" book="HH3: Extermination" page="231" hidden="false">
       <profiles/>
       <rules/>
       <infoLinks/>
       <modifiers/>
       <description>If the Knight chooses to Run instead of firing a weapon in the shooting phase, may move 3D6&quot;</description>
-    </rule>
-    <rule id="e574-3c61-a76c-ce9e" name="God-Engine" book="HH1: Betrayal" page="273" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>All friendly Mechanicum units within 24&quot; are Fearless</description>
-    </rule>
-    <rule id="0aa87e3d-7cb4-d681-0280-017ebea94c1f" name="Graviton Pulse" book="HH4: Conquest" page="308" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Instead of rolling to wound normally with this weapon, any model caught in its blast must instead roll equal to or under their Strength on a D6 or sugger a wound (a roll of a 6 always counts as a failure).  After the Graviton pulse weapon has been fired, leave the Blast marker in place.  This area now counts as both difficult terrain and dangerous terrain for the next turn.  </description>
     </rule>
     <rule id="d169-a0dc-6155-c754" name="Household Rank" book="HH4: Conquest" page="301" hidden="false">
       <profiles/>
@@ -16500,53 +16471,12 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
       <modifiers/>
       <description>The model is subject to the Household Rank special rule, which may grant it an alteration to its basic profile and additional special rules as shown in the Questoris Knight Crusade Army Special Rules section on page 295. </description>
     </rule>
-    <rule id="1a39d585-c6e2-729c-4c0b-6de16ab9ee49" name="Objective Secured" book="HH4: Conquest" page="297" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-    </rule>
     <rule id="409ed051-b4d2-fcc4-916d-1f2e7090366f" name="Overtaxed Reactor" book="HH4: Conquest" page="303" hidden="false">
       <profiles/>
       <rules/>
       <infoLinks/>
       <modifiers/>
       <description>When destroyed, the knight adds +1 to the result rolled on the Catastrophic Damage table.  </description>
-    </rule>
-    <rule id="5345cd77-a0ed-7c00-c236-7fca4f3bdeeb" name="Paragon of Metal" book="HH3: Extermination" page="209" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>- Not subject to the Programmed Behavior special rule and gains It Will Not Die and Rampage special rules
-- Never counts as scoring regardless of mission type
-- In the case of a failed Cybertheurgy attempt, always apply Malifica instead of rolling</description>
-    </rule>
-    <rule id="5df0114e-9c76-158b-dee0-a8b617249554" name="Programmed Behaviour" book="HH3: Extermination" page="206" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Unless within 12&quot; of a friendly model with a Cortex Controller, the following restrictions apply (unless already locked in an assault)
-
-- Methodical: May not make Sweeping Advances or Run moves
-- Target Priority: If enemy models are within 12&quot; and line of sight during their shooting phase, the unit must fire all its weapons against the closest enemy unit it is able to harm.  If this is not the case, they are free to select targets as normal.
-- Onslaught: If enemy units are within 12&quot; during their Assault phase, them must attempt to charge the closest enemy unit.  May still only charge a unit fired upon.  If consolidating, must consolidate towards the closest enemy if within 12&quot;
-- Fire Protocols: May fire up to three weapons in the shooting phase against the same target. </description>
-    </rule>
-    <rule id="304d15d2-5775-efdf-f680-aa75b73911ad" name="Reactor Blast" book="HH3: Extermination" page="207" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>When losing its final wound, roll a D6.  On a 6, inflict a Str 4 AP - hit on all models within D6&quot;</description>
-    </rule>
-    <rule id="1903-1111-b174-5005" name="Reactor Meltdown" book="HH1: Betrayal" page="273" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>If suffers an Apocalyptic Explosion result, Str D range is 6D6&quot;</description>
     </rule>
     <rule id="5a6e2a63-286a-a771-587c-6a41724b1e6b" name="Warning Relay" book="HH3: Extermination" page="207" hidden="false">
       <profiles/>


### PR DESCRIPTION
Main things to review are that armys work. I had to remove duplicate enteries from the GST and I picked the wrong one for Rotor cannons and Siege Wrecker so I had to update each catalogue with the new ID.

Next are three fixes, Terminator Command squad costs should be right now. 15 per marine and 15 for each suit of terminator armour.
Hand flamer limit on the Command squad.
Crusade Fleet units in the mechicum list are no longer limited.

Some rules clean up on the legion file. It had local copies of Scout, It will not die and Infiltrate.