### PR TITLE
Update (HH) Talons of the Emperor Army List.cat

### DIFF
--- a/(HH) Talons of the Emperor Army List.cat
+++ b/(HH) Talons of the Emperor Army List.cat
@@ -5048,7 +5048,7 @@
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="54c7-0ce0-a7b1-ac19" name="New InfoLink" hidden="false" targetId="4845-0bfe-2c22-883f" type="profile">
+        <infoLink id="54c7-0ce0-a7b1-ac19" name="Refractor Field" hidden="false" targetId="4845-0bfe-2c22-883f" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -6183,13 +6183,19 @@
               <infoLinks/>
               <modifiers/>
             </infoLink>
-            <infoLink id="ca05-4f8e-8851-736c" name="New InfoLink" hidden="false" targetId="dcf0-ff9a-7712-e3e1" type="profile">
+            <infoLink id="ca05-4f8e-8851-736c" name="Custodian Agamatus" hidden="false" targetId="dcf0-ff9a-7712-e3e1" type="profile">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
             </infoLink>
             <infoLink id="dde3-8d94-0c47-d4e0" name="New InfoLink" hidden="false" targetId="fdd4-9bf3-da9d-5479" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="45ac-757b-bc95-cb2e" name="Refractor Field" hidden="false" targetId="4845-0bfe-2c22-883f" type="profile">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -7085,7 +7091,7 @@
               </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="a9ad-4f02-e529-49f0" name="New EntryLink" hidden="false" targetId="011a-b751-e773-6b90" type="selectionEntry">
+            <entryLink id="a9ad-4f02-e529-49f0" name="Refractor Feild" hidden="false" targetId="011a-b751-e773-6b90" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -9534,7 +9540,9 @@ decided.</description>
                       <categoryLinks/>
                     </entryLink>
                   </entryLinks>
-                  <costs/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="0.0"/>
+                  </costs>
                 </selectionEntry>
               </selectionEntries>
               <selectionEntryGroups/>
@@ -11151,7 +11159,9 @@ decided.</description>
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="c632-2ff7-8629-e8fc" name="Archaeotech Kinetic Destroyer" hidden="false" collective="false" type="upgrade">
           <profiles>
@@ -11186,7 +11196,9 @@ decided.</description>
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="27dc-deb9-9379-eb10" name="Tarsus Buckler" hidden="false" collective="false" type="upgrade">
           <profiles>
@@ -11221,7 +11233,9 @@ decided.</description>
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups/>
@@ -13502,7 +13516,7 @@ Overawe(+1 to the total score to determine the result of an assault)</descriptio
         <characteristic name="S" characteristicTypeId="5323232344415441232323" value="5"/>
         <characteristic name="T" characteristicTypeId="5423232344415441232323" value="6"/>
         <characteristic name="W" characteristicTypeId="5723232344415441232323" value="2"/>
-        <characteristic name="I" characteristicTypeId="4923232344415441232323" value="4"/>
+        <characteristic name="I" characteristicTypeId="4923232344415441232323" value="5"/>
         <characteristic name="A" characteristicTypeId="4123232344415441232323" value="2"/>
         <characteristic name="LD" characteristicTypeId="4c4423232344415441232323" value="9"/>
         <characteristic name="Save" characteristicTypeId="5361766523232344415441232323" value="2+"/>


### PR DESCRIPTION
Legio Custodes Agamatus Jetbike Squadron Updates:
Initiative Value Increased to 5 based on 09/07/2018 Errata.
Added Refractor Field profile link


[Talons of the Emperor Agamatus Update.zip](https://github.com/BSData/horus-heresy/files/2823964/Talons.of.the.Emperor.Agamatus.Update.zip)

