### PR TITLE
Leman russ and Knights updates and fixes

### DIFF
--- a/(HH) Imperialis Militia and Cults Army List.cat
+++ b/(HH) Imperialis Militia and Cults Army List.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="90aa-c2c8-ffb0-496e" name="Imperialis Militia and Cults Army List" book="Crusade Imperialis" revision="57" battleScribeVersion="2.01" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="85" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="90aa-c2c8-ffb0-496e" name="Imperialis Militia and Cults Army List" book="Crusade Imperialis" revision="58" battleScribeVersion="2.01" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="85" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules/>
   <infoLinks/>
@@ -945,7 +945,7 @@
         </categoryLink>
       </categoryLinks>
     </entryLink>
-    <entryLink id="a4ea-2697-ec1a-2e14" name="New EntryLink" hidden="false" targetId="837d-73be-55e0-e5d1" type="selectionEntry">
+    <entryLink id="a4ea-2697-ec1a-2e14" name="Militia Auxiliary Battle Tank Attack Squadron" hidden="false" targetId="837d-73be-55e0-e5d1" type="selectionEntry">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -1160,7 +1160,7 @@
         </categoryLink>
       </categoryLinks>
     </entryLink>
-    <entryLink id="e257-2315-b28f-51d5" name="New EntryLink" hidden="false" targetId="6de2-2bf3-3277-afab" type="selectionEntry">
+    <entryLink id="e257-2315-b28f-51d5" name="Imperialis Auxilia Sentinel Scout Squadron" hidden="false" targetId="6de2-2bf3-3277-afab" type="selectionEntry">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -3868,8 +3868,8 @@ D3     Mutation
           <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ad03-acc9-027a-06c7" type="min"/>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="834c-ee41-50bd-d121" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ad03-acc9-027a-06c7" type="min"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="834c-ee41-50bd-d121" type="max"/>
           </constraints>
           <categoryLinks/>
           <selectionEntries>
@@ -3897,10 +3897,39 @@ D3     Mutation
                 <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d6ba-6158-5adf-617b" type="max"/>
               </constraints>
               <categoryLinks/>
-              <selectionEntries/>
+              <selectionEntries>
+                <selectionEntry id="0ae0-007d-e949-8cc6" name="Twin-linked lascannon" hidden="false" collective="false" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="31ae-269b-9af1-c83b" name="Lascannon" book="HH: CIAL" page="63" hidden="false" targetId="1cce-972c-022a-2590" type="profile">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers>
+                        <modifier type="append" field="5479706523232344415441232323" value="Twin-linked">
+                          <repeats/>
+                          <conditions/>
+                          <conditionGroups/>
+                        </modifier>
+                      </modifiers>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a97c-d892-b574-80a8" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bb86-413a-db82-63ea" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs/>
+                </selectionEntry>
+              </selectionEntries>
               <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="7026-5eda-86af-181e" hidden="false" targetId="4be5-eee6-ab84-8558" type="selectionEntryGroup">
+                <entryLink id="7026-5eda-86af-181e" name="May exchange heavy bolter for:" book="" hidden="false" targetId="4be5-eee6-ab84-8558" type="selectionEntryGroup">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -3924,7 +3953,7 @@ D3     Mutation
                   <constraints/>
                   <categoryLinks/>
                 </entryLink>
-                <entryLink id="8809-a6d1-512a-49a3" hidden="false" targetId="525c-a63f-e928-d7d5" type="selectionEntryGroup">
+                <entryLink id="8809-a6d1-512a-49a3" name="May take a pair of sponsons:" hidden="false" targetId="525c-a63f-e928-d7d5" type="selectionEntryGroup">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -3961,10 +3990,39 @@ D3     Mutation
                 <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2576-ae4f-5b82-dcce" type="max"/>
               </constraints>
               <categoryLinks/>
-              <selectionEntries/>
+              <selectionEntries>
+                <selectionEntry id="c643-8ea4-35f9-f522" name="Exterminator autocannon" hidden="false" collective="false" type="upgrade">
+                  <profiles>
+                    <profile id="6410-0b2b-1ce1-cf90" name="Exterminator autocannon" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <characteristics>
+                        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="48&quot;"/>
+                        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="7"/>
+                        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="4"/>
+                        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 4, Twin-linked"/>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2c05-7c14-1971-844f" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="81cf-678f-58ec-b0a3" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs/>
+                </selectionEntry>
+              </selectionEntries>
               <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="b6d0-caa9-7637-7c64" hidden="false" targetId="4be5-eee6-ab84-8558" type="selectionEntryGroup">
+                <entryLink id="b6d0-caa9-7637-7c64" name="May exchange heavy bolter for:" hidden="false" targetId="4be5-eee6-ab84-8558" type="selectionEntryGroup">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -4025,10 +4083,39 @@ D3     Mutation
                 <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1cd6-fa68-dd4a-a71a" type="max"/>
               </constraints>
               <categoryLinks/>
-              <selectionEntries/>
+              <selectionEntries>
+                <selectionEntry id="9a41-d614-c6c2-be6a" name="Demolisher Cannon" hidden="false" collective="false" type="upgrade">
+                  <profiles>
+                    <profile id="baa7-8c9f-ea3e-2c90" name="Demolisher Cannon" book="HH: CIAL" page="63" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <characteristics>
+                        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="24&quot;"/>
+                        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="10"/>
+                        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="2"/>
+                        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Ordnance 1, Large Blast"/>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f427-81b1-7dc9-ced0" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b17d-28d6-e3f1-bfbe" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs/>
+                </selectionEntry>
+              </selectionEntries>
               <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="19da-a7e0-a156-90b3" hidden="false" targetId="4be5-eee6-ab84-8558" type="selectionEntryGroup">
+                <entryLink id="19da-a7e0-a156-90b3" name="May exchange heavy bolter for:" hidden="false" targetId="4be5-eee6-ab84-8558" type="selectionEntryGroup">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -4089,10 +4176,46 @@ D3     Mutation
                 <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="538b-19e5-fe76-2187" type="max"/>
               </constraints>
               <categoryLinks/>
-              <selectionEntries/>
+              <selectionEntries>
+                <selectionEntry id="fa36-7bf8-3d7f-071c" name="Vanquisher battlecannon" hidden="false" collective="false" type="upgrade">
+                  <profiles>
+                    <profile id="2350-d0fa-fe3c-d767" name="Vanquisher battlecannon" book="HH: CIAL" page="63" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <characteristics>
+                        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="72&quot;"/>
+                        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="8"/>
+                        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="2"/>
+                        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 1, Armourbane"/>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="0951-4aaa-729e-59cd" name="Armourbane" hidden="false" targetId="e182-50cd-0867-9a8d" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="38f4-c3b3-b03e-5263" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d93e-3ce4-34a2-82e0" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs/>
+                </selectionEntry>
+              </selectionEntries>
               <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="fade-aba7-bcc6-ee94" hidden="false" targetId="4be5-eee6-ab84-8558" type="selectionEntryGroup">
+                <entryLink id="fade-aba7-bcc6-ee94" name="May exchange heavy bolter for:" hidden="false" targetId="4be5-eee6-ab84-8558" type="selectionEntryGroup">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -4116,7 +4239,7 @@ D3     Mutation
                   <constraints/>
                   <categoryLinks/>
                 </entryLink>
-                <entryLink id="a185-22bf-c09d-5d88" hidden="false" targetId="525c-a63f-e928-d7d5" type="selectionEntryGroup">
+                <entryLink id="a185-22bf-c09d-5d88" name="May take a pair of sponsons:" hidden="false" targetId="525c-a63f-e928-d7d5" type="selectionEntryGroup">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -4153,10 +4276,33 @@ D3     Mutation
                 <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2b12-e3ab-323b-4da4" type="max"/>
               </constraints>
               <categoryLinks/>
-              <selectionEntries/>
+              <selectionEntries>
+                <selectionEntry id="ff3d-7968-ed23-b378" name="Battlecannon" hidden="false" collective="false" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="c4fd-8615-35f6-c492" name="Battle cannon" book="HH: CIAL" page="63" hidden="false" targetId="94da-501b-a2f5-6c61" type="profile">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2171-4b6a-34bb-493b" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8a43-88c4-3cb3-3357" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs/>
+                </selectionEntry>
+              </selectionEntries>
               <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="ca26-a3e9-8733-c72e" hidden="false" targetId="4be5-eee6-ab84-8558" type="selectionEntryGroup">
+                <entryLink id="ca26-a3e9-8733-c72e" name="May exchange heavy bolter for:" hidden="false" targetId="4be5-eee6-ab84-8558" type="selectionEntryGroup">
                   <profiles/>
                   <rules/>
                   <infoLinks/>

--- a/(HH) Mechanicum - Questoris Knight.cat
+++ b/(HH) Mechanicum - Questoris Knight.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="32d1ddc6-3187-cf6f-3bf8-9891e527a002" name="Questoris Knight Crusade Army" book="HH4: Conquest" revision="39" battleScribeVersion="2.01" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="85" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="32d1ddc6-3187-cf6f-3bf8-9891e527a002" name="Questoris Knight Crusade Army" book="HH4: Conquest" revision="40" battleScribeVersion="2.01" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="85" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules/>
   <infoLinks/>
@@ -930,7 +930,7 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
         </categoryLink>
       </categoryLinks>
     </entryLink>
-    <entryLink id="02c6-f507-ac2e-504c" name="New EntryLink" hidden="false" targetId="7719-aa4f-3366-84f2" type="selectionEntry">
+    <entryLink id="02c6-f507-ac2e-504c" name="Allegiance" hidden="false" targetId="7719-aa4f-3366-84f2" type="selectionEntry">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -1434,7 +1434,7 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
         </categoryLink>
       </categoryLinks>
     </entryLink>
-    <entryLink id="af0b-35c7-e928-7476" name="New EntryLink" hidden="false" targetId="9f5b-eccc-689a-2948" type="selectionEntry">
+    <entryLink id="af0b-35c7-e928-7476" name="Aquila Strongpoint" hidden="false" targetId="9f5b-eccc-689a-2948" type="selectionEntry">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -2479,9 +2479,17 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
               <profiles/>
               <rules/>
               <infoLinks/>
-              <modifiers/>
+              <modifiers>
+                <modifier type="set" field="18ef-3206-400c-0b5a" value="1">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="27575b75-5e1e-26ab-1074-fa91b73e2216" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b4b3-8e17-78f3-c89c" type="max"/>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="18ef-3206-400c-0b5a" type="min"/>
               </constraints>
               <categoryLinks/>
               <selectionEntries/>
@@ -2496,9 +2504,7 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
               <rules/>
               <infoLinks/>
               <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f654-63fb-6b90-b7c8" type="max"/>
-              </constraints>
+              <constraints/>
               <categoryLinks/>
               <selectionEntries/>
               <selectionEntryGroups/>

--- a/(HH) Mechanicum - Questoris Knight.cat
+++ b/(HH) Mechanicum - Questoris Knight.cat
@@ -259,7 +259,6 @@
           <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="06f8-7455-9c01-216c" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2721-9040-ab9d-ef3e" type="min"/>
           </constraints>
         </categoryLink>
         <categoryLink id="b3ea-e268-8cb2-0152-466173742041747461636b23232344415441232323" name="Fast Attack" hidden="false" targetId="466173742041747461636b23232344415441232323" primary="false">
@@ -305,6 +304,15 @@
           <infoLinks/>
           <modifiers/>
           <constraints/>
+        </categoryLink>
+        <categoryLink id="65f1-470e-d0b3-f1e5" name="Compulsory Troops" hidden="false" targetId="219d-aefa-dfa5-44db" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="300b-b95f-88ba-6bcc" type="min"/>
+          </constraints>
         </categoryLink>
       </categoryLinks>
     </forceEntry>
@@ -588,6 +596,13 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
           <modifiers/>
           <constraints/>
         </categoryLink>
+        <categoryLink id="4a8e-4fc8-a57b-75aa" name="New CategoryLink" hidden="false" targetId="219d-aefa-dfa5-44db" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
       </categoryLinks>
       <selectionEntries/>
       <selectionEntryGroups/>
@@ -712,6 +727,13 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
       <constraints/>
       <categoryLinks>
         <categoryLink id="5053f8a2-cc7f-f635-1044-b149aed1513e-54726f6f707323232344415441232323" hidden="false" targetId="54726f6f707323232344415441232323" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="4d6a-d089-7507-6e98" name="New CategoryLink" hidden="false" targetId="219d-aefa-dfa5-44db" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1156,7 +1178,7 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
         </categoryLink>
       </categoryLinks>
     </entryLink>
-    <entryLink id="26ca-4396-c361-760f" name="New EntryLink" hidden="false" targetId="bbd4-5f41-35d1-6c5f" type="selectionEntry">
+    <entryLink id="26ca-4396-c361-760f" name="Void Shield Generator" hidden="false" targetId="bbd4-5f41-35d1-6c5f" type="selectionEntry">
       <profiles/>
       <rules/>
       <infoLinks/>

--- a/(HH) Mechanicum - Questoris Knight.cat
+++ b/(HH) Mechanicum - Questoris Knight.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="32d1ddc6-3187-cf6f-3bf8-9891e527a002" name="Questoris Knight Crusade Army" book="HH4: Conquest" revision="40" battleScribeVersion="2.01" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="85" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="32d1ddc6-3187-cf6f-3bf8-9891e527a002" name="Questoris Knight Crusade Army" book="Age of Darkness Crusade Army List" revision="41" battleScribeVersion="2.01" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="85" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules/>
   <infoLinks/>
@@ -318,7 +318,7 @@
     </forceEntry>
   </forceEntries>
   <selectionEntries>
-    <selectionEntry id="48ee846f-5f68-d83d-4f9a-e1a797dc1cd1" name="Aucteller" book="HH4: Conquest" page="296" hidden="false" collective="false" type="model">
+    <selectionEntry id="48ee846f-5f68-d83d-4f9a-e1a797dc1cd1" name="Aucteller" book="HH4: Conquest" page="296" hidden="false" collective="false" type="unit">
       <profiles/>
       <rules>
         <rule id="1a6b815b-3423-47b1-06e4-98cb5e9119ee" name="Sworn Enemy" book="HH4: Conquest" page="296" hidden="false">
@@ -368,7 +368,7 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
         <cost name="pts" costTypeId="points" value="35.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="c9c2bc37-7048-4ed5-80c0-fb13d224f96a" name="Lord Scion" book="HH4: Conquest" page="295" hidden="false" collective="false" type="model">
+    <selectionEntry id="c9c2bc37-7048-4ed5-80c0-fb13d224f96a" name="Lord Scion" book="HH4: Conquest" page="295" hidden="false" collective="false" type="unit">
       <profiles/>
       <rules>
         <rule id="bfe1e278-e31a-bfcd-ee10-5c38fedf7314" name="Veteran Knight" book="HH4: Conquest" page="295" hidden="false">
@@ -409,7 +409,7 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
         <cost name="pts" costTypeId="points" value="25.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="5137fc47-e383-8e21-a01a-cdf4cbb73094" name="Preceptor" book="HH4: Conquest" page="296" hidden="false" collective="false" type="model">
+    <selectionEntry id="5137fc47-e383-8e21-a01a-cdf4cbb73094" name="Preceptor" book="HH4: Conquest" page="296" hidden="false" collective="false" type="unit">
       <profiles/>
       <rules>
         <rule id="c95171e5-7f98-b827-ef57-0b6e15cc6719" name="Oracle of Battle" book="HH4: Conquest" page="296" hidden="false">
@@ -448,7 +448,7 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
         <cost name="pts" costTypeId="points" value="25.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="0374f5e8-736f-e990-acd5-75cb44d303a1" name="Scion Arbalester" book="HH4: Conquest" page="298" hidden="false" collective="false" type="model">
+    <selectionEntry id="0374f5e8-736f-e990-acd5-75cb44d303a1" name="Scion Arbalester" book="HH4: Conquest" page="298" hidden="false" collective="false" type="unit">
       <profiles/>
       <rules>
         <rule id="b6d3b822-a604-fbc5-8dbf-4dcdb913ad6b" name="Weapon Calibration" book="HH4: Conquest" page="298" hidden="false">
@@ -494,7 +494,7 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
         <cost name="pts" costTypeId="points" value="25.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="2f44-17e9-3707-22f2" name="Scion Aspirant" book="HH4: Conquest" page="297" hidden="false" collective="false" type="model">
+    <selectionEntry id="2f44-17e9-3707-22f2" name="Scion Aspirant" book="HH4: Conquest" page="297" hidden="false" collective="false" type="unit">
       <profiles/>
       <rules>
         <rule id="20c36841-86b5-f4c2-406e-c82ca71c107a" name="Aspirant" book="HH4: Conquest" page="297" hidden="false">
@@ -620,7 +620,7 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
         <cost name="pts" costTypeId="points" value="-35.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="97fcca37-2121-18e9-f084-4f254332c535" name="Scion Dolorous" book="HH4: Conquest" page="297" hidden="false" collective="false" type="model">
+    <selectionEntry id="97fcca37-2121-18e9-f084-4f254332c535" name="Scion Dolorous" book="HH4: Conquest" page="297" hidden="false" collective="false" type="unit">
       <profiles/>
       <rules>
         <rule id="1ad8fa30-bf2e-1ade-84b2-f035101f3d86" name="Dolorous Charge" book="HH4: Conquest" page="297" hidden="false">
@@ -666,7 +666,7 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
         <cost name="pts" costTypeId="points" value="25.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="a9b3942b-357b-159d-698d-73661a1f3bff" name="Scion Implacable" book="HH4: Conquest" page="298" hidden="false" collective="false" type="model">
+    <selectionEntry id="a9b3942b-357b-159d-698d-73661a1f3bff" name="Scion Implacable" book="HH4: Conquest" page="298" hidden="false" collective="false" type="unit">
       <profiles/>
       <rules>
         <rule id="f6ca3bc6-aa39-58f0-dd9e-2ba8d2c83fbf" name="Wall Breaker" book="HH4: Conquest" page="298" hidden="false">
@@ -712,7 +712,7 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
         <cost name="pts" costTypeId="points" value="35.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="5053f8a2-cc7f-f635-1044-b149aed1513e" name="Scion Martial" book="HH4: Conquest" page="297" hidden="false" collective="false" type="model">
+    <selectionEntry id="5053f8a2-cc7f-f635-1044-b149aed1513e" name="Scion Martial" book="HH4: Conquest" page="297" hidden="false" collective="false" type="unit">
       <profiles/>
       <rules/>
       <infoLinks>
@@ -757,7 +757,7 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="ff61-cf0e-681b-82bb" name="Scion Uhlan" book="HH4: Conquest" page="297" hidden="false" collective="false" type="model">
+    <selectionEntry id="ff61-cf0e-681b-82bb" name="Scion Uhlan" book="HH4: Conquest" page="297" hidden="false" collective="false" type="unit">
       <profiles/>
       <rules>
         <rule id="955c6a6d-62db-3190-a6fb-ad53119398ca" name="Impetuous Advance" book="HH4: Conquest" page="297" hidden="false">
@@ -816,7 +816,7 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="33d55e37-58db-535e-ffb4-0c9136c15e25" name="Seneschal" book="HH4: Conquest" page="295" hidden="false" collective="false" type="model">
+    <selectionEntry id="33d55e37-58db-535e-ffb4-0c9136c15e25" name="Seneschal" book="HH4: Conquest" page="295" hidden="false" collective="false" type="unit">
       <profiles/>
       <rules>
         <rule id="22371748-eb17-a4bd-f77d-29db844784f2" name="Master Knight" book="HH4: Conquest" page="295" hidden="false">
@@ -870,7 +870,15 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
       <profiles/>
       <rules/>
       <infoLinks/>
-      <modifiers/>
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <repeats/>
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="44a9-d907-13fa-4fc4" type="equalTo"/>
+          </conditions>
+          <conditionGroups/>
+        </modifier>
+      </modifiers>
       <constraints/>
       <categoryLinks>
         <categoryLink id="849c-0f60-509d-16d1-485123232344415441232323" hidden="false" targetId="485123232344415441232323" primary="true">

--- a/(HH) Solar Auxilia - Crusade Army List.cat
+++ b/(HH) Solar Auxilia - Crusade Army List.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="7f243fc5-c5fd-8b2c-7b07-907bf684bb72" name="Solar Auxilia" book="Crusade Imperialis" revision="44" battleScribeVersion="2.01" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="28" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="7f243fc5-c5fd-8b2c-7b07-907bf684bb72" name="Solar Auxilia" book="Crusade Imperialis" revision="45" battleScribeVersion="2.01" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="28" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules/>
   <infoLinks/>
@@ -4542,8 +4542,8 @@
           <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="99c3-e400-a8f0-3c2d" type="min"/>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="bce7-d34c-caa9-acd9" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="99c3-e400-a8f0-3c2d" type="min"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bce7-d34c-caa9-acd9" type="max"/>
           </constraints>
           <categoryLinks>
             <categoryLink id="2868-e5b1-e0c3-00d4" name="New CategoryLink" hidden="false" targetId="e59c-462e-9d9c-66dd" primary="false">
@@ -4578,22 +4578,10 @@
                     <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Tank"/>
                   </characteristics>
                 </profile>
-                <profile id="c659-b03d-2c08-fcbe" name="Demolisher Cannon" book="HH4: Conquest" page="278" hidden="false" profileTypeId="576561706f6e23232344415441232323">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <characteristics>
-                    <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="24&quot;"/>
-                    <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="10"/>
-                    <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="2"/>
-                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Ordnance 1, Large Blast"/>
-                  </characteristics>
-                </profile>
               </profiles>
               <rules/>
               <infoLinks>
-                <infoLink id="c206-368e-32fb-0f1b" hidden="false" targetId="b17f-2d29-e5e1-93ba" type="profile">
+                <infoLink id="c206-368e-32fb-0f1b" name="Auxiliary Drive" hidden="false" targetId="b17f-2d29-e5e1-93ba" type="profile">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -4616,8 +4604,52 @@
               <constraints>
                 <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8921-fc87-0462-6be4" type="max"/>
               </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
+              <categoryLinks>
+                <categoryLink id="b76f-0089-b25d-893d" name="New CategoryLink" hidden="false" targetId="53bd-99e7-aba0-e79f" primary="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+                <categoryLink id="0a24-b022-72a2-e5ab" name="New CategoryLink" hidden="false" targetId="e59c-462e-9d9c-66dd" primary="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+              <selectionEntries>
+                <selectionEntry id="8d9e-0209-3795-15aa" name="Demolisher Cannon" hidden="false" collective="false" type="upgrade">
+                  <profiles>
+                    <profile id="861e-3de4-6c5b-dd11" name="Demolisher Cannon" book="HH: CIAL" page="63" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <characteristics>
+                        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="24&quot;"/>
+                        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="10"/>
+                        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="2"/>
+                        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Ordnance 1, Large Blast"/>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6189-5aac-1eb4-96e6" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="232f-8376-d00b-2ddf" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs/>
+                </selectionEntry>
+              </selectionEntries>
               <selectionEntryGroups/>
               <entryLinks>
                 <entryLink id="09a4-8242-3f56-6015" hidden="false" targetId="728b0618-438e-2698-33e7-2230ecd7bb2e" type="selectionEntryGroup">
@@ -4657,22 +4689,10 @@
                     <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Tank"/>
                   </characteristics>
                 </profile>
-                <profile id="1d15-598d-1c99-fd4e" name="Volkite Demi-culverin" book="HH4: Conquest" page="278" hidden="false" profileTypeId="576561706f6e23232344415441232323">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <characteristics>
-                    <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="45&quot;"/>
-                    <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="7"/>
-                    <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="5"/>
-                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 5, Deflagrate"/>
-                  </characteristics>
-                </profile>
               </profiles>
               <rules/>
               <infoLinks>
-                <infoLink id="029b-f164-b79f-cfe8" hidden="false" targetId="b17f-2d29-e5e1-93ba" type="profile">
+                <infoLink id="029b-f164-b79f-cfe8" name="Auxiliary Drive" hidden="false" targetId="b17f-2d29-e5e1-93ba" type="profile">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -4702,10 +4722,46 @@
                 <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="70d8-aa2f-27d2-fa7c" type="max"/>
               </constraints>
               <categoryLinks/>
-              <selectionEntries/>
+              <selectionEntries>
+                <selectionEntry id="5451-96ed-55fb-de67" name="Volkite Demi-culverin" hidden="false" collective="false" type="upgrade">
+                  <profiles>
+                    <profile id="60e6-47b8-e353-69fc" name="Volkite Demi-culverin" book="HH: CIAL" page="63" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <characteristics>
+                        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="45&quot;"/>
+                        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="7"/>
+                        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="5"/>
+                        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 5, Deflagrate"/>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="d01d-7458-2f85-6a1b" name="Deflagrate" hidden="false" targetId="cbcf-5f25-f8ea-7cfd" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1c82-7947-36fe-4585" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1e79-0734-188b-22ac" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs/>
+                </selectionEntry>
+              </selectionEntries>
               <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="283b-d408-ee88-cc82" hidden="false" targetId="728b0618-438e-2698-33e7-2230ecd7bb2e" type="selectionEntryGroup">
+                <entryLink id="283b-d408-ee88-cc82" name="May exchange heavy bolter for:" hidden="false" targetId="728b0618-438e-2698-33e7-2230ecd7bb2e" type="selectionEntryGroup">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -4742,22 +4798,10 @@
                     <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Tank"/>
                   </characteristics>
                 </profile>
-                <profile id="0695-cd1c-50b8-8c9d" name="Executioner Cannon" book="HH4: Conquest" page="278" hidden="false" profileTypeId="576561706f6e23232344415441232323">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <characteristics>
-                    <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="36&quot;"/>
-                    <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="7"/>
-                    <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="2"/>
-                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 3, Blast"/>
-                  </characteristics>
-                </profile>
               </profiles>
               <rules/>
               <infoLinks>
-                <infoLink id="e7bf-4430-8cb4-c2d7" hidden="false" targetId="b17f-2d29-e5e1-93ba" type="profile">
+                <infoLink id="e7bf-4430-8cb4-c2d7" name="Auxiliary Drive" hidden="false" targetId="b17f-2d29-e5e1-93ba" type="profile">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -4781,7 +4825,36 @@
                 <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f87f-3ae7-cdd8-b87d" type="max"/>
               </constraints>
               <categoryLinks/>
-              <selectionEntries/>
+              <selectionEntries>
+                <selectionEntry id="323f-8a9a-282a-cd48" name="Executioner Cannon" hidden="false" collective="false" type="upgrade">
+                  <profiles>
+                    <profile id="f8e8-23d0-b4d0-e0dc" name="Executioner Cannon" book="HH: CIAL" page="63" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <characteristics>
+                        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="36&quot;"/>
+                        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="7"/>
+                        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="2"/>
+                        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 3, Blast"/>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b193-2598-c980-780b" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="396d-5627-1648-a270" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs/>
+                </selectionEntry>
+              </selectionEntries>
               <selectionEntryGroups/>
               <entryLinks>
                 <entryLink id="cc6a-75ba-eb07-37b1" hidden="false" targetId="728b0618-438e-2698-33e7-2230ecd7bb2e" type="selectionEntryGroup">
@@ -4907,7 +4980,30 @@
                 <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2a71-361c-2cab-0552" type="max"/>
               </constraints>
               <categoryLinks/>
-              <selectionEntries/>
+              <selectionEntries>
+                <selectionEntry id="1152-a557-3773-6384" name="Battlecannon" hidden="false" collective="false" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="9e7b-0226-70c1-2c71" name="Battle cannon" book="HH: CIAL" page="63" hidden="false" targetId="94da-501b-a2f5-6c61" type="profile">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2d0c-7027-4d9a-7f34" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dbb0-c269-8eaf-31d3" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs/>
+                </selectionEntry>
+              </selectionEntries>
               <selectionEntryGroups/>
               <entryLinks>
                 <entryLink id="5425-db45-039b-4089" hidden="false" targetId="728b0618-438e-2698-33e7-2230ecd7bb2e" type="selectionEntryGroup">
@@ -4947,7 +5043,7 @@
                     <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Tank"/>
                   </characteristics>
                 </profile>
-                <profile id="58d2-172f-f0a5-40f5" name="Exterminator Autocannon" book="" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+                <profile id="58d2-172f-f0a5-40f5" name="Exterminator Autocannon" book="HH: CIAL" page="63" hidden="false" profileTypeId="576561706f6e23232344415441232323">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -4992,7 +5088,36 @@
                 <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6774-1d77-565f-8b49" type="max"/>
               </constraints>
               <categoryLinks/>
-              <selectionEntries/>
+              <selectionEntries>
+                <selectionEntry id="06f0-a620-c2be-b46e" name="Exterminator autocannon" hidden="false" collective="false" type="upgrade">
+                  <profiles>
+                    <profile id="8984-7c01-b89d-91ee" name="Exterminator autocannon" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <characteristics>
+                        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="48&quot;"/>
+                        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="7"/>
+                        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="4"/>
+                        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 4, Twin-linked"/>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cb6b-d560-d037-c31c" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="01f2-9edd-5a4c-e5cf" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs/>
+                </selectionEntry>
+              </selectionEntries>
               <selectionEntryGroups/>
               <entryLinks>
                 <entryLink id="e7c1-1569-b36c-28b2" hidden="false" targetId="728b0618-438e-2698-33e7-2230ecd7bb2e" type="selectionEntryGroup">
@@ -5065,7 +5190,36 @@
                 <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="da77-ffbe-eee6-377d" type="max"/>
               </constraints>
               <categoryLinks/>
-              <selectionEntries/>
+              <selectionEntries>
+                <selectionEntry id="5baf-7f35-dc25-3ab2" name="Twin-linked lascannon" hidden="false" collective="false" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="28b5-506b-e15e-0d43" name="Lascannon" book="HH: CIAL" page="63" hidden="false" targetId="1cce-972c-022a-2590" type="profile">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers>
+                        <modifier type="append" field="5479706523232344415441232323" value="Twin-linked">
+                          <repeats/>
+                          <conditions/>
+                          <conditionGroups/>
+                        </modifier>
+                      </modifiers>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e02-e2e6-d024-77f3" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2557-9eca-0bba-59b6" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs/>
+                </selectionEntry>
+              </selectionEntries>
               <selectionEntryGroups/>
               <entryLinks>
                 <entryLink id="3a4e-fb57-1764-1c8f" hidden="false" targetId="728b0618-438e-2698-33e7-2230ecd7bb2e" type="selectionEntryGroup">
@@ -5076,7 +5230,7 @@
                   <constraints/>
                   <categoryLinks/>
                 </entryLink>
-                <entryLink id="3dac-35a7-1a2c-65ec" hidden="false" targetId="e2c18037-76a2-67ad-2abc-cdf9bdf62e01" type="selectionEntryGroup">
+                <entryLink id="3dac-35a7-1a2c-65ec" name="May take any of the following:" hidden="false" targetId="e2c18037-76a2-67ad-2abc-cdf9bdf62e01" type="selectionEntryGroup">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -5105,22 +5259,10 @@
                     <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Tank"/>
                   </characteristics>
                 </profile>
-                <profile id="0a10-3b3f-49be-d398" name="Vanquisher battlecannon" book="HH4: Conquest" page="274" hidden="false" profileTypeId="576561706f6e23232344415441232323">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <characteristics>
-                    <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="72&quot;"/>
-                    <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="8"/>
-                    <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="2"/>
-                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 1, Armourbane"/>
-                  </characteristics>
-                </profile>
               </profiles>
               <rules/>
               <infoLinks>
-                <infoLink id="0ec9-6a0b-6cc2-da10" hidden="false" targetId="b17f-2d29-e5e1-93ba" type="profile">
+                <infoLink id="0ec9-6a0b-6cc2-da10" name="Auxiliary Drive" hidden="false" targetId="b17f-2d29-e5e1-93ba" type="profile">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -5150,7 +5292,43 @@
                 <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3198-e575-44d9-e194" type="max"/>
               </constraints>
               <categoryLinks/>
-              <selectionEntries/>
+              <selectionEntries>
+                <selectionEntry id="df7b-6baa-c935-cc06" name="Vanquisher battlecannon" hidden="false" collective="false" type="upgrade">
+                  <profiles>
+                    <profile id="56b2-a5e7-0309-f687" name="Vanquisher battlecannon" book="HH: CIAL" page="63" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <characteristics>
+                        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="72&quot;"/>
+                        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="8"/>
+                        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="2"/>
+                        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 1, Armourbane"/>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="3159-c797-09ea-ba75" name="Armourbane" hidden="false" targetId="e182-50cd-0867-9a8d" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d0f2-df46-780b-cdfb" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b19d-8daf-4441-6e8a" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs/>
+                </selectionEntry>
+              </selectionEntries>
               <selectionEntryGroups/>
               <entryLinks>
                 <entryLink id="bbf8-b519-b385-f40c" hidden="false" targetId="728b0618-438e-2698-33e7-2230ecd7bb2e" type="selectionEntryGroup">

--- a/(HH) Solar Auxilia - Crusade Army List.cat
+++ b/(HH) Solar Auxilia - Crusade Army List.cat
@@ -5120,7 +5120,7 @@
               </selectionEntries>
               <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="e7c1-1569-b36c-28b2" hidden="false" targetId="728b0618-438e-2698-33e7-2230ecd7bb2e" type="selectionEntryGroup">
+                <entryLink id="e7c1-1569-b36c-28b2" name="May exchange heavy bolter for:" hidden="false" targetId="728b0618-438e-2698-33e7-2230ecd7bb2e" type="selectionEntryGroup">
                   <profiles/>
                   <rules/>
                   <infoLinks/>

--- a/The Horus Heresy.gst
+++ b/The Horus Heresy.gst
@@ -129,7 +129,7 @@
     </profileType>
   </profileTypes>
   <categoryEntries>
-    <categoryEntry id="bedc-6602-002c-79af" name="Gargantuan Flying Creature" hidden="false">
+    <categoryEntry id="bedc-6602-002c-79af" name="Flying Gargantuan Creature" book="HH: Rulebook" page="69" hidden="false">
       <profiles/>
       <rules/>
       <infoLinks>
@@ -212,9 +212,17 @@
       <modifiers/>
       <constraints/>
     </categoryEntry>
-    <categoryEntry id="85b9-e0e8-56b9-2bd3" name="Super-Heavy Vehicle" book="" hidden="false">
+    <categoryEntry id="85b9-e0e8-56b9-2bd3" name="Super-Heavy Vehicle" book="HH: Rulebook" page="90" hidden="false">
       <profiles/>
-      <rules/>
+      <rules>
+        <rule id="3f70-0816-8f4d-8b7a" name="Thunderblitz" book="HH: Rulebook" page="91" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <description>Super-heavy Vehicles may Tank Shock or Ram. When they do so, roll once on the Thunderblitz table immediatley before taking the morale check for the unit being Tank Shocked or immediatley before rolling for armour penetration when preforming a Ram.</description>
+        </rule>
+      </rules>
       <infoLinks>
         <infoLink id="19b3-cb6d-3c93-0d54" name="Fear" hidden="false" targetId="52ff-4074-570b-4ea1" type="rule">
           <profiles/>
@@ -238,9 +246,17 @@
       <modifiers/>
       <constraints/>
     </categoryEntry>
-    <categoryEntry id="59f5-766f-b21c-d584" name="Super-Heavy Walker" hidden="false">
+    <categoryEntry id="59f5-766f-b21c-d584" name="Super-Heavy Walker" book="HH: Rulebook" page="92" hidden="false">
       <profiles/>
-      <rules/>
+      <rules>
+        <rule id="78aa-b371-405b-de13" name="Stomp" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <description>Super-heavy Walkers engaged in combat may make a special type of attack called a Stomp Attack. This is made in addition to the Super-heavy walkers normal attacks. Stomp attacks are resolved during the Fight sub-phase at Initiative step1.</description>
+        </rule>
+      </rules>
       <infoLinks>
         <infoLink id="4e5c-7262-1cd9-00f1" name="Fear" hidden="false" targetId="52ff-4074-570b-4ea1" type="rule">
           <profiles/>
@@ -288,7 +304,7 @@
       <modifiers/>
       <constraints/>
     </categoryEntry>
-    <categoryEntry id="7ba3-1f62-b66a-75d8" name="Gargantuan Creature" hidden="false">
+    <categoryEntry id="7ba3-1f62-b66a-75d8" name="Gargantuan Creature" book="HH: Rulebook" page="68" hidden="false">
       <profiles/>
       <rules/>
       <infoLinks>
@@ -335,6 +351,345 @@
           <modifiers/>
         </infoLink>
         <infoLink id="ddd7-d6d1-f35b-9109" name="Feel No Pain" hidden="false" targetId="9bdd-5ec7-8dd6-63c0" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="070e-4392-e330-38ff" name="Bike" book="HH: Rulebook" page="64" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="ba61-8f3f-8080-b2c1" name="Relentless" hidden="false" targetId="3c7d-a1fa-c68b-caad" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="cafb-d6a5-6184-4e40" name="Hammer of Wrath" hidden="false" targetId="6f66-b417-6004-0916" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="2b31-1744-3707-d19e" name="Jink" hidden="false" targetId="d3e5-b43d-a89c-3bd8" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="b19a-0b5c-7f35-394c" name="Very Bulky" hidden="false" targetId="abc9-8566-bb61-4b7c" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="d4d1-3371-784f-6bc5" name="Jetbike" book="HH: Rulebook" page="64" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="0a37-9e5c-6fbc-b145" name="Relentless" hidden="false" targetId="3c7d-a1fa-c68b-caad" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="e569-ebb7-ee0a-e28a" name="Hammer of Wrath" hidden="false" targetId="6f66-b417-6004-0916" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="9ca3-d053-56f8-2866" name="Jink" hidden="false" targetId="d3e5-b43d-a89c-3bd8" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="90bb-2c5a-27b7-ab65" name="Very Bulky" hidden="false" targetId="abc9-8566-bb61-4b7c" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="9c5e-1393-264d-b3db" name="Jump Units" book="HH: Rulebook" page="66" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="6ae7-20ae-e826-6532" name="Very Bulky" hidden="false" targetId="abc9-8566-bb61-4b7c" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="72f8-b58e-8360-cfc7" name="Deep Strike" hidden="false" targetId="d219-2314-4834-c054" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="84e8-6136-d246-3b26" name="Jet Pack Units" book="HH: Rulebook" page="66" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="4b68-9262-23c6-fb72" name="Very Bulky" hidden="false" targetId="abc9-8566-bb61-4b7c" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="c6cc-f441-0873-0951" name="Deep Strike" hidden="false" targetId="d219-2314-4834-c054" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="e40d-0be5-aaef-3729" name="Relentless" hidden="false" targetId="3c7d-a1fa-c68b-caad" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="2682-26e4-ea54-d490" name="Beasts" book="HH: Rulebook" page="67" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="6d8d-4383-9175-0646" name="Fleet" hidden="false" targetId="69e5-fc02-1f9d-63c2" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="2112-9f21-28b0-ebdd" name="Cavalry" book="HH: Rulebook" page="67" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="83cf-ea73-d68e-27db" name="Fleet" hidden="false" targetId="69e5-fc02-1f9d-63c2" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="8921-8b19-774f-549f" name="Hammer of Wrath" hidden="false" targetId="6f66-b417-6004-0916" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="7f05-b8f0-c167-f377" name="Monstrous Creature" book="HH: Rulebook" page="67" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="c539-f9ed-c6b5-0c69" name="Fear" hidden="false" targetId="52ff-4074-570b-4ea1" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="c398-9141-8999-1fed" name="Hammer of Wrath" hidden="false" targetId="6f66-b417-6004-0916" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="2630-9e6c-233f-246f" name="Move Through Cover" hidden="false" targetId="6d06-5ea0-9a17-ca97" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="18a4-70c0-6b1c-ff43" name="Relentless" hidden="false" targetId="3c7d-a1fa-c68b-caad" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="68ea-45a6-cc52-fb0f" name="Smash" hidden="false" targetId="4284-18a1-9844-a0bd" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="1964-e9c0-cfd1-3401" name="Flying Monstrous Creature" book="HH: Rulebook" page="67" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="e6d1-c0bd-1ab5-8758" name="Fear" hidden="false" targetId="52ff-4074-570b-4ea1" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="ab5e-490f-b69e-2307" name="Hammer of Wrath" hidden="false" targetId="6f66-b417-6004-0916" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="93e9-234f-bc9f-be81" name="Move Through Cover" hidden="false" targetId="6d06-5ea0-9a17-ca97" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="71bb-b453-0c7a-2f4a" name="Relentless" hidden="false" targetId="3c7d-a1fa-c68b-caad" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="a37f-b719-9e53-8d03" name="Smash" hidden="false" targetId="4284-18a1-9844-a0bd" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="ed2e-f4f7-82fe-df42" name="Vector Strike" hidden="false" targetId="5341-7110-d8d4-171a" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="3710-a935-5295-8103" name="Jink" hidden="false" targetId="d3e5-b43d-a89c-3bd8" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="b55b-f1fd-e5ac-10e8" name="Vehicle" book="HH: Rulebook" page="70" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="9eab-1097-b74d-d71b" name="Transport" book="HH: Rulebook" page="77" hidden="false">
+      <profiles/>
+      <rules>
+        <rule id="df8b-3546-2da6-a1fa" name="Unshakeable Nerve" book="HH: Rulebook" page="77" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <description>Units embarked upon transports have the Fearless special rule while they are embarked.</description>
+        </rule>
+      </rules>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="df36-613c-927b-9d71" name="Flyer" hidden="false">
+      <profiles/>
+      <rules>
+        <rule id="1456-1dcd-c05c-3654" name="Zooming Flyer" book="HH: Rulebook" page="81" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <description>Zooming Flyers can choose whether or not to use the Skyfire special rule at the start of each Shooting phase. If they do, all weapons they fire that phase are treated as having the Skyfire special rule.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="9d4b-29da-9bfb-ff1c" name="Jink" hidden="false" targetId="d3e5-b43d-a89c-3bd8" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="b939-5cb1-f2f0-d428" name="Chariots" book="HH: Rulebook" page="82" hidden="false">
+      <profiles/>
+      <rules>
+        <rule id="2ee4-e762-f69d-87c2" name="Chariot Hammer of Wrath" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <description>A Chariot has the Hammer of Warth special rule but gains D6 attacks rather than one, resolved at Strenght 6 AP- unless otherwise stated. </description>
+        </rule>
+      </rules>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="578e-f7c5-d7da-5038" name="Skimmer" book="HH: Rulebook" page="85" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="0425-9d3f-e5ee-a194" name="Jink" hidden="false" targetId="d3e5-b43d-a89c-3bd8" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="c736-2564-4061-7049" name="Walker" book="HH: Rulebook" page="86" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="3d1a-d8b1-b063-6832" name="Hammer of Wrath" hidden="false" targetId="6f66-b417-6004-0916" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="1d4d-797e-ae2c-ec41" name="Super-Heavy Flyer" book="HH: Rulebook" page="93" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="9395-d115-0276-9a2c" name="Fear" hidden="false" targetId="52ff-4074-570b-4ea1" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="c6d6-89ad-9604-97f7" name="Invincible Behemoth" hidden="false" targetId="b5c1-4b08-5ddc-1504" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>

--- a/The Horus Heresy.gst
+++ b/The Horus Heresy.gst
@@ -9771,7 +9771,7 @@ The Bunkers of the Castellum Stronghold have a 5+ invulnerable save against shoo
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="pts" costTypeId="points" value="375.0"/>
+        <cost name="pts" costTypeId="points" value="385.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="74b8-f485-4b58-0071" name="Questoris Knight Gallant" book="C:IK" page="105" hidden="false" collective="false" type="model">
@@ -10033,7 +10033,7 @@ The Bunkers of the Castellum Stronghold have a 5+ invulnerable save against shoo
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="pts" costTypeId="points" value="325.0"/>
+        <cost name="pts" costTypeId="points" value="335.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="09ee-4370-1462-2cb5" name="Questoris Knight Crusader" book="C:IK" page="106" hidden="false" collective="false" type="model">
@@ -10348,7 +10348,7 @@ The Bunkers of the Castellum Stronghold have a 5+ invulnerable save against shoo
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="pts" costTypeId="points" value="425.0"/>
+        <cost name="pts" costTypeId="points" value="435.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="baad-77d0-04c2-e05f" name="Cerastus Knight-Atrapos" book="HH6: Retribution" page="278" hidden="false" collective="false" type="model">

--- a/The Horus Heresy.gst
+++ b/The Horus Heresy.gst
@@ -157,6 +157,32 @@
       <modifiers/>
       <constraints/>
     </categoryEntry>
+    <categoryEntry id="85b9-e0e8-56b9-2bd3" name="Super-Heavy Vehicle" book="" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="19b3-cb6d-3c93-0d54" name="Fear" hidden="false" targetId="52ff-4074-570b-4ea1" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="b4a0-a2ba-4d32-b8f6" name="Move Through Cover" hidden="false" targetId="6d06-5ea0-9a17-ca97" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="db67-3554-9745-99b5" name="Invincible Behemoth" hidden="false" targetId="b5c1-4b08-5ddc-1504" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
   </categoryEntries>
   <forceEntries>
     <forceEntry id="61f7-09c7-326c-8c49" name="New ForceEntry" hidden="true">

--- a/The Horus Heresy.gst
+++ b/The Horus Heresy.gst
@@ -183,6 +183,56 @@
       <modifiers/>
       <constraints/>
     </categoryEntry>
+    <categoryEntry id="59f5-766f-b21c-d584" name="Super-Heavy Walker" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="4e5c-7262-1cd9-00f1" name="Fear" hidden="false" targetId="52ff-4074-570b-4ea1" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="6bcd-9993-c0fd-a525" name="Hammer of Wrath" hidden="false" targetId="6f66-b417-6004-0916" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="879c-d7c7-0001-f24a" name="Invincible Behemoth" hidden="false" targetId="b5c1-4b08-5ddc-1504" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="563c-e6f2-55f0-3ef5" name="Move Through Cover" hidden="false" targetId="6d06-5ea0-9a17-ca97" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="fb3a-87cf-fce5-e245" name="Relentless" hidden="false" targetId="3c7d-a1fa-c68b-caad" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="c9d2-90ee-6269-3498" name="Smash" hidden="false" targetId="4284-18a1-9844-a0bd" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="2289-9f03-fb22-829f" name="Strikedown" hidden="false" targetId="dd83-7fb9-6f58-0c96" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
   </categoryEntries>
   <forceEntries>
     <forceEntry id="61f7-09c7-326c-8c49" name="New ForceEntry" hidden="true">
@@ -649,6 +699,13 @@ Use at the start of the controlling player’s turn. Until the beginning of thei
           <modifiers/>
           <constraints/>
         </categoryLink>
+        <categoryLink id="43b9-b232-7fec-1d8b" name="New CategoryLink" hidden="false" targetId="59f5-766f-b21c-d584" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
       </categoryLinks>
       <selectionEntries/>
       <selectionEntryGroups>
@@ -927,16 +984,7 @@ Use at the start of the controlling player’s turn. Until the beginning of thei
           <entryLinks/>
         </selectionEntryGroup>
       </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="1f6b-92d2-799f-d6df" name="New EntryLink" hidden="false" targetId="1782-c86b-a434-19d8" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
-      </entryLinks>
+      <entryLinks/>
       <costs>
         <cost name="pts" costTypeId="points" value="750.0"/>
       </costs>
@@ -1007,6 +1055,13 @@ Use at the start of the controlling player’s turn. Until the beginning of thei
       <constraints/>
       <categoryLinks>
         <categoryLink id="828c-23dc-f6ce-ae53" name="New CategoryLink" hidden="false" targetId="121d-dc17-273c-40d0" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="5ac2-32e1-7558-6658" name="New CategoryLink" hidden="false" targetId="59f5-766f-b21c-d584" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1597,16 +1652,7 @@ Use at the start of the controlling player’s turn. Until the beginning of thei
           <entryLinks/>
         </selectionEntryGroup>
       </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="1394-e2e8-78da-7418" name="New EntryLink" hidden="false" targetId="1782-c86b-a434-19d8" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
-      </entryLinks>
+      <entryLinks/>
       <costs>
         <cost name="pts" costTypeId="points" value="1475.0"/>
       </costs>
@@ -1716,6 +1762,13 @@ D6    Result		S	AP
       <constraints/>
       <categoryLinks>
         <categoryLink id="d9ec-347a-bc64-96be" name="New CategoryLink" hidden="false" targetId="121d-dc17-273c-40d0" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="b301-08d2-000d-4922" name="New CategoryLink" hidden="false" targetId="59f5-766f-b21c-d584" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -2540,16 +2593,7 @@ D6    Result		S	AP
           <entryLinks/>
         </selectionEntryGroup>
       </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="e1e5-dafc-6dba-6446" name="New EntryLink" hidden="false" targetId="1782-c86b-a434-19d8" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
-      </entryLinks>
+      <entryLinks/>
       <costs>
         <cost name="pts" costTypeId="points" value="2750.0"/>
       </costs>
@@ -8357,7 +8401,15 @@ The Bunkers of the Castellum Stronghold have a 5+ invulnerable save against shoo
       <constraints>
         <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
       </constraints>
-      <categoryLinks/>
+      <categoryLinks>
+        <categoryLink id="72c0-7541-7366-f087" name="New CategoryLink" hidden="false" targetId="59f5-766f-b21c-d584" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
       <selectionEntries/>
       <selectionEntryGroups>
         <selectionEntryGroup id="f89283d8-d9d1-7f20-b630-4ad158e12292" name="May exchange Questoris battlecannon for:" hidden="false" collective="false">
@@ -8536,15 +8588,7 @@ The Bunkers of the Castellum Stronghold have a 5+ invulnerable save against shoo
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="1ea6-838e-2df3-78a9" name="New EntryLink" hidden="false" targetId="1782-c86b-a434-19d8" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="6fd6-0678-7777-d0b9" name="New EntryLink" hidden="false" targetId="2f28-c5f0-6110-c614" type="selectionEntry">
+        <entryLink id="6fd6-0678-7777-d0b9" name="Household Rank" hidden="false" targetId="2f28-c5f0-6110-c614" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -8615,7 +8659,15 @@ The Bunkers of the Castellum Stronghold have a 5+ invulnerable save against shoo
       <constraints>
         <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
       </constraints>
-      <categoryLinks/>
+      <categoryLinks>
+        <categoryLink id="43bd-faba-e8e2-e68f" name="New CategoryLink" hidden="false" targetId="59f5-766f-b21c-d584" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
       <selectionEntries/>
       <selectionEntryGroups>
         <selectionEntryGroup id="423c1873-c56d-8ca1-b01f-a2660b0b0198" name="May be upgraded with:" hidden="false" collective="false">
@@ -8753,15 +8805,7 @@ The Bunkers of the Castellum Stronghold have a 5+ invulnerable save against shoo
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="9560-ca69-210a-f115" name="New EntryLink" hidden="false" targetId="1782-c86b-a434-19d8" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="3869-5b07-27b6-2018" name="New EntryLink" hidden="false" targetId="2f28-c5f0-6110-c614" type="selectionEntry">
+        <entryLink id="3869-5b07-27b6-2018" name="Household Rank" hidden="false" targetId="2f28-c5f0-6110-c614" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -8838,7 +8882,15 @@ The Bunkers of the Castellum Stronghold have a 5+ invulnerable save against shoo
       <constraints>
         <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
       </constraints>
-      <categoryLinks/>
+      <categoryLinks>
+        <categoryLink id="293e-427f-069c-7d4f" name="New CategoryLink" hidden="false" targetId="59f5-766f-b21c-d584" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
       <selectionEntries/>
       <selectionEntryGroups>
         <selectionEntryGroup id="f1816b2d-d7ad-435b-6862-843f885c8ecc" name="May exchange its Reaper Chainsword for:" hidden="false" collective="false">
@@ -8923,15 +8975,7 @@ The Bunkers of the Castellum Stronghold have a 5+ invulnerable save against shoo
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="d55c-9631-4112-7b42" name="New EntryLink" hidden="false" targetId="1782-c86b-a434-19d8" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="7914-ad8c-7a1e-e6c7" name="New EntryLink" hidden="false" targetId="2f28-c5f0-6110-c614" type="selectionEntry">
+        <entryLink id="7914-ad8c-7a1e-e6c7" name="Household Rank" hidden="false" targetId="2f28-c5f0-6110-c614" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -9019,7 +9063,15 @@ The Bunkers of the Castellum Stronghold have a 5+ invulnerable save against shoo
       <constraints>
         <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
       </constraints>
-      <categoryLinks/>
+      <categoryLinks>
+        <categoryLink id="e478-9e72-b824-c91d" name="New CategoryLink" hidden="false" targetId="59f5-766f-b21c-d584" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
       <selectionEntries/>
       <selectionEntryGroups>
         <selectionEntryGroup id="f6462c55-4eef-3565-2a00-b18b8444bd20" name="May be upgraded with:" hidden="false" collective="false">
@@ -9044,15 +9096,7 @@ The Bunkers of the Castellum Stronghold have a 5+ invulnerable save against shoo
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="b8dc-d97f-ec91-05d6" name="New EntryLink" hidden="false" targetId="1782-c86b-a434-19d8" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="d7fd-bb6e-dc51-f8ed" name="New EntryLink" hidden="false" targetId="2f28-c5f0-6110-c614" type="selectionEntry">
+        <entryLink id="d7fd-bb6e-dc51-f8ed" name="Household Rank" hidden="false" targetId="2f28-c5f0-6110-c614" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -9141,7 +9185,15 @@ The Bunkers of the Castellum Stronghold have a 5+ invulnerable save against shoo
       <constraints>
         <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
       </constraints>
-      <categoryLinks/>
+      <categoryLinks>
+        <categoryLink id="93bc-c38f-4c2b-19ac" name="New CategoryLink" hidden="false" targetId="59f5-766f-b21c-d584" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
       <selectionEntries/>
       <selectionEntryGroups>
         <selectionEntryGroup id="24723cac-66f3-e231-9092-1333de8d98c1" name="May exchange its Reaper Chainsword for:" hidden="false" collective="false">
@@ -9226,15 +9278,7 @@ The Bunkers of the Castellum Stronghold have a 5+ invulnerable save against shoo
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="92e5-c97f-9080-d4ee" name="New EntryLink" hidden="false" targetId="1782-c86b-a434-19d8" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="3bec-dc40-8e56-a8d7" name="New EntryLink" hidden="false" targetId="2f28-c5f0-6110-c614" type="selectionEntry">
+        <entryLink id="3bec-dc40-8e56-a8d7" name="Household Rank" hidden="false" targetId="2f28-c5f0-6110-c614" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -9325,7 +9369,15 @@ The Bunkers of the Castellum Stronghold have a 5+ invulnerable save against shoo
       <constraints>
         <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
       </constraints>
-      <categoryLinks/>
+      <categoryLinks>
+        <categoryLink id="3557-5237-79f2-d4e4" name="New CategoryLink" hidden="false" targetId="59f5-766f-b21c-d584" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
       <selectionEntries/>
       <selectionEntryGroups>
         <selectionEntryGroup id="5e3a6b4f-0c5e-5b29-cc54-cf20f5668eb3" name="May be upgraded with:" hidden="false" collective="false">
@@ -9350,15 +9402,7 @@ The Bunkers of the Castellum Stronghold have a 5+ invulnerable save against shoo
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="6282-af01-e0d6-6150" name="New EntryLink" hidden="false" targetId="1782-c86b-a434-19d8" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="ae87-4f6a-c839-010a" name="New EntryLink" hidden="false" targetId="2f28-c5f0-6110-c614" type="selectionEntry">
+        <entryLink id="ae87-4f6a-c839-010a" name="Household Rank" hidden="false" targetId="2f28-c5f0-6110-c614" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -9432,7 +9476,7 @@ The Bunkers of the Castellum Stronghold have a 5+ invulnerable save against shoo
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="ed03ee31-8955-4ab8-3285-09590bfed45e" hidden="false" targetId="53c751ef-105f-b2a8-7a17-7812d605b9f2" type="rule">
+        <infoLink id="ed03ee31-8955-4ab8-3285-09590bfed45e" name="Flank Speed" hidden="false" targetId="53c751ef-105f-b2a8-7a17-7812d605b9f2" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -9443,7 +9487,15 @@ The Bunkers of the Castellum Stronghold have a 5+ invulnerable save against shoo
       <constraints>
         <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
       </constraints>
-      <categoryLinks/>
+      <categoryLinks>
+        <categoryLink id="c52e-9a0d-21e9-8cfe" name="New CategoryLink" hidden="false" targetId="59f5-766f-b21c-d584" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
       <selectionEntries/>
       <selectionEntryGroups>
         <selectionEntryGroup id="97a1af42-3800-4b30-9e22-d8955e00394e" name="May be upgraded with:" hidden="false" collective="false">
@@ -9468,15 +9520,7 @@ The Bunkers of the Castellum Stronghold have a 5+ invulnerable save against shoo
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="2e49-d06f-a396-8652" name="New EntryLink" hidden="false" targetId="1782-c86b-a434-19d8" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="1d72-a337-b4a1-c67b" name="New EntryLink" hidden="false" targetId="2f28-c5f0-6110-c614" type="selectionEntry">
+        <entryLink id="1d72-a337-b4a1-c67b" name="Household Rank" hidden="false" targetId="2f28-c5f0-6110-c614" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -9555,7 +9599,15 @@ The Bunkers of the Castellum Stronghold have a 5+ invulnerable save against shoo
       <constraints>
         <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
       </constraints>
-      <categoryLinks/>
+      <categoryLinks>
+        <categoryLink id="0c2f-1672-9805-106a" name="New CategoryLink" hidden="false" targetId="59f5-766f-b21c-d584" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
       <selectionEntries/>
       <selectionEntryGroups>
         <selectionEntryGroup id="c89a-2e7e-cc89-dfc4" name="May be upgraded with:" hidden="false" collective="false">
@@ -9779,15 +9831,7 @@ The Bunkers of the Castellum Stronghold have a 5+ invulnerable save against shoo
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="6ebe-2ff7-97c1-5d25" name="New EntryLink" hidden="false" targetId="1782-c86b-a434-19d8" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="f723-f484-1830-89d6" name="New EntryLink" hidden="false" targetId="2f28-c5f0-6110-c614" type="selectionEntry">
+        <entryLink id="f723-f484-1830-89d6" name="Household Rank" hidden="false" targetId="2f28-c5f0-6110-c614" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -9866,7 +9910,15 @@ The Bunkers of the Castellum Stronghold have a 5+ invulnerable save against shoo
       <constraints>
         <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
       </constraints>
-      <categoryLinks/>
+      <categoryLinks>
+        <categoryLink id="65ee-4b04-f8fa-4b00" name="New CategoryLink" hidden="false" targetId="59f5-766f-b21c-d584" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
       <selectionEntries/>
       <selectionEntryGroups>
         <selectionEntryGroup id="c12e-0c88-5050-819f" name="May be upgraded with:" hidden="false" collective="false">
@@ -10041,15 +10093,7 @@ The Bunkers of the Castellum Stronghold have a 5+ invulnerable save against shoo
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="c7a3-44ad-ebdd-70ce" name="New EntryLink" hidden="false" targetId="1782-c86b-a434-19d8" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="f3c2-a76b-fad8-0cd0" name="New EntryLink" hidden="false" targetId="2f28-c5f0-6110-c614" type="selectionEntry">
+        <entryLink id="f3c2-a76b-fad8-0cd0" name="Household Rank" hidden="false" targetId="2f28-c5f0-6110-c614" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -10126,7 +10170,15 @@ The Bunkers of the Castellum Stronghold have a 5+ invulnerable save against shoo
       <constraints>
         <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
       </constraints>
-      <categoryLinks/>
+      <categoryLinks>
+        <categoryLink id="0b8b-cd22-4fda-0d63" name="New CategoryLink" hidden="false" targetId="59f5-766f-b21c-d584" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
       <selectionEntries/>
       <selectionEntryGroups>
         <selectionEntryGroup id="ee0a-75b3-4033-d106" name="May be upgraded with:" hidden="false" collective="false">
@@ -10356,15 +10408,7 @@ The Bunkers of the Castellum Stronghold have a 5+ invulnerable save against shoo
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="d4d6-a3ee-62d7-0215" name="New EntryLink" hidden="false" targetId="1782-c86b-a434-19d8" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="da6b-9be6-897e-c0c9" name="New EntryLink" hidden="false" targetId="2f28-c5f0-6110-c614" type="selectionEntry">
+        <entryLink id="da6b-9be6-897e-c0c9" name="Household Rank" hidden="false" targetId="2f28-c5f0-6110-c614" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -10437,7 +10481,15 @@ The Bunkers of the Castellum Stronghold have a 5+ invulnerable save against shoo
       <constraints>
         <constraint field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="8f86-62fb-dba4-afc4" type="max"/>
       </constraints>
-      <categoryLinks/>
+      <categoryLinks>
+        <categoryLink id="4478-ce8b-e825-fdff" name="New CategoryLink" hidden="false" targetId="59f5-766f-b21c-d584" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
       <selectionEntries/>
       <selectionEntryGroups>
         <selectionEntryGroup id="797b-8685-04c6-72f4" name="May be upgraded with:" hidden="false" collective="false">
@@ -10586,15 +10638,7 @@ The Bunkers of the Castellum Stronghold have a 5+ invulnerable save against shoo
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="5265-a680-959d-e648" name="New EntryLink" hidden="false" targetId="1782-c86b-a434-19d8" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="d35c-930d-b252-9eb3" name="New EntryLink" hidden="false" targetId="2f28-c5f0-6110-c614" type="selectionEntry">
+        <entryLink id="d35c-930d-b252-9eb3" name="Household Rank" hidden="false" targetId="2f28-c5f0-6110-c614" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -10647,7 +10691,15 @@ The Bunkers of the Castellum Stronghold have a 5+ invulnerable save against shoo
       <constraints>
         <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4f38-2f45-a1a8-1aab" type="max"/>
       </constraints>
-      <categoryLinks/>
+      <categoryLinks>
+        <categoryLink id="efda-c9db-7e79-002c" name="New CategoryLink" hidden="false" targetId="59f5-766f-b21c-d584" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="eb2c-a7c7-2c3f-fc1d" name="Exchange Ironstorm missiles for:" hidden="false" collective="false" type="upgrade">
           <profiles/>
@@ -10786,15 +10838,7 @@ The Bunkers of the Castellum Stronghold have a 5+ invulnerable save against shoo
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="5f03-c1a8-c7c1-f1a5" name="New EntryLink" hidden="false" targetId="1782-c86b-a434-19d8" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="de8d-df3c-f1e5-eae0" name="New EntryLink" hidden="false" targetId="2f28-c5f0-6110-c614" type="selectionEntry">
+        <entryLink id="de8d-df3c-f1e5-eae0" name="Household Rank" hidden="false" targetId="2f28-c5f0-6110-c614" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -10852,66 +10896,6 @@ The Bunkers of the Castellum Stronghold have a 5+ invulnerable save against shoo
       <entryLinks/>
       <costs>
         <cost name="pts" costTypeId="points" value="10.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="1782-c86b-a434-19d8" name="Super Heavy Walker" book="" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="665d-6e62-aa12-926c" name="New InfoLink" hidden="false" targetId="52ff-4074-570b-4ea1" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="e543-687d-3cb8-e079" name="New InfoLink" hidden="false" targetId="6f66-b417-6004-0916" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="d75f-66f2-a649-e93b" name="New InfoLink" hidden="false" targetId="3c7d-a1fa-c68b-caad" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="14fa-b27e-0740-6663" name="New InfoLink" hidden="false" targetId="b5c1-4b08-5ddc-1504" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="5946-1e49-b9d9-de14" name="New InfoLink" hidden="false" targetId="6d06-5ea0-9a17-ca97" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="879b-ed11-c2f4-5782" name="New InfoLink" hidden="false" targetId="4284-18a1-9844-a0bd" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="f8f7-7026-fd60-a7ee" name="New InfoLink" hidden="false" targetId="dd83-7fb9-6f58-0c96" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="da95-f77a-2e96-2fae" type="max"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1240-ab1a-2701-5b08" type="min"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="2f28-c5f0-6110-c614" name="Household Rank" book="CI:AL" page="99" hidden="false" collective="false" type="upgrade">
@@ -11433,6 +11417,13 @@ D6    Result		S	AP
       <constraints/>
       <categoryLinks>
         <categoryLink id="fb62-2108-207b-6a3a" name="New CategoryLink" hidden="false" targetId="121d-dc17-273c-40d0" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="231c-798c-a82f-1881" name="New CategoryLink" hidden="false" targetId="59f5-766f-b21c-d584" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -12025,16 +12016,7 @@ D6    Result		S	AP
           <entryLinks/>
         </selectionEntryGroup>
       </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="7d99-bc44-c392-c6ca" name="New EntryLink" hidden="false" targetId="1782-c86b-a434-19d8" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
-      </entryLinks>
+      <entryLinks/>
       <costs>
         <cost name="pts" costTypeId="points" value="3250.0"/>
       </costs>

--- a/The Horus Heresy.gst
+++ b/The Horus Heresy.gst
@@ -129,10 +129,65 @@
     </profileType>
   </profileTypes>
   <categoryEntries>
-    <categoryEntry id="bedc-6602-002c-79af" name="New CategoryEntry" hidden="false">
+    <categoryEntry id="bedc-6602-002c-79af" name="Gargantuan Flying Creature" hidden="false">
       <profiles/>
       <rules/>
-      <infoLinks/>
+      <infoLinks>
+        <infoLink id="0627-2980-5926-ce72" name="Fear" hidden="false" targetId="52ff-4074-570b-4ea1" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="cfb1-e0ac-a059-d025" name="Fearless" hidden="false" targetId="dc70-e199-5525-e78c" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="8662-0243-2d24-7047" name="Hammer of Wrath" hidden="false" targetId="6f66-b417-6004-0916" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="557a-9a6f-7aef-005e" name="Move Through Cover" hidden="false" targetId="6d06-5ea0-9a17-ca97" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="e17f-311a-4fac-a683" name="Relentless" hidden="false" targetId="3c7d-a1fa-c68b-caad" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="e11b-2f88-1661-1568" name="Smash" hidden="false" targetId="4284-18a1-9844-a0bd" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="03e6-2655-2c03-8fd9" name="Strikedown" hidden="false" targetId="dd83-7fb9-6f58-0c96" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="e480-735f-6415-79e0" name="Vector Strike" hidden="false" targetId="5341-7110-d8d4-171a" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="92fe-6f1a-8df9-5338" name="Feel No Pain" hidden="false" targetId="9bdd-5ec7-8dd6-63c0" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
       <constraints/>
     </categoryEntry>
@@ -224,6 +279,62 @@
           <modifiers/>
         </infoLink>
         <infoLink id="2289-9f03-fb22-829f" name="Strikedown" hidden="false" targetId="dd83-7fb9-6f58-0c96" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="7ba3-1f62-b66a-75d8" name="Gargantuan Creature" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="5075-04a5-dfb5-4277" name="Fear" hidden="false" targetId="52ff-4074-570b-4ea1" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="f93c-aafc-6647-4f2d" name="Fearless" hidden="false" targetId="dc70-e199-5525-e78c" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="5782-e825-8dc4-25cb" name="Hammer of Wrath" hidden="false" targetId="6f66-b417-6004-0916" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="7911-bf39-40db-0444" name="Move Through Cover" hidden="false" targetId="6d06-5ea0-9a17-ca97" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="a883-cf79-7fc9-f6d2" name="Relentless" hidden="false" targetId="3c7d-a1fa-c68b-caad" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="33fb-06c2-2da5-e6cf" name="Smash" hidden="false" targetId="4284-18a1-9844-a0bd" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="8c2c-2954-4343-ed0a" name="Strikedown" hidden="false" targetId="dd83-7fb9-6f58-0c96" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="ddd7-d6d1-f35b-9109" name="Feel No Pain" hidden="false" targetId="9bdd-5ec7-8dd6-63c0" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>

--- a/The Horus Heresy.gst
+++ b/The Horus Heresy.gst
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<gameSystem id="ca571888-56a9-c58e-ddaf-54f4713538bc" name="Warhammer 30,000 - The Horus Heresy" book="Forgeworld Horus Heresy Series" revision="90" battleScribeVersion="2.01" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
+<gameSystem id="ca571888-56a9-c58e-ddaf-54f4713538bc" name="Warhammer 30,000 - The Horus Heresy" book="Forgeworld Horus Heresy Series" revision="91" battleScribeVersion="2.01" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
   <profiles/>
   <rules/>
   <infoLinks/>


### PR DESCRIPTION
Updated Leman russ turrets for Auxilla and Milita cats.

Added Compulsory troop restriction so Castellax do not count towards the troops selection in a Questoris Knights Army.

Added a restriction that requires traitor to be selected when Archmagos DRAYKAVAC is chosen.