### PR TITLE
Arch / Magos Prime : Malagra upgrade stats

### DIFF
--- a/(HH) Mechanicum - Taghmata Army List.cat
+++ b/(HH) Mechanicum - Taghmata Army List.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="cf03-f607-41dc-7545" name="Mechanicum: Taghmata Army List" book="Horus Heresy: Taghmata Army List" revision="77" battleScribeVersion="2.01" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="85" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="cf03-f607-41dc-7545" name="Mechanicum: Taghmata Army List" book="Horus Heresy: Taghmata Army List" revision="78" battleScribeVersion="2.01" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="85" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules/>
   <infoLinks/>
@@ -18296,6 +18296,20 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
               </conditions>
               <conditionGroups/>
             </modifier>
+            <modifier type="increment" field="575323232344415441232323" value="1">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="aa74-77f4-7266-36b6" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c615-024f-f3f7-78e6" type="equalTo"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="4123232344415441232323" value="1">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="aa74-77f4-7266-36b6" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c615-024f-f3f7-78e6" type="equalTo"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
           </modifiers>
           <characteristics>
             <characteristic name="Unit Type" characteristicTypeId="556e6974205479706523232344415441232323" value="Infantry (Character)"/>
@@ -18368,6 +18382,20 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                   <repeats/>
                   <conditions>
                     <condition field="selections" scope="aa74-77f4-7266-36b6" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1ad6-9042-a001-972b" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="increment" field="575323232344415441232323" value="1">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="aa74-77f4-7266-36b6" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c615-024f-f3f7-78e6" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="increment" field="4123232344415441232323" value="1">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="aa74-77f4-7266-36b6" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c615-024f-f3f7-78e6" type="equalTo"/>
                   </conditions>
                   <conditionGroups/>
                 </modifier>


### PR DESCRIPTION
Magos Prime and Archmagos Prime updated to have the +1WS and Attack given by the Malagra upgrade.

File to test
https://drive.google.com/file/d/17bkZhVr0T71m2rmOToZNPTZ3rfsESUdL/view?usp=sharing