### PR TITLE
Knight Dominus and Armigers

### DIFF
--- a/(HH) Mechanicum - Questoris Knight.cat
+++ b/(HH) Mechanicum - Questoris Knight.cat
@@ -2549,14 +2549,22 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
                   <infoLinks/>
                   <modifiers/>
                   <characteristics>
-                    <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323"/>
-                    <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323"/>
-                    <characteristic name="AP" characteristicTypeId="415023232344415441232323"/>
-                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323"/>
+                    <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="48&quot;"/>
+                    <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="9"/>
+                    <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="3"/>
+                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 1, Shieldbreaker, One Use"/>
                   </characteristics>
                 </profile>
               </profiles>
-              <rules/>
+              <rules>
+                <rule id="1914-6183-4806-e211" name="Shieldbreaker" hidden="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <description>Shieldbreaker: Invulnerable saves may not be taken against Wounds or Hull points inflicted by a weapon with this type.</description>
+                </rule>
+              </rules>
               <infoLinks/>
               <modifiers/>
               <constraints>
@@ -2658,7 +2666,15 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
                   </characteristics>
                 </profile>
               </profiles>
-              <rules/>
+              <rules>
+                <rule id="f7b6-8df9-dbcb-5260" name="Thundercoil Harpoon" hidden="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <description>Harpoon: Once fired, regardless of whether the attack results in a hit or not, this weapon may not be fired again in the controlling player’s next Shooting phase. Effectively, it may only be fired every other turn. In addition, any model that fails a save against a Wound or Hull point of damage inflicted by a weapon with this type suffers D6 Wounds or D6 Hull points of damage instead of just one (these wounds do not carry over to other models in the same unit).</description>
+                </rule>
+              </rules>
               <infoLinks/>
               <modifiers/>
               <constraints>

--- a/(HH) Mechanicum - Questoris Knight.cat
+++ b/(HH) Mechanicum - Questoris Knight.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="32d1ddc6-3187-cf6f-3bf8-9891e527a002" name="Questoris Knight Crusade Army" book="Age of Darkness Crusade Army List" revision="42" battleScribeVersion="2.01" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="85" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="32d1ddc6-3187-cf6f-3bf8-9891e527a002" name="Questoris Knight Crusade Army" book="Age of Darkness Crusade Army List" revision="43" battleScribeVersion="2.01" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="85" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules/>
   <infoLinks/>
@@ -456,7 +456,7 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks>
-        <entryLink id="0d826049-6db2-6635-065c-6b6c34faf886" hidden="false" targetId="3fc4-9d7f-969b-35bb" type="selectionEntryGroup">
+        <entryLink id="0d826049-6db2-6635-065c-6b6c34faf886" name="Knight Armour" hidden="false" targetId="3fc4-9d7f-969b-35bb" type="selectionEntryGroup">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -924,6 +924,44 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
         <cost name="pts" costTypeId="points" value="50.0"/>
       </costs>
     </selectionEntry>
+    <selectionEntry id="dbcc-f750-c3cb-2dcf" name="Scion Auxilia" book="HH4: Conquest" page="297" hidden="false" collective="false" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="9f59-5499-23fb-9144" name="Objective Secured" hidden="false" targetId="4764-48d9-da41-afaa" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="dc12-2675-4bfb-2b03" hidden="false" targetId="54726f6f707323232344415441232323" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="6592-ed1e-78ca-c6eb" name="Questoris Knight Armiger Talon" hidden="false" targetId="1072-d634-f6c6-b41e" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="25.0"/>
+      </costs>
+    </selectionEntry>
   </selectionEntries>
   <entryLinks>
     <entryLink id="849c-0f60-509d-16d1" name="Archmagos Draykavac" hidden="false" targetId="27575b75-5e1e-26ab-1074-fa91b73e2216" type="selectionEntry">
@@ -1086,22 +1124,6 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
         </categoryLink>
       </categoryLinks>
     </entryLink>
-    <entryLink id="b0e9-ab77-4a71-28bf" name="New EntryLink" hidden="false" targetId="b973-7d7d-754e-b022" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks>
-        <categoryLink id="b0e9-ab77-4a71-28bf-1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
     <entryLink id="53b7-53cc-3df0-a8a1" name="New EntryLink" hidden="false" targetId="ab80-0fef-3e93-8e64" type="selectionEntry">
       <profiles/>
       <rules/>
@@ -1150,7 +1172,7 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
         </categoryLink>
       </categoryLinks>
     </entryLink>
-    <entryLink id="3f06-44f6-7e22-ed9a" name="New EntryLink" hidden="false" targetId="a505-05af-bd44-56b6" type="selectionEntry">
+    <entryLink id="3f06-44f6-7e22-ed9a" name="Aegis Defense Line" hidden="false" targetId="a505-05af-bd44-56b6" type="selectionEntry">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -1158,22 +1180,6 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
       <constraints/>
       <categoryLinks>
         <categoryLink id="3f06-44f6-7e22-ed9a-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="4ddf-3bf2-60fd-acde" name="New EntryLink" hidden="false" targetId="0d50-24ac-a53e-5db7" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks>
-        <categoryLink id="4ddf-3bf2-60fd-acde-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1190,22 +1196,6 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
       <constraints/>
       <categoryLinks>
         <categoryLink id="8e68-7554-29f8-0870-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="7190-7b3a-6f1d-5f9a" name="New EntryLink" hidden="false" targetId="053a-fd01-be65-238e" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks>
-        <categoryLink id="7190-7b3a-6f1d-5f9a-1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1246,54 +1236,6 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
         </categoryLink>
       </categoryLinks>
     </entryLink>
-    <entryLink id="26ca-4396-c361-760f" name="Void Shield Generator" hidden="false" targetId="bbd4-5f41-35d1-6c5f" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks>
-        <categoryLink id="26ca-4396-c361-760f-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="ad41-b005-10af-8422" name="New EntryLink" hidden="false" targetId="796a-21c2-7281-17a8" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks>
-        <categoryLink id="ad41-b005-10af-8422-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="bb08-0f30-e857-b6fc" name="New EntryLink" hidden="false" targetId="5cdd-edbb-07c3-0ba5" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks>
-        <categoryLink id="bb08-0f30-e857-b6fc-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
     <entryLink id="25b9-2bfa-a936-84c4" name="New EntryLink" hidden="false" targetId="595a-908e-96a1-f121" type="selectionEntry">
       <profiles/>
       <rules/>
@@ -1318,22 +1260,6 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
       <constraints/>
       <categoryLinks>
         <categoryLink id="2639-13a0-1091-5189-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="584c-4bbb-c37f-7d9a" name="New EntryLink" hidden="false" targetId="1a59-dd0f-a7f2-32be" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks>
-        <categoryLink id="584c-4bbb-c37f-7d9a-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1406,22 +1332,6 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
         </categoryLink>
       </categoryLinks>
     </entryLink>
-    <entryLink id="20e9-9cd8-3ecc-7f8b" name="New EntryLink" hidden="false" targetId="ed7e-757a-4ced-adff" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks>
-        <categoryLink id="20e9-9cd8-3ecc-7f8b-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
     <entryLink id="9d3b-652a-8f38-ba48" name="New EntryLink" hidden="false" targetId="e40b-468f-f1d7-d05d" type="selectionEntry">
       <profiles/>
       <rules/>
@@ -1430,86 +1340,6 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
       <constraints/>
       <categoryLinks>
         <categoryLink id="9d3b-652a-8f38-ba48-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="1e22-7150-2f1c-9c1a" name="New EntryLink" hidden="false" targetId="06e2-2420-ffc8-13b8" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks>
-        <categoryLink id="1e22-7150-2f1c-9c1a-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="8757-0ab9-6fd5-19b8" name="New EntryLink" hidden="false" targetId="0fe6-096b-23ae-1134" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks>
-        <categoryLink id="8757-0ab9-6fd5-19b8-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="a345-9df0-fecd-5263" name="New EntryLink" hidden="false" targetId="33f8-e6da-89a3-01d5" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks>
-        <categoryLink id="a345-9df0-fecd-5263-1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="1bcb-c525-07af-da24" name="New EntryLink" hidden="false" targetId="8300-7ced-aafd-2a27" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks>
-        <categoryLink id="1bcb-c525-07af-da24-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="af0b-35c7-e928-7476" name="Aquila Strongpoint" hidden="false" targetId="9f5b-eccc-689a-2948" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks>
-        <categoryLink id="af0b-35c7-e928-7476-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -2591,6 +2421,622 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
+    <selectionEntry id="3902-a5e5-c69e-7a01" name="Questoris Knight Dominus" book="HH-Questoris-Knight-Dominus Download" page="" hidden="false" collective="false" type="model">
+      <profiles>
+        <profile id="ecb2-e57a-adb8-0ab8" name="Questoris Knight Dominus" book="HH-Questoris-Knight-Dominus Download" page="" hidden="false" profileTypeId="0694-6ddb-9e1d-40bd" profileTypeName="Super-heavy Walker">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="WS" characteristicTypeId="abd6-ed07-8491-eb85" value="4"/>
+            <characteristic name="BS" characteristicTypeId="aabf-e6cf-1929-65fd" value="4"/>
+            <characteristic name="S" characteristicTypeId="8d3d-332e-0576-3813" value="10"/>
+            <characteristic name="Front" characteristicTypeId="a3b5-f395-614e-95dc" value="13"/>
+            <characteristic name="Side" characteristicTypeId="4f2c-13a4-98b7-ff72" value="13"/>
+            <characteristic name="Rear" characteristicTypeId="c45e-7fb0-f4c7-2909" value="12"/>
+            <characteristic name="I" characteristicTypeId="d7de-23c6-aa99-cb87" value="3"/>
+            <characteristic name="A" characteristicTypeId="ec4e-6e09-1493-1867" value="3"/>
+            <characteristic name="HP" characteristicTypeId="36e0-e195-2d91-3e2a" value="7"/>
+            <characteristic name="Type" characteristicTypeId="c887-e846-fa1f-9389" value="Super-Heavy Walker"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="337d-4388-852d-759f" name="Ion Shield" hidden="false" targetId="342d5e83-9f9b-42c0-cecb-e6c9c197ab9d" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries>
+        <selectionEntry id="164f-e083-7cc9-0038" name="Twin-Linked Meltaguns" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="84f0-bb09-4d41-c863" name="Twin-Linked Meltagun" hidden="false" targetId="3084-edd3-6247-da94" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4759-48d1-f5d5-9bfb" type="max"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7054-cd48-fae5-9e66" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="40d2-b432-3a8e-f14b" name="May be upgraded with:" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="a3e5-e508-71d5-268b" name="Occular Augmetics" hidden="false" targetId="348b-40f4-c774-1f9a" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="4754-e94e-cb94-7ed8" name="May take Three of the following carapace weapons:" hidden="false" collective="false" defaultSelectionEntryId="4ce9-ebbc-bc9e-4059">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0869-9c49-3855-d2d9" type="max"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3084-6034-6dd7-4295" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries>
+            <selectionEntry id="4ce9-ebbc-bc9e-4059" name="Twin-Linked Siegebreaker Cannon" book="HH-Questoris-Knight-Dominus Download" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="49eb-459a-037c-6f71" name="Twin-Linked Siegebreaker Cannon" book="HH-Questoris-Knight-Dominus Download" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="48&quot;"/>
+                    <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="7"/>
+                    <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="4"/>
+                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 2, Twin-Linked"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a6d0-8256-eb24-dc7e" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="de42-1578-e085-e2af" name="Two Shieldbreaker Missiles" book="HH-Questoris-Knight-Dominus Download" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="8a99-ba52-8233-478b" name="Two Shieldbreaker Missiles" book="HH-Questoris-Knight-Dominus Download" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323"/>
+                    <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323"/>
+                    <characteristic name="AP" characteristicTypeId="415023232344415441232323"/>
+                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ee86-0ceb-0df8-b3d6" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="b586-4020-ddad-4473" name="May take 2 weapons for the following" hidden="false" collective="false" defaultSelectionEntryId="a3a5-cfa9-4075-19c9">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4c5c-068e-e051-df61" type="max"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bd11-c71e-cbe4-c027" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries>
+            <selectionEntry id="a3a5-cfa9-4075-19c9" name="Canflagration Cannon" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="7d01-170d-5ad8-1b5d" name="Conflagration Cannon" book="HH-Questoris-Knight-Dominus Download" page="" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="Hellstorm"/>
+                    <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="7"/>
+                    <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="3"/>
+                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Ordnance 1"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="294a-a7e8-0879-4d87" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="30.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="2960-54a3-7350-6b2c" name="Plasma Decimator" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="9595-6887-dfe5-2411" name="Plasma Decimator" book="HH-Questoris-Knight-Dominus Download" page="" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="48&quot;"/>
+                    <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="8"/>
+                    <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="2"/>
+                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 1, Large Blast 5&quot;, Gets Hot"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7dbe-a6b6-85a0-d624" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="55.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="c8a8-c30e-1557-3f15" name="Thundercoil Harpoon" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="7f72-40cb-8212-8ca0" name="Thundercoil Harpoon" book="HH-Questoris-Knight-Dominus Download" page="" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="12&quot;"/>
+                    <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="10"/>
+                    <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="1"/>
+                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Ordnance 1, Armourbane, Fleshbane, Instant Death, Sunder, Harpoon"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f7ea-2317-0da3-745d" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="50.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="8cd2-6b1d-d537-1c8e" name="Volcano Lance" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="8b6e-01c6-02d5-7425" name="Volcano Lance" book="HH-Questoris-Knight-Dominus Download" page="" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="80&quot;"/>
+                    <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="9"/>
+                    <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="2"/>
+                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 1, Blast 3&quot;"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ff8a-5756-26a1-09ec" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="45.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="e2bc-e4ca-f7b9-bec8" name="Household Rank" hidden="false" targetId="2f28-c5f0-6110-c614" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="7c89-7095-26d0-a6a3" name="Blessed Autosimulacra" hidden="false" targetId="b09a-5d32-464b-4b2d" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="360.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1072-d634-f6c6-b41e" name="Questoris Knight Armiger Talon" book="HH-Questoris-Knight-Dominus Download" page="" hidden="false" collective="false" type="model">
+      <profiles>
+        <profile id="283a-5c7c-cf45-1d93" name="Questoris Knight Armiger Talon" book="HH-Questoris-Knight-Armiger-Talon Download" page="" hidden="false" profileTypeId="57616c6b657223232344415441232323" profileTypeName="Walker">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="WS" characteristicTypeId="575323232344415441232323" value="4"/>
+            <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="4"/>
+            <characteristic name="S" characteristicTypeId="5323232344415441232323" value="7"/>
+            <characteristic name="Front" characteristicTypeId="46726f6e7423232344415441232323" value="12"/>
+            <characteristic name="Side" characteristicTypeId="5369646523232344415441232323" value="12"/>
+            <characteristic name="Rear" characteristicTypeId="5265617223232344415441232323" value="11"/>
+            <characteristic name="I" characteristicTypeId="4923232344415441232323" value="4"/>
+            <characteristic name="A" characteristicTypeId="4123232344415441232323" value="2"/>
+            <characteristic name="HP" characteristicTypeId="485023232344415441232323" value="4"/>
+            <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Vehicle (Walker)"/>
+          </characteristics>
+        </profile>
+        <profile id="82fe-5976-eb52-f87e" name="Ion Buckler" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323" profileTypeName="Wargear Item">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Description" characteristicTypeId="4465736372697074696f6e23232344415441232323" value="An Armiger Knight armour is constructed with a smaller, less power-hungry ion shielding array. This device is capable of switching its defensive alignment both more swiftly and more accurately than the larger ion shield, but provides only a fraction of its larger cousin’s protection. An ion buckler grants the Questoris Knight Armiger a 5+ invulnerable save against all shooting attacks, but grants no benefits against close combat attacks. "/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="71a4-0f4a-6206-ac92" name="Longstride" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <description>The Questoris Knight Armiger is constructed to keep pace with their larger cousins, roving ahead of the main advance of a Knight Household to identify and neutralise smaller threats. A Questoris Knight Armiger that chooses to Run in the Shooting phase does not roll a dice to determine the distance moved, instead always moving up to 12&quot;. Additionally, on any turn in which a Questoris Knight Armiger chooses to Run in the Shooting phase, it may fire a single weapon as a Snap Shot after completing the Run move.</description>
+        </rule>
+        <rule id="4ccb-02dd-6bfb-64d0" name="Scion Auxilia" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <description>Scions Auxilia may not benefit from Warlord Traits that target other friendly Knights or models.</description>
+        </rule>
+        <rule id="db50-34df-2188-0523" name="Armiger Talon" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <description>When first deployed on the battlefield (either at the start of the game or when arriving via Reserves), the Knights in a Talon must be placed within 6&quot; of each other, and afterwards are not treated as a vehicle squadron but operate independently as individual units for the purposes of taking any actions, as well for determining Victory points in missions which make use of Victory points for destroying units.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="d093-3802-81a6-8852" name="Implacable Advance" hidden="false" targetId="5ecb-551d-0f68-3a79" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bfcf-dc21-205d-ba14" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="23f7-3615-4d95-bd73" type="min"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="fcad-4f0f-99fc-0eea" name="May take One weapon for the following" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="be8b-e52b-e3d7-b121" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="451b-cd15-bd45-1bfa" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries>
+            <selectionEntry id="1339-4875-1437-b228" name="Heavy Stubber" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="b9b6-e629-bd38-a8bc" name="Heavy Stubber" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="36&quot;"/>
+                    <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="4"/>
+                    <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="6"/>
+                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 3"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5d53-b2b2-425f-c8ee" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="c749-a58d-b86e-1a51" name="Meltagun" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="031b-80c8-50ef-1146" name="Meltagun" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="12&quot;"/>
+                    <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="8"/>
+                    <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="1"/>
+                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Assult 1, Melta"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="15.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="95d6-6eb0-2d77-36b7" name="Must take Two weapons for the following" hidden="false" collective="false" defaultSelectionEntryId="918d-2398-9da1-5cf6">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0017-ed45-eb5d-3139" type="max"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e86-96fc-61b0-dce4" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries>
+            <selectionEntry id="918d-2398-9da1-5cf6" name="Dreadnaught Close Combat Weapon" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="83b6-e34b-605e-7080" name="Dreadnaught Close Combat Weapon" book="" page="" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="-"/>
+                    <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="10"/>
+                    <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="2"/>
+                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Melee"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0ca9-9daa-d247-33c8" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="0320-28f4-46f7-ca89" name="Armiger Autocannon" book="HH-Questoris-Knight-Armiger-Talon Download" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="8303-fed8-7388-ff02" name="Armiger Autocannon (Armour Piercing Rounds)" book="HH-Questoris-Knight-Dominus Download" page="" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="64&quot;"/>
+                    <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="7"/>
+                    <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="3"/>
+                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 2, Sunder"/>
+                  </characteristics>
+                </profile>
+                <profile id="59d2-d3ed-7f5c-740d" name="Armiger Autocannon (Incediary Rounds)" book="HH-Questoris-Knight-Dominus Download" page="" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="64&quot;"/>
+                    <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="7"/>
+                    <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="3"/>
+                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 2, Ignores Cover"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a381-df56-7aed-04d4" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="15.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="2ab8-f653-fb91-e6ae" name="Armiger Thermal Spear" book="HH-Questoris-Knight-Armiger-Talon Download" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="0d5a-6abd-ea6e-9fd9" name="Armiger Thermal Spear" book="HH-Questoris-Knight-Dominus Download" page="" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="36&quot;"/>
+                    <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="8"/>
+                    <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="2"/>
+                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 1, Melta"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1ca8-4645-2a47-9988" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="10.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="67ff-11a1-7990-c20e" name="May Take Bio-Corrosive Rounds for Heavy Stubber" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="1072-d634-f6c6-b41e" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1339-4875-1437-b228" type="equalTo"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="78cd-164a-0769-53df" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries>
+            <selectionEntry id="802b-988c-eb01-a502" name="Bio-Corrosive Rounds" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="cfb6-0425-9090-20c2" name="Bio-Corrosive Rounds" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="30&quot;"/>
+                    <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="2"/>
+                    <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="6"/>
+                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 3, Poisoned (4+)"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="10.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="150.0"/>
+      </costs>
+    </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup id="3fc4-9d7f-969b-35bb" name="Knight Armour" hidden="false" collective="false">
@@ -2606,7 +3052,7 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks>
-        <entryLink id="e8e1-c9e9-394d-5fbf" name="Acheron" hidden="false" targetId="b4ddbe68-7095-397e-dec4-162170dbdbcd" type="selectionEntry">
+        <entryLink id="e8e1-c9e9-394d-5fbf" name="Cerastus Knight-Acheron" hidden="false" targetId="b4ddbe68-7095-397e-dec4-162170dbdbcd" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -2614,7 +3060,7 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
           <constraints/>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="e499-4dc2-bbfd-53dd" name="Atrapos" hidden="false" targetId="baad-77d0-04c2-e05f" type="selectionEntry">
+        <entryLink id="e499-4dc2-bbfd-53dd" name="Cerastus Knight-Atrapos" hidden="false" targetId="baad-77d0-04c2-e05f" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -2622,7 +3068,7 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
           <constraints/>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="2aff-c26b-26b6-fd14" name="Castigator" hidden="false" targetId="b1cf8528-c9d0-2c2a-3f19-522e5532f273" type="selectionEntry">
+        <entryLink id="2aff-c26b-26b6-fd14" name="Cerastus Knight-Castigator" hidden="false" targetId="b1cf8528-c9d0-2c2a-3f19-522e5532f273" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -2638,7 +3084,7 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
           <constraints/>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="eae7-2fc9-40d1-3977" name="Crusader" hidden="false" targetId="09ee-4370-1462-2cb5" type="selectionEntry">
+        <entryLink id="eae7-2fc9-40d1-3977" name="Questoris Knight Crusader" hidden="false" targetId="09ee-4370-1462-2cb5" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -2654,7 +3100,7 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
           <constraints/>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="a918-71fe-b21c-cbf8" name="Gallant" hidden="false" targetId="74b8-f485-4b58-0071" type="selectionEntry">
+        <entryLink id="a918-71fe-b21c-cbf8" name="Questoris Knight Gallant" hidden="false" targetId="74b8-f485-4b58-0071" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -2670,7 +3116,7 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
           <constraints/>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="f4cf-f09c-20a4-b376" name="Paladin" hidden="false" targetId="02eb28bb-1883-8603-0af7-b8bf2b7b69c8" type="selectionEntry">
+        <entryLink id="f4cf-f09c-20a4-b376" name="Questoris Knight Paladin" hidden="false" targetId="02eb28bb-1883-8603-0af7-b8bf2b7b69c8" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -2678,7 +3124,7 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
           <constraints/>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="9a04-fad2-e544-64e5" name="Styrix" hidden="false" targetId="a5b350ff-895e-4557-70a6-d24a936919c2" type="selectionEntry">
+        <entryLink id="9a04-fad2-e544-64e5" name="Questoris Knight Styrix" hidden="false" targetId="a5b350ff-895e-4557-70a6-d24a936919c2" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -2686,7 +3132,7 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
           <constraints/>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="1b11-f6ea-15eb-3c0f" name="Warden" hidden="false" targetId="f4f1-dad6-0596-ca5a" type="selectionEntry">
+        <entryLink id="1b11-f6ea-15eb-3c0f" name="Questoris Knight Warden" hidden="false" targetId="f4f1-dad6-0596-ca5a" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -2694,7 +3140,7 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
           <constraints/>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="d945-aaa8-2751-4c23" name="New EntryLink" hidden="false" targetId="4ded-9de3-f964-33a7" type="selectionEntry">
+        <entryLink id="d945-aaa8-2751-4c23" name="Acastus Knight Porphyrion" hidden="false" targetId="4ded-9de3-f964-33a7" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -2713,6 +3159,14 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
               </conditionGroups>
             </modifier>
           </modifiers>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="38ae-7cc3-463a-a8de" name="Questoris Knight Dominus" hidden="false" targetId="3902-a5e5-c69e-7a01" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
           <constraints/>
           <categoryLinks/>
         </entryLink>

--- a/(HH) Mechanicum - Taghmata Army List.cat
+++ b/(HH) Mechanicum - Taghmata Army List.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="cf03-f607-41dc-7545" name="Mechanicum: Taghmata Army List" book="Horus Heresy: Taghmata Army List" revision="80" battleScribeVersion="2.01" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="85" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="cf03-f607-41dc-7545" name="Mechanicum: Taghmata Army List" book="Horus Heresy: Taghmata Army List" revision="81" battleScribeVersion="2.01" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="85" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules/>
   <infoLinks/>
@@ -1567,7 +1567,329 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
       </categoryLinks>
     </forceEntry>
   </forceEntries>
-  <selectionEntries/>
+  <selectionEntries>
+    <selectionEntry id="2da6-98c4-2a24-507d" name="Questoris Knight Armiger Talon" book="HH-Questoris-Knight-Dominus Download" page="" hidden="false" collective="false" type="model">
+      <profiles>
+        <profile id="4277-a86b-ccc3-22f8" name="Ion Buckler" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323" profileTypeName="Wargear Item">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Description" characteristicTypeId="4465736372697074696f6e23232344415441232323" value="An Armiger Knight armour is constructed with a smaller, less power-hungry ion shielding array. This device is capable of switching its defensive alignment both more swiftly and more accurately than the larger ion shield, but provides only a fraction of its larger cousin’s protection. An ion buckler grants the Questoris Knight Armiger a 5+ invulnerable save against all shooting attacks, but grants no benefits against close combat attacks. "/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="17dd-5002-dad1-f0d3" name="Longstride" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <description>The Questoris Knight Armiger is constructed to keep pace with their larger cousins, roving ahead of the main advance of a Knight Household to identify and neutralise smaller threats. A Questoris Knight Armiger that chooses to Run in the Shooting phase does not roll a dice to determine the distance moved, instead always moving up to 12&quot;. Additionally, on any turn in which a Questoris Knight Armiger chooses to Run in the Shooting phase, it may fire a single weapon as a Snap Shot after completing the Run move.</description>
+        </rule>
+        <rule id="9bcc-030f-b214-f81c" name="Armiger Talon" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <description>When first deployed on the battlefield (either at the start of the game or when arriving via Reserves), the Knights in a Talon must be placed within 6&quot; of each other, and afterwards are not treated as a vehicle squadron but operate independently as individual units for the purposes of taking any actions, as well for determining Victory points in missions which make use of Victory points for destroying units.</description>
+        </rule>
+      </rules>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3f17-d1bb-2a1a-b1ca" type="max"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="0f11-7749-1067-0d45" name="Heavy Support" hidden="false" targetId="486561767920537570706f727423232344415441232323" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="3fdc-7519-c4cb-629c" name="Questoris Knight Armiger Talon" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="4743-0d81-03ca-524f" name="Questoris Knight Armiger Talon" book="HH-Questoris-Knight-Armiger-Talon Download" page="" hidden="false" profileTypeId="57616c6b657223232344415441232323" profileTypeName="Walker">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="WS" characteristicTypeId="575323232344415441232323" value="4"/>
+                <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="4"/>
+                <characteristic name="S" characteristicTypeId="5323232344415441232323" value="7"/>
+                <characteristic name="Front" characteristicTypeId="46726f6e7423232344415441232323" value="12"/>
+                <characteristic name="Side" characteristicTypeId="5369646523232344415441232323" value="12"/>
+                <characteristic name="Rear" characteristicTypeId="5265617223232344415441232323" value="11"/>
+                <characteristic name="I" characteristicTypeId="4923232344415441232323" value="4"/>
+                <characteristic name="A" characteristicTypeId="4123232344415441232323" value="2"/>
+                <characteristic name="HP" characteristicTypeId="485023232344415441232323" value="4"/>
+                <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Vehicle (Walker)"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d04a-b543-3bba-0d4d" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="06cb-879f-6a84-0947" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="332b-7b6a-f817-7f32" name="May Take Bio-Corrosive Rounds for Heavy Stubber" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="3fdc-7519-c4cb-629c" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="afc1-b3b3-7d97-ed5c" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4930-d46a-e026-f3c8" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries>
+                <selectionEntry id="5858-0396-92d9-d535" name="Bio-Corrosive Rounds" hidden="false" collective="false" type="upgrade">
+                  <profiles>
+                    <profile id="6670-76d8-a314-5917" name="Bio-Corrosive Rounds" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <characteristics>
+                        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="30&quot;"/>
+                        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="2"/>
+                        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="6"/>
+                        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 3, Poisoned (4+)"/>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks/>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="7876-a5b0-8d98-a624" name="May take One weapon for the following" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9894-5ca0-cb79-a053" type="max"/>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2451-847a-d4ff-a986" type="min"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries>
+                <selectionEntry id="afc1-b3b3-7d97-ed5c" name="Heavy Stubber" hidden="false" collective="false" type="upgrade">
+                  <profiles>
+                    <profile id="e17c-aa08-d05f-5988" name="Heavy Stubber" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <characteristics>
+                        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="36&quot;"/>
+                        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="4"/>
+                        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="6"/>
+                        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 3"/>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2c3f-c983-5cae-c675" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="5.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="8dc1-c63a-6610-732d" name="Meltagun" hidden="false" collective="false" type="upgrade">
+                  <profiles>
+                    <profile id="1bb0-279a-4082-4ccb" name="Meltagun" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <characteristics>
+                        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="12&quot;"/>
+                        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="8"/>
+                        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="1"/>
+                        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Assult 1, Melta"/>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="15.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks/>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="bf52-59bc-bc5e-9c1f" name="Must take Two weapons for the following" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8675-d6c2-6fd9-a5e0" type="max"/>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ce54-79f5-9661-881d" type="min"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries>
+                <selectionEntry id="449d-2945-bcce-8d7b" name="Dreadnaught Close Combat Weapon" hidden="false" collective="false" type="upgrade">
+                  <profiles>
+                    <profile id="d746-9140-39bd-5cd2" name="Dreadnaught Close Combat Weapon" book="" page="" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <characteristics>
+                        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="-"/>
+                        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="10"/>
+                        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="2"/>
+                        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Melee"/>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="36fe-92e6-0a67-646d" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="09b4-801a-443a-62ad" name="Armiger Autocannon" book="HH-Questoris-Knight-Armiger-Talon Download" hidden="false" collective="false" type="upgrade">
+                  <profiles>
+                    <profile id="d545-7041-bfa2-8684" name="Armiger Autocannon (Armour Piercing Rounds)" book="HH-Questoris-Knight-Dominus Download" page="" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <characteristics>
+                        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="64&quot;"/>
+                        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="7"/>
+                        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="3"/>
+                        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 2, Sunder"/>
+                      </characteristics>
+                    </profile>
+                    <profile id="d931-96fd-af72-a4d3" name="Armiger Autocannon (Incediary Rounds)" book="HH-Questoris-Knight-Dominus Download" page="" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <characteristics>
+                        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="64&quot;"/>
+                        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="7"/>
+                        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="3"/>
+                        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 2, Ignores Cover"/>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a5e4-1134-bc18-7f74" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="15.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="11a5-3c02-dcc1-54d0" name="Armiger Thermal Spear" book="HH-Questoris-Knight-Armiger-Talon Download" hidden="false" collective="false" type="upgrade">
+                  <profiles>
+                    <profile id="ca49-fd40-d919-b46d" name="Armiger Thermal Spear" book="HH-Questoris-Knight-Dominus Download" page="" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <characteristics>
+                        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="36&quot;"/>
+                        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="8"/>
+                        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="2"/>
+                        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 1, Melta"/>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c7ff-c0cb-0e1a-8b69" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks/>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="150.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="25.0"/>
+      </costs>
+    </selectionEntry>
+  </selectionEntries>
   <entryLinks>
     <entryLink id="6a75-6b49-08b0-c64e" name="Macrocarid Explorator" hidden="false" targetId="0de5-5b51-907d-e5e2" type="selectionEntry">
       <profiles/>
@@ -4050,7 +4372,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
                       <infoLinks/>
                       <modifiers/>
                     </infoLink>
-                    <infoLink id="4d1b-77dd-0db2-93ae" hidden="false" targetId="fe2f-3220-3fef-b177" type="rule">
+                    <infoLink id="4d1b-77dd-0db2-93ae" name="Wrecker" hidden="false" targetId="fe2f-3220-3fef-b177" type="rule">
                       <profiles/>
                       <rules/>
                       <infoLinks/>
@@ -11258,7 +11580,7 @@ Buildings and Fortifications D</description>
         <cost name="pts" costTypeId="points" value="135.0"/>
       </costs>
     </selectionEntry>
-   <selectionEntry id="4f6b-4baa-d1e2-9b03" name="Allegiance" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="4f6b-4baa-d1e2-9b03" name="Allegiance" hidden="false" collective="false" type="upgrade">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -24799,9 +25121,7 @@ Any abilities that allow the vehicle to fire multiple shots will use the same sh
       </rules>
       <infoLinks/>
       <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="6d6b-19bd-f118-0d47" type="min"/>
-      </constraints>
+      <constraints/>
       <categoryLinks>
         <categoryLink id="ed34-99a1-7e6c-f750" name="Heavy Support" hidden="false" targetId="486561767920537570706f727423232344415441232323" primary="true">
           <profiles/>
@@ -26539,7 +26859,6 @@ Any abilities that allow the vehicle to fire multiple shots will use the same sh
         <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Melee, +1 Attack, Machine Destroyer"/>
       </characteristics>
     </profile>
-   
     <profile id="6eb5b812-8b8b-9e7c-279e-c9e9c93fefe9" name="Atomantic Shielding" book="HH3: Extermination" page="207" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323">
       <profiles/>
       <rules/>

--- a/(HH) Talons of the Emperor Army List.cat
+++ b/(HH) Talons of the Emperor Army List.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="a30a-7522-3343-553a" name="Talons of the Emperor" book="HH7" page="" revision="94" battleScribeVersion="2.01" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="85" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="a30a-7522-3343-553a" name="Talons of the Emperor" book="HH7" page="" revision="95" battleScribeVersion="2.01" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="85" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules/>
   <infoLinks/>
@@ -766,7 +766,7 @@
         </categoryLink>
       </categoryLinks>
     </entryLink>
-    <entryLink id="0721-ca72-d85d-be71" name="New EntryLink" hidden="false" targetId="c6da-100a-a655-0e7d" type="selectionEntry">
+    <entryLink id="0721-ca72-d85d-be71" name="Legio Custodes Custodian Guard Squad" hidden="false" targetId="c6da-100a-a655-0e7d" type="selectionEntry">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -878,7 +878,7 @@
         </categoryLink>
       </categoryLinks>
     </entryLink>
-    <entryLink id="fe13-642f-90dd-c376" name="New EntryLink" hidden="false" targetId="335e-a873-5aa2-19e0" type="selectionEntry">
+    <entryLink id="fe13-642f-90dd-c376" name="Legio Custodes Contemptor-Galatus Dreadnought" hidden="false" targetId="335e-a873-5aa2-19e0" type="selectionEntry">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -1070,38 +1070,6 @@
         </categoryLink>
       </categoryLinks>
     </entryLink>
-    <entryLink id="1c26-c19e-e442-8a00" name="New EntryLink" hidden="false" targetId="053a-fd01-be65-238e" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks>
-        <categoryLink id="1c26-c19e-e442-8a00-1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="b920-fb43-b5e2-898a" name="New EntryLink" hidden="false" targetId="b973-7d7d-754e-b022" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks>
-        <categoryLink id="b920-fb43-b5e2-898a-1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
     <entryLink id="df91-2dd1-d3bf-007a" name="New EntryLink" hidden="false" targetId="16d6-25c4-af92-4329" type="selectionEntry">
       <profiles/>
       <rules/>
@@ -1150,22 +1118,6 @@
         </categoryLink>
       </categoryLinks>
     </entryLink>
-    <entryLink id="44e3-4a3f-2907-9c7c" name="New EntryLink" hidden="false" targetId="5cdd-edbb-07c3-0ba5" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks>
-        <categoryLink id="44e3-4a3f-2907-9c7c-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
     <entryLink id="3e1c-c1d7-5869-99af" name="New EntryLink" hidden="false" targetId="df05-8179-624e-f8b2" type="selectionEntry">
       <profiles/>
       <rules/>
@@ -1182,22 +1134,6 @@
         </categoryLink>
       </categoryLinks>
     </entryLink>
-    <entryLink id="9d69-43fa-d39b-c0a0" name="New EntryLink" hidden="false" targetId="796a-21c2-7281-17a8" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks>
-        <categoryLink id="9d69-43fa-d39b-c0a0-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
     <entryLink id="6350-dbfb-92aa-1a71" name="New EntryLink" hidden="false" targetId="04bf-6c22-19fb-4e46" type="selectionEntry">
       <profiles/>
       <rules/>
@@ -1206,22 +1142,6 @@
       <constraints/>
       <categoryLinks>
         <categoryLink id="6350-dbfb-92aa-1a71-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="004a-fcdb-158e-5ab6" name="New EntryLink" hidden="false" targetId="bbd4-5f41-35d1-6c5f" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks>
-        <categoryLink id="004a-fcdb-158e-5ab6-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1278,22 +1198,6 @@
         </categoryLink>
       </categoryLinks>
     </entryLink>
-    <entryLink id="7c43-ef2f-1fb7-8b5a" name="New EntryLink" hidden="false" targetId="0d50-24ac-a53e-5db7" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks>
-        <categoryLink id="7c43-ef2f-1fb7-8b5a-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
     <entryLink id="bd48-8789-0713-9aba" name="New EntryLink" hidden="false" targetId="e0b3-77ca-af76-bd8b" type="selectionEntry">
       <profiles/>
       <rules/>
@@ -1310,22 +1214,6 @@
         </categoryLink>
       </categoryLinks>
     </entryLink>
-    <entryLink id="f990-ea2e-c240-1fa8" name="New EntryLink" hidden="false" targetId="1a59-dd0f-a7f2-32be" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks>
-        <categoryLink id="f990-ea2e-c240-1fa8-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
     <entryLink id="84a7-8b67-aa9e-b91b" name="New EntryLink" hidden="false" targetId="0116-c81b-1c0f-251c" type="selectionEntry">
       <profiles/>
       <rules/>
@@ -1334,22 +1222,6 @@
       <constraints/>
       <categoryLinks>
         <categoryLink id="84a7-8b67-aa9e-b91b-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="1e69-8c22-d823-bc5f" name="New EntryLink" hidden="false" targetId="ed7e-757a-4ced-adff" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks>
-        <categoryLink id="1e69-8c22-d823-bc5f-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1422,54 +1294,6 @@
         </categoryLink>
       </categoryLinks>
     </entryLink>
-    <entryLink id="6174-6255-732b-a4a9" name="New EntryLink" hidden="false" targetId="0fe6-096b-23ae-1134" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks>
-        <categoryLink id="6174-6255-732b-a4a9-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="fe76-5ca5-561b-0c0d" name="New EntryLink" hidden="false" targetId="06e2-2420-ffc8-13b8" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks>
-        <categoryLink id="fe76-5ca5-561b-0c0d-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="ac74-cbfe-4111-8c9a" name="New EntryLink" hidden="false" targetId="8300-7ced-aafd-2a27" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks>
-        <categoryLink id="ac74-cbfe-4111-8c9a-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
     <entryLink id="07bd-ce47-7d2a-3145" name="New EntryLink" hidden="false" targetId="e10f-7b90-ecd3-80a5" type="selectionEntry">
       <profiles/>
       <rules/>
@@ -1486,23 +1310,7 @@
         </categoryLink>
       </categoryLinks>
     </entryLink>
-    <entryLink id="61d1-64bd-0337-d234" name="New EntryLink" hidden="false" targetId="9f5b-eccc-689a-2948" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks>
-        <categoryLink id="61d1-64bd-0337-d234-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="c837-6391-c00e-39f3" name="New EntryLink" hidden="false" targetId="a505-05af-bd44-56b6" type="selectionEntry">
+    <entryLink id="c837-6391-c00e-39f3" name="Aegis Defense Line" hidden="false" targetId="a505-05af-bd44-56b6" type="selectionEntry">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -1566,22 +1374,6 @@
         </categoryLink>
       </categoryLinks>
     </entryLink>
-    <entryLink id="4670-6f85-a962-d3d3" name="New EntryLink" hidden="false" targetId="33f8-e6da-89a3-01d5" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks>
-        <categoryLink id="4670-6f85-a962-d3d3-1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-      </categoryLinks>
-    </entryLink>
     <entryLink id="18fd-5b4a-396b-96e9" name="Legio Custodes Telemon Heavy Dreadnought" hidden="false" targetId="5804-0f3c-116f-46e2" type="selectionEntry">
       <profiles/>
       <rules/>
@@ -1598,6 +1390,22 @@
       <constraints/>
       <categoryLinks>
         <categoryLink id="7407-408f-5fe2-244c" name="New CategoryLink" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="5f2e-a3ed-84e3-9a4d" name="Legio Custodes Venatari Squad" hidden="false" targetId="702e-27bd-4148-e4e5" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="893a-a363-fbc1-7d73" name="Fast Attack" hidden="false" targetId="466173742041747461636b23232344415441232323" primary="true">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -2170,7 +1978,7 @@
               </selectionEntries>
               <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="8f84-e218-f34d-0ec1" name="New EntryLink" hidden="false" targetId="dc9c-fe1d-8c26-fb07" type="selectionEntry">
+                <entryLink id="8f84-e218-f34d-0ec1" name="Guardian Spear" hidden="false" targetId="dc9c-fe1d-8c26-fb07" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -2196,7 +2004,7 @@
                   </constraints>
                   <categoryLinks/>
                 </entryLink>
-                <entryLink id="da95-2481-9d42-f8a8" name="New EntryLink" hidden="false" targetId="0179-aa55-899c-aa0b" type="selectionEntry">
+                <entryLink id="da95-2481-9d42-f8a8" name="Adrasite Spear" hidden="false" targetId="0179-aa55-899c-aa0b" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -4102,7 +3910,9 @@
               <categoryLinks/>
             </entryLink>
           </entryLinks>
-          <costs/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="636a-99b5-1e62-eb2d" name="Teleportation Transponders" hidden="true" collective="false" type="upgrade">
           <profiles/>
@@ -4146,7 +3956,9 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups/>
@@ -9596,7 +9408,9 @@ decided.</description>
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="7d72-4429-d25c-54f3" name="Teleportation Transponders" hidden="true" collective="false" type="upgrade">
       <profiles/>
@@ -9626,7 +9440,210 @@ decided.</description>
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="702e-27bd-4148-e4e5" name="Legio Custodes Venatari Squad" book="FW Download" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="7a14-cab3-a31f-d4b1" name="Bulky" hidden="false" targetId="38d5-b6eb-bda8-2497" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="d1cd-897f-a852-586c" name="Crusader" hidden="false" targetId="2b06-29a6-641a-b22e" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="0343-a60c-128b-5321" name="Fleet" hidden="false" targetId="69e5-fc02-1f9d-63c2" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="79d8-3d93-4ce1-4071" name="Move Through Cover" hidden="false" targetId="6d06-5ea0-9a17-ca97" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries>
+        <selectionEntry id="517b-051c-5f6c-b86a" name="Venatari" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="88b0-771f-6e49-043f" name="Custodian Venatari" hidden="false" targetId="11d9-f1a7-f2de-8ffa" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7228-487b-516e-15e9" type="min"/>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ad5e-a8fb-0de7-d892" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="f53c-ad3c-d292-e6d4" name="May Replace Archaeotech Kinetic Destroyer &amp; Tarsus Buckler with" hidden="false" collective="false" defaultSelectionEntryId="b294-3593-41f9-86a4">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2766-5a22-ef59-6fce" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="08f0-d2bf-aaba-b4ef" type="min"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries>
+                <selectionEntry id="b294-3593-41f9-86a4" name="Archaeotech Kinetic Destroyer &amp; Tarsus Buckler" hidden="false" collective="false" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="bb00-e4c7-211f-12e1" name="Archaeotech Kinetic Destroyer" hidden="false" targetId="c632-2ff7-8629-e8fc" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                      <categoryLinks/>
+                    </entryLink>
+                    <entryLink id="ecf9-8c49-64b7-30c9" name="Tarsus Buckler" hidden="false" targetId="27dc-deb9-9379-eb10" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                      <categoryLinks/>
+                    </entryLink>
+                  </entryLinks>
+                  <costs/>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="c3c0-11c8-5386-8035" name="Venatari Lance" hidden="false" targetId="c8bb-78c1-0ffc-0a1a" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="set" field="points" value="10">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="5cd7-f5bc-aa20-4573" name="Custodian Jump Harness" hidden="false" targetId="19b9-4cf5-d024-132d" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="43f0-7d2e-c854-b0b1" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2632-1e73-ef99-4ca5" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="f891-e8dc-c152-845e" name="Refractor Feild" hidden="false" targetId="011a-b751-e773-6b90" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f6a1-ec8a-f815-9f63" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2bf9-3ce3-97cf-c8cd" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="6da5-cc1f-678c-bd5c" name="Plasma + Krak Grenades" hidden="false" targetId="42e2-2cc0-6353-4d47" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="86d3-2d3b-dcd9-b08f" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c8be-3822-00b5-5f7d" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="65.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="417c-2d09-9e00-5c5a" name="Entire squad may be equipped with:" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="cec1-4e26-6240-6f23" name="Melta bombs" hidden="false" targetId="648a-e853-bb44-9cee" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="5">
+                  <repeats>
+                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="517b-051c-5f6c-b86a" repeats="1" roundUp="false"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7c8c-2402-00ea-4b71" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="e55c-9688-faae-2e73" name="Legio Custodes" hidden="false" targetId="a502-5799-a2f4-310b" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="238d-4fed-dd44-d6ca" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="60e3-1a3c-803b-1ee2" type="min"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="15.0"/>
+      </costs>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
@@ -10379,13 +10396,13 @@ decided.</description>
           <profiles/>
           <rules/>
           <infoLinks>
-            <infoLink id="98ee-218e-56ae-9862" name="New InfoLink" hidden="false" targetId="f07e-858e-d637-e858" type="profile">
+            <infoLink id="98ee-218e-56ae-9862" name="Custodian Armour" hidden="false" targetId="f07e-858e-d637-e858" type="profile">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
             </infoLink>
-            <infoLink id="713b-3293-5140-a0da" name="New InfoLink" hidden="false" targetId="6d06-5ea0-9a17-ca97" type="rule">
+            <infoLink id="713b-3293-5140-a0da" name="Move Through Cover" hidden="false" targetId="6d06-5ea0-9a17-ca97" type="rule">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -10444,6 +10461,36 @@ decided.</description>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2cb0-2b44-bc81-3f0f" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="20cc-b904-af29-7ac7" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="19b9-4cf5-d024-132d" name="Custodian Jump Harness" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="dd67-98a7-e5e7-b9f9" name="Custodian Jump Harness" hidden="false" targetId="783e-c8f7-4312-98c7" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="5ccd-0d60-74e0-a879" name="Auramite Pinions" hidden="false" targetId="320e-ff0d-18d2-10f7" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3140-0b86-5da2-2f03" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2470-55ee-e333-b0b0" type="min"/>
           </constraints>
           <categoryLinks/>
           <selectionEntries/>
@@ -10787,19 +10834,19 @@ decided.</description>
                 </modifier>
               </modifiers>
             </infoLink>
-            <infoLink id="eb47-500f-4f1e-ed49" name="New InfoLink" hidden="false" targetId="a37c-753a-33b4-8101" type="rule">
+            <infoLink id="eb47-500f-4f1e-ed49" name="Lightning Blows" hidden="false" targetId="a37c-753a-33b4-8101" type="rule">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
             </infoLink>
-            <infoLink id="30fc-70c3-5ac4-21a9" name="New InfoLink" hidden="false" targetId="7ee3-d437-bc44-3630" type="rule">
+            <infoLink id="30fc-70c3-5ac4-21a9" name="Specialist Weapon" hidden="false" targetId="7ee3-d437-bc44-3630" type="rule">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
             </infoLink>
-            <infoLink id="bda3-55dc-0edf-acea" name="New InfoLink" hidden="false" targetId="6f85-7ba6-232a-5938" type="profile">
+            <infoLink id="bda3-55dc-0edf-acea" name="Paragon Bolter" hidden="false" targetId="6f85-7ba6-232a-5938" type="profile">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -11043,6 +11090,138 @@ decided.</description>
           <costs>
             <cost name="pts" costTypeId="points" value="0.0"/>
           </costs>
+        </selectionEntry>
+        <selectionEntry id="c8bb-78c1-0ffc-0a1a" name="Venatari Lance" book="FW Download" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="febd-cc98-8da6-d4c9" name="Venatari Lance : Archaeotech Repeater" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="12&quot;"/>
+                <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="7"/>
+                <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="3"/>
+                <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Assualt 2, Master-Crafted"/>
+              </characteristics>
+            </profile>
+            <profile id="a4eb-545b-3e04-ca65" name="Venatari Lance : Power Blade" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="Melee"/>
+                <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="As User/+1*"/>
+                <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="3/2*"/>
+                <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Melee, Lightning Blows, Two-Handed, Specialist Weapon. *Use the second profile if the model has charged this turn"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks>
+            <infoLink id="f618-c41c-5b99-68b6" name="Lightning Blows" hidden="false" targetId="a37c-753a-33b4-8101" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="f1e4-42a0-65ae-669a" name="Specialist Weapon" hidden="false" targetId="7ee3-d437-bc44-3630" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="f575-ece3-b9ef-8a55" name="Two-Handed" hidden="false" targetId="b11c-0ef4-af6b-d96f" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="fa51-1068-08e0-c2f4" name="Master-crafted" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs/>
+        </selectionEntry>
+        <selectionEntry id="c632-2ff7-8629-e8fc" name="Archaeotech Kinetic Destroyer" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="f766-666e-5e9b-8dcc" name="Archaeotech Kinetic Destoryer" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="12&quot;"/>
+                <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="7"/>
+                <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="3"/>
+                <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Pistol, Master-Crafted, Fan Burst"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks>
+            <infoLink id="df9d-6e5d-1f08-e8c8" name="Fan-Burst" hidden="false" targetId="bad5-67d0-2390-90f5" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0b5a-a363-52f8-31bc" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bafe-3424-7f67-7452" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs/>
+        </selectionEntry>
+        <selectionEntry id="27dc-deb9-9379-eb10" name="Tarsus Buckler" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="9b9b-9bea-0c97-6a8f" name="Tarsus Buckler" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="Melee"/>
+                <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="+1"/>
+                <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="3"/>
+                <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Melee, Energy Nullifer"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks>
+            <infoLink id="8fb5-c38e-886e-f51e" name="Energy Nullifier" hidden="false" targetId="8fa4-a1c0-c588-34e6" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7698-8200-3303-ff9e" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d5bb-d8ed-7bbd-7fdc" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs/>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups/>
@@ -12317,6 +12496,27 @@ Overawe(+1 to the total score to determine the result of an assault)</descriptio
       <modifiers/>
       <description>Members of the unit may fire once with each of their weapons in the Shooting phase</description>
     </rule>
+    <rule id="320e-ff0d-18d2-10f7" name="Auramite Pinions" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>A Model with this special rule has an invulnerable save of 4+ when locked in close combat.</description>
+    </rule>
+    <rule id="bad5-67d0-2390-90f5" name="Fan-Burst" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>On the roll of a 6 To Hit, the bearer may make an extra shooting attack with this weapon (up to a miximum of six rolls To Hit)</description>
+    </rule>
+    <rule id="8fa4-a1c0-c588-34e6" name="Energy Nullifier" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>The AP value of any attack made agaisnt a model bearing wargear with the Energy Nullifier rule is reduced by 1 (for example, the attacks of a power sword striking a model equipped with a Tarsus buckler are resolved at AP 4 instead of AP 3).</description>
+    </rule>
   </sharedRules>
   <sharedProfiles>
     <profile id="d0e4-db08-9380-21f1" name="Sentinel Warblade (Bolt Caster)" book="HH7" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
@@ -13443,6 +13643,33 @@ Overawe(+1 to the total score to determine the result of an assault)</descriptio
         <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="7"/>
         <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="2"/>
         <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 5, Rending, Heliothermic Detonation"/>
+      </characteristics>
+    </profile>
+    <profile id="783e-c8f7-4312-98c7" name="Custodian Jump Harness" book="" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323" profileTypeName="Wargear Item">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Description" characteristicTypeId="4465736372697074696f6e23232344415441232323" value="Custodian jump harness provides a 3+ armour save and the Auramite Pinions special rule."/>
+      </characteristics>
+    </profile>
+    <profile id="11d9-f1a7-f2de-8ffa" name="Custodian Venatari" book="" hidden="false" profileTypeId="556e697423232344415441232323" profileTypeName="Unit">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Unit Type" characteristicTypeId="556e6974205479706523232344415441232323" value="Jump Infantry (Character)"/>
+        <characteristic name="WS" characteristicTypeId="575323232344415441232323" value="5"/>
+        <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="5"/>
+        <characteristic name="S" characteristicTypeId="5323232344415441232323" value="5"/>
+        <characteristic name="T" characteristicTypeId="5423232344415441232323" value="5"/>
+        <characteristic name="W" characteristicTypeId="5723232344415441232323" value="2"/>
+        <characteristic name="I" characteristicTypeId="4923232344415441232323" value="5"/>
+        <characteristic name="A" characteristicTypeId="4123232344415441232323" value="2"/>
+        <characteristic name="LD" characteristicTypeId="4c4423232344415441232323" value="9"/>
+        <characteristic name="Save" characteristicTypeId="5361766523232344415441232323" value="3+"/>
       </characteristics>
     </profile>
   </sharedProfiles>

--- a/The Horus Heresy.gst
+++ b/The Horus Heresy.gst
@@ -10416,10 +10416,10 @@ Immediately place an objective marker within 3&quot; of any part of the Crashed 
                   <infoLinks/>
                   <modifiers/>
                   <characteristics>
-                    <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323"/>
-                    <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323"/>
-                    <characteristic name="AP" characteristicTypeId="415023232344415441232323"/>
-                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323"/>
+                    <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="48&quot;"/>
+                    <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="9"/>
+                    <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="3"/>
+                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 1, Shieldbreaker, One Use"/>
                   </characteristics>
                 </profile>
               </profiles>
@@ -10525,7 +10525,15 @@ Immediately place an objective marker within 3&quot; of any part of the Crashed 
                   </characteristics>
                 </profile>
               </profiles>
-              <rules/>
+              <rules>
+                <rule id="0f61-e7b9-bda8-7629" name="Harpoon" hidden="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <description>Once fired, regardless of whether the attack results in a hit or not, this weapon may not be fired again in the controlling player’s next Shooting phase. Effectively, it may only be fired every other turn. In addition, any model that fails a save against a Wound or Hull point of damage inflicted by a weapon with this type suffers D6 Wounds or D6 Hull points of damage instead of just one (these wounds do not carry over to other models in the same unit).</description>
+                </rule>
+              </rules>
               <infoLinks/>
               <modifiers/>
               <constraints>

--- a/The Horus Heresy.gst
+++ b/The Horus Heresy.gst
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<gameSystem id="ca571888-56a9-c58e-ddaf-54f4713538bc" name="Warhammer 30,000 - The Horus Heresy" book="Forgeworld Horus Heresy Series" revision="101" battleScribeVersion="2.01" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
+<gameSystem id="ca571888-56a9-c58e-ddaf-54f4713538bc" name="Warhammer 30,000 - The Horus Heresy" book="Forgeworld Horus Heresy Series" revision="102" battleScribeVersion="2.01" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
   <profiles/>
   <rules/>
   <infoLinks/>
@@ -301,9 +301,25 @@
         </categoryLink>
       </categoryLinks>
     </entryLink>
+    <entryLink id="78a9-6f20-6fe6-a0e2" name="Questoris Knight Dominus" hidden="false" targetId="6eec-767d-0b14-95ab" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="1daa-66b3-bbef-8da8" name="New CategoryLink" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+    </entryLink>
   </entryLinks>
   <sharedSelectionEntries>
-     <selectionEntry id="11c8-2e78-8328-31e4" name="Crusade Fleet Avenger Strike Fighter" book="HH:MT" page="47" hidden="false" collective="false" type="unit">
+    <selectionEntry id="11c8-2e78-8328-31e4" name="Crusade Fleet Avenger Strike Fighter" book="HH:MT" page="47" hidden="false" collective="false" type="unit">
       <profiles>
         <profile id="341f-27c1-0e88-9c83" name="Avenger Bolt-cannon" book="HH1: Betrayal" page="272" hidden="false" profileTypeId="576561706f6e23232344415441232323">
           <profiles/>
@@ -373,29 +389,7 @@
       </infoLinks>
       <modifiers/>
       <constraints/>
-      <categoryLinks>
-        <categoryLink id="22bd-5e71-4294-eb77" name="New CategoryLink" hidden="false" targetId="2d6f-e613-ab10-e55a" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-        <categoryLink id="8d3a-a583-71b1-4721" name="New CategoryLink" hidden="false" targetId="df44-81ea-e2ee-9849" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-        <categoryLink id="9326-fd1a-4e07-f1a2" name="New CategoryLink" hidden="false" targetId="53bd-99e7-aba0-e79f" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-      </categoryLinks>
+      <categoryLinks/>
       <selectionEntries/>
       <selectionEntryGroups>
         <selectionEntryGroup id="11ed-18c7-bdf5-2bd4" name="May be equipped with:" hidden="false" collective="false">
@@ -644,7 +638,7 @@
         <cost name="pts" costTypeId="points" value="150.0"/>
       </costs>
     </selectionEntry>
-	<selectionEntry id="66c9-eaa6-a91a-00ed" name="Fortification" hidden="true" collective="false" type="upgrade">
+    <selectionEntry id="66c9-eaa6-a91a-00ed" name="Fortification" hidden="true" collective="false" type="upgrade">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -8098,7 +8092,7 @@ The Bunkers of the Castellum Stronghold have a 5+ invulnerable save against shoo
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="d1c7-21da-3aad-a67f" hidden="false" targetId="981c9d9e-9866-7245-ed4c-8d5e4f9b17f4" type="profile">
+        <infoLink id="d1c7-21da-3aad-a67f" name="Heavy Stubber" hidden="false" targetId="981c9d9e-9866-7245-ed4c-8d5e4f9b17f4" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -10292,6 +10286,305 @@ Immediately place an objective marker within 3&quot; of any part of the Crashed 
       <entryLinks/>
       <costs>
         <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6eec-767d-0b14-95ab" name="Questoris Knight Dominus" book="HH-Questoris-Knight-Dominus Download" page="" hidden="false" collective="false" type="model">
+      <profiles>
+        <profile id="a3b2-1faa-b33e-2e3d" name="Questoris Knight Dominus" book="HH-Questoris-Knight-Dominus Download" page="" hidden="false" profileTypeId="0694-6ddb-9e1d-40bd" profileTypeName="Super-heavy Walker">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="WS" characteristicTypeId="abd6-ed07-8491-eb85" value="4"/>
+            <characteristic name="BS" characteristicTypeId="aabf-e6cf-1929-65fd" value="4"/>
+            <characteristic name="S" characteristicTypeId="8d3d-332e-0576-3813" value="10"/>
+            <characteristic name="Front" characteristicTypeId="a3b5-f395-614e-95dc" value="13"/>
+            <characteristic name="Side" characteristicTypeId="4f2c-13a4-98b7-ff72" value="13"/>
+            <characteristic name="Rear" characteristicTypeId="c45e-7fb0-f4c7-2909" value="12"/>
+            <characteristic name="I" characteristicTypeId="d7de-23c6-aa99-cb87" value="3"/>
+            <characteristic name="A" characteristicTypeId="ec4e-6e09-1493-1867" value="3"/>
+            <characteristic name="HP" characteristicTypeId="36e0-e195-2d91-3e2a" value="7"/>
+            <characteristic name="Type" characteristicTypeId="c887-e846-fa1f-9389" value="Super-Heavy Walker"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="8c07-caf0-2bff-3f08" name="Ion Shield" hidden="false" targetId="342d5e83-9f9b-42c0-cecb-e6c9c197ab9d" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries>
+        <selectionEntry id="09cb-c235-3d33-c28d" name="Twin-Linked Meltaguns" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="a9d2-2db0-4ba5-0a41" name="Twin-Linked Meltagun" hidden="false" targetId="3084-edd3-6247-da94" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3675-d6da-3a78-3ad0" type="max"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0317-e7c9-7800-00ec" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="3847-b91a-939b-e57b" name="May be upgraded with:" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="fd0e-d219-805e-fdaf" name="Occular Augmetics" hidden="false" targetId="348b-40f4-c774-1f9a" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="47e0-33bf-7ed9-db78" name="May take Three of the following carapace weapons:" hidden="false" collective="false" defaultSelectionEntryId="f687-ee00-9d48-f14d">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b075-2282-b17f-b2b3" type="max"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="57f7-1cbf-a142-c87c" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries>
+            <selectionEntry id="f687-ee00-9d48-f14d" name="Twin-Linked Siegebreaker Cannon" book="HH-Questoris-Knight-Dominus Download" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="2885-bab4-7713-3172" name="Twin-Linked Siegebreaker Cannon" book="HH-Questoris-Knight-Dominus Download" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="48&quot;"/>
+                    <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="7"/>
+                    <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="4"/>
+                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 2, Twin-Linked"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0b6f-06d6-d6ec-6715" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="35d2-a3b3-5853-36f6" name="Two Shieldbreaker Missiles" book="HH-Questoris-Knight-Dominus Download" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="b804-d938-06ab-91e4" name="Two Shieldbreaker Missiles" book="HH-Questoris-Knight-Dominus Download" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323"/>
+                    <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323"/>
+                    <characteristic name="AP" characteristicTypeId="415023232344415441232323"/>
+                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8041-348e-4cee-f2ea" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="9cd8-0c11-3a8c-a176" name="May take 2 weapons for the following" hidden="false" collective="false" defaultSelectionEntryId="7ce7-0abc-5ee8-7760">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1621-d6c6-49d7-9982" type="max"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a901-f6e4-e3b1-5aa5" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries>
+            <selectionEntry id="7ce7-0abc-5ee8-7760" name="Canflagration Cannon" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="ff17-70e2-8229-d57f" name="Conflagration Cannon" book="HH-Questoris-Knight-Dominus Download" page="" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="Hellstorm"/>
+                    <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="7"/>
+                    <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="3"/>
+                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Ordnance 1"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="938b-92e7-d38d-bf9c" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="30.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="8b49-18a1-9b65-1cac" name="Plasma Decimator" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="4bf5-2c1d-2e7a-ddd5" name="Plasma Decimator" book="HH-Questoris-Knight-Dominus Download" page="" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="48&quot;"/>
+                    <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="8"/>
+                    <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="2"/>
+                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 1, Large Blast 5&quot;, Gets Hot"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="558f-f728-39a9-49d6" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="55.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="a5ae-f632-aae1-a99c" name="Thundercoil Harpoon" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="2b58-4c2a-dd23-b822" name="Thundercoil Harpoon" book="HH-Questoris-Knight-Dominus Download" page="" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="12&quot;"/>
+                    <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="10"/>
+                    <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="1"/>
+                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Ordnance 1, Armourbane, Fleshbane, Instant Death, Sunder, Harpoon"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a84b-0f85-ac03-69db" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="50.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="9438-64ab-798b-4ade" name="Volcano Lance" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="b839-ed30-5604-100f" name="Volcano Lance" book="HH-Questoris-Knight-Dominus Download" page="" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="80&quot;"/>
+                    <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="9"/>
+                    <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="2"/>
+                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 1, Blast 3&quot;"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2577-986e-d563-93ea" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="45.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="84e9-a8fd-9156-746f" name="Household Rank" hidden="false" targetId="2f28-c5f0-6110-c614" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="360.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>
@@ -14195,7 +14488,7 @@ Some can also Hover – see page 81. Zooming allows the Flyer to move at extreme
     </rule>
   </sharedRules>
   <sharedProfiles>
-  <profile id="c812-a8fe-2b49-75a5" name="Multi-laser" book="HH4: Conquest" page="247" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+    <profile id="c812-a8fe-2b49-75a5" name="Multi-laser" book="HH4: Conquest" page="247" hidden="false" profileTypeId="576561706f6e23232344415441232323">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -14225,7 +14518,7 @@ Some can also Hover – see page 81. Zooming allows the Flyer to move at extreme
         <characteristic name="Description" characteristicTypeId="4465736372697074696f6e23232344415441232323" value="Confers Night Vision special rule"/>
       </characteristics>
     </profile>
-     <profile id="0e9bdcf2-a925-e661-dbb5-755ee50c4967" name="Tactical Bombs" book="HH1: Betrayal" page="272" hidden="false" profileTypeId="576561706f6e23232344415441232323">
+    <profile id="0e9bdcf2-a925-e661-dbb5-755ee50c4967" name="Tactical Bombs" book="HH1: Betrayal" page="272" hidden="false" profileTypeId="576561706f6e23232344415441232323">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -14237,8 +14530,7 @@ Some can also Hover – see page 81. Zooming allows the Flyer to move at extreme
         <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 1, Barrage, Bomb, Blast, One Use"/>
       </characteristics>
     </profile>
-    
-	<profile id="c3bb10b0-0ad1-3d7e-5b6e-20b2f57fbaba" name="Chaff/Flare Launchers" book="HH:LACAL" page="90" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323">
+    <profile id="c3bb10b0-0ad1-3d7e-5b6e-20b2f57fbaba" name="Chaff/Flare Launchers" book="HH:LACAL" page="90" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -14246,8 +14538,8 @@ Some can also Hover – see page 81. Zooming allows the Flyer to move at extreme
       <characteristics>
         <characteristic name="Description" characteristicTypeId="4465736372697074696f6e23232344415441232323" value="Gains 4++ invulnerable against damage caused by missile weapons. "/>
       </characteristics>
-   </profile>
-   <profile id="06710a9d-a2a8-638f-91b0-2af2fb3e95c2" name="Armoured Cockpit" book="HH:LACAL" page="88" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323">
+    </profile>
+    <profile id="06710a9d-a2a8-638f-91b0-2af2fb3e95c2" name="Armoured Cockpit" book="HH:LACAL" page="88" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -16741,6 +17033,18 @@ Some can also Hover – see page 81. Zooming allows the Flyer to move at extreme
         <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="User"/>
         <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="-"/>
         <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Melee"/>
+      </characteristics>
+    </profile>
+    <profile id="3084-edd3-6247-da94" name="Twin-Linked Meltagun" book="HH: AoD Rulebook" page="178" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="12&quot;"/>
+        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="8"/>
+        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="1"/>
+        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Assault 1, Melta, Twin-Linked"/>
       </characteristics>
     </profile>
   </sharedProfiles>


### PR DESCRIPTION
Changes

Added the Questoris Knight Dominus Horus Heresy.gst file as a lord of war for all armies without Blessed Autosimulacra

Added the Questoris Knight Dominus to Questoris Knight.cat as an armour variant for all current ranks of knights and Blessed Autosimulacra

Added Scion Auxilia with Questoris Knight Armiger to Questoris Knight.cat as non-compulsory troops, with Implacable Advance

Added Questoris Knight Armiger to Mechanicum - Tahmata Army List.cat as a 0-1 Heavy Support choice, without Implacable Advance

## Test Case
https://drive.google.com/open?id=1QHlWgj_n1bZo-14Ru0TjrcSEdg5sWP6s link to test file. Can't see any issues from my end.

