### PR TITLE
Thallax (Icarian) fix #1446

### DIFF
--- a/(HH) Mechanicum - Taghmata Army List.cat
+++ b/(HH) Mechanicum - Taghmata Army List.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="cf03-f607-41dc-7545" name="Mechanicum: Taghmata Army List" book="Horus Heresy: Taghmata Army List" revision="78" battleScribeVersion="2.01" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="85" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="cf03-f607-41dc-7545" name="Mechanicum: Taghmata Army List" book="Horus Heresy: Taghmata Army List" revision="79" battleScribeVersion="2.01" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="85" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules/>
   <infoLinks/>
@@ -2060,38 +2060,6 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         </categoryLink>
       </categoryLinks>
     </entryLink>
-    <entryLink id="4725-8e03-7ea7-1e78" name="Wall of Martyrs Imperial Defence Strongpoint" hidden="false" targetId="053a-fd01-be65-238e" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks>
-        <categoryLink id="4725-8e03-7ea7-1e78-1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="a6f0-bdb7-5552-5629" name="Grand Redoubt" hidden="false" targetId="b973-7d7d-754e-b022" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks>
-        <categoryLink id="a6f0-bdb7-5552-5629-1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
     <entryLink id="f163-b853-4f1b-2414" name="Warlord-Sinister Patter Battle Psi-Titan" hidden="false" targetId="fb92-d215-2011-f911" type="selectionEntry">
       <profiles/>
       <rules/>
@@ -2148,22 +2116,6 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
       <constraints/>
       <categoryLinks>
         <categoryLink id="6853-c72e-77f7-7fe9-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="2555-ca8d-d329-1f9d" name="Wall of Martyrs Imperial Defence Network" hidden="false" targetId="0d50-24ac-a53e-5db7" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks>
-        <categoryLink id="2555-ca8d-d329-1f9d-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -2236,54 +2188,6 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         </categoryLink>
       </categoryLinks>
     </entryLink>
-    <entryLink id="95c4-1dad-9180-53fb" name="Void Shield Generator" hidden="false" targetId="bbd4-5f41-35d1-6c5f" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks>
-        <categoryLink id="95c4-1dad-9180-53fb-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="cc11-e8a8-79a9-3ef4" name="Void Relay Network" hidden="false" targetId="796a-21c2-7281-17a8" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks>
-        <categoryLink id="cc11-e8a8-79a9-3ef4-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="e1be-a3f7-f15e-1233" name="Skyshield Landing Pad" hidden="false" targetId="5cdd-edbb-07c3-0ba5" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks>
-        <categoryLink id="e1be-a3f7-f15e-1233-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
     <entryLink id="4d39-e78e-aa8c-3526" name="Shrine of the Aquila" hidden="false" targetId="595a-908e-96a1-f121" type="selectionEntry">
       <profiles/>
       <rules/>
@@ -2316,22 +2220,6 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         </categoryLink>
       </categoryLinks>
     </entryLink>
-    <entryLink id="937e-748f-0ccb-b821" name="Promethium Relay Pipes" hidden="false" targetId="1a59-dd0f-a7f2-32be" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks>
-        <categoryLink id="937e-748f-0ccb-b821-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
     <entryLink id="425f-a363-f672-7867" name="Plasma Obliterator" hidden="false" targetId="3015-0b77-e848-c0f5" type="selectionEntry">
       <profiles/>
       <rules/>
@@ -2356,22 +2244,6 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
       <constraints/>
       <categoryLinks>
         <categoryLink id="31e2-35e7-32ad-acb8-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="e8de-63d9-3cd5-47f8" name="Imperial Strongpoint" hidden="false" targetId="ed7e-757a-4ced-adff" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks>
-        <categoryLink id="e8de-63d9-3cd5-47f8-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -2428,70 +2300,6 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         </categoryLink>
       </categoryLinks>
     </entryLink>
-    <entryLink id="b293-4fe8-27d9-d56d" name="Honoured Imperium" hidden="false" targetId="0fe6-096b-23ae-1134" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks>
-        <categoryLink id="b293-4fe8-27d9-d56d-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="a834-83b9-78fd-4770" name="Haemotrope Reactors" hidden="false" targetId="06e2-2420-ffc8-13b8" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks>
-        <categoryLink id="a834-83b9-78fd-4770-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="c3bb-2bb6-c9f8-a518" name="Fortress of Redemption" hidden="false" targetId="8300-7ced-aafd-2a27" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks>
-        <categoryLink id="c3bb-2bb6-c9f8-a518-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="e1dd-1575-7822-9351" name="Firestorm Nexus" hidden="false" targetId="33f8-e6da-89a3-01d5" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks>
-        <categoryLink id="e1dd-1575-7822-9351-1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
     <entryLink id="54f6-9b6b-c64c-753a" name="Basilica Administratum" hidden="false" targetId="e10f-7b90-ecd3-80a5" type="selectionEntry">
       <profiles/>
       <rules/>
@@ -2500,22 +2308,6 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
       <constraints/>
       <categoryLinks>
         <categoryLink id="54f6-9b6b-c64c-753a-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="2fca-c119-4680-491a" name="Aquila Strongpoint" hidden="false" targetId="9f5b-eccc-689a-2948" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks>
-        <categoryLink id="2fca-c119-4680-491a-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -2624,13 +2416,6 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
       </modifiers>
       <constraints/>
       <categoryLinks>
-        <categoryLink id="c5e0-2138-0800-80fc" name="New CategoryLink" hidden="false" targetId="54726f6f707323232344415441232323" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
         <categoryLink id="57d9-dbe2-d0a5-3541" name="New CategoryLink" hidden="false" targetId="afa3-c43a-c8c1-d8b6" primary="false">
           <profiles/>
           <rules/>
@@ -2639,6 +2424,13 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
           <constraints/>
         </categoryLink>
         <categoryLink id="5b19-0f5f-c84b-b5d8" name="New CategoryLink" hidden="false" targetId="37f2-7398-84ee-6fdf" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="9d75-6e8e-d457-0cbe" name="New CategoryLink" hidden="false" targetId="54726f6f707323232344415441232323" primary="true">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -3501,6 +3293,36 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
       <constraints/>
       <categoryLinks>
         <categoryLink id="f6a5-749e-217f-10f1" name="New CategoryLink" hidden="false" targetId="485123232344415441232323" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="5c3a-0189-ddc2-0eb2" name="Thallax Cohort (Icarian)" hidden="false" targetId="d893-4871-06f4-d2a9" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="17e3-b3a8-5e10-db91" name="New CategoryLink" hidden="false" targetId="afa3-c43a-c8c1-d8b6" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="066d-3b13-644d-c8ba" name="New CategoryLink" hidden="false" targetId="37f2-7398-84ee-6fdf" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="9646-7e4e-c0b4-2f2b" name="Heavy Support" hidden="false" targetId="486561767920537570706f727423232344415441232323" primary="true">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -12253,7 +12075,7 @@ Buildings and Fortifications D</description>
                 </infoLink>
               </infoLinks>
               <modifiers>
-                <modifier type="increment" field="points" value="5.0">
+                <modifier type="increment" field="points" value="5">
                   <repeats>
                     <repeat field="selections" scope="b39b-9817-025c-62da" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
                   </repeats>
@@ -25303,6 +25125,371 @@ Any abilities that allow the vehicle to fire multiple shots will use the same sh
         <cost name="pts" costTypeId="points" value="375.0"/>
       </costs>
     </selectionEntry>
+    <selectionEntry id="d893-4871-06f4-d2a9" name="Thallax Cohort (Icarian)" book="" hidden="false" collective="false" type="unit">
+      <profiles/>
+      <rules>
+        <rule id="355c-4fbc-d3c6-5e77" name="Icarian*" book="HH:MT" page="39" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <description>If stationary that turn, the Cohort may, if wished, count as having the
+                                        Skyfire special rule for all its ranged weapons that turn. Units with this
+                                        augment count as a Heavy Support choice instead of a troops choice for the army.</description>
+        </rule>
+      </rules>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="6d6b-19bd-f118-0d47" type="min"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="ed34-99a1-7e6c-f750" name="Heavy Support" hidden="false" targetId="486561767920537570706f727423232344415441232323" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="d31f-ce89-11a2-099d" name="Thallax" hidden="false" collective="false" type="model">
+          <profiles>
+            <profile id="5b08-6ef8-3674-064f" name="Thallax" book="HH4: Conquest" page="290" hidden="false" profileTypeId="556e697423232344415441232323">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Unit Type" characteristicTypeId="556e6974205479706523232344415441232323" value="Jet Pack Infantry"/>
+                <characteristic name="WS" characteristicTypeId="575323232344415441232323" value="3"/>
+                <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="4"/>
+                <characteristic name="S" characteristicTypeId="5323232344415441232323" value="5"/>
+                <characteristic name="T" characteristicTypeId="5423232344415441232323" value="5"/>
+                <characteristic name="W" characteristicTypeId="5723232344415441232323" value="3"/>
+                <characteristic name="I" characteristicTypeId="4923232344415441232323" value="2"/>
+                <characteristic name="A" characteristicTypeId="4123232344415441232323" value="2"/>
+                <characteristic name="LD" characteristicTypeId="4c4423232344415441232323" value="8"/>
+                <characteristic name="Save" characteristicTypeId="5361766523232344415441232323" value="4+"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks>
+            <infoLink id="ae5a-29d3-b532-0057" name="Lorica Thallax" hidden="false" targetId="405d3ced-c3a6-9f99-2018-9ab90162b6b1" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="a048-e0f2-fddd-1ce4" hidden="false" targetId="988c7311-fd57-a973-0678-7545d8d58f48" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="9c8f-3606-07d8-f1b7" name="Stubborn" hidden="false" targetId="7be5-30af-1a02-0a89" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="659b-8da3-6778-1292" name="Bulky" hidden="false" targetId="38d5-b6eb-bda8-2497" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4ef9-70c5-d32a-be59" type="min"/>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6cf1-b5a6-3045-4c38" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="40.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="1c71-0413-95eb-5412" name="Lightning gun" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="a475-d4c5-edaa-5966" name="Lightning Gun" hidden="false" targetId="ec450cd6-6dba-ca68-091c-9c48fcbc2112" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="c680-19ab-0a30-88c2" name="Rending" hidden="false" targetId="8269-2cd6-9236-16e7" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="1673-53f8-5e98-eebd" name="Shred" hidden="false" targetId="89da-0cb5-bee4-8ec2" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4d9a-272e-70ff-478f" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6117-03d9-c308-f90b" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="83ad-8404-1f92-1134" name="Any Thallax may exchange their close combat weapon for:" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries>
+            <selectionEntry id="edbf-9c9b-ffcb-e2f2" name="Heavy Chainblade" hidden="false" collective="false" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="0766-1419-57cb-7461" name="Heavy Chainblade" hidden="false" targetId="fed8-2dba-f78c-5bcc" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers>
+                <modifier type="increment" field="8f04-5ec2-75ae-cf21" value="1">
+                  <repeats>
+                    <repeat field="selections" scope="d893-4871-06f4-d2a9" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8f04-5ec2-75ae-cf21" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="75e5-54c9-6a89-0f4d" name="Entire squad may take:" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries>
+            <selectionEntry id="43ae-5618-7c59-f987" name="Melta bombs" hidden="false" collective="false" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="ebb6-a3b9-7fd0-e001" name="New InfoLink" hidden="false" targetId="a1d8-f9f3-865a-9faf" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers>
+                <modifier type="increment" field="points" value="5">
+                  <repeats>
+                    <repeat field="selections" scope="d893-4871-06f4-d2a9" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9c24-aeaf-627c-a9fc" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="614d-295c-2617-24f9" name="One in three may exchange their Lightning Gun for:" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="a726-01e2-ae2e-233a" value="1">
+              <repeats>
+                <repeat field="selections" scope="d893-4871-06f4-d2a9" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a726-01e2-ae2e-233a" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries>
+            <selectionEntry id="0a60-6b61-f71b-d420" name="Multi-laser" hidden="false" collective="false" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="59d7-7fa2-1989-c144" hidden="false" targetId="c812-a8fe-2b49-75a5" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a2d1-2d62-35fb-ba48" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="1e5f-5e8e-70e9-0a73" name="Phase Plasma-fusil" hidden="false" collective="false" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="7f10-f073-47a5-a99f" hidden="false" targetId="71ed050b-073d-852a-e50a-425b96eb71cd" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="93ba-0b95-0968-ced6" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="4920-147d-4bb2-b9c5" name="Irad-cleanser" hidden="false" collective="false" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="906a-282c-ff68-91a7" hidden="false" targetId="087e3cad-c849-204a-b83a-29093869a431" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8ea3-5875-e944-8087" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="292c-844d-ce4b-60e8" name="Multi-melta" hidden="false" collective="false" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="a7a0-38eb-9894-5658" name="Multi-melta" hidden="false" targetId="ed91-7534-4852-fb7a" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d3e7-e7cd-1bb5-ef82" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="15.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="08eb-767a-4f2b-2e11" name="Photon Thruster" hidden="false" collective="false" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="be73-acc8-c1ef-3e70" hidden="false" targetId="43648289-5a0f-99d3-1cfc-55b689750afa" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c851-e00a-7a01-43a2" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="25.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="17ec-e320-3e40-61cd" name="Triaros Armoured Conveyor" hidden="false" targetId="bb6538b0-0f23-8a43-9752-dd356ba76e46" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="40.0"/>
+      </costs>
+    </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup id="d696-042d-2afa-b026" name="Heavy Bolter or Heavy Flamer" hidden="false" collective="false">
@@ -25861,48 +26048,6 @@ Any abilities that allow the vehicle to fire multiple shots will use the same sh
       </constraints>
       <categoryLinks/>
       <selectionEntries>
-        <selectionEntry id="a534-3d38-fe9e-b1a7" name="Icarian" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules>
-            <rule id="62b6-3bb4-5f22-7b39" name="Icarian*" book="HH:MT" page="39" hidden="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <description>If stationary that turn, the Cohort may, if wished, count as having the
-                                        Skyfire special rule for all its ranged weapons that turn. Units with this
-                                        augment count as a Heavy Support choice instead of a troops choice for the army.</description>
-            </rule>
-          </rules>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="set" field="826b-0942-92c8-491d" value="1">
-              <repeats/>
-              <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="486561767920537570706f727423232344415441232323" type="equalTo"/>
-              </conditions>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="set" field="bd4d-b32b-dba6-4501" value="0">
-              <repeats/>
-              <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="54726f6f707323232344415441232323" type="equalTo"/>
-              </conditions>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="bd4d-b32b-dba6-4501" type="max"/>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="826b-0942-92c8-491d" type="min"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="25.0"/>
-          </costs>
-        </selectionEntry>
         <selectionEntry id="73fd-45ff-5b7f-7980" name="Ferrox" hidden="false" collective="false" type="upgrade">
           <profiles/>
           <rules>


### PR DESCRIPTION
Thallax with Icarian upgrade were not moving into heavy support. Recreated an additional Thallax entry. This one has the upgrade included in base profile. Option for Icarian upgrade for Troop version has been removed.

Test File
https://drive.google.com/file/d/1cshp1orD9x2kG5edQsj1sAnsD4FpRZoY/view?usp=sharing