### PR TITLE
bugfix(castallax, moritat, consul defaults):

### DIFF
--- a/(HH) Mechanicum - Taghmata Army List.cat
+++ b/(HH) Mechanicum - Taghmata Army List.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="cf03-f607-41dc-7545" name="Mechanicum: Taghmata Army List" book="Horus Heresy: Taghmata Army List" revision="83" battleScribeVersion="2.01" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="85" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="cf03-f607-41dc-7545" name="Mechanicum: Taghmata Army List" book="Horus Heresy: Taghmata Army List" revision="84" battleScribeVersion="2.01" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="85" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules/>
   <infoLinks/>
@@ -4387,14 +4387,14 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
                 <modifier type="set" field="5d2a-e961-7953-6b83" value="1">
                   <repeats/>
                   <conditions>
-                    <condition field="selections" scope="48db-84ca-2bad-520f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f11e-3352-b97f-3693" type="equalTo"/>
+                    <condition field="selections" scope="09ad-ef83-4a62-46fe" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f11e-3352-b97f-3693" type="equalTo"/>
                   </conditions>
                   <conditionGroups/>
                 </modifier>
                 <modifier type="set" field="813e-6a3e-bd63-d89a" value="1">
                   <repeats/>
                   <conditions>
-                    <condition field="selections" scope="48db-84ca-2bad-520f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f11e-3352-b97f-3693" type="equalTo"/>
+                    <condition field="selections" scope="09ad-ef83-4a62-46fe" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f11e-3352-b97f-3693" type="equalTo"/>
                   </conditions>
                   <conditionGroups/>
                 </modifier>


### PR DESCRIPTION
## Description
* bolter requirements were set to the whole squad in stead of individual units
* moritats second pistol was not properly displaying
* consul default loadout was defaulting to a terminator weapon despite not having terminator armor

## Test Case
Add two castalaxes to a unit and set one to use a siege wrecker, before the fix it would report both models needing to set there bolters to 1, after the fix the wargear of other castallax should no effect eachothers bolter requirements.
