### PR TITLE
Fortification update

### DIFF
--- a/The Horus Heresy.gst
+++ b/The Horus Heresy.gst
@@ -127,6 +127,16 @@
         <characteristicType id="ae34-f5c0-19af-4883" name="Agility"/>
       </characteristicTypes>
     </profileType>
+    <profileType id="c2e2-42f3-9e28-c3fa" name="Fortification/Terrain">
+      <characteristicTypes>
+        <characteristicType id="d34f-9153-d292-adab" name="Composition"/>
+        <characteristicType id="98d6-2143-3017-6d46" name="Terrain type"/>
+        <characteristicType id="beac-711d-f76d-e254" name="Access Points &amp; Fire Points"/>
+        <characteristicType id="0ecb-8865-b3eb-97c9" name="Weapons"/>
+        <characteristicType id="a782-1362-048c-ff45" name="Options"/>
+        <characteristicType id="51b9-8d40-8186-fd23" name="Special Rules"/>
+      </characteristicTypes>
+    </profileType>
   </profileTypes>
   <categoryEntries>
     <categoryEntry id="bedc-6602-002c-79af" name="Flying Gargantuan Creature" book="HH: Rulebook" page="69" hidden="false">
@@ -696,6 +706,13 @@
           <modifiers/>
         </infoLink>
       </infoLinks>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="d278-7f17-e143-54e1" name="Terrain" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
       <constraints/>
     </categoryEntry>
@@ -3333,11 +3350,11 @@ D6    Result		S	AP
         <cost name="pts" costTypeId="points" value="50.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="16d6-25c4-af92-4329" name="Aquila Strongpoint" book="Planetary Onslaught" page="" hidden="false" collective="false" type="model">
+    <selectionEntry id="16d6-25c4-af92-4329" name="Aquila Strongpoint" book="AoD: Rulebook" page="117" hidden="false" collective="false" type="model">
       <profiles/>
       <rules/>
       <infoLinks>
-        <infoLink id="ca07-96ca-ec6d-844b" hidden="false" targetId="cf90-39d9-c923-f6bf" type="rule">
+        <infoLink id="ca07-96ca-ec6d-844b" name="Repel the Enemy" hidden="false" targetId="cf90-39d9-c923-f6bf" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -3349,7 +3366,7 @@ D6    Result		S	AP
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="3229-dd8d-f6a0-9cf2" hidden="false" targetId="ad74-698e-d727-4b16" type="rule">
+        <infoLink id="3229-dd8d-f6a0-9cf2" name="Massive Fortification" hidden="false" targetId="ad74-698e-d727-4b16" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -3545,15 +3562,13 @@ D6    Result		S	AP
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="110.0"/>
-              </costs>
+              <costs/>
             </selectionEntry>
             <selectionEntry id="9102-7f7e-3d4a-d72e" name="Macro Cannon" book="Planetary Onslaught" page="88" hidden="false" collective="false" type="upgrade">
               <profiles/>
               <rules/>
               <infoLinks>
-                <infoLink id="0589-671c-0dc5-9af4" hidden="false" targetId="39bf-dff4-053a-7360" type="profile">
+                <infoLink id="0589-671c-0dc5-9af4" name="Macro Shell" hidden="false" targetId="39bf-dff4-053a-7360" type="profile">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -3565,7 +3580,7 @@ D6    Result		S	AP
                   <infoLinks/>
                   <modifiers/>
                 </infoLink>
-                <infoLink id="efd8-44e3-8192-1efd" hidden="false" targetId="63c3-7047-44b3-6aaa" type="rule">
+                <infoLink id="efd8-44e3-8192-1efd" name="Sonic Boom" hidden="false" targetId="63c3-7047-44b3-6aaa" type="rule">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -3588,9 +3603,7 @@ D6    Result		S	AP
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="110.0"/>
-              </costs>
+              <costs/>
             </selectionEntry>
           </selectionEntries>
           <selectionEntryGroups/>
@@ -3599,10 +3612,10 @@ D6    Result		S	AP
       </selectionEntryGroups>
       <entryLinks/>
       <costs>
-        <cost name="pts" costTypeId="points" value="425.0"/>
+        <cost name="pts" costTypeId="points" value="535.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="e10f-7b90-ecd3-80a5" name="Basilica Administratum" book="Planetary Onslaught" page="94" hidden="false" collective="false" type="model">
+    <selectionEntry id="e10f-7b90-ecd3-80a5" name="Basilica Administratum" book="AoD: Rulebook" page="120" hidden="false" collective="false" type="model">
       <profiles>
         <profile id="3565-9ece-4ada-e7dc" name="Basilica Administratum" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323" profileTypeName="Wargear Item">
           <profiles/>
@@ -3614,17 +3627,9 @@ D6    Result		S	AP
           </characteristics>
         </profile>
       </profiles>
-      <rules>
-        <rule id="0ae8-898b-912a-2cc7" name="The Eternal Progress to Victory" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <description>A unit that identifies a Mysterious Objective (see BRB) that is in a Basilica Administratum can choose to re-roll the dice to determine what it is.</description>
-        </rule>
-      </rules>
+      <rules/>
       <infoLinks>
-        <infoLink id="e85c-ddb0-47cd-400c" name="New InfoLink" hidden="false" targetId="12af-0798-6659-e21e" type="rule">
+        <infoLink id="e85c-ddb0-47cd-400c" name="Ruins" hidden="false" targetId="12af-0798-6659-e21e" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -3637,9 +3642,7 @@ D6    Result		S	AP
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="20.0"/>
-      </costs>
+      <costs/>
     </selectionEntry>
     <selectionEntry id="7b11-22c7-16af-3bd4" name="BRB: Command Traits" hidden="false" collective="false" type="upgrade">
       <profiles>
@@ -4824,7 +4827,7 @@ D6    Result		S	AP
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="053a-fd01-be65-238e" name="Wall of Martyrs Defence Strongpoint" book="Warzone Damnos" page="" hidden="false" collective="false" type="unit">
+    <selectionEntry id="053a-fd01-be65-238e" name="Wall of Martyrs Defence Strongpoint (Legacy)" book="Warzone Damnos" page="" hidden="false" collective="false" type="unit">
       <profiles/>
       <rules>
         <rule id="b315-579b-33ac-b5f3" name="Magos Machine Spirit" book="Warzone Damnos" page="" hidden="false">
@@ -4942,9 +4945,9 @@ D6    Result		S	AP
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="a172-78de-aaa6-2201" name="Wall of Martyrs Firestorm Redoubt" book="Planetary Onslaught" page="85" hidden="false" collective="false" type="model">
+    <selectionEntry id="a172-78de-aaa6-2201" name="Firestorm Redoubt" book="AoD: Rulebook" page="114" hidden="false" collective="false" type="model">
       <profiles>
-        <profile id="bab6-1527-ba02-6d52" name="Firestorm Redoubt" hidden="false" profileTypeId="286c-0cd4-7630-47d0">
+        <profile id="bab6-1527-ba02-6d52" name="Firestorm Redoubt" book="AoD: Rulebook" page="114" hidden="false" profileTypeId="286c-0cd4-7630-47d0">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -4997,8 +5000,8 @@ D6    Result		S	AP
           <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b1b1-b3d9-e146-83d7" type="min"/>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0835-e963-a243-dc99" type="max"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b1b1-b3d9-e146-83d7" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0835-e963-a243-dc99" type="max"/>
           </constraints>
           <categoryLinks/>
           <selectionEntries>
@@ -5112,9 +5115,9 @@ D6    Result		S	AP
         <cost name="pts" costTypeId="points" value="200.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="04bf-6c22-19fb-4e46" name="Wall of Martyrs Vengeance Weapon Battery" book="Planetary Onslaught" page="86" hidden="false" collective="false" type="model">
+    <selectionEntry id="04bf-6c22-19fb-4e46" name="Vengeance Weapon Battery" book="AoD: Rulebook" page="115" hidden="false" collective="false" type="model">
       <profiles>
-        <profile id="c8cf-d554-7744-259b" name="Vengeance Weapons Battery" hidden="false" profileTypeId="286c-0cd4-7630-47d0">
+        <profile id="c8cf-d554-7744-259b" name="Vengeance Weapon Battery" book="AoD: Rulebook" page="115" hidden="false" profileTypeId="286c-0cd4-7630-47d0">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -5149,7 +5152,7 @@ D6    Result		S	AP
       <categoryLinks/>
       <selectionEntries/>
       <selectionEntryGroups>
-        <selectionEntryGroup id="b5fd-935c-f68f-0c1a" name="Emplaced Weapons" hidden="false" collective="false" defaultSelectionEntryId="8c32-30a7-713f-6e2d">
+        <selectionEntryGroup id="b5fd-935c-f68f-0c1a" name="Emplaced Weapons" hidden="false" collective="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -5160,38 +5163,6 @@ D6    Result		S	AP
           </constraints>
           <categoryLinks/>
           <selectionEntries>
-            <selectionEntry id="8c32-30a7-713f-6e2d" name="Punisher Gatling Cannon" page="" hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="5819-995b-334f-359f" hidden="false" targetId="69ab-ade0-e0b6-f48e" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="00b9-bfd1-f36d-2385" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="8aed-888a-214d-26dd" hidden="false" targetId="ad42-921f-358f-2970" type="selectionEntryGroup">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <categoryLinks/>
-                </entryLink>
-              </entryLinks>
-              <costs>
-                <cost name="pts" costTypeId="points" value="75.0"/>
-              </costs>
-            </selectionEntry>
             <selectionEntry id="6056-ffd8-14e6-d1b6" name="Battle Cannon" page="" hidden="false" collective="false" type="upgrade">
               <profiles/>
               <rules/>
@@ -5221,7 +5192,7 @@ D6    Result		S	AP
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="pts" costTypeId="points" value="85.0"/>
+                <cost name="pts" costTypeId="points" value="75.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="975e-85ba-2c90-0f99" name="Quad Icarus lascannon" page="" hidden="false" collective="false" type="upgrade">
@@ -5262,11 +5233,9 @@ D6    Result		S	AP
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
+      <costs/>
     </selectionEntry>
-    <selectionEntry id="0d50-24ac-a53e-5db7" name="Wall of Martyrs Imperial Defence Network" book="Planetary Onslaught" page="87" hidden="false" collective="false" type="unit">
+    <selectionEntry id="0d50-24ac-a53e-5db7" name="Wall of Martyrs Imperial Defence Network (Legacyy)" book="Planetary Onslaught" page="87" hidden="false" collective="false" type="unit">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -5394,9 +5363,9 @@ D6    Result		S	AP
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="0f73-97f2-b832-f6d0" name="Wall of Martyrs Imperial Defence Line" book="Planetary Onslaught" page="82" hidden="false" collective="false" type="model">
+    <selectionEntry id="0f73-97f2-b832-f6d0" name="Defence Line" book="AoD: Rulebook" page="110" hidden="false" collective="false" type="model">
       <profiles>
-        <profile id="944e-63e0-c589-b37c" name="Imperial Defence Line" book="Stronghold Assault" page="" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323" profileTypeName="Wargear Item">
+        <profile id="944e-63e0-c589-b37c" name="Imperial Defence Line" book="AoD: Rulebook" page="111" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323" profileTypeName="Wargear Item">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -5408,19 +5377,19 @@ D6    Result		S	AP
       </profiles>
       <rules/>
       <infoLinks>
-        <infoLink id="9aa7-8601-781e-ead8" hidden="false" targetId="7d5c-1af6-942c-8ca2" type="profile">
+        <infoLink id="9aa7-8601-781e-ead8" name="Wreckage and Rubble" hidden="false" targetId="7d5c-1af6-942c-8ca2" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="52b1-bc21-f8d7-cde9" hidden="false" targetId="afb7-b281-a9ce-4272" type="rule">
+        <infoLink id="52b1-bc21-f8d7-cde9" name="Stalwart Defence" hidden="false" targetId="afb7-b281-a9ce-4272" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="caa1-2762-e454-b1fa" name="" hidden="false" targetId="7be5-30af-1a02-0a89" type="rule">
+        <infoLink id="caa1-2762-e454-b1fa" name="Stubborn" hidden="false" targetId="7be5-30af-1a02-0a89" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -5433,7 +5402,7 @@ D6    Result		S	AP
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks>
-        <entryLink id="d067-83d6-3f88-f98f" hidden="false" targetId="ad42-921f-358f-2970" type="selectionEntryGroup">
+        <entryLink id="d067-83d6-3f88-f98f" name="Obstacles List" hidden="false" targetId="ad42-921f-358f-2970" type="selectionEntryGroup">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -5446,9 +5415,9 @@ D6    Result		S	AP
         <cost name="pts" costTypeId="points" value="80.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="df05-8179-624e-f8b2" name="Wall of Martyrs Imperial Defence Emplacement" book="Planetary Onslaught" page="83" hidden="false" collective="false" type="model">
+    <selectionEntry id="df05-8179-624e-f8b2" name="Defence Emplacement" book="AoD: Rulebook" page="112" hidden="false" collective="false" type="model">
       <profiles>
-        <profile id="e1cc-0dae-51d0-b061" name="Imperial Defence Emplacement" book="Stronghold Assault" page="" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323" profileTypeName="Wargear Item">
+        <profile id="e1cc-0dae-51d0-b061" name="Imperial Defence Emplacement" book="AoD: Rulebook" page="112" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323" profileTypeName="Wargear Item">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -5460,19 +5429,19 @@ D6    Result		S	AP
       </profiles>
       <rules/>
       <infoLinks>
-        <infoLink id="9d3f-9ea3-e8ce-8c7c" hidden="false" targetId="afb7-b281-a9ce-4272" type="rule">
+        <infoLink id="9d3f-9ea3-e8ce-8c7c" name="Stalwart Defence" book="AoD: Rulebook" page="112" hidden="false" targetId="afb7-b281-a9ce-4272" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="73fa-1db4-4d85-0daf" name="" hidden="false" targetId="7be5-30af-1a02-0a89" type="rule">
+        <infoLink id="73fa-1db4-4d85-0daf" name="Stubborn" book="AoD: Rulebook" page="112" hidden="false" targetId="7be5-30af-1a02-0a89" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="3f5a-bdfa-c3a9-54a1" name="New InfoLink" hidden="false" targetId="d191-d6ec-e3c8-31f6" type="rule">
+        <infoLink id="3f5a-bdfa-c3a9-54a1" name="Improved Arcs of Fire" hidden="false" targetId="d191-d6ec-e3c8-31f6" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -5485,7 +5454,7 @@ D6    Result		S	AP
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks>
-        <entryLink id="2758-2f92-8d3a-05ae" hidden="false" targetId="ad42-921f-358f-2970" type="selectionEntryGroup">
+        <entryLink id="2758-2f92-8d3a-05ae" name="Obstacles List" hidden="false" targetId="ad42-921f-358f-2970" type="selectionEntryGroup">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -5498,9 +5467,9 @@ D6    Result		S	AP
         <cost name="pts" costTypeId="points" value="40.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="0116-c81b-1c0f-251c" name="Wall of Martyrs Imperial Bunker" book="Planetary Onslaught" page="84" hidden="false" collective="false" type="model">
+    <selectionEntry id="0116-c81b-1c0f-251c" name="Bunker" book="AoD: Rulebook" page="113" hidden="false" collective="false" type="model">
       <profiles>
-        <profile id="1aa3-6499-e787-5b5d" name="Imperial Bunker" hidden="false" profileTypeId="286c-0cd4-7630-47d0">
+        <profile id="1aa3-6499-e787-5b5d" name="Imperial Bunker" book="AoD: Rulebook" page="113" hidden="false" profileTypeId="286c-0cd4-7630-47d0">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -5517,13 +5486,13 @@ D6    Result		S	AP
       </profiles>
       <rules/>
       <infoLinks>
-        <infoLink id="e5e1-2b8c-850b-8371" hidden="false" targetId="cf90-39d9-c923-f6bf" type="rule">
+        <infoLink id="e5e1-2b8c-850b-8371" name="Repel the Enemy" hidden="false" targetId="cf90-39d9-c923-f6bf" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="5adf-1a24-8d58-f151" name="New InfoLink" hidden="false" targetId="207b-b21e-68cb-ace0" type="rule">
+        <infoLink id="5adf-1a24-8d58-f151" name="Wide Firing Points" hidden="false" targetId="207b-b21e-68cb-ace0" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -5573,7 +5542,7 @@ D6    Result		S	AP
         <cost name="pts" costTypeId="points" value="55.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="bbd4-5f41-35d1-6c5f" name="Void Shield Generator" book="Planetary Onslaught" page="92" hidden="false" collective="false" type="model">
+    <selectionEntry id="bbd4-5f41-35d1-6c5f" name="Void Shield Generator (Legacy)" book="Planetary Onslaught" page="92" hidden="false" collective="false" type="model">
       <profiles>
         <profile id="002c-d06c-4447-a02b" name="Void Shield Generator" hidden="false" profileTypeId="286c-0cd4-7630-47d0">
           <profiles/>
@@ -5612,7 +5581,7 @@ Each projected void shield has an Armour Value of 12. A glancing or penetrating 
             </rule>
           </rules>
           <infoLinks>
-            <infoLink id="95ce-71dc-06d1-6167" hidden="false" targetId="e144-1293-ec28-d3a9" type="profile">
+            <infoLink id="95ce-71dc-06d1-6167" name="Void Shield" hidden="false" targetId="e144-1293-ec28-d3a9" type="profile">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -5731,25 +5700,30 @@ Each projected void shield has an Armour Value of 12. A glancing or penetrating 
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="474a-96df-3847-a5d8" name="Twisted Copse" book="Planetary Onslaught" page="100" hidden="false" collective="false" type="model">
+    <selectionEntry id="474a-96df-3847-a5d8" name="Twisted Copse" book="AoD: Rulebook " page="123" hidden="false" collective="false" type="model">
       <profiles>
-        <profile id="2cd1-e95c-df57-4840" name="Twisted Copse" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323" profileTypeName="Wargear Item">
+        <profile id="4cb8-4245-607a-f629" name="Twisted Copse" book="AoD: Rulebook" page="125" hidden="false" profileTypeId="c2e2-42f3-9e28-c3fa" profileTypeName="Fortification/Terrain">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <characteristics>
-            <characteristic name="Description" characteristicTypeId="4465736372697074696f6e23232344415441232323" value="Difficult Terrain"/>
+            <characteristic name="Composition" characteristicTypeId="d34f-9153-d292-adab" value="1 Citadel Wood"/>
+            <characteristic name="Terrain type" characteristicTypeId="98d6-2143-3017-6d46" value="Difficult terrain"/>
+            <characteristic name="Access Points &amp; Fire Points" characteristicTypeId="beac-711d-f76d-e254" value="None"/>
+            <characteristic name="Weapons" characteristicTypeId="0ecb-8865-b3eb-97c9" value="None"/>
+            <characteristic name="Options" characteristicTypeId="a782-1362-048c-ff45" value="None"/>
+            <characteristic name="Special Rules" characteristicTypeId="51b9-8d40-8186-fd23" value="Dense Thicket"/>
           </characteristics>
         </profile>
       </profiles>
       <rules>
-        <rule id="46bb-f210-13f2-b7c1" name="Dense Thicket" hidden="false">
+        <rule id="46bb-f210-13f2-b7c1" name="Dense Thicket" book="AoD: Rulebook" page="124" hidden="false">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <description>With the exception of vehicles and monstrous creatures, a model on the base of a Citadel Wood model receives a 5+ cover save, regardless of whether or not it is 25% obscured.</description>
+          <description>Models on the base of a Citadel Wood model receive a 5+ cover save, regardless of whether or not they are 25% obscured.</description>
         </rule>
       </rules>
       <infoLinks/>
@@ -5759,9 +5733,7 @@ Each projected void shield has an Armour Value of 12. A glancing or penetrating 
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="10.0"/>
-      </costs>
+      <costs/>
     </selectionEntry>
     <selectionEntry id="1a59-dd0f-a7f2-32be" name="Promethium Relay Pipes" book="Planetary Onslaught" page="103" hidden="false" collective="false" type="model">
       <profiles>
@@ -6208,9 +6180,9 @@ Each projected void shield has an Armour Value of 12. A glancing or penetrating 
         <cost name="pts" costTypeId="points" value="220.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="55c6-268b-357f-d070" name="Imperial Bastion" book="Planetary Onslaught" page="80" hidden="false" collective="false" type="model">
+    <selectionEntry id="55c6-268b-357f-d070" name="Bastion" book="AoD: Rulebook" page="110" hidden="false" collective="false" type="model">
       <profiles>
-        <profile id="67c7-0b8b-bba6-e965" name="Imperial Bastion" hidden="false" profileTypeId="286c-0cd4-7630-47d0">
+        <profile id="67c7-0b8b-bba6-e965" name="Imperial Bastion" book="AoD: Rulebook" page="110" hidden="false" profileTypeId="286c-0cd4-7630-47d0">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -6238,7 +6210,7 @@ Each projected void shield has an Armour Value of 12. A glancing or penetrating 
       <constraints/>
       <categoryLinks/>
       <selectionEntries>
-        <selectionEntry id="f8c9-8047-e3cc-b2c2" name="Heavy Bolters" page="" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="f8c9-8047-e3cc-b2c2" name="Eemplaced Heavy Bolters" page="" hidden="false" collective="false" type="upgrade">
           <profiles/>
           <rules/>
           <infoLinks>
@@ -6281,7 +6253,7 @@ Each projected void shield has an Armour Value of 12. A glancing or penetrating 
           <constraints/>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="e3f5-954e-ed7a-0510" hidden="false" targetId="6bfa-e532-4165-63ce" type="selectionEntryGroup">
+        <entryLink id="e3f5-954e-ed7a-0510" name="Buildings List" hidden="false" targetId="6bfa-e532-4165-63ce" type="selectionEntryGroup">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -6354,9 +6326,9 @@ Unfurled: If a unit deep strikes on top of an unfurled Skyshield Landing Pad, it
         <cost name="pts" costTypeId="points" value="75.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="595a-908e-96a1-f121" name="Shrine of the Aquila" book="Planetary Onslaught" page="97" hidden="false" collective="false" type="model">
+    <selectionEntry id="595a-908e-96a1-f121" name="Shrine of the Aquila" book="AoD: Rulebook" page="118" hidden="false" collective="false" type="model">
       <profiles>
-        <profile id="6cf9-a002-6ee6-5742" name="Shrine of the Aquila" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323" profileTypeName="Wargear Item">
+        <profile id="6cf9-a002-6ee6-5742" name="Shrine of the Aquila" book="AoD: Rulebook" page="118" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323" profileTypeName="Wargear Item">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -6367,12 +6339,12 @@ Unfurled: If a unit deep strikes on top of an unfurled Skyshield Landing Pad, it
         </profile>
       </profiles>
       <rules>
-        <rule id="b27c-0dbd-e299-41b3" name="The Eagle&apos;s Gaze" hidden="false">
+        <rule id="b27c-0dbd-e299-41b3" name="The Eagle&apos;s Gaze" book="AoD: Rulebook" page="118" hidden="false">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <description>If a unit from The Armies of the Imperium (as defined in BRB) has any of its models within a Shrine of the Aquila, it re-rolls failed Morale checks. Any other model that is in a Shrine of the Aquila has the Hatred (Armies of the Imperium) special rule.</description>
+          <description>If a unit with the Loyalist Allegiance has any of its models within a Shrine of the Aquila, it re-rolls failed Morale checks. Any unit with the Traitor Allegiance that is in a Shrine of the Aquila has the Hatred (Loyalist) special rule.</description>
         </rule>
       </rules>
       <infoLinks>
@@ -6389,9 +6361,7 @@ Unfurled: If a unit deep strikes on top of an unfurled Skyshield Landing Pad, it
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="20.0"/>
-      </costs>
+      <costs/>
     </selectionEntry>
     <selectionEntry id="b973-7d7d-754e-b022" name="Grand Redoubt" book="40k Apocalypse 2nd Ed" page="" hidden="false" collective="false" type="unit">
       <profiles/>
@@ -6714,9 +6684,9 @@ A reactor can be shot at and attacked in close combat. If destroyed, the closest
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="6140-dc64-5896-957f" name="Manufactorum" book="Planetary Onslaught" page="95" hidden="false" collective="false" type="model">
+    <selectionEntry id="6140-dc64-5896-957f" name="Manufactorum" book="AoD: Rulebook" page="119" hidden="false" collective="false" type="model">
       <profiles>
-        <profile id="840b-724f-c215-9cfb" name="Manufactorum" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323" profileTypeName="Wargear Item">
+        <profile id="840b-724f-c215-9cfb" name="Manufactorum" book="AoD: Rulebook" page="119" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323" profileTypeName="Wargear Item">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -6727,7 +6697,7 @@ A reactor can be shot at and attacked in close combat. If destroyed, the closest
         </profile>
       </profiles>
       <rules>
-        <rule id="139f-39f2-d453-9968" name="The Omnissiah&apos;s Benediction" hidden="false">
+        <rule id="139f-39f2-d453-9968" name="The Omnissiah&apos;s Benediction" book="AoD: Rulebook" page="119" hidden="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -6749,11 +6719,9 @@ A reactor can be shot at and attacked in close combat. If destroyed, the closest
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="20.0"/>
-      </costs>
+      <costs/>
     </selectionEntry>
-    <selectionEntry id="63b0-0b66-5eb0-382a" name="Munitorum Armoured Container Cache" book="Planetary Onslaught" page="98" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="63b0-0b66-5eb0-382a" name="Munitorum Armoured Container Cache (Legacy)" book="Planetary Onslaught" page="98" hidden="false" collective="false" type="upgrade">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -7491,9 +7459,9 @@ In the event of enemy models embarking inside the Primus Redoubt, the Battle Cre
         <cost name="pts" costTypeId="points" value="650.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="e0b3-77ca-af76-bd8b" name="Sanctum Imperialis" book="Planetary Onslaught" page="96" hidden="false" collective="false" type="model">
+    <selectionEntry id="e0b3-77ca-af76-bd8b" name="Sanctum Imperialis" book="AoD: Rulebook" page="121" hidden="false" collective="false" type="model">
       <profiles>
-        <profile id="b7b9-5650-b83d-96f3" name="Sanctum Imperialis" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323" profileTypeName="Wargear Item">
+        <profile id="b7b9-5650-b83d-96f3" name="Sanctum Imperialis" book="AoD: Rulebook" page="121" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323" profileTypeName="Wargear Item">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -7504,7 +7472,7 @@ In the event of enemy models embarking inside the Primus Redoubt, the Battle Cre
         </profile>
       </profiles>
       <rules>
-        <rule id="8c64-b74c-64a9-1c95" name="Benevolent Light" hidden="false">
+        <rule id="8c64-b74c-64a9-1c95" name="Benevolent Light" book="AoD: Rulebook" page="121" hidden="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -7538,9 +7506,7 @@ In the event of enemy models embarking inside the Primus Redoubt, the Battle Cre
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="20.0"/>
-      </costs>
+      <costs/>
     </selectionEntry>
     <selectionEntry id="ed7e-757a-4ced-adff" name="Imperial Strongpoint" book="Planetary Onslaught" page="81" hidden="false" collective="false" type="unit">
       <profiles/>
@@ -11952,7 +11918,7 @@ D6    Result		S	AP
         <cost name="pts" costTypeId="points" value="3250.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="9f5b-eccc-689a-2948" name="Aquila Strongpoint" book="Planetary Onslaught" page="" hidden="false" collective="false" type="model">
+    <selectionEntry id="9f5b-eccc-689a-2948" name="Aquila Strongpoint (remove)" book="" page="116" hidden="false" collective="false" type="model">
       <profiles/>
       <rules/>
       <infoLinks>
@@ -12169,6 +12135,121 @@ D6    Result		S	AP
       <costs>
         <cost name="pts" costTypeId="points" value="425.0"/>
       </costs>
+    </selectionEntry>
+    <selectionEntry id="31af-e5e2-8167-a480" name="Battlescape" book="AoD: Rulebook" page="122" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="2ae2-373e-7f2e-0dbd" name="Battlescape" book="AoD: Rulebook" page="122" hidden="false" profileTypeId="c2e2-42f3-9e28-c3fa" profileTypeName="Terrain">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Composition" characteristicTypeId="d34f-9153-d292-adab" value="1 Battlescape"/>
+            <characteristic name="Terrain type" characteristicTypeId="98d6-2143-3017-6d46" value="Dangerous Terrain"/>
+            <characteristic name="Access Points &amp; Fire Points" characteristicTypeId="beac-711d-f76d-e254" value="None"/>
+            <characteristic name="Weapons" characteristicTypeId="0ecb-8865-b3eb-97c9" value="None"/>
+            <characteristic name="Options" characteristicTypeId="a782-1362-048c-ff45" value="None"/>
+            <characteristic name="Special Rules" characteristicTypeId="51b9-8d40-8186-fd23" value="Desperate Shelter"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="f9bb-df9c-02e3-fabc" name="Desperate Shelter" book="AoD: Rulebook" page="122" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <description>Models on the base of a Battlescape model receive a 5+ cover save, regardless of whether or not they are 25% obscured.</description>
+        </rule>
+      </rules>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs/>
+    </selectionEntry>
+    <selectionEntry id="7507-ce88-4e5a-ccc2" name="Crashed Imperial Lander" book="AoD: Rulebook" page="123" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="c501-5663-8d53-3f9b" name="Crashed Imperial Lander" hidden="false" profileTypeId="c2e2-42f3-9e28-c3fa" profileTypeName="Fortification/Terrain">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Composition" characteristicTypeId="d34f-9153-d292-adab" value="1 Crashed Imperial Lander."/>
+            <characteristic name="Terrain type" characteristicTypeId="98d6-2143-3017-6d46" value="Difficult terrain"/>
+            <characteristic name="Access Points &amp; Fire Points" characteristicTypeId="beac-711d-f76d-e254" value="None"/>
+            <characteristic name="Weapons" characteristicTypeId="0ecb-8865-b3eb-97c9" value="None"/>
+            <characteristic name="Options" characteristicTypeId="a782-1362-048c-ff45" value="None"/>
+            <characteristic name="Special Rules" characteristicTypeId="51b9-8d40-8186-fd23" value="Mysterious Wreckage"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="0ecc-85fa-880b-5e24" name="Mysterious Wreckage" book="AoD: Rulebook" page="123" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <description>The first time a unit enters or deploys in base contact with a Crashed Imperial Lander, roll a D6 and consult the following table:
+
+D6 Result
+1 Unstable Fuel Core: 
+The unit that entered or deployed in base contact with the Crashed Imperial Lander immediately suffers D6 Strength 5 AP- hits with the Ignores Cover special rule. Wounds are Randomly Allocated.
+
+2-4 Nothing of Note: 
+The Crashed Imperial Lander has no additional effects this game.
+
+5-6 Archaeotech Cargo: 
+Immediately place an objective marker within 3&quot; of any part of the Crashed Imperial Lander. Whichever side controls this objective marker at the end of the game scores 1 additional Victory point. If the mission does not use Victory points (see page 145), treat this result as Nothing of Note instead.</description>
+        </rule>
+      </rules>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs/>
+    </selectionEntry>
+    <selectionEntry id="3027-0a29-19c0-40f5" name="Moonscape" book="AoD: Rulebook" page="125" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="d61e-492c-cf78-828e" name="Moonscape" book="AoD: Rulebook1" page="125" hidden="false" profileTypeId="c2e2-42f3-9e28-c3fa" profileTypeName="Fortification/Terrain">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Composition" characteristicTypeId="d34f-9153-d292-adab" value="1 Moonscape or Citadel Craters set."/>
+            <characteristic name="Terrain type" characteristicTypeId="98d6-2143-3017-6d46" value="Battlefield debris (craters)"/>
+            <characteristic name="Access Points &amp; Fire Points" characteristicTypeId="beac-711d-f76d-e254" value="None"/>
+            <characteristic name="Weapons" characteristicTypeId="0ecb-8865-b3eb-97c9" value="None"/>
+            <characteristic name="Options" characteristicTypeId="a782-1362-048c-ff45" value="None"/>
+            <characteristic name="Special Rules" characteristicTypeId="51b9-8d40-8186-fd23" value="Foxholes"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="1977-5241-c842-f51a" name="Foxholes" book="AoD: Rulebook" page="125" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <description>Models in Moonscape Craters receive a 6+ cover save, regardless of whether or not they are 25% obscured. If a unit Goes to Ground, models from the unit gain +2 to their cover save if they are in Moonscape Craters rather than +1.</description>
+        </rule>
+      </rules>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs/>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>

--- a/The Horus Heresy.gst
+++ b/The Horus Heresy.gst
@@ -5373,7 +5373,7 @@ D6    Result		S	AP
     </selectionEntry>
     <selectionEntry id="0f73-97f2-b832-f6d0" name="Defence Line" book="AoD: Rulebook" page="110" hidden="false" collective="false" type="model">
       <profiles>
-        <profile id="944e-63e0-c589-b37c" name="Imperial Defence Line" book="AoD: Rulebook" page="111" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323" profileTypeName="Wargear Item">
+        <profile id="944e-63e0-c589-b37c" name="Defence Line" book="AoD: Rulebook" page="111" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323" profileTypeName="Wargear Item">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -5425,7 +5425,7 @@ D6    Result		S	AP
     </selectionEntry>
     <selectionEntry id="df05-8179-624e-f8b2" name="Defence Emplacement" book="AoD: Rulebook" page="112" hidden="false" collective="false" type="model">
       <profiles>
-        <profile id="e1cc-0dae-51d0-b061" name="Imperial Defence Emplacement" book="AoD: Rulebook" page="112" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323" profileTypeName="Wargear Item">
+        <profile id="e1cc-0dae-51d0-b061" name="Defence Emplacement" book="AoD: Rulebook" page="112" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323" profileTypeName="Wargear Item">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -5897,11 +5897,11 @@ Each projected void shield has an Armour Value of 12. A glancing or penetrating 
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="8300-7ced-aafd-2a27" name="Fortress of Redemption" book="Planetary Onslaught" page="91" hidden="false" collective="false" type="model">
+    <selectionEntry id="8300-7ced-aafd-2a27" name="Fortress of Redemption (remove)" book="Planetary Onslaught" page="91" hidden="false" collective="false" type="model">
       <profiles/>
       <rules/>
       <infoLinks>
-        <infoLink id="e35c-c2a8-8036-570d" hidden="false" targetId="cf90-39d9-c923-f6bf" type="rule">
+        <infoLink id="e35c-c2a8-8036-570d" name="Repel the Enemy" hidden="false" targetId="cf90-39d9-c923-f6bf" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -6177,7 +6177,7 @@ Each projected void shield has an Armour Value of 12. A glancing or penetrating 
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="b789-6db3-92d2-ee8a" hidden="false" targetId="ad42-921f-358f-2970" type="selectionEntryGroup">
+        <entryLink id="b789-6db3-92d2-ee8a" name="Obstacles List" hidden="false" targetId="ad42-921f-358f-2970" type="selectionEntryGroup">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -6607,7 +6607,7 @@ Unfurled: If a unit deep strikes on top of an unfurled Skyshield Landing Pad, it
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="06e2-2420-ffc8-13b8" name="Haemotrope Reactors" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="06e2-2420-ffc8-13b8" name="Haemotrope Reactors (remove)" hidden="false" collective="false" type="upgrade">
       <profiles/>
       <rules>
         <rule id="836f-f195-e6a6-1c83" name="Plasma Feed" hidden="false">
@@ -17505,8 +17505,7 @@ Some can also Hover – see page 81. Zooming allows the Flyer to move at extreme
       <infoLinks/>
       <modifiers/>
       <characteristics>
-        <characteristic name="Description" characteristicTypeId="4465736372697074696f6e23232344415441232323" value="A model in cover behind a barricade or wall has a 4+ cover save.
-For the purposes of charge moves, models that are both in base contact with a barricade and within 2&quot; of each other are treated as being in base contact. Despite the models on either side not literally being in base contact, they may fight in the Fight sub-phase as normal. Units charging an enemy that is behind a barricade or wall count as charging through difficult terrain."/>
+        <characteristic name="Description" characteristicTypeId="4465736372697074696f6e23232344415441232323" value="A model in cover behind a barricade or wall has a 4+ cover save. For the purposes of charge moves, models that are both in base contact with a barricade and within 2&quot; of each other are treated as being in base contact. Despite the models on either side not literally being in base contact, they may fight in the Fight sub-phase as normal. Units charging an enemy that is behind a barricade or wall count as charging through difficult terrain."/>
       </characteristics>
     </profile>
     <profile id="2a6f-53c2-d2ea-092f" name="Booby Traps" book="HH: AoD Rulebook" page="106" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323" profileTypeName="Wargear Item">

--- a/The Horus Heresy.gst
+++ b/The Horus Heresy.gst
@@ -4833,7 +4833,7 @@ D6    Result		S	AP
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="053a-fd01-be65-238e" name="Wall of Martyrs Defence Strongpoint (remove)" book="Warzone Damnos" page="" hidden="false" collective="false" type="unit">
+    <selectionEntry id="053a-fd01-be65-238e" name="π Wall of Martyrs Defence Strongpoint (remove)" book="Warzone Damnos" page="" hidden="false" collective="false" type="unit">
       <profiles/>
       <rules>
         <rule id="b315-579b-33ac-b5f3" name="Magos Machine Spirit" book="Warzone Damnos" page="" hidden="false">
@@ -5243,7 +5243,7 @@ D6    Result		S	AP
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="0d50-24ac-a53e-5db7" name="Wall of Martyrs Imperial Defence Network (remove)" book="Planetary Onslaught" page="87" hidden="false" collective="false" type="unit">
+    <selectionEntry id="0d50-24ac-a53e-5db7" name="π Wall of Martyrs Imperial Defence Network (remove)" book="Planetary Onslaught" page="87" hidden="false" collective="false" type="unit">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -5550,7 +5550,7 @@ D6    Result		S	AP
         <cost name="pts" costTypeId="points" value="55.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="bbd4-5f41-35d1-6c5f" name="Void Shield Generator (remove)" book="Planetary Onslaught" page="92" hidden="false" collective="false" type="model">
+    <selectionEntry id="bbd4-5f41-35d1-6c5f" name="π Void Shield Generator (remove)" book="Planetary Onslaught" page="92" hidden="false" collective="false" type="model">
       <profiles>
         <profile id="002c-d06c-4447-a02b" name="Void Shield Generator" hidden="false" profileTypeId="286c-0cd4-7630-47d0">
           <profiles/>
@@ -5625,7 +5625,7 @@ Each projected void shield has an Armour Value of 12. A glancing or penetrating 
         <cost name="pts" costTypeId="points" value="25.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="796a-21c2-7281-17a8" name="Void Relay Network (remove)" book="Planetary Onslaught" page="93" hidden="false" collective="false" type="unit">
+    <selectionEntry id="796a-21c2-7281-17a8" name="π Void Relay Network (remove)" book="Planetary Onslaught" page="93" hidden="false" collective="false" type="unit">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -5745,7 +5745,7 @@ Each projected void shield has an Armour Value of 12. A glancing or penetrating 
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="1a59-dd0f-a7f2-32be" name="Promethium Relay Pipes (remove)" book="Planetary Onslaught" page="103" hidden="false" collective="false" type="model">
+    <selectionEntry id="1a59-dd0f-a7f2-32be" name="π Promethium Relay Pipes (remove)" book="Planetary Onslaught" page="103" hidden="false" collective="false" type="model">
       <profiles>
         <profile id="1c76-1592-2725-da7f" name="Promethium Relay Pipes" book="Stronghold Assault" page="" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323" profileTypeName="Wargear Item">
           <profiles/>
@@ -5791,7 +5791,7 @@ Each projected void shield has an Armour Value of 12. A glancing or penetrating 
         <cost name="pts" costTypeId="points" value="40.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="0fe6-096b-23ae-1134" name="Honoured Imperium (remove)" book="Planetary Onslaught" page="102" hidden="false" collective="false" type="model">
+    <selectionEntry id="0fe6-096b-23ae-1134" name="π Honoured Imperium (remove)" book="Planetary Onslaught" page="102" hidden="false" collective="false" type="model">
       <profiles/>
       <rules/>
       <infoLinks>
@@ -5839,7 +5839,7 @@ Each projected void shield has an Armour Value of 12. A glancing or penetrating 
         <cost name="pts" costTypeId="points" value="40.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="33f8-e6da-89a3-01d5" name="Firestorm Nexus (remove)" book="Remove - No longer used" page="" hidden="false" collective="false" type="unit">
+    <selectionEntry id="33f8-e6da-89a3-01d5" name="π Firestorm Nexus (remove)" book="Remove - No longer used" page="" hidden="false" collective="false" type="unit">
       <profiles>
         <profile id="03b2-5174-5847-b78a" name="Firestorm" book="Warzone Armageddon" page="" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
           <profiles/>
@@ -5897,7 +5897,7 @@ Each projected void shield has an Armour Value of 12. A glancing or penetrating 
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="8300-7ced-aafd-2a27" name="Fortress of Redemption (remove)" book="Planetary Onslaught" page="91" hidden="false" collective="false" type="model">
+    <selectionEntry id="8300-7ced-aafd-2a27" name="π Fortress of Redemption (remove)" book="Planetary Onslaught" page="91" hidden="false" collective="false" type="model">
       <profiles/>
       <rules/>
       <infoLinks>
@@ -6282,7 +6282,7 @@ Each projected void shield has an Armour Value of 12. A glancing or penetrating 
         <cost name="pts" costTypeId="points" value="75.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="5cdd-edbb-07c3-0ba5" name="Skyshield Landing Pad (remove)" book="Planetary Onslaught" page="101" hidden="false" collective="false" type="model">
+    <selectionEntry id="5cdd-edbb-07c3-0ba5" name="π Skyshield Landing Pad (remove)" book="Planetary Onslaught" page="101" hidden="false" collective="false" type="model">
       <profiles>
         <profile id="4eff-4ef5-3fae-f3d8" name="Skyshield Landing Pad" book="Stronghold Assault" page="" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323" profileTypeName="Wargear Item">
           <profiles/>
@@ -6607,7 +6607,7 @@ Unfurled: If a unit deep strikes on top of an unfurled Skyshield Landing Pad, it
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="06e2-2420-ffc8-13b8" name="Haemotrope Reactors (remove)" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="06e2-2420-ffc8-13b8" name="π Haemotrope Reactors (remove)" hidden="false" collective="false" type="upgrade">
       <profiles/>
       <rules>
         <rule id="836f-f195-e6a6-1c83" name="Plasma Feed" hidden="false">
@@ -6995,7 +6995,7 @@ A reactor can be shot at and attacked in close combat. If destroyed, the closest
         <cost name="pts" costTypeId="points" value="230.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="c05d-2231-2481-4037" name="Imperial Primus Redoubt (remove)" hidden="false" collective="false" type="model">
+    <selectionEntry id="c05d-2231-2481-4037" name="Imperial Primus Redoubt" book="HH: AoDAL" page="93" hidden="false" collective="false" type="model">
       <profiles>
         <profile id="254b-5059-bde3-4eac" name="Primus Redoubt" hidden="false" profileTypeId="286c-0cd4-7630-47d0">
           <profiles/>
@@ -7524,7 +7524,7 @@ In the event of enemy models embarking inside the Primus Redoubt, the Battle Cre
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="ed7e-757a-4ced-adff" name="Imperial Strongpoint (remove)" book="Planetary Onslaught" page="81" hidden="false" collective="false" type="unit">
+    <selectionEntry id="ed7e-757a-4ced-adff" name="π Imperial Strongpoint (remove)" book="Planetary Onslaught" page="81" hidden="false" collective="false" type="unit">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -11934,7 +11934,7 @@ D6    Result		S	AP
         <cost name="pts" costTypeId="points" value="3250.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="9f5b-eccc-689a-2948" name="Aquila Strongpoint (remove)" book="Remove - No longer in use" page="" hidden="false" collective="false" type="model">
+    <selectionEntry id="9f5b-eccc-689a-2948" name="π Aquila Strongpoint (remove)" book="Remove - No longer in use" page="" hidden="false" collective="false" type="model">
       <profiles/>
       <rules/>
       <infoLinks>

--- a/The Horus Heresy.gst
+++ b/The Horus Heresy.gst
@@ -3337,7 +3337,7 @@ D6    Result		S	AP
           <constraints/>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="72f7-b924-082c-60be" hidden="false" targetId="ad42-921f-358f-2970" type="selectionEntryGroup">
+        <entryLink id="72f7-b924-082c-60be" name="Obstacles List" hidden="false" targetId="ad42-921f-358f-2970" type="selectionEntryGroup">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -3562,7 +3562,9 @@ D6    Result		S	AP
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks/>
-              <costs/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="9102-7f7e-3d4a-d72e" name="Macro Cannon" book="Planetary Onslaught" page="88" hidden="false" collective="false" type="upgrade">
               <profiles/>
@@ -3603,7 +3605,9 @@ D6    Result		S	AP
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks/>
-              <costs/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
             </selectionEntry>
           </selectionEntries>
           <selectionEntryGroups/>
@@ -3642,7 +3646,9 @@ D6    Result		S	AP
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="7b11-22c7-16af-3bd4" name="BRB: Command Traits" hidden="false" collective="false" type="upgrade">
       <profiles>
@@ -4827,7 +4833,7 @@ D6    Result		S	AP
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="053a-fd01-be65-238e" name="Wall of Martyrs Defence Strongpoint (Legacy)" book="Warzone Damnos" page="" hidden="false" collective="false" type="unit">
+    <selectionEntry id="053a-fd01-be65-238e" name="Wall of Martyrs Defence Strongpoint (remove)" book="Warzone Damnos" page="" hidden="false" collective="false" type="unit">
       <profiles/>
       <rules>
         <rule id="b315-579b-33ac-b5f3" name="Magos Machine Spirit" book="Warzone Damnos" page="" hidden="false">
@@ -4970,7 +4976,7 @@ D6    Result		S	AP
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="b717-b44c-2221-2059" hidden="false" targetId="d04c-20b3-dc49-ea06" type="rule">
+        <infoLink id="b717-b44c-2221-2059" name="Very Wide Fire Point" hidden="false" targetId="d04c-20b3-dc49-ea06" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -5233,9 +5239,11 @@ D6    Result		S	AP
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
     </selectionEntry>
-    <selectionEntry id="0d50-24ac-a53e-5db7" name="Wall of Martyrs Imperial Defence Network (Legacyy)" book="Planetary Onslaught" page="87" hidden="false" collective="false" type="unit">
+    <selectionEntry id="0d50-24ac-a53e-5db7" name="Wall of Martyrs Imperial Defence Network (remove)" book="Planetary Onslaught" page="87" hidden="false" collective="false" type="unit">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -5542,7 +5550,7 @@ D6    Result		S	AP
         <cost name="pts" costTypeId="points" value="55.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="bbd4-5f41-35d1-6c5f" name="Void Shield Generator (Legacy)" book="Planetary Onslaught" page="92" hidden="false" collective="false" type="model">
+    <selectionEntry id="bbd4-5f41-35d1-6c5f" name="Void Shield Generator (remove)" book="Planetary Onslaught" page="92" hidden="false" collective="false" type="model">
       <profiles>
         <profile id="002c-d06c-4447-a02b" name="Void Shield Generator" hidden="false" profileTypeId="286c-0cd4-7630-47d0">
           <profiles/>
@@ -5617,7 +5625,7 @@ Each projected void shield has an Armour Value of 12. A glancing or penetrating 
         <cost name="pts" costTypeId="points" value="25.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="796a-21c2-7281-17a8" name="Void Relay Network" book="Planetary Onslaught" page="93" hidden="false" collective="false" type="unit">
+    <selectionEntry id="796a-21c2-7281-17a8" name="Void Relay Network (remove)" book="Planetary Onslaught" page="93" hidden="false" collective="false" type="unit">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -5684,7 +5692,7 @@ Each projected void shield has an Armour Value of 12. A glancing or penetrating 
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="5575-1a19-edf8-40d1" hidden="false" targetId="1a59-dd0f-a7f2-32be" type="selectionEntry">
+            <entryLink id="5575-1a19-edf8-40d1" name="Promethium Relay Pipes" hidden="false" targetId="1a59-dd0f-a7f2-32be" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -5733,9 +5741,11 @@ Each projected void shield has an Armour Value of 12. A glancing or penetrating 
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
     </selectionEntry>
-    <selectionEntry id="1a59-dd0f-a7f2-32be" name="Promethium Relay Pipes" book="Planetary Onslaught" page="103" hidden="false" collective="false" type="model">
+    <selectionEntry id="1a59-dd0f-a7f2-32be" name="Promethium Relay Pipes (remove)" book="Planetary Onslaught" page="103" hidden="false" collective="false" type="model">
       <profiles>
         <profile id="1c76-1592-2725-da7f" name="Promethium Relay Pipes" book="Stronghold Assault" page="" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323" profileTypeName="Wargear Item">
           <profiles/>
@@ -5781,7 +5791,7 @@ Each projected void shield has an Armour Value of 12. A glancing or penetrating 
         <cost name="pts" costTypeId="points" value="40.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="0fe6-096b-23ae-1134" name="Honoured Imperium" book="Planetary Onslaught" page="102" hidden="false" collective="false" type="model">
+    <selectionEntry id="0fe6-096b-23ae-1134" name="Honoured Imperium (remove)" book="Planetary Onslaught" page="102" hidden="false" collective="false" type="model">
       <profiles/>
       <rules/>
       <infoLinks>
@@ -5791,7 +5801,7 @@ Each projected void shield has an Armour Value of 12. A glancing or penetrating 
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="96ba-2919-deff-2d0a" hidden="false" targetId="7571-d9f2-17b0-c3e0" type="profile">
+        <infoLink id="96ba-2919-deff-2d0a" name="Imperial Statuary" hidden="false" targetId="7571-d9f2-17b0-c3e0" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -5829,7 +5839,7 @@ Each projected void shield has an Armour Value of 12. A glancing or penetrating 
         <cost name="pts" costTypeId="points" value="40.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="33f8-e6da-89a3-01d5" name="Firestorm Nexus" book="Warzone Armageddon" page="" hidden="false" collective="false" type="unit">
+    <selectionEntry id="33f8-e6da-89a3-01d5" name="Firestorm Nexus (remove)" book="Remove - No longer used" page="" hidden="false" collective="false" type="unit">
       <profiles>
         <profile id="03b2-5174-5847-b78a" name="Firestorm" book="Warzone Armageddon" page="" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
           <profiles/>
@@ -6272,7 +6282,7 @@ Each projected void shield has an Armour Value of 12. A glancing or penetrating 
         <cost name="pts" costTypeId="points" value="75.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="5cdd-edbb-07c3-0ba5" name="Skyshield Landing Pad" book="Planetary Onslaught" page="101" hidden="false" collective="false" type="model">
+    <selectionEntry id="5cdd-edbb-07c3-0ba5" name="Skyshield Landing Pad (remove)" book="Planetary Onslaught" page="101" hidden="false" collective="false" type="model">
       <profiles>
         <profile id="4eff-4ef5-3fae-f3d8" name="Skyshield Landing Pad" book="Stronghold Assault" page="" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323" profileTypeName="Wargear Item">
           <profiles/>
@@ -6361,7 +6371,9 @@ Unfurled: If a unit deep strikes on top of an unfurled Skyshield Landing Pad, it
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="b973-7d7d-754e-b022" name="Grand Redoubt" book="40k Apocalypse 2nd Ed" page="" hidden="false" collective="false" type="unit">
       <profiles/>
@@ -6719,7 +6731,9 @@ A reactor can be shot at and attacked in close combat. If destroyed, the closest
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="63b0-0b66-5eb0-382a" name="Munitorum Armoured Container Cache (Legacy)" book="Planetary Onslaught" page="98" hidden="false" collective="false" type="upgrade">
       <profiles/>
@@ -6981,7 +6995,7 @@ A reactor can be shot at and attacked in close combat. If destroyed, the closest
         <cost name="pts" costTypeId="points" value="230.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="c05d-2231-2481-4037" name="Imperial Primus Redoubt" hidden="false" collective="false" type="model">
+    <selectionEntry id="c05d-2231-2481-4037" name="Imperial Primus Redoubt (remove)" hidden="false" collective="false" type="model">
       <profiles>
         <profile id="254b-5059-bde3-4eac" name="Primus Redoubt" hidden="false" profileTypeId="286c-0cd4-7630-47d0">
           <profiles/>
@@ -7432,7 +7446,7 @@ In the event of enemy models embarking inside the Primus Redoubt, the Battle Cre
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="b34f-574b-cdc5-2d17" hidden="false" targetId="ad42-921f-358f-2970" type="selectionEntryGroup">
+        <entryLink id="b34f-574b-cdc5-2d17" name="Obstacles List" hidden="false" targetId="ad42-921f-358f-2970" type="selectionEntryGroup">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -7506,9 +7520,11 @@ In the event of enemy models embarking inside the Primus Redoubt, the Battle Cre
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
     </selectionEntry>
-    <selectionEntry id="ed7e-757a-4ced-adff" name="Imperial Strongpoint" book="Planetary Onslaught" page="81" hidden="false" collective="false" type="unit">
+    <selectionEntry id="ed7e-757a-4ced-adff" name="Imperial Strongpoint (remove)" book="Planetary Onslaught" page="81" hidden="false" collective="false" type="unit">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -7553,7 +7569,7 @@ In the event of enemy models embarking inside the Primus Redoubt, the Battle Cre
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="daf6-5ca2-4cea-91dd" hidden="false" targetId="55c6-268b-357f-d070" type="selectionEntry">
+            <entryLink id="daf6-5ca2-4cea-91dd" name="Bastion" hidden="false" targetId="55c6-268b-357f-d070" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -7576,7 +7592,7 @@ In the event of enemy models embarking inside the Primus Redoubt, the Battle Cre
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="8aa0-05da-fdaa-51bd" name="" hidden="false" targetId="5cdd-edbb-07c3-0ba5" type="selectionEntry">
+            <entryLink id="8aa0-05da-fdaa-51bd" name="Skyshield Landing Pad" hidden="false" targetId="5cdd-edbb-07c3-0ba5" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -7599,7 +7615,7 @@ In the event of enemy models embarking inside the Primus Redoubt, the Battle Cre
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="c576-7c0d-8118-d341" hidden="false" targetId="0fe6-096b-23ae-1134" type="selectionEntry">
+            <entryLink id="c576-7c0d-8118-d341" name="Honoured Imperium" hidden="false" targetId="0fe6-096b-23ae-1134" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -10659,7 +10675,7 @@ The Bunkers of the Castellum Stronghold have a 5+ invulnerable save against shoo
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="3f65-ad04-8903-6c6d" name="New EntryLink" hidden="false" targetId="2553-eaa0-d6af-2ec0" type="selectionEntry">
+            <entryLink id="3f65-ad04-8903-6c6d" name="Magna Lascannon" hidden="false" targetId="2553-eaa0-d6af-2ec0" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -10915,7 +10931,7 @@ The Bunkers of the Castellum Stronghold have a 5+ invulnerable save against shoo
       <profiles/>
       <rules/>
       <infoLinks>
-        <infoLink id="3b85-56e6-b738-a687" name="New InfoLink" hidden="false" targetId="3e31-9d8c-29ab-2e70" type="profile">
+        <infoLink id="3b85-56e6-b738-a687" name="Magna Lascannon" hidden="false" targetId="3e31-9d8c-29ab-2e70" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -11918,7 +11934,7 @@ D6    Result		S	AP
         <cost name="pts" costTypeId="points" value="3250.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="9f5b-eccc-689a-2948" name="Aquila Strongpoint (remove)" book="" page="116" hidden="false" collective="false" type="model">
+    <selectionEntry id="9f5b-eccc-689a-2948" name="Aquila Strongpoint (remove)" book="Remove - No longer in use" page="" hidden="false" collective="false" type="model">
       <profiles/>
       <rules/>
       <infoLinks>
@@ -12169,9 +12185,11 @@ D6    Result		S	AP
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
     </selectionEntry>
-    <selectionEntry id="7507-ce88-4e5a-ccc2" name="Crashed Imperial Lander" book="AoD: Rulebook" page="123" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="7507-ce88-4e5a-ccc2" name="Crashed Imperial Lander" book="AoD: Rulebook" page="123" hidden="false" collective="false" type="model">
       <profiles>
         <profile id="c501-5663-8d53-3f9b" name="Crashed Imperial Lander" hidden="false" profileTypeId="c2e2-42f3-9e28-c3fa" profileTypeName="Fortification/Terrain">
           <profiles/>
@@ -12214,7 +12232,9 @@ Immediately place an objective marker within 3&quot; of any part of the Crashed 
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="3027-0a29-19c0-40f5" name="Moonscape" book="AoD: Rulebook" page="125" hidden="false" collective="false" type="upgrade">
       <profiles>
@@ -12249,7 +12269,9 @@ Immediately place an objective marker within 3&quot; of any part of the Crashed 
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
@@ -12365,7 +12387,7 @@ Fortress-bound: Each fortification deployed on the table must be occupied by at 
               </selectionEntries>
               <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="cd56-c5b6-35fb-b4b3" name="New EntryLink" hidden="false" targetId="66c9-eaa6-a91a-00ed" type="selectionEntry">
+                <entryLink id="cd56-c5b6-35fb-b4b3" name="Fortification" hidden="false" targetId="66c9-eaa6-a91a-00ed" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -14067,7 +14089,7 @@ Command Benefits:
           <profiles/>
           <rules/>
           <infoLinks>
-            <infoLink id="359f-949e-fa6c-f375" hidden="false" targetId="58a2-c92e-57cc-d44c" type="profile">
+            <infoLink id="359f-949e-fa6c-f375" name="Ammunition Dump" hidden="false" targetId="58a2-c92e-57cc-d44c" type="profile">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -14090,7 +14112,7 @@ Command Benefits:
           <profiles/>
           <rules/>
           <infoLinks>
-            <infoLink id="c111-e21c-0718-d8d7" hidden="false" targetId="70aa-366f-15ac-da4d" type="profile">
+            <infoLink id="c111-e21c-0718-d8d7" name="Comms Relay" hidden="false" targetId="70aa-366f-15ac-da4d" type="profile">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -14113,19 +14135,19 @@ Command Benefits:
           <profiles/>
           <rules/>
           <infoLinks>
-            <infoLink id="e451-84da-1115-23cb" hidden="false" targetId="1da7-2e0b-0114-762c" type="profile">
+            <infoLink id="e451-84da-1115-23cb" name="Gun Emplacement" hidden="false" targetId="1da7-2e0b-0114-762c" type="profile">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
             </infoLink>
-            <infoLink id="c4f7-3c4d-38eb-2484" hidden="false" targetId="cb26-27b4-9393-a768" type="profile">
+            <infoLink id="c4f7-3c4d-38eb-2484" name="Icarus Lascannon" hidden="false" targetId="cb26-27b4-9393-a768" type="profile">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
             </infoLink>
-            <infoLink id="ceef-e79c-eddc-37a6" hidden="false" targetId="705c-91aa-6591-507b" type="profile">
+            <infoLink id="ceef-e79c-eddc-37a6" name="Gun Emplacement (Details)" hidden="false" targetId="705c-91aa-6591-507b" type="profile">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -14160,7 +14182,7 @@ Command Benefits:
               <infoLinks/>
               <modifiers/>
             </infoLink>
-            <infoLink id="5712-0be9-2ca9-0aea" hidden="false" targetId="1da7-2e0b-0114-762c" type="profile">
+            <infoLink id="5712-0be9-2ca9-0aea" name="Gun Emplacement" hidden="false" targetId="1da7-2e0b-0114-762c" type="profile">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -14197,7 +14219,7 @@ Command Benefits:
           <profiles/>
           <rules/>
           <infoLinks>
-            <infoLink id="cc9c-2e71-b0cf-2d0d" hidden="false" targetId="d4b6-7a3a-aee5-d293" type="profile">
+            <infoLink id="cc9c-2e71-b0cf-2d0d" name="Ammo Store" hidden="false" targetId="d4b6-7a3a-aee5-d293" type="profile">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -14220,7 +14242,7 @@ Command Benefits:
           <profiles/>
           <rules/>
           <infoLinks>
-            <infoLink id="143c-5441-54cd-c77d" hidden="false" targetId="2a6f-53c2-d2ea-092f" type="profile">
+            <infoLink id="143c-5441-54cd-c77d" name="Booby Traps" hidden="false" targetId="2a6f-53c2-d2ea-092f" type="profile">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -14243,7 +14265,7 @@ Command Benefits:
           <profiles/>
           <rules/>
           <infoLinks>
-            <infoLink id="f515-ed41-f326-62a6" hidden="false" targetId="e144-1293-ec28-d3a9" type="profile">
+            <infoLink id="f515-ed41-f326-62a6" name="Void Shield" hidden="false" targetId="e144-1293-ec28-d3a9" type="profile">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -14266,7 +14288,7 @@ Command Benefits:
           <profiles/>
           <rules/>
           <infoLinks>
-            <infoLink id="be10-ffb2-a8d3-723f" hidden="false" targetId="9bb4-3833-5343-0dd9" type="profile">
+            <infoLink id="be10-ffb2-a8d3-723f" name="Searchlight" hidden="false" targetId="9bb4-3833-5343-0dd9" type="profile">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -14289,7 +14311,7 @@ Command Benefits:
           <profiles/>
           <rules/>
           <infoLinks>
-            <infoLink id="ed19-4a65-da02-1d2e" hidden="false" targetId="4986-b80f-dc78-d02f" type="profile">
+            <infoLink id="ed19-4a65-da02-1d2e" name="Escape Hatch" hidden="false" targetId="4986-b80f-dc78-d02f" type="profile">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -14312,7 +14334,7 @@ Command Benefits:
           <profiles/>
           <rules/>
           <infoLinks>
-            <infoLink id="583c-c3fa-d802-4db1" hidden="false" targetId="31ba-2b94-6600-22f3" type="profile">
+            <infoLink id="583c-c3fa-d802-4db1" name="Magos Machine Spirit" hidden="false" targetId="31ba-2b94-6600-22f3" type="profile">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -14349,7 +14371,7 @@ Command Benefits:
           <profiles/>
           <rules/>
           <infoLinks>
-            <infoLink id="a3f7-2cdf-78f2-f8bf" hidden="false" targetId="e158-7adf-1565-ef08" type="profile">
+            <infoLink id="a3f7-2cdf-78f2-f8bf" name="Tanglewire" book="HH: AoD Rulebook" page="101" hidden="false" targetId="e158-7adf-1565-ef08" type="profile">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -14372,7 +14394,7 @@ Command Benefits:
           <profiles/>
           <rules/>
           <infoLinks>
-            <infoLink id="a149-5d28-9796-309d" hidden="false" targetId="68d8-f686-c260-76db" type="profile">
+            <infoLink id="a149-5d28-9796-309d" name="Barricades" hidden="false" targetId="68d8-f686-c260-76db" type="profile">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -14395,7 +14417,7 @@ Command Benefits:
           <profiles/>
           <rules/>
           <infoLinks>
-            <infoLink id="f133-1126-a49c-52c0" hidden="false" targetId="4a45-65e5-2d8c-8792" type="profile">
+            <infoLink id="f133-1126-a49c-52c0" name="Tank Traps" hidden="false" targetId="4a45-65e5-2d8c-8792" type="profile">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -16490,13 +16512,13 @@ Some can also Hover – see page 81. Zooming allows the Flyer to move at extreme
         <characteristic name="Description" characteristicTypeId="4465736372697074696f6e23232344415441232323" value="Model with Atomantic Shielding gains a 5++ Invulnerable save from shooting attacks and explosions, and a 6++ Invulnerable save against attacks suffered in close combat.  In addition, if the model suffers a Reactor Blast explosion, add +1&quot; to the radius of the blast caused. "/>
       </characteristics>
     </profile>
-    <profile id="9bb4-3833-5343-0dd9" name="Searchlight" book="BRB 7th" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323" profileTypeName="Wargear Item">
+    <profile id="9bb4-3833-5343-0dd9" name="Searchlight" book="HH: AoD Rulebook" page="106" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323" profileTypeName="Wargear Item">
       <profiles/>
       <rules/>
       <infoLinks/>
       <modifiers/>
       <characteristics>
-        <characteristic name="Description" characteristicTypeId="4465736372697074696f6e23232344415441232323" value="Night fighting only. It can illuminate a target it has fired at. Illuminates itself in the process (illuminated units lose Night Fighting benefits)"/>
+        <characteristic name="Description" characteristicTypeId="4465736372697074696f6e23232344415441232323" value="Night fighting only. it can, after firing all of its weapons, choose to illuminate its target with the searchlight. If it does so, it also illuminates itself."/>
       </characteristics>
     </profile>
     <profile id="a8c1-185a-cdd9-b5ce" name="Infravisor" book="HH:MT" page="111" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323">
@@ -17459,7 +17481,7 @@ Some can also Hover – see page 81. Zooming allows the Flyer to move at extreme
         <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Ordance 1, Large Blast"/>
       </characteristics>
     </profile>
-    <profile id="d4b6-7a3a-aee5-d293" name="Ammo Store" book="Planetary Onslaught" page="110" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323" profileTypeName="Wargear Item">
+    <profile id="d4b6-7a3a-aee5-d293" name="Ammo Store" book="HH: AoD Rulebook" page="106" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323" profileTypeName="Wargear Item">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -17468,7 +17490,7 @@ Some can also Hover – see page 81. Zooming allows the Flyer to move at extreme
         <characteristic name="Description" characteristicTypeId="4465736372697074696f6e23232344415441232323" value="A unit occupying this building re-rolls To Hit rolls of a 1 when firing out of the building’s fire points. Note this does not apply to a model manually firing an emplaced weapon."/>
       </characteristics>
     </profile>
-    <profile id="58a2-c92e-57cc-d44c" name="Ammunition Dump" book="Planetary Onslaught" page="110" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323" profileTypeName="Wargear Item">
+    <profile id="58a2-c92e-57cc-d44c" name="Ammunition Dump" book="HH: AoD Rulebook" page="101" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323" profileTypeName="Wargear Item">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -17477,22 +17499,23 @@ Some can also Hover – see page 81. Zooming allows the Flyer to move at extreme
         <characteristic name="Description" characteristicTypeId="4465736372697074696f6e23232344415441232323" value="A model in cover behind an ammunition dump has a 5+ cover save. Any model within 2&quot; of an ammunition dump re-rolls failed To Hit rolls of 1 in the Shooting phase."/>
       </characteristics>
     </profile>
-    <profile id="68d8-f686-c260-76db" name="Barricades" book="Stronghold Assault" page="" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323" profileTypeName="Wargear Item">
+    <profile id="68d8-f686-c260-76db" name="Barricades" book="HH: AoD Rulebook" page="101" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323" profileTypeName="Wargear Item">
       <profiles/>
       <rules/>
       <infoLinks/>
       <modifiers/>
       <characteristics>
-        <characteristic name="Description" characteristicTypeId="4465736372697074696f6e23232344415441232323" value="A model in cover behind a barricade or wall has a 4+ cover save. Models that are in base contact with a barricade or wall are treated as being in base contact with any enemy models who are directly opposite them and in base contact with the other side of that barricade or wall. Units charging an enemy that is behind a barricade or wall count as charging through difficult terrain."/>
+        <characteristic name="Description" characteristicTypeId="4465736372697074696f6e23232344415441232323" value="A model in cover behind a barricade or wall has a 4+ cover save.
+For the purposes of charge moves, models that are both in base contact with a barricade and within 2&quot; of each other are treated as being in base contact. Despite the models on either side not literally being in base contact, they may fight in the Fight sub-phase as normal. Units charging an enemy that is behind a barricade or wall count as charging through difficult terrain."/>
       </characteristics>
     </profile>
-    <profile id="2a6f-53c2-d2ea-092f" name="Booby Traps" book="Planetary Onslaught" page="110" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323" profileTypeName="Wargear Item">
+    <profile id="2a6f-53c2-d2ea-092f" name="Booby Traps" book="HH: AoD Rulebook" page="106" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323" profileTypeName="Wargear Item">
       <profiles/>
       <rules/>
       <infoLinks/>
       <modifiers/>
       <characteristics>
-        <characteristic name="Description" characteristicTypeId="4465736372697074696f6e23232344415441232323"/>
+        <characteristic name="Description" characteristicTypeId="4465736372697074696f6e23232344415441232323" value="The first unit to occupy this building (friend or foe) immediately suffers 2D6 Strength 4 AP 5 hits with the Ignores Cover special rule."/>
       </characteristics>
     </profile>
     <profile id="8194-4688-65b3-f996" name="Chainfist" book="HH: AoD Rulebook" page="180" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
@@ -17507,7 +17530,7 @@ Some can also Hover – see page 81. Zooming allows the Flyer to move at extreme
         <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Melee, Armourbane, Specialist Weapon, Unwieldy"/>
       </characteristics>
     </profile>
-    <profile id="70aa-366f-15ac-da4d" name="Comms Relay" book="Stronghold Assault" page="" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323" profileTypeName="Wargear Item">
+    <profile id="70aa-366f-15ac-da4d" name="Comms Relay" book="HH: AoD Rulebook" page="101" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323" profileTypeName="Wargear Item">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -17528,7 +17551,7 @@ Some can also Hover – see page 81. Zooming allows the Flyer to move at extreme
         <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Melee"/>
       </characteristics>
     </profile>
-    <profile id="4986-b80f-dc78-d02f" name="Escape Hatch" book="Stronghold Assault" page="" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323" profileTypeName="Wargear Item">
+    <profile id="4986-b80f-dc78-d02f" name="Escape Hatch" book="HH: AoD Rulebook" page="106" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323" profileTypeName="Wargear Item">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -17585,16 +17608,25 @@ Some can also Hover – see page 81. Zooming allows the Flyer to move at extreme
         <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Melee, Force"/>
       </characteristics>
     </profile>
-    <profile id="1da7-2e0b-0114-762c" name="Gun Emplacement" book="Stronghold Assault" page="" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323" profileTypeName="Wargear Item">
+    <profile id="1da7-2e0b-0114-762c" name="Gun Emplacement" book="HH: Rulebook" page="101" hidden="false" profileTypeId="556e697423232344415441232323" profileTypeName="Unit">
       <profiles/>
       <rules/>
       <infoLinks/>
       <modifiers/>
       <characteristics>
-        <characteristic name="Description" characteristicTypeId="4465736372697074696f6e23232344415441232323"/>
+        <characteristic name="Unit Type" characteristicTypeId="556e6974205479706523232344415441232323"/>
+        <characteristic name="WS" characteristicTypeId="575323232344415441232323" value="-"/>
+        <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="-"/>
+        <characteristic name="S" characteristicTypeId="5323232344415441232323" value="-"/>
+        <characteristic name="T" characteristicTypeId="5423232344415441232323" value="7"/>
+        <characteristic name="W" characteristicTypeId="5723232344415441232323" value="2"/>
+        <characteristic name="I" characteristicTypeId="4923232344415441232323" value="-"/>
+        <characteristic name="A" characteristicTypeId="4123232344415441232323" value="-"/>
+        <characteristic name="LD" characteristicTypeId="4c4423232344415441232323" value="-"/>
+        <characteristic name="Save" characteristicTypeId="5361766523232344415441232323" value="3+"/>
       </characteristics>
     </profile>
-    <profile id="705c-91aa-6591-507b" name="Gun Emplacement (Details)" book="Stronghold Assault" page="" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323" profileTypeName="Wargear Item">
+    <profile id="705c-91aa-6591-507b" name="Gun Emplacement (Details)" book="HH: Rulebook" page="101" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323" profileTypeName="Wargear Item">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -17684,7 +17716,7 @@ Some can also Hover – see page 81. Zooming allows the Flyer to move at extreme
         <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Primary Weapon 2, Large Blast"/>
       </characteristics>
     </profile>
-    <profile id="31ba-2b94-6600-22f3" name="Magos Machine Spirit" book="Stronghold Assault" page="" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323" profileTypeName="Wargear Item">
+    <profile id="31ba-2b94-6600-22f3" name="Magos Machine Spirit" book="HH: AoD Rulebook" page="106" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323" profileTypeName="Wargear Item">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -17777,7 +17809,7 @@ Some can also Hover – see page 81. Zooming allows the Flyer to move at extreme
         <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Assault 2"/>
       </characteristics>
     </profile>
-    <profile id="e158-7adf-1565-ef08" name="Tanglewire" book="Stronghold Assault" page="" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323" profileTypeName="Wargear Item">
+    <profile id="e158-7adf-1565-ef08" name="Tanglewire" book="HH: AoD Rulebook" page="101" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323" profileTypeName="Wargear Item">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -17786,7 +17818,7 @@ Some can also Hover – see page 81. Zooming allows the Flyer to move at extreme
         <characteristic name="Description" characteristicTypeId="4465736372697074696f6e23232344415441232323" value="Dangerous Terrain. A model in cover behind tanglewire has a 6+ cover save."/>
       </characteristics>
     </profile>
-    <profile id="4a45-65e5-2d8c-8792" name="Tank Traps" book="Stronghold Assault" page="" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323" profileTypeName="Wargear Item">
+    <profile id="4a45-65e5-2d8c-8792" name="Tank Traps" book="HH: AoD Rulebook" page="101" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323" profileTypeName="Wargear Item">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -17795,7 +17827,7 @@ Some can also Hover – see page 81. Zooming allows the Flyer to move at extreme
         <characteristic name="Description" characteristicTypeId="4465736372697074696f6e23232344415441232323" value="Impassable Terrain to non-Skimmer vehicles, Dangerous Terrain to Bikes, and open ground for all other units. A model in cover behind tank traps hasa 4+ cover save."/>
       </characteristics>
     </profile>
-    <profile id="e144-1293-ec28-d3a9" name="Void Shield" book="Stronghold Assault" page="" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323" profileTypeName="Wargear Item">
+    <profile id="e144-1293-ec28-d3a9" name="Void Shield" book="HH: AoD Rulebook" page="106" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323" profileTypeName="Wargear Item">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -18152,7 +18184,7 @@ Some can also Hover – see page 81. Zooming allows the Flyer to move at extreme
         <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 3"/>
       </characteristics>
     </profile>
-    <profile id="d9b3-3506-e372-22e2" name="Turbo-laser Destructor" book="HH:LACAL" page="73" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+    <profile id="d9b3-3506-e372-22e2" name="Turbo Laser Destructor" book="HH:LACAL" page="73" hidden="false" profileTypeId="576561706f6e23232344415441232323">
       <profiles/>
       <rules/>
       <infoLinks/>


### PR DESCRIPTION
Update to match the current main rulebook.

Points and profiles have been updated, entries that have not been included in the rulebook have been marked with (remove) so we'll need to remove/reorganise the entries in each catalogue. I didn't delete them straight away as that would cause errors in the other files.

Some pieces have 9 cost now, I'd suggest moving them from the fortifications category to a new "Terrain" category unless there's a compelling argument to remove them completely or leave them as they are.