### PR TITLE
Fixed Cybernetica Cortex on Arlatax's in Mechanicum

### DIFF
--- a/(HH) Mechanicum - Taghmata Army List.cat
+++ b/(HH) Mechanicum - Taghmata Army List.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="cf03-f607-41dc-7545" name="Mechanicum: Taghmata Army List" book="Horus Heresy: Taghmata Army List" revision="67" battleScribeVersion="2.01" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="85" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="cf03-f607-41dc-7545" name="Mechanicum: Taghmata Army List" book="Horus Heresy: Taghmata Army List" revision="68" battleScribeVersion="2.01" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="85" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules/>
   <infoLinks/>
@@ -4427,7 +4427,7 @@
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="7ba1-5765-e358-4868" hidden="false" targetId="3ebf-b52d-5006-2426" type="rule">
+        <infoLink id="7ba1-5765-e358-4868" name="Cybernetica Cortex" hidden="false" targetId="f6c9-cdb7-c695-5b6b" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>


### PR DESCRIPTION
Arlatax's should have the Cybernetica Cortex rule, not the Cybernetic Resilience (They get that rule through the Cybernetica Cortex).