### PR TITLE
Zopha

### DIFF
--- a/(HH) Talons of the Emperor Army List.cat
+++ b/(HH) Talons of the Emperor Army List.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="a30a-7522-3343-553a" name="Talons of the Emperor" book="HH7" page="" revision="79" battleScribeVersion="2.01" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="85" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="a30a-7522-3343-553a" name="Talons of the Emperor" book="HH7" page="" revision="80" battleScribeVersion="2.01" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="85" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules/>
   <infoLinks/>
@@ -11510,7 +11510,8 @@ decided.</description>
       <infoLinks/>
       <modifiers/>
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b1e6-f153-521a-5f66" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="b1e6-f153-521a-5f66" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="1f9f-6c8b-d132-7b46" type="max"/>
       </constraints>
       <categoryLinks/>
       <selectionEntries>
@@ -11545,9 +11546,7 @@ decided.</description>
             </infoLink>
           </infoLinks>
           <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="54ea-7b4d-5f1a-6558" type="max"/>
-          </constraints>
+          <constraints/>
           <categoryLinks/>
           <selectionEntries>
             <selectionEntry id="0388-aed0-80c0-1f28" name="Proteus Plasma Projector" hidden="false" collective="false" type="upgrade">
@@ -11631,9 +11630,7 @@ decided.</description>
             </infoLink>
           </infoLinks>
           <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4206-2c9b-937e-543e" type="max"/>
-          </constraints>
+          <constraints/>
           <categoryLinks/>
           <selectionEntries/>
           <selectionEntryGroups/>


### PR DESCRIPTION
Updates to thunderhawks.
Added Sicaran variants.
Updated Darkwing
Test run of excess rules removal from Polux, 285 lines removed after clean up.

Fixed Telemon weapon limitations and changed selection to a radio button format from checkboxes.