### PR TITLE
#1549 Thousand Sons, #1556 DotRS, #1557 Talons fixes

### DIFF
--- a/(HH) Daemons of the Ruinstorm Army List.cat
+++ b/(HH) Daemons of the Ruinstorm Army List.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="8700-b3bb-a471-a0ad" name="Daemons of the Ruinstorm" revision="6" battleScribeVersion="2.02" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="85" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="8700-b3bb-a471-a0ad" name="Daemons of the Ruinstorm" revision="7" battleScribeVersion="2.02" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="85" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="8700-b3bb-pubN65537" name="HH8: Malevolence"/>
     <publication id="8700-b3bb-pubN75780" name="BRB"/>
@@ -198,7 +198,7 @@
         <categoryLink id="d499-276f-f4fe-5100" name="HQ" hidden="false" targetId="485123232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="d518-5909-d60f-79db" name="Samus Unbound, Daemon Lord of the Ruinstorm" hidden="true" collective="false" targetId="777d-7ee1-4f6d-9ca8" type="selectionEntry">
+    <entryLink id="d518-5909-d60f-79db" name="Samus Unbound, Daemon Lord of the Ruinstorm" hidden="false" collective="false" targetId="777d-7ee1-4f6d-9ca8" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="feb9-0a69-7838-340a" name="HQ" hidden="false" targetId="485123232344415441232323" primary="true"/>
       </categoryLinks>
@@ -221,17 +221,6 @@
               <conditions>
                 <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3e2a-e0d1-0561-3872" type="equalTo"/>
                 <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5ddb-4a5d-5b2d-c540" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="777d-7ee1-4f6d-9ca8" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5ddb-4a5d-5b2d-c540" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3e2a-e0d1-0561-3872" type="equalTo"/>
                 <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="777d-7ee1-4f6d-9ca8" type="equalTo"/>
               </conditions>
             </conditionGroup>
@@ -747,7 +736,7 @@
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1bd5-5962-2608-d4b4" type="max"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1bd5-5962-2608-d4b4" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="07fd-9d5f-ed3e-a352" name="Crushing Claws" hidden="false" collective="false" targetId="a4fc-26a9-cd55-3b4b" type="selectionEntry">
@@ -1426,6 +1415,16 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="1c0c-a8bb-13c6-daea" name="Crimson Fury" hidden="false" collective="false" type="upgrade">
+      <modifiers>
+        <modifier type="set" field="4632-6854-da60-0105" value="1">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3e2a-e0d1-0561-3872" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4632-6854-da60-0105" type="min"/>
+      </constraints>
       <categoryLinks>
         <categoryLink id="91cb-adbc-d386-a574" name="Aetheric Dominion" hidden="false" targetId="5297-7e0f-fa0b-3537" primary="true"/>
       </categoryLinks>
@@ -1442,6 +1441,16 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="5a0b-2e45-8c90-360e" name="Creeping Scourge" publicationId="8700-b3bb-pubN65537" hidden="false" collective="false" type="upgrade">
+      <modifiers>
+        <modifier type="set" field="0715-b682-d447-5c10" value="1">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5ddb-4a5d-5b2d-c540" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0715-b682-d447-5c10" type="min"/>
+      </constraints>
       <categoryLinks>
         <categoryLink id="4ac0-d3ef-0316-6008" name="Aetheric Dominion" hidden="false" targetId="5297-7e0f-fa0b-3537" primary="true"/>
       </categoryLinks>
@@ -1458,6 +1467,16 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="dc24-bd44-bce4-a7f1" name="Resplendent Terror" publicationId="8700-b3bb-pubN65537" hidden="false" collective="false" type="upgrade">
+      <modifiers>
+        <modifier type="set" field="3d92-7ea6-6e8f-7684" value="1">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="777d-7ee1-4f6d-9ca8" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3d92-7ea6-6e8f-7684" type="min"/>
+      </constraints>
       <categoryLinks>
         <categoryLink id="383f-5901-c8a4-33f5" name="Aetheric Dominion" hidden="false" targetId="5297-7e0f-fa0b-3537" primary="true"/>
       </categoryLinks>
@@ -1465,7 +1484,7 @@
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="3e2a-e0d1-0561-3872" name="Ka&apos;Bandha, Daemon General of Signus" publicationId="8700-b3bb-pubN65537" hidden="true" collective="false" type="model">
+    <selectionEntry id="3e2a-e0d1-0561-3872" name="Ka&apos;Bandha, Daemon General of Signus" publicationId="8700-b3bb-pubN65537" hidden="false" collective="false" type="model">
       <modifiers>
         <modifier type="set" field="33f3-58b0-0dc9-4d8e" value="1">
           <conditionGroups>
@@ -1473,18 +1492,6 @@
               <conditions>
                 <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b1f5-228b-2edc-93d5" type="equalTo"/>
                 <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="92c6-2146-8ca7-bd35" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="777d-7ee1-4f6d-9ca8" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-        <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b1f5-228b-2edc-93d5" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="92c6-2146-8ca7-bd35" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="777d-7ee1-4f6d-9ca8" type="equalTo"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -2032,18 +2039,8 @@ Eternal Rivalry: If Sanguinius is removed as a casualty while it is fighting in 
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="5ddb-4a5d-5b2d-c540" name="Cor&apos;bax Utterblight Unbound, Daemon Lord Of The Ruinstorm" hidden="true" collective="false" type="upgrade">
+    <selectionEntry id="5ddb-4a5d-5b2d-c540" name="Cor&apos;bax Utterblight Unbound, Daemon Lord Of The Ruinstorm" hidden="false" collective="false" type="upgrade">
       <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="92c6-2146-8ca7-bd35" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c40c-cbf9-905c-29e9" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
         <modifier type="set" field="ca6b-6f29-c512-6a3e" value="1">
           <conditionGroups>
             <conditionGroup type="and">
@@ -2123,23 +2120,11 @@ Eternal Rivalry: If Sanguinius is removed as a casualty while it is fighting in 
     </selectionEntry>
     <selectionEntry id="777d-7ee1-4f6d-9ca8" name="Samus Unbound, Daemon Lord of the Ruinstorm" hidden="false" collective="false" type="model">
       <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b1f5-228b-2edc-93d5" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="92c6-2146-8ca7-bd35" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3e2a-e0d1-0561-3872" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
         <modifier type="set" field="47bb-db5c-c3f6-5d14" value="1">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b1f5-228b-2edc-93d5" type="equalTo"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3e2a-e0d1-0561-3872" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="394c-38b0-fa5d-0598" type="equalTo"/>
                 <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="92c6-2146-8ca7-bd35" type="equalTo"/>
               </conditions>
             </conditionGroup>

--- a/(HH) Talons of the Emperor Army List.cat
+++ b/(HH) Talons of the Emperor Army List.cat
@@ -1,155 +1,72 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="a30a-7522-3343-553a" name="Talons of the Emperor" book="HH7 / HH8" page="" revision="98" battleScribeVersion="2.01" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="85" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
-  <profiles/>
-  <rules/>
-  <infoLinks/>
-  <costTypes/>
-  <profileTypes/>
+<catalogue id="a30a-7522-3343-553a" name="Talons of the Emperor" revision="99" battleScribeVersion="2.02" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="85" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+  <publications>
+    <publication id="a30a-7522-pubN65537" name="HH7 / HH8"/>
+    <publication id="a30a-7522-pubN69988" name="Forgeworld.co.uk"/>
+    <publication id="a30a-7522-pubN72320" name="White Dwarf"/>
+    <publication id="a30a-7522-pubN77499" name="HH8: Malevolence"/>
+    <publication id="a30a-7522-pubN94337" name="FW Download"/>
+    <publication id="a30a-7522-pubN94931" name="HH8"/>
+    <publication id="a30a-7522-pubN95872" name="HH7"/>
+    <publication id="a30a-7522-pubN96662" name="HH1: Betrayal"/>
+    <publication id="a30a-7522-pubN99459" name="WH40k BRB"/>
+    <publication id="a30a-7522-pubN101730" name="LA:AODAL"/>
+    <publication id="a30a-7522-pubN102882" name="HH7:Inferno"/>
+    <publication id="a30a-7522-pubN105003" name="HH:LACAL"/>
+  </publications>
   <categoryEntries>
-    <categoryEntry id="485123232344415441232323" name="HQ" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-    </categoryEntry>
-    <categoryEntry id="456c6974657323232344415441232323" name="Elites" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-    </categoryEntry>
-    <categoryEntry id="54726f6f707323232344415441232323" name="Troops" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-    </categoryEntry>
-    <categoryEntry id="466173742041747461636b23232344415441232323" name="Fast Attack" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-    </categoryEntry>
-    <categoryEntry id="486561767920537570706f727423232344415441232323" name="Heavy Support" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-    </categoryEntry>
-    <categoryEntry id="5297-7e0f-fa0b-3537" name="Allegiance" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-    </categoryEntry>
-    <categoryEntry id="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" name="Lords of War" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-    </categoryEntry>
-    <categoryEntry id="466f7274696669636174696f6e23232344415441232323" name="Fortification" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-    </categoryEntry>
+    <categoryEntry id="485123232344415441232323" name="HQ" hidden="false"/>
+    <categoryEntry id="456c6974657323232344415441232323" name="Elites" hidden="false"/>
+    <categoryEntry id="54726f6f707323232344415441232323" name="Troops" hidden="false"/>
+    <categoryEntry id="466173742041747461636b23232344415441232323" name="Fast Attack" hidden="false"/>
+    <categoryEntry id="486561767920537570706f727423232344415441232323" name="Heavy Support" hidden="false"/>
+    <categoryEntry id="5297-7e0f-fa0b-3537" name="Allegiance" hidden="false"/>
+    <categoryEntry id="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" name="Lords of War" hidden="false"/>
+    <categoryEntry id="466f7274696669636174696f6e23232344415441232323" name="Fortification" hidden="false"/>
   </categoryEntries>
   <forceEntries>
     <forceEntry id="98db-b4ba-fbcd-3239" name=" Crusade" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <forceEntries/>
       <categoryLinks>
         <categoryLink id="98db-b4ba-fbcd-3239-485123232344415441232323" name="HQ" hidden="false" targetId="485123232344415441232323" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f2b9-40d0-95c5-7e0f" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4c7f-d2d5-b2d3-813c" type="min"/>
           </constraints>
         </categoryLink>
         <categoryLink id="98db-b4ba-fbcd-3239-456c6974657323232344415441232323" name="Elites" hidden="false" targetId="456c6974657323232344415441232323" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eefe-ee16-b931-4d55" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="98db-b4ba-fbcd-3239-54726f6f707323232344415441232323" name="Troops" hidden="false" targetId="54726f6f707323232344415441232323" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f266-ee67-dd6a-23b7" type="max"/>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e8cb-55d1-4bdc-0ed6" type="min"/>
           </constraints>
         </categoryLink>
         <categoryLink id="98db-b4ba-fbcd-3239-466173742041747461636b23232344415441232323" name="Fast Attack" hidden="false" targetId="466173742041747461636b23232344415441232323" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7dc2-6233-f84f-1dd3" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="98db-b4ba-fbcd-3239-486561767920537570706f727423232344415441232323" name="Heavy Support" hidden="false" targetId="486561767920537570706f727423232344415441232323" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e116-a824-3a5e-9c94" type="max"/>
           </constraints>
         </categoryLink>
-        <categoryLink id="98db-b4ba-fbcd-3239-5297-7e0f-fa0b-3537" name="Allegiance" hidden="false" targetId="5297-7e0f-fa0b-3537" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
+        <categoryLink id="98db-b4ba-fbcd-3239-5297-7e0f-fa0b-3537" name="Allegiance" hidden="false" targetId="5297-7e0f-fa0b-3537" primary="false"/>
         <categoryLink id="98db-b4ba-fbcd-3239-1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" name="Lords of War" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="70a0-1ebc-39cf-f0cc" type="max"/>
             <constraint field="limit::points" scope="roster" value="25.0" percentValue="true" shared="true" includeChildSelections="false" includeChildForces="true" id="12a1-3a1f-5f6f-b56b" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="98db-b4ba-fbcd-3239-466f7274696669636174696f6e23232344415441232323" name="Fortification" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a448-1827-d3b4-aa38" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="b1fb-de50-77ea-35a3" name="Use Playtest Rules" hidden="false" targetId="fdf4-0683-3e84-5a4b" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="0cb0-bf5d-1691-4560" type="max"/>
           </constraints>
@@ -157,13 +74,8 @@
       </categoryLinks>
     </forceEntry>
     <forceEntry id="657a-bc81-4ae3-8a5b" name="Allied Detachment" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
       <modifiers>
         <modifier type="set" field="028c-b3c3-133e-a4b3" value="1">
-          <repeats/>
-          <conditions/>
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
@@ -172,7 +84,6 @@
                 <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8666-c0df-4dfa-08f1" type="equalTo"/>
                 <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1a2c-902b-cdb9-7640" type="equalTo"/>
               </conditions>
-              <conditionGroups/>
             </conditionGroup>
           </conditionGroups>
         </modifier>
@@ -180,67 +91,36 @@
       <constraints>
         <constraint field="selections" scope="roster" value="-1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="028c-b3c3-133e-a4b3" type="max"/>
       </constraints>
-      <forceEntries/>
       <categoryLinks>
         <categoryLink id="657a-bc81-4ae3-8a5b-54726f6f707323232344415441232323" name="Troops" hidden="false" targetId="54726f6f707323232344415441232323" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="582a-2005-2d35-209e" type="min"/>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="73be-4c7a-97c6-6531" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="657a-bc81-4ae3-8a5b-485123232344415441232323" name="HQ" hidden="false" targetId="485123232344415441232323" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="8ad9-de98-bab5-8e1b" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ebf6-27ec-4116-7a8e" type="min"/>
           </constraints>
         </categoryLink>
         <categoryLink id="657a-bc81-4ae3-8a5b-456c6974657323232344415441232323" name="Elites" hidden="false" targetId="456c6974657323232344415441232323" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="ecfe-b249-2699-e742" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="657a-bc81-4ae3-8a5b-466173742041747461636b23232344415441232323" name="Fast Attack" hidden="false" targetId="466173742041747461636b23232344415441232323" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="111e-cc4c-4f45-2d56" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="657a-bc81-4ae3-8a5b-486561767920537570706f727423232344415441232323" name="Heavy Support" hidden="false" targetId="486561767920537570706f727423232344415441232323" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="696d-d0b5-9a81-bcb9" type="max"/>
           </constraints>
         </categoryLink>
-        <categoryLink id="657a-bc81-4ae3-8a5b-5297-7e0f-fa0b-3537" name="Allegiance" hidden="false" targetId="5297-7e0f-fa0b-3537" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
+        <categoryLink id="657a-bc81-4ae3-8a5b-5297-7e0f-fa0b-3537" name="Allegiance" hidden="false" targetId="5297-7e0f-fa0b-3537" primary="false"/>
         <categoryLink id="7b0c-b818-cf03-ff3d" name="Use Playtest Rules" hidden="false" targetId="fdf4-0683-3e84-5a4b" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="ccf1-aa52-1f31-43f4" type="max"/>
           </constraints>
@@ -248,72 +128,36 @@
       </categoryLinks>
     </forceEntry>
     <forceEntry id="089f-7e79-bde1-90dd" name=" Zone Mortalis - Attacker" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <forceEntries/>
       <categoryLinks>
         <categoryLink id="089f-7e79-bde1-90dd-456c6974657323232344415441232323" name="Elites" hidden="false" targetId="456c6974657323232344415441232323" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f9c9-4987-6479-3ea5" type="min"/>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="12e1-2102-0fc6-7350" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="089f-7e79-bde1-90dd-485123232344415441232323" name="HQ" hidden="false" targetId="485123232344415441232323" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="62aa-1d44-43b3-980a" type="min"/>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="4995-5484-126b-ee9f" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="089f-7e79-bde1-90dd-466173742041747461636b23232344415441232323" name="Fast Attack" hidden="false" targetId="466173742041747461636b23232344415441232323" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="66fb-08e3-9d45-f687" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="089f-7e79-bde1-90dd-54726f6f707323232344415441232323" name="Troops" hidden="false" targetId="54726f6f707323232344415441232323" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="b138-4b79-afc0-363e" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="089f-7e79-bde1-90dd-486561767920537570706f727423232344415441232323" name="Heavy Support" hidden="false" targetId="486561767920537570706f727423232344415441232323" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="a908-e2ef-de24-fb58" type="max"/>
           </constraints>
         </categoryLink>
-        <categoryLink id="089f-7e79-bde1-90dd-5297-7e0f-fa0b-3537" name="Allegiance" hidden="false" targetId="5297-7e0f-fa0b-3537" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
+        <categoryLink id="089f-7e79-bde1-90dd-5297-7e0f-fa0b-3537" name="Allegiance" hidden="false" targetId="5297-7e0f-fa0b-3537" primary="false"/>
         <categoryLink id="8726-24b8-cadd-599c" name="Use Playtest Rules" hidden="false" targetId="fdf4-0683-3e84-5a4b" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="ce41-ed42-0a0a-f6db" type="max"/>
           </constraints>
@@ -321,70 +165,32 @@
       </categoryLinks>
     </forceEntry>
     <forceEntry id="7b39-af6b-52e1-b4d7" name=" Zone Mortalis - Defender" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <forceEntries/>
       <categoryLinks>
         <categoryLink id="7b39-af6b-52e1-b4d7-456c6974657323232344415441232323" name="Elites" hidden="false" targetId="456c6974657323232344415441232323" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="a740-efb0-8b33-63d3" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="7b39-af6b-52e1-b4d7-485123232344415441232323" name="HQ" hidden="false" targetId="485123232344415441232323" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="717b-1ca4-91b6-c7f8" type="min"/>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="f62c-4adf-8bdb-8993" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="7b39-af6b-52e1-b4d7-466173742041747461636b23232344415441232323" name="Fast Attack" hidden="false" targetId="466173742041747461636b23232344415441232323" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="ca58-852e-5912-65dd" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="7b39-af6b-52e1-b4d7-54726f6f707323232344415441232323" name="Troops" hidden="false" targetId="54726f6f707323232344415441232323" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e44b-ce09-fc52-d409" type="min"/>
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="50e7-c9a6-844a-d500" type="max"/>
           </constraints>
         </categoryLink>
-        <categoryLink id="7b39-af6b-52e1-b4d7-486561767920537570706f727423232344415441232323" name="Heavy Support" hidden="false" targetId="486561767920537570706f727423232344415441232323" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-        <categoryLink id="7b39-af6b-52e1-b4d7-5297-7e0f-fa0b-3537" name="Allegiance" hidden="false" targetId="5297-7e0f-fa0b-3537" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
+        <categoryLink id="7b39-af6b-52e1-b4d7-486561767920537570706f727423232344415441232323" name="Heavy Support" hidden="false" targetId="486561767920537570706f727423232344415441232323" primary="false"/>
+        <categoryLink id="7b39-af6b-52e1-b4d7-5297-7e0f-fa0b-3537" name="Allegiance" hidden="false" targetId="5297-7e0f-fa0b-3537" primary="false"/>
         <categoryLink id="23e7-9a0f-e5ef-6d9f" name="Use Playtest Rules" hidden="false" targetId="fdf4-0683-3e84-5a4b" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="7643-97fa-727f-b8b6" type="max"/>
           </constraints>
@@ -392,72 +198,36 @@
       </categoryLinks>
     </forceEntry>
     <forceEntry id="7e48-c376-8ffe-8ae7" name=" Zone Mortalis - Combatant" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <forceEntries/>
       <categoryLinks>
         <categoryLink id="7e48-c376-8ffe-8ae7-456c6974657323232344415441232323" name="Elites" hidden="false" targetId="456c6974657323232344415441232323" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="7791-e3c6-5cba-f33c" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="7e48-c376-8ffe-8ae7-485123232344415441232323" name="HQ" hidden="false" targetId="485123232344415441232323" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7ed2-9008-8e34-ad3d" type="min"/>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="6178-cdc3-642a-6951" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="7e48-c376-8ffe-8ae7-466173742041747461636b23232344415441232323" name="Fast Attack" hidden="false" targetId="466173742041747461636b23232344415441232323" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="d6dc-4536-8e69-d87c" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="7e48-c376-8ffe-8ae7-54726f6f707323232344415441232323" name="Troops" hidden="false" targetId="54726f6f707323232344415441232323" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6b5c-0ec5-d109-e17a" type="min"/>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="01c9-7cd2-13d7-6c69" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="7e48-c376-8ffe-8ae7-486561767920537570706f727423232344415441232323" name="Heavy Support" hidden="false" targetId="486561767920537570706f727423232344415441232323" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="6791-6c2e-b2ba-e22c" type="max"/>
           </constraints>
         </categoryLink>
-        <categoryLink id="7e48-c376-8ffe-8ae7-5297-7e0f-fa0b-3537" name="Allegiance" hidden="false" targetId="5297-7e0f-fa0b-3537" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
+        <categoryLink id="7e48-c376-8ffe-8ae7-5297-7e0f-fa0b-3537" name="Allegiance" hidden="false" targetId="5297-7e0f-fa0b-3537" primary="false"/>
         <categoryLink id="7cbf-6cc7-1c6e-965f" name="Use Playtest Rules" hidden="false" targetId="fdf4-0683-3e84-5a4b" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="15fd-8026-0b00-4c23" type="max"/>
           </constraints>
@@ -465,83 +235,43 @@
       </categoryLinks>
     </forceEntry>
     <forceEntry id="d1ef-61e1-3d67-5a19" name="Optional - Onslaught" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <forceEntries/>
       <categoryLinks>
         <categoryLink id="d1ef-61e1-3d67-5a19-456c6974657323232344415441232323" name="Elites" hidden="false" targetId="456c6974657323232344415441232323" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="182d-f09c-fdaa-c4f6" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="d1ef-61e1-3d67-5a19-485123232344415441232323" name="HQ" hidden="false" targetId="485123232344415441232323" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="343b-808a-804d-ffc3" type="min"/>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e13f-c844-9f9e-ef84" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="d1ef-61e1-3d67-5a19-54726f6f707323232344415441232323" name="Troops" hidden="false" targetId="54726f6f707323232344415441232323" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="131e-c6ee-0e8e-1aab" type="min"/>
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ac7-f020-34c0-013c" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="d1ef-61e1-3d67-5a19-466173742041747461636b23232344415441232323" name="Fast Attack" hidden="false" targetId="466173742041747461636b23232344415441232323" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8454-3747-cef6-1f17" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="d1ef-61e1-3d67-5a19-486561767920537570706f727423232344415441232323" name="Heavy Support" hidden="false" targetId="486561767920537570706f727423232344415441232323" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b7dc-35f2-972b-fc49" type="min"/>
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8d9c-0c3c-3386-2f41" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="d1ef-61e1-3d67-5a19-1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" name="Lords of War" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8113-abb6-fd0c-2077" type="max"/>
             <constraint field="limit::points" scope="roster" value="25.0" percentValue="true" shared="true" includeChildSelections="false" includeChildForces="true" id="5231-3e8d-57cb-fcf5" type="max"/>
           </constraints>
         </categoryLink>
-        <categoryLink id="d1ef-61e1-3d67-5a19-5297-7e0f-fa0b-3537" name="Allegiance" hidden="false" targetId="5297-7e0f-fa0b-3537" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
+        <categoryLink id="d1ef-61e1-3d67-5a19-5297-7e0f-fa0b-3537" name="Allegiance" hidden="false" targetId="5297-7e0f-fa0b-3537" primary="false"/>
         <categoryLink id="248c-6d8a-72d6-575a" name="Use Playtest Rules" hidden="false" targetId="fdf4-0683-3e84-5a4b" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="8b7b-7d03-bf24-f894" type="max"/>
           </constraints>
@@ -549,92 +279,48 @@
       </categoryLinks>
     </forceEntry>
     <forceEntry id="3a6f-6d67-a8b2-e911" name="Optional - Castellan" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <forceEntries/>
       <categoryLinks>
         <categoryLink id="3a6f-6d67-a8b2-e911-485123232344415441232323" name="HQ" hidden="false" targetId="485123232344415441232323" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="39f8-d08b-29e4-2ed1" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7b97-2208-169e-650c" type="min"/>
           </constraints>
         </categoryLink>
         <categoryLink id="3a6f-6d67-a8b2-e911-456c6974657323232344415441232323" name="Elites" hidden="false" targetId="456c6974657323232344415441232323" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="df0e-49ec-2773-d207" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="3a6f-6d67-a8b2-e911-54726f6f707323232344415441232323" name="Troops" hidden="false" targetId="54726f6f707323232344415441232323" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="126b-063c-e9e5-f184" type="max"/>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="36e0-d6b3-6a9b-0d98" type="min"/>
           </constraints>
         </categoryLink>
         <categoryLink id="3a6f-6d67-a8b2-e911-466173742041747461636b23232344415441232323" name="Fast Attack" hidden="false" targetId="466173742041747461636b23232344415441232323" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bff0-7eed-cc95-2836" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="3a6f-6d67-a8b2-e911-486561767920537570706f727423232344415441232323" name="Heavy Support" hidden="false" targetId="486561767920537570706f727423232344415441232323" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dab8-5a1e-6174-b64f" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="3a6f-6d67-a8b2-e911-1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" name="Lords of War" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b33c-194d-0c8c-45e3" type="max"/>
             <constraint field="limit::points" scope="roster" value="25.0" percentValue="true" shared="true" includeChildSelections="false" includeChildForces="true" id="cb8f-4568-7b79-aa31" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="3a6f-6d67-a8b2-e911-466f7274696669636174696f6e23232344415441232323" name="Fortification" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="de74-e33c-031d-e6ea" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2da9-adca-c45f-31d7" type="min"/>
           </constraints>
         </categoryLink>
-        <categoryLink id="3a6f-6d67-a8b2-e911-5297-7e0f-fa0b-3537" name="Allegiance" hidden="false" targetId="5297-7e0f-fa0b-3537" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
+        <categoryLink id="3a6f-6d67-a8b2-e911-5297-7e0f-fa0b-3537" name="Allegiance" hidden="false" targetId="5297-7e0f-fa0b-3537" primary="false"/>
         <categoryLink id="7be2-31a3-e07b-4e52" name="Use Playtest Rules" hidden="false" targetId="fdf4-0683-3e84-5a4b" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="87f3-2bed-8a7d-d3ba" type="max"/>
           </constraints>
@@ -642,35 +328,15 @@
       </categoryLinks>
     </forceEntry>
     <forceEntry id="f715-cdf4-0c5e-213a" name="Optional - Leviathan" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <forceEntries/>
       <categoryLinks>
         <categoryLink id="f715-cdf4-0c5e-213a-1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" name="Lords of War" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="13fd-8baa-143b-71cb" type="min"/>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f84e-2a12-fea2-8e79" type="max"/>
           </constraints>
         </categoryLink>
-        <categoryLink id="f715-cdf4-0c5e-213a-5297-7e0f-fa0b-3537" name="Allegiance" hidden="false" targetId="5297-7e0f-fa0b-3537" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
+        <categoryLink id="f715-cdf4-0c5e-213a-5297-7e0f-fa0b-3537" name="Allegiance" hidden="false" targetId="5297-7e0f-fa0b-3537" primary="false"/>
         <categoryLink id="4845-9d20-8e8c-981d" name="Use Playtest Rules" hidden="false" targetId="fdf4-0683-3e84-5a4b" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="0c1c-8595-3af0-dba5" type="max"/>
           </constraints>
@@ -678,74 +344,40 @@
       </categoryLinks>
     </forceEntry>
     <forceEntry id="1a2c-902b-cdb9-7640" name=" Strategic Raid - Raider" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <forceEntries/>
       <categoryLinks>
         <categoryLink id="1a2c-902b-cdb9-7640-485123232344415441232323" name="HQ" hidden="false" targetId="485123232344415441232323" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6885-6bae-5294-3e07" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="991c-d805-430c-2870" type="min"/>
           </constraints>
         </categoryLink>
         <categoryLink id="1a2c-902b-cdb9-7640-456c6974657323232344415441232323" name="Elites" hidden="false" targetId="456c6974657323232344415441232323" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b668-9ad3-99e5-1565" type="min"/>
             <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="510b-d8c0-1bf0-7955" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="1a2c-902b-cdb9-7640-54726f6f707323232344415441232323" name="Troops" hidden="false" targetId="54726f6f707323232344415441232323" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="64e8-495a-cf5a-5bbd" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="1a2c-902b-cdb9-7640-466173742041747461636b23232344415441232323" name="Fast Attack" hidden="false" targetId="466173742041747461636b23232344415441232323" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="249a-1988-7b4e-1d89" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="1a2c-902b-cdb9-7640-486561767920537570706f727423232344415441232323" name="Heavy Support" hidden="false" targetId="486561767920537570706f727423232344415441232323" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af02-e421-faf8-729d" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="1a2c-902b-cdb9-7640-1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" name="Lords of War" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="20a1-90d6-fb1d-2730" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="71aa-2bd1-473b-b803" name="Use Playtest Rules" hidden="false" targetId="fdf4-0683-3e84-5a4b" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="8642-b9b6-73bf-31c4" type="max"/>
           </constraints>
@@ -753,84 +385,46 @@
       </categoryLinks>
     </forceEntry>
     <forceEntry id="8666-c0df-4dfa-08f1" name=" Strategic Raid - Garrison" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <forceEntries/>
       <categoryLinks>
         <categoryLink id="8666-c0df-4dfa-08f1-485123232344415441232323" name="HQ" hidden="false" targetId="485123232344415441232323" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cbd8-e704-a817-c323" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dbd2-848d-3900-9496" type="min"/>
           </constraints>
         </categoryLink>
         <categoryLink id="8666-c0df-4dfa-08f1-456c6974657323232344415441232323" name="Elites" hidden="false" targetId="456c6974657323232344415441232323" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a890-5971-c6fd-38fa" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="8666-c0df-4dfa-08f1-54726f6f707323232344415441232323" name="Troops" hidden="false" targetId="54726f6f707323232344415441232323" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bd9b-6c64-b392-8ba6" type="max"/>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="02af-f662-658b-4df8" type="min"/>
           </constraints>
         </categoryLink>
         <categoryLink id="8666-c0df-4dfa-08f1-466173742041747461636b23232344415441232323" name="Fast Attack" hidden="false" targetId="466173742041747461636b23232344415441232323" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="76e7-d417-7113-72ab" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="8666-c0df-4dfa-08f1-486561767920537570706f727423232344415441232323" name="Heavy Support" hidden="false" targetId="486561767920537570706f727423232344415441232323" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b6df-a43a-8ad7-22e7" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="8666-c0df-4dfa-08f1-1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" name="Lords of War" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="24cc-15d2-4bb6-8a0c" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="8666-c0df-4dfa-08f1-466f7274696669636174696f6e23232344415441232323" name="Fortification" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8127-4547-e39a-62f2" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7a49-4460-0e7f-abf5" type="min"/>
           </constraints>
         </categoryLink>
         <categoryLink id="19ad-7bf1-7420-2bad" name="Use Playtest Rules" hidden="false" targetId="fdf4-0683-3e84-5a4b" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="7b48-0020-e262-162d" type="max"/>
           </constraints>
@@ -838,2688 +432,1164 @@
       </categoryLinks>
     </forceEntry>
   </forceEntries>
-  <selectionEntries/>
   <entryLinks>
-    <entryLink id="55a4-3c7c-28ec-878f" name="New EntryLink" hidden="false" targetId="dab7-cef6-7603-3be2" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
+    <entryLink id="55a4-3c7c-28ec-878f" name="New EntryLink" hidden="false" collective="false" targetId="dab7-cef6-7603-3be2" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="55a4-3c7c-28ec-878f-54726f6f707323232344415441232323" hidden="false" targetId="54726f6f707323232344415441232323" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
+        <categoryLink id="55a4-3c7c-28ec-878f-54726f6f707323232344415441232323" hidden="false" targetId="54726f6f707323232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="0721-ca72-d85d-be71" name="Legio Custodes Custodian Guard Squad" hidden="false" targetId="c6da-100a-a655-0e7d" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
+    <entryLink id="0721-ca72-d85d-be71" name="Legio Custodes Custodian Guard Squad" hidden="false" collective="false" targetId="c6da-100a-a655-0e7d" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="0721-ca72-d85d-be71-54726f6f707323232344415441232323" hidden="false" targetId="54726f6f707323232344415441232323" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
+        <categoryLink id="0721-ca72-d85d-be71-54726f6f707323232344415441232323" hidden="false" targetId="54726f6f707323232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="527b-773b-9fc2-3664" name="Legio Custodes Caladius Grav-Tank" hidden="false" targetId="2973-f08c-8b34-5df5" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
+    <entryLink id="527b-773b-9fc2-3664" name="Legio Custodes Caladius Grav-Tank" hidden="false" collective="false" targetId="2973-f08c-8b34-5df5" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="527b-773b-9fc2-3664-486561767920537570706f727423232344415441232323" hidden="false" targetId="486561767920537570706f727423232344415441232323" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
+        <categoryLink id="527b-773b-9fc2-3664-486561767920537570706f727423232344415441232323" hidden="false" targetId="486561767920537570706f727423232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="597e-fb29-b8f0-bca5" name="New EntryLink" hidden="false" targetId="38a5-b278-eb49-3779" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
+    <entryLink id="597e-fb29-b8f0-bca5" name="New EntryLink" hidden="false" collective="false" targetId="38a5-b278-eb49-3779" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="597e-fb29-b8f0-bca5-485123232344415441232323" hidden="false" targetId="485123232344415441232323" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
+        <categoryLink id="597e-fb29-b8f0-bca5-485123232344415441232323" hidden="false" targetId="485123232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="de59-9a90-c4b5-5469" name="New EntryLink" hidden="false" targetId="cc00-5542-b66c-07ee" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
+    <entryLink id="de59-9a90-c4b5-5469" name="New EntryLink" hidden="false" collective="false" targetId="cc00-5542-b66c-07ee" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="de59-9a90-c4b5-5469-485123232344415441232323" hidden="false" targetId="485123232344415441232323" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
+        <categoryLink id="de59-9a90-c4b5-5469-485123232344415441232323" hidden="false" targetId="485123232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="b1fb-32c1-f910-6651" name="New EntryLink" hidden="false" targetId="e5cb-9892-6a0d-9c40" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
+    <entryLink id="b1fb-32c1-f910-6651" name="New EntryLink" hidden="false" collective="false" targetId="e5cb-9892-6a0d-9c40" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="b1fb-32c1-f910-6651-466173742041747461636b23232344415441232323" hidden="false" targetId="466173742041747461636b23232344415441232323" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
+        <categoryLink id="b1fb-32c1-f910-6651-466173742041747461636b23232344415441232323" hidden="false" targetId="466173742041747461636b23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="00ee-96bc-de42-dc49" name="New EntryLink" hidden="false" targetId="6ced-0f69-b659-41da" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
+    <entryLink id="00ee-96bc-de42-dc49" name="New EntryLink" hidden="false" collective="false" targetId="6ced-0f69-b659-41da" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="00ee-96bc-de42-dc49-456c6974657323232344415441232323" hidden="false" targetId="456c6974657323232344415441232323" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
+        <categoryLink id="00ee-96bc-de42-dc49-456c6974657323232344415441232323" hidden="false" targetId="456c6974657323232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="433c-9641-fae4-c698" name="New EntryLink" hidden="false" targetId="95b0-bc7c-b477-069b" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
+    <entryLink id="433c-9641-fae4-c698" name="New EntryLink" hidden="false" collective="false" targetId="95b0-bc7c-b477-069b" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="433c-9641-fae4-c698-456c6974657323232344415441232323" hidden="false" targetId="456c6974657323232344415441232323" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
+        <categoryLink id="433c-9641-fae4-c698-456c6974657323232344415441232323" hidden="false" targetId="456c6974657323232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="fe13-642f-90dd-c376" name="Legio Custodes Contemptor-Galatus Dreadnought" hidden="false" targetId="335e-a873-5aa2-19e0" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
+    <entryLink id="fe13-642f-90dd-c376" name="Legio Custodes Contemptor-Galatus Dreadnought" hidden="false" collective="false" targetId="335e-a873-5aa2-19e0" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="fe13-642f-90dd-c376-486561767920537570706f727423232344415441232323" hidden="false" targetId="486561767920537570706f727423232344415441232323" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
+        <categoryLink id="fe13-642f-90dd-c376-486561767920537570706f727423232344415441232323" hidden="false" targetId="486561767920537570706f727423232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="ce30-2f93-dba9-98c0" name="New EntryLink" hidden="false" targetId="d290-734d-18b9-e387" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
+    <entryLink id="ce30-2f93-dba9-98c0" name="New EntryLink" hidden="false" collective="false" targetId="d290-734d-18b9-e387" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="ce30-2f93-dba9-98c0-456c6974657323232344415441232323" hidden="false" targetId="456c6974657323232344415441232323" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
+        <categoryLink id="ce30-2f93-dba9-98c0-456c6974657323232344415441232323" hidden="false" targetId="456c6974657323232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="2e56-bd49-d9f3-9cb5" name="Legio Custodes Pallas Grav-Attack Squadron" hidden="false" targetId="5ef4-118e-6aba-94a9" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
+    <entryLink id="2e56-bd49-d9f3-9cb5" name="Legio Custodes Pallas Grav-Attack Squadron" hidden="false" collective="false" targetId="5ef4-118e-6aba-94a9" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="2e56-bd49-d9f3-9cb5-466173742041747461636b23232344415441232323" hidden="false" targetId="466173742041747461636b23232344415441232323" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
+        <categoryLink id="2e56-bd49-d9f3-9cb5-466173742041747461636b23232344415441232323" hidden="false" targetId="466173742041747461636b23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="69f7-13e8-abc8-7e8f" name="New EntryLink" hidden="false" targetId="5f2c-6d5f-60a2-c648" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
+    <entryLink id="69f7-13e8-abc8-7e8f" name="New EntryLink" hidden="false" collective="false" targetId="5f2c-6d5f-60a2-c648" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="69f7-13e8-abc8-7e8f-486561767920537570706f727423232344415441232323" hidden="false" targetId="486561767920537570706f727423232344415441232323" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
+        <categoryLink id="69f7-13e8-abc8-7e8f-486561767920537570706f727423232344415441232323" hidden="false" targetId="486561767920537570706f727423232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="7066-ede9-5077-68d6" name="New EntryLink" hidden="false" targetId="5e4a-d122-6e76-2634" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
+    <entryLink id="7066-ede9-5077-68d6" name="New EntryLink" hidden="false" collective="false" targetId="5e4a-d122-6e76-2634" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="7066-ede9-5077-68d6-485123232344415441232323" hidden="false" targetId="485123232344415441232323" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
+        <categoryLink id="7066-ede9-5077-68d6-485123232344415441232323" hidden="false" targetId="485123232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="64f9-bed3-1fd6-3379" name="New EntryLink" hidden="false" targetId="1ebb-ff7d-d5f8-ee60" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
+    <entryLink id="64f9-bed3-1fd6-3379" name="New EntryLink" hidden="false" collective="false" targetId="1ebb-ff7d-d5f8-ee60" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="64f9-bed3-1fd6-3379-485123232344415441232323" hidden="false" targetId="485123232344415441232323" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
+        <categoryLink id="64f9-bed3-1fd6-3379-485123232344415441232323" hidden="false" targetId="485123232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="52cd-55ec-998f-deb6" name="New EntryLink" hidden="false" targetId="80ba-e9bc-4e45-0c8f" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
+    <entryLink id="52cd-55ec-998f-deb6" name="New EntryLink" hidden="false" collective="false" targetId="80ba-e9bc-4e45-0c8f" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="52cd-55ec-998f-deb6-456c6974657323232344415441232323" hidden="false" targetId="456c6974657323232344415441232323" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
+        <categoryLink id="52cd-55ec-998f-deb6-456c6974657323232344415441232323" hidden="false" targetId="456c6974657323232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="b954-9079-02fb-cbf5" name="New EntryLink" hidden="false" targetId="26dd-4eb2-fe70-ea73" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
+    <entryLink id="b954-9079-02fb-cbf5" name="New EntryLink" hidden="false" collective="false" targetId="26dd-4eb2-fe70-ea73" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="b954-9079-02fb-cbf5-485123232344415441232323" hidden="false" targetId="485123232344415441232323" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
+        <categoryLink id="b954-9079-02fb-cbf5-485123232344415441232323" hidden="false" targetId="485123232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="7d31-27e1-340d-9f3f" name="New EntryLink" hidden="false" targetId="17c2-d576-4704-9d48" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
+    <entryLink id="7d31-27e1-340d-9f3f" name="New EntryLink" hidden="false" collective="false" targetId="17c2-d576-4704-9d48" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="7d31-27e1-340d-9f3f-466173742041747461636b23232344415441232323" hidden="false" targetId="466173742041747461636b23232344415441232323" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
+        <categoryLink id="7d31-27e1-340d-9f3f-466173742041747461636b23232344415441232323" hidden="false" targetId="466173742041747461636b23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="4cf4-c467-a64c-ed40" name="New EntryLink" hidden="false" targetId="2547-40ab-cb22-90a2" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
+    <entryLink id="4cf4-c467-a64c-ed40" name="New EntryLink" hidden="false" collective="false" targetId="2547-40ab-cb22-90a2" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="4cf4-c467-a64c-ed40-54726f6f707323232344415441232323" hidden="false" targetId="54726f6f707323232344415441232323" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
+        <categoryLink id="4cf4-c467-a64c-ed40-54726f6f707323232344415441232323" hidden="false" targetId="54726f6f707323232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="e31e-ad7b-b162-dcf5" name="New EntryLink" hidden="false" targetId="08a1-0907-5ed0-2a6c" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
+    <entryLink id="e31e-ad7b-b162-dcf5" name="New EntryLink" hidden="false" collective="false" targetId="08a1-0907-5ed0-2a6c" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="e31e-ad7b-b162-dcf5-486561767920537570706f727423232344415441232323" hidden="false" targetId="486561767920537570706f727423232344415441232323" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
+        <categoryLink id="e31e-ad7b-b162-dcf5-486561767920537570706f727423232344415441232323" hidden="false" targetId="486561767920537570706f727423232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="990c-a548-b447-1e9a" name="New EntryLink" hidden="false" targetId="7017-b303-200f-730b" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
+    <entryLink id="990c-a548-b447-1e9a" name="New EntryLink" hidden="false" collective="false" targetId="7017-b303-200f-730b" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="990c-a548-b447-1e9a-54726f6f707323232344415441232323" hidden="false" targetId="54726f6f707323232344415441232323" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
+        <categoryLink id="990c-a548-b447-1e9a-54726f6f707323232344415441232323" hidden="false" targetId="54726f6f707323232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="df91-2dd1-d3bf-007a" name="New EntryLink" hidden="false" targetId="16d6-25c4-af92-4329" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
+    <entryLink id="df91-2dd1-d3bf-007a" name="New EntryLink" hidden="false" collective="false" targetId="16d6-25c4-af92-4329" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="df91-2dd1-d3bf-007a-1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
+        <categoryLink id="df91-2dd1-d3bf-007a-1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="ec5b-a27a-4574-fcbb" name="New EntryLink" hidden="false" targetId="fb92-d215-2011-f911" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
+    <entryLink id="ec5b-a27a-4574-fcbb" name="New EntryLink" hidden="false" collective="false" targetId="fb92-d215-2011-f911" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="ec5b-a27a-4574-fcbb-1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
+        <categoryLink id="ec5b-a27a-4574-fcbb-1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="a6e2-0bf3-51ac-d3e9" name="New EntryLink" hidden="false" targetId="a172-78de-aaa6-2201" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
+    <entryLink id="a6e2-0bf3-51ac-d3e9" name="New EntryLink" hidden="false" collective="false" targetId="a172-78de-aaa6-2201" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="a6e2-0bf3-51ac-d3e9-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
+        <categoryLink id="a6e2-0bf3-51ac-d3e9-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="3e1c-c1d7-5869-99af" name="New EntryLink" hidden="false" targetId="df05-8179-624e-f8b2" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
+    <entryLink id="3e1c-c1d7-5869-99af" name="New EntryLink" hidden="false" collective="false" targetId="df05-8179-624e-f8b2" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="3e1c-c1d7-5869-99af-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
+        <categoryLink id="3e1c-c1d7-5869-99af-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="6350-dbfb-92aa-1a71" name="New EntryLink" hidden="false" targetId="04bf-6c22-19fb-4e46" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
+    <entryLink id="6350-dbfb-92aa-1a71" name="New EntryLink" hidden="false" collective="false" targetId="04bf-6c22-19fb-4e46" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="6350-dbfb-92aa-1a71-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
+        <categoryLink id="6350-dbfb-92aa-1a71-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="8bb3-5432-57ce-d3c6" name="New EntryLink" hidden="false" targetId="0f73-97f2-b832-f6d0" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
+    <entryLink id="8bb3-5432-57ce-d3c6" name="New EntryLink" hidden="false" collective="false" targetId="0f73-97f2-b832-f6d0" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="8bb3-5432-57ce-d3c6-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
+        <categoryLink id="8bb3-5432-57ce-d3c6-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="5e81-c325-81e7-585b" name="New EntryLink" hidden="false" targetId="595a-908e-96a1-f121" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
+    <entryLink id="5e81-c325-81e7-585b" name="New EntryLink" hidden="false" collective="false" targetId="595a-908e-96a1-f121" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="5e81-c325-81e7-585b-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
+        <categoryLink id="5e81-c325-81e7-585b-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="1b5c-a6b3-188c-511b" name="New EntryLink" hidden="false" targetId="6140-dc64-5896-957f" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
+    <entryLink id="1b5c-a6b3-188c-511b" name="New EntryLink" hidden="false" collective="false" targetId="6140-dc64-5896-957f" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="1b5c-a6b3-188c-511b-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
+        <categoryLink id="1b5c-a6b3-188c-511b-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="bd48-8789-0713-9aba" name="New EntryLink" hidden="false" targetId="e0b3-77ca-af76-bd8b" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
+    <entryLink id="bd48-8789-0713-9aba" name="New EntryLink" hidden="false" collective="false" targetId="e0b3-77ca-af76-bd8b" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="bd48-8789-0713-9aba-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
+        <categoryLink id="bd48-8789-0713-9aba-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="84a7-8b67-aa9e-b91b" name="New EntryLink" hidden="false" targetId="0116-c81b-1c0f-251c" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
+    <entryLink id="84a7-8b67-aa9e-b91b" name="New EntryLink" hidden="false" collective="false" targetId="0116-c81b-1c0f-251c" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="84a7-8b67-aa9e-b91b-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
+        <categoryLink id="84a7-8b67-aa9e-b91b-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="123f-629b-f3e4-b9e0" name="New EntryLink" hidden="false" targetId="3015-0b77-e848-c0f5" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
+    <entryLink id="123f-629b-f3e4-b9e0" name="New EntryLink" hidden="false" collective="false" targetId="3015-0b77-e848-c0f5" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="123f-629b-f3e4-b9e0-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
+        <categoryLink id="123f-629b-f3e4-b9e0-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="d6ad-e26f-6719-568c" name="New EntryLink" hidden="false" targetId="c05d-2231-2481-4037" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
+    <entryLink id="d6ad-e26f-6719-568c" name="New EntryLink" hidden="false" collective="false" targetId="c05d-2231-2481-4037" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="d6ad-e26f-6719-568c-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
+        <categoryLink id="d6ad-e26f-6719-568c-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="7f84-41bd-8d98-965d" name="New EntryLink" hidden="false" targetId="e40b-468f-f1d7-d05d" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
+    <entryLink id="7f84-41bd-8d98-965d" name="New EntryLink" hidden="false" collective="false" targetId="e40b-468f-f1d7-d05d" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="7f84-41bd-8d98-965d-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
+        <categoryLink id="7f84-41bd-8d98-965d-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="664b-7f0c-e827-a28b" name="New EntryLink" hidden="false" targetId="55c6-268b-357f-d070" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
+    <entryLink id="664b-7f0c-e827-a28b" name="New EntryLink" hidden="false" collective="false" targetId="55c6-268b-357f-d070" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="664b-7f0c-e827-a28b-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
+        <categoryLink id="664b-7f0c-e827-a28b-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="07bd-ce47-7d2a-3145" name="New EntryLink" hidden="false" targetId="e10f-7b90-ecd3-80a5" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
+    <entryLink id="07bd-ce47-7d2a-3145" name="New EntryLink" hidden="false" collective="false" targetId="e10f-7b90-ecd3-80a5" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="07bd-ce47-7d2a-3145-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
+        <categoryLink id="07bd-ce47-7d2a-3145-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="c837-6391-c00e-39f3" name="Aegis Defense Line" hidden="false" targetId="a505-05af-bd44-56b6" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
+    <entryLink id="c837-6391-c00e-39f3" name="Aegis Defense Line" hidden="false" collective="false" targetId="a505-05af-bd44-56b6" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="c837-6391-c00e-39f3-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
+        <categoryLink id="c837-6391-c00e-39f3-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="b692-9da3-7f7c-e767" name="New EntryLink" hidden="false" targetId="ab80-0fef-3e93-8e64" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
+    <entryLink id="b692-9da3-7f7c-e767" name="New EntryLink" hidden="false" collective="false" targetId="ab80-0fef-3e93-8e64" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="b692-9da3-7f7c-e767-1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
+        <categoryLink id="b692-9da3-7f7c-e767-1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="0826-246b-1403-0735" name="New EntryLink" hidden="false" targetId="b894-adfc-6d3d-fde4" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
+    <entryLink id="0826-246b-1403-0735" name="New EntryLink" hidden="false" collective="false" targetId="b894-adfc-6d3d-fde4" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="0826-246b-1403-0735-1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
+        <categoryLink id="0826-246b-1403-0735-1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="d2bb-eee9-1b44-5f22" name="Legio Titanicus Reaver Battle Titan" hidden="false" targetId="1fa3-1f86-94a6-bf48" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
+    <entryLink id="d2bb-eee9-1b44-5f22" name="Legio Titanicus Reaver Battle Titan" hidden="false" collective="false" targetId="1fa3-1f86-94a6-bf48" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="d2bb-eee9-1b44-5f22-1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
+        <categoryLink id="d2bb-eee9-1b44-5f22-1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="18fd-5b4a-396b-96e9" name="Legio Custodes Telemon Heavy Dreadnought" hidden="false" targetId="5804-0f3c-116f-46e2" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-    </entryLink>
-    <entryLink id="d2ee-4a5e-54c7-d7ff" name="Orion Assault Dropship" hidden="false" targetId="8594-6f9f-c58d-440d" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
+    <entryLink id="18fd-5b4a-396b-96e9" name="Legio Custodes Telemon Heavy Dreadnought" hidden="false" collective="false" targetId="5804-0f3c-116f-46e2" type="selectionEntry"/>
+    <entryLink id="d2ee-4a5e-54c7-d7ff" name="Orion Assault Dropship" hidden="false" collective="false" targetId="8594-6f9f-c58d-440d" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="7407-408f-5fe2-244c" name="New CategoryLink" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
+        <categoryLink id="7407-408f-5fe2-244c" name="New CategoryLink" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="5f2e-a3ed-84e3-9a4d" name="Legio Custodes Venatari Squad" hidden="false" targetId="702e-27bd-4148-e4e5" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
+    <entryLink id="5f2e-a3ed-84e3-9a4d" name="Legio Custodes Venatari Squad" hidden="false" collective="false" targetId="702e-27bd-4148-e4e5" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="893a-a363-fbc1-7d73" name="Fast Attack" hidden="false" targetId="466173742041747461636b23232344415441232323" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
+        <categoryLink id="893a-a363-fbc1-7d73" name="Fast Attack" hidden="false" targetId="466173742041747461636b23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="54e3-8c7b-733b-a65d" name="Legio Titanicus Warbringer Nemesis Titan" hidden="false" targetId="ecb3-83b9-4ba7-47a9" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
+    <entryLink id="54e3-8c7b-733b-a65d" name="Legio Titanicus Warbringer Nemesis Titan" hidden="false" collective="false" targetId="ecb3-83b9-4ba7-47a9" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="d7e3-aadc-da41-bde9" name="Lords of War" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
+        <categoryLink id="d7e3-aadc-da41-bde9" name="Lords of War" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="4e23-2495-e5df-20e0" name="Ares Gunship" hidden="false" targetId="dc85-086f-2a21-9002" type="selectionEntry">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
+    <entryLink id="4e23-2495-e5df-20e0" name="Ares Gunship" hidden="false" collective="false" targetId="dc85-086f-2a21-9002" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="b249-6170-650f-2ee9" name="New CategoryLink" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
+        <categoryLink id="b249-6170-650f-2ee9" name="New CategoryLink" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
       </categoryLinks>
     </entryLink>
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="dab7-cef6-7603-3be2" name="Legio Custodes Sentinel Guard Squad" hidden="false" collective="false" type="upgrade">
-      <profiles/>
       <rules>
-        <rule id="009e-3165-fcaf-6ae8" name="Shield Barricade" book="Forgeworld.co.uk" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
+        <rule id="009e-3165-fcaf-6ae8" name="Shield Barricade" publicationId="a30a-7522-pubN69988" hidden="false">
           <description>Friendly Infantry units being targeted by ranged attacks which pass through the area occupied by a unit composed entirely of models with this special rule gain a 4+ cover save.</description>
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="7fa2-b2ab-695a-5db5" name="New InfoLink" hidden="false" targetId="38d5-b6eb-bda8-2497" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="4581-e0d5-1da0-7452" name="New InfoLink" hidden="false" targetId="2b06-29a6-641a-b22e" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
+        <infoLink id="7fa2-b2ab-695a-5db5" name="New InfoLink" hidden="false" targetId="38d5-b6eb-bda8-2497" type="rule"/>
+        <infoLink id="4581-e0d5-1da0-7452" name="New InfoLink" hidden="false" targetId="2b06-29a6-641a-b22e" type="rule"/>
       </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
       <selectionEntries>
         <selectionEntry id="a2a0-7ede-3c28-4bc0" name="Sentinel Guard" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="b381-6977-5f72-a434" name="Sentinel Guard" hidden="false" targetId="c131-8798-6ce6-2bcb" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1614-15dd-c31a-8af8" type="min"/>
             <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c447-4e7c-d331-58c6" type="max"/>
           </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
+          <infoLinks>
+            <infoLink id="b381-6977-5f72-a434" name="Sentinel Guard" hidden="false" targetId="c131-8798-6ce6-2bcb" type="profile"/>
+          </infoLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="5ea8-8d8f-151e-5c16" name="May Replace his Sentinel Warblade with:" hidden="false" collective="false" defaultSelectionEntryId="0f27-5c35-7438-092a">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8684-8f1c-38a5-9d06" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1bde-a82f-73c1-ac23" type="min"/>
               </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="0f27-5c35-7438-092a" name="New EntryLink" hidden="false" targetId="0caf-31e2-cd7b-a4dd" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
+                <entryLink id="0f27-5c35-7438-092a" name="New EntryLink" hidden="false" collective="false" targetId="0caf-31e2-cd7b-a4dd" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fbd2-b644-cf17-fd63" type="max"/>
                   </constraints>
-                  <categoryLinks/>
                 </entryLink>
-                <entryLink id="b020-af73-9082-e9fa" name="Solerite Power Gauntlet" hidden="false" targetId="8ba6-041a-ff23-98f6" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
+                <entryLink id="b020-af73-9082-e9fa" name="Solerite Power Gauntlet" hidden="false" collective="false" targetId="8ba6-041a-ff23-98f6" type="selectionEntry">
                   <modifiers>
-                    <modifier type="set" field="points" value="15">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
+                    <modifier type="set" field="points" value="15"/>
                   </modifiers>
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="27d1-0e2a-d1a3-db37" type="max"/>
                   </constraints>
-                  <categoryLinks/>
                 </entryLink>
-                <entryLink id="7615-1d71-82fc-a751" name="Solerite Power Talon" hidden="false" targetId="cb99-fafa-3e9d-035e" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
+                <entryLink id="7615-1d71-82fc-a751" name="Solerite Power Talon" hidden="false" collective="false" targetId="cb99-fafa-3e9d-035e" type="selectionEntry">
                   <modifiers>
-                    <modifier type="set" field="points" value="10">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
+                    <modifier type="set" field="points" value="10"/>
                   </modifiers>
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="686a-7b13-afd3-de4d" type="max"/>
                   </constraints>
-                  <categoryLinks/>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="ecc2-bd0c-83ea-d7a2" name="One may replace his Shield with:" hidden="false" collective="false" defaultSelectionEntryId="e738-a249-1860-ca8e">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d57c-2560-27b1-1aef" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3c76-2e3c-0b50-8663" type="min"/>
               </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="6f28-af10-36bd-b15c" name="Magisterium Vexilla" hidden="false" targetId="b7c1-be91-5d72-c763" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
+                <entryLink id="6f28-af10-36bd-b15c" name="Magisterium Vexilla" hidden="false" collective="false" targetId="b7c1-be91-5d72-c763" type="selectionEntry">
                   <modifiers>
-                    <modifier type="set" field="points" value="10">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
+                    <modifier type="set" field="points" value="10"/>
                   </modifiers>
                   <constraints>
                     <constraint field="selections" scope="dab7-cef6-7603-3be2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9d7a-15a6-a97b-889e" type="max"/>
                   </constraints>
-                  <categoryLinks/>
                 </entryLink>
-                <entryLink id="e738-a249-1860-ca8e" name="Praesidium Shield" hidden="false" targetId="a521-ee67-6936-d9b2" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
+                <entryLink id="e738-a249-1860-ca8e" name="Praesidium Shield" hidden="false" collective="false" targetId="a521-ee67-6936-d9b2" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a682-d568-c3c4-43e7" type="max"/>
                   </constraints>
-                  <categoryLinks/>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks>
-            <entryLink id="04f0-96c1-aca6-f3cf" name="New EntryLink" hidden="false" targetId="3060-5ce0-cb9d-3bbd" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="04f0-96c1-aca6-f3cf" name="New EntryLink" hidden="false" collective="false" targetId="3060-5ce0-cb9d-3bbd" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="595e-4105-7fcc-47a1" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7f48-a18c-2638-a4cc" type="min"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="88fe-aab8-dbb7-eda7" name="New EntryLink" hidden="false" targetId="2c5a-1976-04e4-e277" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="88fe-aab8-dbb7-eda7" name="New EntryLink" hidden="false" collective="false" targetId="2c5a-1976-04e4-e277" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="50d3-735e-afa9-6ae0" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5efe-a7b6-8dba-9626" type="max"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="9895-ff78-d4ba-f1dc" name="New EntryLink" hidden="false" targetId="011a-b751-e773-6b90" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="9895-ff78-d4ba-f1dc" name="New EntryLink" hidden="false" collective="false" targetId="011a-b751-e773-6b90" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="444c-dc3e-0596-771a" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2d6c-2c27-9e5a-b6fd" type="max"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="0332-e833-ab17-10e8" name="New EntryLink" hidden="false" targetId="42e2-2cc0-6353-4d47" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="0332-e833-ab17-10e8" name="New EntryLink" hidden="false" collective="false" targetId="42e2-2cc0-6353-4d47" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f84a-dd7a-f928-f070" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b5be-1178-ec9b-f1ea" type="max"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="pts" costTypeId="points" value="65.0"/>
+            <cost name="pts" typeId="points" value="65.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="2be2-aa65-9e16-fba1" name="Entire squad may be equipped with:" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="3fdd-fc76-46bf-1f02" name="Melta bombs" hidden="false" targetId="648a-e853-bb44-9cee" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
+            <entryLink id="3fdd-fc76-46bf-1f02" name="Melta bombs" hidden="false" collective="false" targetId="648a-e853-bb44-9cee" type="selectionEntry">
               <modifiers>
                 <modifier type="increment" field="points" value="5">
                   <repeats>
                     <repeat field="selections" scope="dab7-cef6-7603-3be2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a2a0-7ede-3c28-4bc0" repeats="1" roundUp="false"/>
                   </repeats>
-                  <conditions/>
-                  <conditionGroups/>
                 </modifier>
               </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dfc0-64c6-dd2a-3dcc" type="max"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="5fd8-a65f-95f0-1092" name="Arae-Shrikes" hidden="false" targetId="be4a-0e91-0f1f-4c1d" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
+            <entryLink id="5fd8-a65f-95f0-1092" name="Arae-Shrikes" hidden="false" collective="false" targetId="be4a-0e91-0f1f-4c1d" type="selectionEntry">
               <modifiers>
                 <modifier type="increment" field="points" value="15">
                   <repeats>
                     <repeat field="selections" scope="dab7-cef6-7603-3be2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a2a0-7ede-3c28-4bc0" repeats="1" roundUp="false"/>
                   </repeats>
-                  <conditions/>
-                  <conditionGroups/>
                 </modifier>
               </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d1aa-5e65-a3c0-64de" type="max"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="719e-1eaa-b9f1-67b7" name="New EntryLink" hidden="false" targetId="81f8-eb55-e1fd-c90a" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
+            <entryLink id="719e-1eaa-b9f1-67b7" name="New EntryLink" hidden="false" collective="false" targetId="81f8-eb55-e1fd-c90a" type="selectionEntry">
               <modifiers>
                 <modifier type="increment" field="points" value="5">
                   <repeats>
                     <repeat field="selections" scope="dab7-cef6-7603-3be2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a2a0-7ede-3c28-4bc0" repeats="1" roundUp="false"/>
                   </repeats>
-                  <conditions/>
-                  <conditionGroups/>
                 </modifier>
               </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e12f-6414-c4e6-6d7d" type="max"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="e1a4-8565-2728-9896" name="Teleportation Transponders" hidden="false" targetId="7d72-4429-d25c-54f3" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
+            <entryLink id="e1a4-8565-2728-9896" name="Teleportation Transponders" hidden="false" collective="false" targetId="7d72-4429-d25c-54f3" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="7141-4a53-9d98-e764" name="New EntryLink" hidden="false" targetId="a502-5799-a2f4-310b" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
+        <entryLink id="7141-4a53-9d98-e764" name="New EntryLink" hidden="false" collective="false" targetId="a502-5799-a2f4-310b" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="001c-24d2-d501-b158" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0484-5560-ae13-27f3" type="min"/>
           </constraints>
-          <categoryLinks/>
         </entryLink>
-        <entryLink id="f0ee-b60e-2ab3-8a9e" name="New EntryLink" hidden="false" targetId="c43b-5c09-9eae-27ba" type="selectionEntryGroup">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
+        <entryLink id="f0ee-b60e-2ab3-8a9e" name="New EntryLink" hidden="false" collective="false" targetId="c43b-5c09-9eae-27ba" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
-              <repeats/>
               <conditions>
                 <condition field="selections" scope="dab7-cef6-7603-3be2" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a2a0-7ede-3c28-4bc0" type="greaterThan"/>
               </conditions>
-              <conditionGroups/>
             </modifier>
           </modifiers>
-          <constraints/>
-          <categoryLinks/>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="pts" costTypeId="points" value="-15.0"/>
+        <cost name="pts" typeId="points" value="-15.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="c6da-100a-a655-0e7d" name="Legio Custodes Custodian Guard Squad" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
       <infoLinks>
-        <infoLink id="0338-a6b2-1055-153f" name="New InfoLink" hidden="false" targetId="38d5-b6eb-bda8-2497" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="c02c-dce3-16fd-400d" name="New InfoLink" hidden="false" targetId="2b06-29a6-641a-b22e" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
+        <infoLink id="0338-a6b2-1055-153f" name="New InfoLink" hidden="false" targetId="38d5-b6eb-bda8-2497" type="rule"/>
+        <infoLink id="c02c-dce3-16fd-400d" name="New InfoLink" hidden="false" targetId="2b06-29a6-641a-b22e" type="rule"/>
       </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
       <selectionEntries>
         <selectionEntry id="495c-766f-15c3-481e" name="Custodian Guard" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="1dd0-4071-2165-5a13" name="Custodian Guard" hidden="false" targetId="99fd-6a57-9e37-571e" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9cfa-16b1-efe1-7112" type="min"/>
             <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="48a3-b4c9-7fc8-72a4" type="max"/>
           </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
+          <infoLinks>
+            <infoLink id="1dd0-4071-2165-5a13" name="Custodian Guard" hidden="false" targetId="99fd-6a57-9e37-571e" type="profile"/>
+          </infoLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="209d-803b-f874-681e" name="May Replace his Custodian Spear with:" hidden="false" collective="false" defaultSelectionEntryId="8f84-e218-f34d-0ec1">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e86a-8645-7f0f-a02a" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b8d9-874f-18d4-cfb0" type="min"/>
               </constraints>
-              <categoryLinks/>
               <selectionEntries>
                 <selectionEntry id="04f0-13a1-4635-e602" name="Magisterium Vexilla and a Master-Crafted Power Weapon" hidden="false" collective="false" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
                   <modifiers>
                     <modifier type="set" field="a451-7c30-b038-f2fe" value="0.0">
-                      <repeats/>
                       <conditions>
                         <condition field="selections" scope="c6da-100a-a655-0e7d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1315-6777-dfa3-68c1" type="equalTo"/>
                       </conditions>
-                      <conditionGroups/>
                     </modifier>
                   </modifiers>
                   <constraints>
                     <constraint field="selections" scope="c6da-100a-a655-0e7d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a451-7c30-b038-f2fe" type="max"/>
                   </constraints>
-                  <categoryLinks/>
-                  <selectionEntries/>
                   <selectionEntryGroups>
                     <selectionEntryGroup id="6286-8a46-9fd9-a2f8" name="Power Weapon" hidden="false" collective="false">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
                       <constraints>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e884-a63e-db2a-9011" type="max"/>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ebc-4cc3-d8e6-38b9" type="min"/>
                       </constraints>
-                      <categoryLinks/>
                       <selectionEntries>
                         <selectionEntry id="64b4-b61d-920b-62c4" name="Power Sword" hidden="false" collective="false" type="upgrade">
-                          <profiles/>
-                          <rules/>
                           <infoLinks>
-                            <infoLink id="0ef4-108c-7890-342b" name="New InfoLink" hidden="false" targetId="038e-23ec-4886-8b00" type="profile">
-                              <profiles/>
-                              <rules/>
-                              <infoLinks/>
-                              <modifiers/>
-                            </infoLink>
-                            <infoLink id="3096-f667-cfb5-c644" name="New InfoLink" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule">
-                              <profiles/>
-                              <rules/>
-                              <infoLinks/>
-                              <modifiers/>
-                            </infoLink>
+                            <infoLink id="0ef4-108c-7890-342b" name="New InfoLink" hidden="false" targetId="038e-23ec-4886-8b00" type="profile"/>
+                            <infoLink id="3096-f667-cfb5-c644" name="New InfoLink" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule"/>
                           </infoLinks>
-                          <modifiers/>
-                          <constraints/>
-                          <categoryLinks/>
-                          <selectionEntries/>
-                          <selectionEntryGroups/>
-                          <entryLinks/>
                           <costs>
-                            <cost name="pts" costTypeId="points" value="0.0"/>
+                            <cost name="pts" typeId="points" value="0.0"/>
                           </costs>
                         </selectionEntry>
                         <selectionEntry id="fee6-5410-e6a7-0c03" name="Power Lance" hidden="false" collective="false" type="upgrade">
-                          <profiles/>
-                          <rules/>
                           <infoLinks>
-                            <infoLink id="a7e2-9227-c829-365e" name="New InfoLink" hidden="false" targetId="fdd4-9bf3-da9d-5479" type="profile">
-                              <profiles/>
-                              <rules/>
-                              <infoLinks/>
-                              <modifiers/>
-                            </infoLink>
-                            <infoLink id="d066-1749-49be-73bc" name="New InfoLink" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule">
-                              <profiles/>
-                              <rules/>
-                              <infoLinks/>
-                              <modifiers/>
-                            </infoLink>
+                            <infoLink id="a7e2-9227-c829-365e" name="New InfoLink" hidden="false" targetId="fdd4-9bf3-da9d-5479" type="profile"/>
+                            <infoLink id="d066-1749-49be-73bc" name="New InfoLink" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule"/>
                           </infoLinks>
-                          <modifiers/>
-                          <constraints/>
-                          <categoryLinks/>
-                          <selectionEntries/>
-                          <selectionEntryGroups/>
-                          <entryLinks/>
                           <costs>
-                            <cost name="pts" costTypeId="points" value="0.0"/>
+                            <cost name="pts" typeId="points" value="0.0"/>
                           </costs>
                         </selectionEntry>
                         <selectionEntry id="f18a-ccd0-0b86-d1de" name="Power Maul" hidden="false" collective="false" type="upgrade">
-                          <profiles/>
-                          <rules/>
                           <infoLinks>
-                            <infoLink id="2e63-e710-f0da-a1eb" name="New InfoLink" hidden="false" targetId="6bbe-f2c1-78e2-da59" type="profile">
-                              <profiles/>
-                              <rules/>
-                              <infoLinks/>
-                              <modifiers/>
-                            </infoLink>
-                            <infoLink id="4863-5a59-c7ca-8d9f" name="New InfoLink" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule">
-                              <profiles/>
-                              <rules/>
-                              <infoLinks/>
-                              <modifiers/>
-                            </infoLink>
+                            <infoLink id="2e63-e710-f0da-a1eb" name="New InfoLink" hidden="false" targetId="6bbe-f2c1-78e2-da59" type="profile"/>
+                            <infoLink id="4863-5a59-c7ca-8d9f" name="New InfoLink" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule"/>
                           </infoLinks>
-                          <modifiers/>
-                          <constraints/>
-                          <categoryLinks/>
-                          <selectionEntries/>
-                          <selectionEntryGroups/>
-                          <entryLinks/>
                           <costs>
-                            <cost name="pts" costTypeId="points" value="0.0"/>
+                            <cost name="pts" typeId="points" value="0.0"/>
                           </costs>
                         </selectionEntry>
                         <selectionEntry id="b2cc-50df-b08d-42f2" name="Power Axe" hidden="false" collective="false" type="upgrade">
-                          <profiles/>
-                          <rules/>
                           <infoLinks>
-                            <infoLink id="4506-705b-bc95-a608" name="New InfoLink" hidden="false" targetId="b3af-1eca-6629-4894" type="profile">
-                              <profiles/>
-                              <rules/>
-                              <infoLinks/>
-                              <modifiers/>
-                            </infoLink>
-                            <infoLink id="7aad-d9ed-ad6f-7154" name="New InfoLink" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule">
-                              <profiles/>
-                              <rules/>
-                              <infoLinks/>
-                              <modifiers/>
-                            </infoLink>
+                            <infoLink id="4506-705b-bc95-a608" name="New InfoLink" hidden="false" targetId="b3af-1eca-6629-4894" type="profile"/>
+                            <infoLink id="7aad-d9ed-ad6f-7154" name="New InfoLink" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule"/>
                           </infoLinks>
-                          <modifiers/>
-                          <constraints/>
-                          <categoryLinks/>
-                          <selectionEntries/>
-                          <selectionEntryGroups/>
-                          <entryLinks/>
                           <costs>
-                            <cost name="pts" costTypeId="points" value="0.0"/>
+                            <cost name="pts" typeId="points" value="0.0"/>
                           </costs>
                         </selectionEntry>
                       </selectionEntries>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
                     </selectionEntryGroup>
                   </selectionEntryGroups>
                   <entryLinks>
-                    <entryLink id="5f0d-c128-d040-9985" name="New EntryLink" hidden="false" targetId="b7c1-be91-5d72-c763" type="selectionEntry">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
+                    <entryLink id="5f0d-c128-d040-9985" name="New EntryLink" hidden="false" collective="false" targetId="b7c1-be91-5d72-c763" type="selectionEntry">
                       <constraints>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f0fd-7ca7-086c-1d80" type="max"/>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a587-4542-2c21-e3fb" type="min"/>
                       </constraints>
-                      <categoryLinks/>
                     </entryLink>
                   </entryLinks>
                   <costs>
-                    <cost name="pts" costTypeId="points" value="15.0"/>
+                    <cost name="pts" typeId="points" value="15.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="1315-6777-dfa3-68c1" name="Magisterium Vexilla and a Sentinel Warblade" hidden="false" collective="false" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
                   <modifiers>
                     <modifier type="set" field="949e-bec5-2e77-881d" value="0.0">
-                      <repeats/>
                       <conditions>
                         <condition field="selections" scope="c6da-100a-a655-0e7d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="04f0-13a1-4635-e602" type="equalTo"/>
                       </conditions>
-                      <conditionGroups/>
                     </modifier>
                   </modifiers>
                   <constraints>
                     <constraint field="selections" scope="c6da-100a-a655-0e7d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="949e-bec5-2e77-881d" type="max"/>
                   </constraints>
-                  <categoryLinks/>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
                   <entryLinks>
-                    <entryLink id="3df8-e595-70a3-00c9" name="New EntryLink" hidden="false" targetId="0caf-31e2-cd7b-a4dd" type="selectionEntry">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
+                    <entryLink id="3df8-e595-70a3-00c9" name="New EntryLink" hidden="false" collective="false" targetId="0caf-31e2-cd7b-a4dd" type="selectionEntry">
                       <constraints>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="22f8-783e-0abe-fd49" type="max"/>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3f92-cc43-3214-a2fe" type="min"/>
                       </constraints>
-                      <categoryLinks/>
                     </entryLink>
-                    <entryLink id="8480-3939-03cd-d6aa" name="New EntryLink" hidden="false" targetId="b7c1-be91-5d72-c763" type="selectionEntry">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
+                    <entryLink id="8480-3939-03cd-d6aa" name="New EntryLink" hidden="false" collective="false" targetId="b7c1-be91-5d72-c763" type="selectionEntry">
                       <constraints>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="424f-2748-8ab2-acbd" type="max"/>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f3a-ae00-9e6d-8d26" type="min"/>
                       </constraints>
-                      <categoryLinks/>
                     </entryLink>
                   </entryLinks>
                   <costs>
-                    <cost name="pts" costTypeId="points" value="20.0"/>
+                    <cost name="pts" typeId="points" value="20.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
-              <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="8f84-e218-f34d-0ec1" name="Guardian Spear" hidden="false" targetId="dc9c-fe1d-8c26-fb07" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
+                <entryLink id="8f84-e218-f34d-0ec1" name="Guardian Spear" hidden="false" collective="false" targetId="dc9c-fe1d-8c26-fb07" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4fba-277f-9558-a937" type="max"/>
                   </constraints>
-                  <categoryLinks/>
                 </entryLink>
-                <entryLink id="2e20-14ce-3188-1401" name="Pyrithite Spear" hidden="false" targetId="4af1-fc20-e881-7ad9" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
+                <entryLink id="2e20-14ce-3188-1401" name="Pyrithite Spear" hidden="false" collective="false" targetId="4af1-fc20-e881-7ad9" type="selectionEntry">
                   <modifiers>
-                    <modifier type="set" field="points" value="15">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
+                    <modifier type="set" field="points" value="15"/>
                   </modifiers>
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="83b3-f624-4191-aa79" type="max"/>
                   </constraints>
-                  <categoryLinks/>
                 </entryLink>
-                <entryLink id="da95-2481-9d42-f8a8" name="Adrasite Spear" hidden="false" targetId="0179-aa55-899c-aa0b" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
+                <entryLink id="da95-2481-9d42-f8a8" name="Adrasite Spear" hidden="false" collective="false" targetId="0179-aa55-899c-aa0b" type="selectionEntry">
                   <modifiers>
-                    <modifier type="set" field="points" value="10">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
+                    <modifier type="set" field="points" value="10"/>
                   </modifiers>
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5af4-bf15-3c00-51e3" type="max"/>
                   </constraints>
-                  <categoryLinks/>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks>
-            <entryLink id="fa61-dabd-f850-0835" name="New EntryLink" hidden="false" targetId="3060-5ce0-cb9d-3bbd" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="fa61-dabd-f850-0835" name="New EntryLink" hidden="false" collective="false" targetId="3060-5ce0-cb9d-3bbd" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5a21-f630-db11-e9c3" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="487a-6000-c4d8-b7e2" type="min"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="f17d-fdfa-c409-b08d" name="New EntryLink" hidden="false" targetId="2c5a-1976-04e4-e277" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="f17d-fdfa-c409-b08d" name="New EntryLink" hidden="false" collective="false" targetId="2c5a-1976-04e4-e277" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1356-abcf-7b63-3105" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5e80-2755-0268-853a" type="max"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="5a87-4a7a-b0c4-6934" name="New EntryLink" hidden="false" targetId="011a-b751-e773-6b90" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="5a87-4a7a-b0c4-6934" name="New EntryLink" hidden="false" collective="false" targetId="011a-b751-e773-6b90" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="be48-f494-d09f-bac6" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f6dd-628b-154e-0397" type="max"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="c221-cc93-bcfd-b030" name="New EntryLink" hidden="false" targetId="42e2-2cc0-6353-4d47" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="c221-cc93-bcfd-b030" name="New EntryLink" hidden="false" collective="false" targetId="42e2-2cc0-6353-4d47" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7bbc-eabd-2b6a-53f3" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d319-843c-e529-06f5" type="max"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="pts" costTypeId="points" value="55.0"/>
+            <cost name="pts" typeId="points" value="55.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="47bb-c967-e031-4dae" name="Entire squad may be equipped with:" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="0a04-5d21-6a26-4877" name="New EntryLink" hidden="false" targetId="648a-e853-bb44-9cee" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
+            <entryLink id="0a04-5d21-6a26-4877" name="New EntryLink" hidden="false" collective="false" targetId="648a-e853-bb44-9cee" type="selectionEntry">
               <modifiers>
                 <modifier type="increment" field="points" value="5">
                   <repeats>
                     <repeat field="selections" scope="c6da-100a-a655-0e7d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="495c-766f-15c3-481e" repeats="1" roundUp="false"/>
                   </repeats>
-                  <conditions/>
-                  <conditionGroups/>
                 </modifier>
               </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="687f-99dc-1361-5032" type="max"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="76c2-a1a1-b69b-dd00" name="Arae-Shrikes" hidden="false" targetId="be4a-0e91-0f1f-4c1d" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
+            <entryLink id="76c2-a1a1-b69b-dd00" name="Arae-Shrikes" hidden="false" collective="false" targetId="be4a-0e91-0f1f-4c1d" type="selectionEntry">
               <modifiers>
                 <modifier type="increment" field="points" value="15">
                   <repeats>
                     <repeat field="selections" scope="c6da-100a-a655-0e7d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="495c-766f-15c3-481e" repeats="1" roundUp="false"/>
                   </repeats>
-                  <conditions/>
-                  <conditionGroups/>
                 </modifier>
               </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5cbe-eb17-7667-aeb4" type="max"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="ee4b-0fce-caa0-9701" name="New EntryLink" hidden="false" targetId="81f8-eb55-e1fd-c90a" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
+            <entryLink id="ee4b-0fce-caa0-9701" name="New EntryLink" hidden="false" collective="false" targetId="81f8-eb55-e1fd-c90a" type="selectionEntry">
               <modifiers>
                 <modifier type="increment" field="points" value="5">
                   <repeats>
                     <repeat field="selections" scope="c6da-100a-a655-0e7d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="495c-766f-15c3-481e" repeats="1" roundUp="false"/>
                   </repeats>
-                  <conditions/>
-                  <conditionGroups/>
                 </modifier>
               </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5eca-7fda-79db-f970" type="max"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="339b-b7bd-a225-6d13" name="Teleportation Transponders" hidden="false" targetId="7d72-4429-d25c-54f3" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
+            <entryLink id="339b-b7bd-a225-6d13" name="Teleportation Transponders" hidden="false" collective="false" targetId="7d72-4429-d25c-54f3" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="b4f6-43b7-f28e-6bda" name="New EntryLink" hidden="false" targetId="a502-5799-a2f4-310b" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
+        <entryLink id="b4f6-43b7-f28e-6bda" name="New EntryLink" hidden="false" collective="false" targetId="a502-5799-a2f4-310b" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2104-08ca-dd74-6b78" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="22c1-269e-5afb-b58d" type="min"/>
           </constraints>
-          <categoryLinks/>
         </entryLink>
-        <entryLink id="b1da-cf75-29de-2197" name="New EntryLink" hidden="false" targetId="c43b-5c09-9eae-27ba" type="selectionEntryGroup">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
+        <entryLink id="b1da-cf75-29de-2197" name="New EntryLink" hidden="false" collective="false" targetId="c43b-5c09-9eae-27ba" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
-              <repeats/>
               <conditions>
                 <condition field="selections" scope="c6da-100a-a655-0e7d" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="495c-766f-15c3-481e" type="greaterThan"/>
               </conditions>
-              <conditionGroups/>
             </modifier>
           </modifiers>
-          <constraints/>
-          <categoryLinks/>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="2973-f08c-8b34-5df5" name="Legio Custodes Caladius Grav-Tank" hidden="false" collective="false" type="upgrade">
       <profiles>
-        <profile id="2479-4bfa-1a6a-2ffe" name="Caladius Grav-Tank" book="White Dwarf" hidden="false" profileTypeId="56656869636c6523232344415441232323" profileTypeName="Vehicle">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
+        <profile id="2479-4bfa-1a6a-2ffe" name="Caladius Grav-Tank" publicationId="a30a-7522-pubN72320" hidden="false" typeId="56656869636c6523232344415441232323" typeName="Vehicle">
           <characteristics>
-            <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="5"/>
-            <characteristic name="Front" characteristicTypeId="46726f6e7423232344415441232323" value="13"/>
-            <characteristic name="Side" characteristicTypeId="5369646523232344415441232323" value="13"/>
-            <characteristic name="Rear" characteristicTypeId="5265617223232344415441232323" value="11"/>
-            <characteristic name="HP" characteristicTypeId="485023232344415441232323" value="3"/>
-            <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Vehicle (Skimmer, Fast)"/>
+            <characteristic name="BS" typeId="425323232344415441232323">5</characteristic>
+            <characteristic name="Front" typeId="46726f6e7423232344415441232323">13</characteristic>
+            <characteristic name="Side" typeId="5369646523232344415441232323">13</characteristic>
+            <characteristic name="Rear" typeId="5265617223232344415441232323">11</characteristic>
+            <characteristic name="HP" typeId="485023232344415441232323">3</characteristic>
+            <characteristic name="Type" typeId="5479706523232344415441232323">Vehicle (Skimmer, Fast)</characteristic>
           </characteristics>
         </profile>
       </profiles>
-      <rules/>
       <infoLinks>
-        <infoLink id="5967-19b4-7350-9ea7" name="New InfoLink" hidden="false" targetId="d219-2314-4834-c054" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="74e3-ca65-c8b6-4c35" name="New InfoLink" hidden="false" targetId="de18-25a0-504b-74be" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="b34e-a5d7-20ae-1693" name="New InfoLink" hidden="false" targetId="1254-9285-e876-010d" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
+        <infoLink id="5967-19b4-7350-9ea7" name="New InfoLink" hidden="false" targetId="d219-2314-4834-c054" type="rule"/>
+        <infoLink id="74e3-ca65-c8b6-4c35" name="New InfoLink" hidden="false" targetId="de18-25a0-504b-74be" type="rule"/>
+        <infoLink id="b34e-a5d7-20ae-1693" name="New InfoLink" hidden="false" targetId="1254-9285-e876-010d" type="rule"/>
       </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
       <selectionEntries>
         <selectionEntry id="02b5-0bb6-d293-dbbf" name="Twin-linked Lastrum Bolt Cannon" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="8338-d45d-9333-4576" name="New InfoLink" hidden="false" targetId="10a8-8d89-0bec-3e21" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="84d1-1cb1-f248-4762" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3086-1742-6894-7053" type="min"/>
           </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
+          <infoLinks>
+            <infoLink id="8338-d45d-9333-4576" name="New InfoLink" hidden="false" targetId="10a8-8d89-0bec-3e21" type="rule"/>
+          </infoLinks>
           <entryLinks>
-            <entryLink id="b7ca-8248-becf-9427" name="Lastrum Bolt Cannon" hidden="false" targetId="e854-b201-250d-5b1b" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="b7ca-8248-becf-9427" name="Lastrum Bolt Cannon" hidden="false" collective="false" targetId="e854-b201-250d-5b1b" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5e9b-a5b1-173b-ce87" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d043-7169-40b3-553c" type="min"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="4d8b-d09f-bde5-1b24" name="May take any of the following upgrades:" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="7d96-43a5-9de8-7675" name="Extra Armour" hidden="false" targetId="a6cd-f04b-711e-c083" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="ff55-44cd-7d7e-82a5" name="New EntryLink" hidden="false" targetId="eef6-a613-e479-7274" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
+            <entryLink id="7d96-43a5-9de8-7675" name="Extra Armour" hidden="false" collective="false" targetId="a6cd-f04b-711e-c083" type="selectionEntry"/>
+            <entryLink id="ff55-44cd-7d7e-82a5" name="New EntryLink" hidden="false" collective="false" targetId="eef6-a613-e479-7274" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="1619-cdde-794e-0786" name="Illastus Accelerator Cannon" hidden="false" collective="false" defaultSelectionEntryId="c689-06f2-ee31-012a">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5c06-54d9-7b0b-f23c" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="36d5-c624-a43c-e736" type="min"/>
           </constraints>
-          <categoryLinks/>
           <selectionEntries>
             <selectionEntry id="c689-06f2-ee31-012a" name="Illastus Accelerator Cannon" hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="1579-25c5-210b-861c" name="Twin-linked" hidden="false" targetId="10a8-8d89-0bec-3e21" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
               <modifiers>
-                <modifier type="set" field="name" value="Twin-Linked Illastus Accelerator Cannon">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
+                <modifier type="set" field="name" value="Twin-Linked Illastus Accelerator Cannon"/>
               </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="37d8-6202-28c0-0052" type="max"/>
               </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
+              <infoLinks>
+                <infoLink id="1579-25c5-210b-861c" name="Twin-linked" hidden="false" targetId="10a8-8d89-0bec-3e21" type="rule"/>
+              </infoLinks>
               <entryLinks>
-                <entryLink id="4c1f-4e49-7d66-52fc" name="Illastus Accelerator Cannon" hidden="false" targetId="d9f3-ece0-5749-021e" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
+                <entryLink id="4c1f-4e49-7d66-52fc" name="Illastus Accelerator Cannon" hidden="false" collective="false" targetId="d9f3-ece0-5749-021e" type="selectionEntry">
                   <modifiers>
-                    <modifier type="set" field="name" value="Twin-Linked Illastus Accelerator Cannon">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
+                    <modifier type="set" field="name" value="Twin-Linked Illastus Accelerator Cannon"/>
                   </modifiers>
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f94d-ac77-d654-e8fb" type="min"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e091-e9d8-65de-383a" type="max"/>
                   </constraints>
-                  <categoryLinks/>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
+                <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1a44-d231-f811-79a2" name="Arachnus Heavy Blaze Cannon" hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="816c-b96b-c88d-c685" name="New InfoLink" hidden="false" targetId="10a8-8d89-0bec-3e21" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
               <modifiers>
-                <modifier type="set" field="name" value="Twin-Linked Arachnus Heavy Blaze Cannon">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
+                <modifier type="set" field="name" value="Twin-Linked Arachnus Heavy Blaze Cannon"/>
               </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ace5-b0fb-7510-ef42" type="max"/>
               </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
+              <infoLinks>
+                <infoLink id="816c-b96b-c88d-c685" name="New InfoLink" hidden="false" targetId="10a8-8d89-0bec-3e21" type="rule"/>
+              </infoLinks>
               <entryLinks>
-                <entryLink id="ea0c-7693-8f54-6862" name="Arachnus Heavy Blaze cannon" hidden="false" targetId="9cee-6cf2-e0af-4002" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
+                <entryLink id="ea0c-7693-8f54-6862" name="Arachnus Heavy Blaze cannon" hidden="false" collective="false" targetId="9cee-6cf2-e0af-4002" type="selectionEntry">
                   <modifiers>
-                    <modifier type="set" field="name" value="Twin-Linked Arachnus Heavy Blaze Cannon">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
+                    <modifier type="set" field="name" value="Twin-Linked Arachnus Heavy Blaze Cannon"/>
                   </modifiers>
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e6b8-2e45-2bf7-18cb" type="max"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e0ae-fbec-cea9-559b" type="min"/>
                   </constraints>
-                  <categoryLinks/>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="pts" costTypeId="points" value="25.0"/>
+                <cost name="pts" typeId="points" value="25.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
-          <selectionEntryGroups/>
-          <entryLinks/>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="fbee-2bca-d1f3-09b9" name="New EntryLink" hidden="false" targetId="5627-96b7-0b67-5274" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="3f64-d8d7-fcb3-796b" name="New EntryLink" hidden="false" targetId="da74-5542-17da-8a49" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="2f6d-99fe-b325-ac93" name="Searchlight" hidden="false" targetId="da87-4ba8-b8cd-bea3" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
+        <entryLink id="fbee-2bca-d1f3-09b9" name="New EntryLink" hidden="false" collective="false" targetId="5627-96b7-0b67-5274" type="selectionEntry"/>
+        <entryLink id="3f64-d8d7-fcb3-796b" name="New EntryLink" hidden="false" collective="false" targetId="da74-5542-17da-8a49" type="selectionEntry"/>
+        <entryLink id="2f6d-99fe-b325-ac93" name="Searchlight" hidden="false" collective="false" targetId="da87-4ba8-b8cd-bea3" type="selectionEntry">
           <modifiers>
-            <modifier type="set" field="95be-bfe6-c04c-fab4" value="1">
-              <repeats/>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="set" field="points" value="0.0">
-              <repeats/>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
+            <modifier type="set" field="95be-bfe6-c04c-fab4" value="1"/>
+            <modifier type="set" field="points" value="0.0"/>
           </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b29e-abe9-d43a-51f4" type="min"/>
           </constraints>
-          <categoryLinks/>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="pts" costTypeId="points" value="220.0"/>
+        <cost name="pts" typeId="points" value="220.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="5e4a-d122-6e76-2634" name="Legio Custodes Shield Captain" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
       <infoLinks>
-        <infoLink id="05ad-f44a-ac4d-887c" name="New InfoLink" hidden="false" targetId="38d5-b6eb-bda8-2497" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="2a42-1169-edd2-9b91" name="New InfoLink" hidden="false" targetId="2b06-29a6-641a-b22e" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="0d6e-ed17-adc9-b0f4" name="New InfoLink" hidden="false" targetId="0900-71d5-1937-aa96" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="4cb0-8b03-42d7-66ef" name="New InfoLink" hidden="false" targetId="4771-b711-0e74-3aee" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="43ce-ceac-a79d-6cb0" name="New InfoLink" hidden="false" targetId="a080-af1b-fb2e-4860" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="edde-e47b-187c-c952" name="New InfoLink" hidden="false" targetId="3ad4-1c37-d60b-1a4e" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="9fc5-e569-4415-3a56" name="Shield Captain" hidden="false" targetId="943e-ce67-f8bb-fed8" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
+        <infoLink id="05ad-f44a-ac4d-887c" name="New InfoLink" hidden="false" targetId="38d5-b6eb-bda8-2497" type="rule"/>
+        <infoLink id="2a42-1169-edd2-9b91" name="New InfoLink" hidden="false" targetId="2b06-29a6-641a-b22e" type="rule"/>
+        <infoLink id="0d6e-ed17-adc9-b0f4" name="New InfoLink" hidden="false" targetId="0900-71d5-1937-aa96" type="rule"/>
+        <infoLink id="4cb0-8b03-42d7-66ef" name="New InfoLink" hidden="false" targetId="4771-b711-0e74-3aee" type="rule"/>
+        <infoLink id="43ce-ceac-a79d-6cb0" name="New InfoLink" hidden="false" targetId="a080-af1b-fb2e-4860" type="rule"/>
+        <infoLink id="edde-e47b-187c-c952" name="New InfoLink" hidden="false" targetId="3ad4-1c37-d60b-1a4e" type="rule"/>
+        <infoLink id="9fc5-e569-4415-3a56" name="Shield Captain" hidden="false" targetId="943e-ce67-f8bb-fed8" type="profile"/>
       </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
       <selectionEntries>
         <selectionEntry id="5beb-9fea-4ae4-a141" name="A Single Shield Captain in your army may be upgraded to a Tribune as long as the detachment they are part of is 2000 points or more." hidden="false" collective="false" type="upgrade">
-          <profiles/>
+          <modifiers>
+            <modifier type="set" field="0696-9416-701b-3785" value="1">
+              <conditions>
+                <condition field="points" scope="force" value="2000.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" childId="any" type="atLeast"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="0696-9416-701b-3785" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="4ddf-9bea-c0a1-5ad1" type="max"/>
+          </constraints>
           <rules>
             <rule id="0369-cd01-ae2d-dc35" name="Legio Custodes Tribune" hidden="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
               <description>A Legio Custodes Tribune retains all the rules and options listed previously, but gains the Fearless and Eternal Warrior speicla rules. In addition, you may select rather than randomly determine a Warlord Trait for them. If present in your Primary Detachment, a Legio Custodes Tribune must be your Warlord unless Constantin Valdor, Jenetia Krole or the Emperor of Mankind is also present</description>
             </rule>
           </rules>
           <infoLinks>
-            <infoLink id="9717-7156-8e09-7d7c" name="New InfoLink" hidden="false" targetId="dc70-e199-5525-e78c" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="f02c-92b2-7106-86b0" name="New InfoLink" hidden="false" targetId="3e0b-be9f-b7eb-8c5e" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
+            <infoLink id="9717-7156-8e09-7d7c" name="Fearless" hidden="false" targetId="dc70-e199-5525-e78c" type="rule"/>
+            <infoLink id="f02c-92b2-7106-86b0" name="Eternal Warrior" hidden="false" targetId="3e0b-be9f-b7eb-8c5e" type="rule"/>
           </infoLinks>
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <repeats/>
-              <conditions>
-                <condition field="points" scope="force" value="2000.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="any" type="lessThan"/>
-              </conditions>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0696-9416-701b-3785" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9d99-2829-e029-a428" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
           <costs>
-            <cost name="pts" costTypeId="points" value="50.0"/>
+            <cost name="pts" typeId="points" value="50.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="8e20-b55f-d272-d847" name="May Be Equipped with any of the Following:" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="ee42-5914-fd38-2da5" name="Arae-Shrikes" hidden="false" targetId="be4a-0e91-0f1f-4c1d" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
+            <entryLink id="ee42-5914-fd38-2da5" name="Arae-Shrikes" hidden="false" collective="false" targetId="be4a-0e91-0f1f-4c1d" type="selectionEntry">
               <modifiers>
-                <modifier type="set" field="points" value="10">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
+                <modifier type="set" field="points" value="10"/>
               </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1c76-f822-3bd7-2926" type="max"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="970f-2368-d143-5d63" name="Praesidium Shield" hidden="false" targetId="a521-ee67-6936-d9b2" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
+            <entryLink id="970f-2368-d143-5d63" name="Praesidium Shield" hidden="false" collective="false" targetId="a521-ee67-6936-d9b2" type="selectionEntry">
               <modifiers>
-                <modifier type="set" field="points" value="15">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
+                <modifier type="set" field="points" value="15"/>
               </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bdf7-a7f4-3ce2-4ee5" type="max"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="1441-8bce-071d-e567" name="Teleportation Transponders" hidden="false" targetId="81f8-eb55-e1fd-c90a" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
+            <entryLink id="1441-8bce-071d-e567" name="Teleportation Transponders" hidden="false" collective="false" targetId="81f8-eb55-e1fd-c90a" type="selectionEntry">
               <modifiers>
-                <modifier type="set" field="points" value="10">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
+                <modifier type="set" field="points" value="10"/>
               </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="12de-51f8-f572-f2d9" type="max"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="ab00-cdde-e3ad-e31b" name="Archaeotech Pistol" hidden="false" targetId="5f1c-b6c2-0caa-f462" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
+            <entryLink id="ab00-cdde-e3ad-e31b" name="Archaeotech Pistol" hidden="false" collective="false" targetId="5f1c-b6c2-0caa-f462" type="selectionEntry">
               <modifiers>
-                <modifier type="set" field="points" value="10">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
+                <modifier type="set" field="points" value="10"/>
               </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a355-7f53-78b9-65f3" type="max"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="a7dc-30d2-3c72-b5ef" name="New EntryLink" hidden="false" targetId="648a-e853-bb44-9cee" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
+            <entryLink id="a7dc-30d2-3c72-b5ef" name="New EntryLink" hidden="false" collective="false" targetId="648a-e853-bb44-9cee" type="selectionEntry">
               <modifiers>
-                <modifier type="set" field="points" value="5">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
+                <modifier type="set" field="points" value="5"/>
               </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0a2c-11f7-a42e-e603" type="max"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="acd0-ba73-b55c-b957" name="Digital Lasers" hidden="false" targetId="155f-54a6-8ca9-27f5" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
+            <entryLink id="acd0-ba73-b55c-b957" name="Digital Lasers" hidden="false" collective="false" targetId="155f-54a6-8ca9-27f5" type="selectionEntry">
               <modifiers>
-                <modifier type="set" field="points" value="15">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
+                <modifier type="set" field="points" value="15"/>
               </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2bdc-a796-2543-bdb6" type="max"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="d645-5984-1d62-e22c" name="Teleportation Transponders" hidden="false" targetId="7d72-4429-d25c-54f3" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
+            <entryLink id="d645-5984-1d62-e22c" name="Teleportation Transponders" hidden="false" collective="false" targetId="7d72-4429-d25c-54f3" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="cf99-2de0-4871-7afa" name="May Replace his Guardian Spear with:" hidden="false" collective="false" defaultSelectionEntryId="83e8-a29e-d4ed-b441">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3b78-5062-d995-b2d7" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cbdf-0b9f-7f29-f6dd" type="min"/>
           </constraints>
-          <categoryLinks/>
           <selectionEntries>
             <selectionEntry id="2509-7796-7a86-7037" name="Pair of Solarite Power Talons" hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
               <modifiers>
-                <modifier type="set" field="points" value="15">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
+                <modifier type="set" field="points" value="15"/>
               </modifiers>
-              <constraints/>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="86f3-2d21-e196-e514" name="Solerite Power Talon" hidden="false" targetId="cb99-fafa-3e9d-035e" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
+                <entryLink id="86f3-2d21-e196-e514" name="Solerite Power Talon" hidden="false" collective="false" targetId="cb99-fafa-3e9d-035e" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed21-cc46-7a96-6a7c" type="max"/>
                     <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6d93-5788-f631-9efa" type="min"/>
                   </constraints>
-                  <categoryLinks/>
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
+                <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
-          <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="83e8-a29e-d4ed-b441" name="New EntryLink" hidden="false" targetId="dc9c-fe1d-8c26-fb07" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
+            <entryLink id="83e8-a29e-d4ed-b441" name="New EntryLink" hidden="false" collective="false" targetId="dc9c-fe1d-8c26-fb07" type="selectionEntry">
               <modifiers>
-                <modifier type="set" field="points" value="0.0">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
+                <modifier type="set" field="points" value="0.0"/>
               </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3af6-3944-d944-5210" type="max"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="b950-af84-9677-67d9" name="Sentinel Warblade" hidden="false" targetId="0caf-31e2-cd7b-a4dd" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="b950-af84-9677-67d9" name="Sentinel Warblade" hidden="false" collective="false" targetId="0caf-31e2-cd7b-a4dd" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6ea6-0c57-e584-8cba" type="max"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="5cd4-940c-8639-ef13" name="Solerite Power Gauntlet" hidden="false" targetId="8ba6-041a-ff23-98f6" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
+            <entryLink id="5cd4-940c-8639-ef13" name="Solerite Power Gauntlet" hidden="false" collective="false" targetId="8ba6-041a-ff23-98f6" type="selectionEntry">
               <modifiers>
-                <modifier type="set" field="points" value="15">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
+                <modifier type="set" field="points" value="15"/>
               </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1414-7551-fe7f-8564" type="max"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="3ac7-3389-c2f2-7870" name="New EntryLink" hidden="false" targetId="cb99-fafa-3e9d-035e" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
+            <entryLink id="3ac7-3389-c2f2-7870" name="New EntryLink" hidden="false" collective="false" targetId="cb99-fafa-3e9d-035e" type="selectionEntry">
               <modifiers>
-                <modifier type="set" field="points" value="10">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
+                <modifier type="set" field="points" value="10"/>
               </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="60ba-e8b2-d9f5-412a" type="max"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="073e-53ba-cdff-fdac" name="Pyrithite Spear" hidden="false" targetId="4af1-fc20-e881-7ad9" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
+            <entryLink id="073e-53ba-cdff-fdac" name="Pyrithite Spear" hidden="false" collective="false" targetId="4af1-fc20-e881-7ad9" type="selectionEntry">
               <modifiers>
-                <modifier type="set" field="points" value="15">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
+                <modifier type="set" field="points" value="15"/>
               </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="71d4-21a1-2137-d756" type="max"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="ccbc-9db0-427b-231f" name="New EntryLink" hidden="false" targetId="0179-aa55-899c-aa0b" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
+            <entryLink id="ccbc-9db0-427b-231f" name="New EntryLink" hidden="false" collective="false" targetId="0179-aa55-899c-aa0b" type="selectionEntry">
               <modifiers>
-                <modifier type="set" field="points" value="10">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
+                <modifier type="set" field="points" value="10"/>
               </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="db10-563a-a5ae-cf49" type="max"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="a934-0f3f-2933-009c" name="New EntryLink" hidden="false" targetId="5111-6e79-1a9b-007a" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
+            <entryLink id="a934-0f3f-2933-009c" name="New EntryLink" hidden="false" collective="false" targetId="5111-6e79-1a9b-007a" type="selectionEntry">
               <modifiers>
-                <modifier type="set" field="points" value="25">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
+                <modifier type="set" field="points" value="25"/>
               </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="44bd-8225-2118-7b4e" type="max"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="ecd5-c32d-d253-4d2e" name="Psyarkana" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c635-5c63-505e-a336" type="max"/>
           </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="09fa-be81-7642-68fe" name="Icon of the Blazing Sun" hidden="false" targetId="b2fe-de24-0c45-9b4d" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
+            <entryLink id="09fa-be81-7642-68fe" name="Icon of the Blazing Sun" hidden="false" collective="false" targetId="b2fe-de24-0c45-9b4d" type="selectionEntry">
               <modifiers>
-                <modifier type="set" field="hidden" value="false">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
+                <modifier type="set" field="hidden" value="false"/>
               </modifiers>
-              <constraints/>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="7bb6-1456-882c-f570" name="Psi-resonant Pentacles" hidden="false" targetId="199f-821c-598a-c660" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
+            <entryLink id="7bb6-1456-882c-f570" name="Psi-resonant Pentacles" hidden="false" collective="false" targetId="199f-821c-598a-c660" type="selectionEntry">
               <modifiers>
-                <modifier type="set" field="points" value="5">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="set" field="hidden" value="false">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
+                <modifier type="set" field="points" value="5"/>
+                <modifier type="set" field="hidden" value="false"/>
               </modifiers>
-              <constraints/>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="fd8e-5e90-ad72-ad5f" name="Terminal Lucidity Injectors" hidden="false" targetId="66e2-6760-fb6a-edc3" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
+            <entryLink id="fd8e-5e90-ad72-ad5f" name="Terminal Lucidity Injectors" hidden="false" collective="false" targetId="66e2-6760-fb6a-edc3" type="selectionEntry">
               <modifiers>
-                <modifier type="set" field="hidden" value="false">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
+                <modifier type="set" field="hidden" value="false"/>
               </modifiers>
-              <constraints/>
-              <categoryLinks/>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="91c4-8ce3-80fb-a334" name="New EntryLink" hidden="false" targetId="a502-5799-a2f4-310b" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
+        <entryLink id="91c4-8ce3-80fb-a334" name="New EntryLink" hidden="false" collective="false" targetId="a502-5799-a2f4-310b" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a0c9-9eb8-7f96-154c" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d443-c257-8c2e-4de2" type="max"/>
           </constraints>
-          <categoryLinks/>
         </entryLink>
-        <entryLink id="2005-c815-d8a1-e391" name="New EntryLink" hidden="false" targetId="81d2-94da-550c-1dd3" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
+        <entryLink id="2005-c815-d8a1-e391" name="New EntryLink" hidden="false" collective="false" targetId="81d2-94da-550c-1dd3" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4143-01f4-69bb-e824" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="779b-acdc-8a84-2372" type="min"/>
           </constraints>
-          <categoryLinks/>
         </entryLink>
-        <entryLink id="ba60-287b-d5b3-c6f5" name="New EntryLink" hidden="false" targetId="2c5a-1976-04e4-e277" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
+        <entryLink id="ba60-287b-d5b3-c6f5" name="New EntryLink" hidden="false" collective="false" targetId="2c5a-1976-04e4-e277" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6c51-8c37-273d-8828" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2033-385d-a605-94b7" type="max"/>
           </constraints>
-          <categoryLinks/>
         </entryLink>
-        <entryLink id="4c8d-b7c1-87ee-7ece" name="New EntryLink" hidden="false" targetId="c60c-dfd9-c5b8-50d1" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
+        <entryLink id="4c8d-b7c1-87ee-7ece" name="New EntryLink" hidden="false" collective="false" targetId="c60c-dfd9-c5b8-50d1" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d6a3-771f-8fa3-8405" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2a4b-2b5d-f187-ae27" type="min"/>
           </constraints>
-          <categoryLinks/>
         </entryLink>
-        <entryLink id="71d9-af3f-67af-35f6" name="New EntryLink" hidden="false" targetId="42e2-2cc0-6353-4d47" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
+        <entryLink id="71d9-af3f-67af-35f6" name="New EntryLink" hidden="false" collective="false" targetId="42e2-2cc0-6353-4d47" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="08f4-da3d-8842-545a" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7541-15b2-b5db-11ad" type="min"/>
           </constraints>
-          <categoryLinks/>
         </entryLink>
-        <entryLink id="8a7c-10cd-47b3-53f7" name="Warlord" hidden="false" targetId="bef2-c1b8-bbe1-eab5" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
+        <entryLink id="8a7c-10cd-47b3-53f7" name="Warlord" hidden="false" collective="false" targetId="bef2-c1b8-bbe1-eab5" type="selectionEntry"/>
       </entryLinks>
       <costs>
-        <cost name="pts" costTypeId="points" value="190.0"/>
+        <cost name="pts" typeId="points" value="190.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="26dd-4eb2-fe70-ea73" name="Sisters of Silence Oblivion Knight-Centura" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
       <infoLinks>
-        <infoLink id="a702-c2b5-f3d4-f9da" name="New InfoLink" hidden="false" targetId="a080-af1b-fb2e-4860" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="8bd1-defc-209f-7351" name="New InfoLink" hidden="false" targetId="584d-e540-7fdd-92c9" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="4d77-283a-1211-d753" name="New InfoLink" hidden="false" targetId="c793-7756-3669-827c" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="6f08-6056-d093-0da9" name="New InfoLink" hidden="false" targetId="9d85-46f7-f5e6-a5f7" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="8c9c-9643-a407-d8f2" name="New InfoLink" hidden="false" targetId="05b9-9f16-29f9-9dad" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="a7f1-fb48-e50a-32c7" name="New InfoLink" hidden="false" targetId="3f68-d37b-6be9-3cd4" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
+        <infoLink id="a702-c2b5-f3d4-f9da" name="New InfoLink" hidden="false" targetId="a080-af1b-fb2e-4860" type="rule"/>
+        <infoLink id="8bd1-defc-209f-7351" name="New InfoLink" hidden="false" targetId="584d-e540-7fdd-92c9" type="rule"/>
+        <infoLink id="4d77-283a-1211-d753" name="New InfoLink" hidden="false" targetId="c793-7756-3669-827c" type="rule"/>
+        <infoLink id="6f08-6056-d093-0da9" name="New InfoLink" hidden="false" targetId="9d85-46f7-f5e6-a5f7" type="rule"/>
+        <infoLink id="8c9c-9643-a407-d8f2" name="New InfoLink" hidden="false" targetId="05b9-9f16-29f9-9dad" type="rule"/>
+        <infoLink id="a7f1-fb48-e50a-32c7" name="New InfoLink" hidden="false" targetId="3f68-d37b-6be9-3cd4" type="profile"/>
       </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
       <selectionEntryGroups>
         <selectionEntryGroup id="e4c8-329d-04d2-4bd8" name="Exchange Execution Blade for:" hidden="false" collective="false" defaultSelectionEntryId="4094-48d6-2d34-6731">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e520-88ef-8fbf-b6e6" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="50d1-ce5f-74af-1431" type="min"/>
           </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="4094-48d6-2d34-6731" name="New EntryLink" hidden="false" targetId="1812-dcf0-818a-5491" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="4094-48d6-2d34-6731" name="New EntryLink" hidden="false" collective="false" targetId="1812-dcf0-818a-5491" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5e63-e41a-ea00-3b61" type="max"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="be5b-75b9-7d4c-7eb1" name="New EntryLink" hidden="false" targetId="e006-9328-106d-5c6a" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
+            <entryLink id="be5b-75b9-7d4c-7eb1" name="New EntryLink" hidden="false" collective="false" targetId="e006-9328-106d-5c6a" type="selectionEntry">
               <modifiers>
-                <modifier type="set" field="points" value="10">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
+                <modifier type="set" field="points" value="10"/>
               </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e3b6-1d98-e1ee-8dbe" type="max"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="1471-cc6c-b1c6-411f" name="New EntryLink" hidden="false" targetId="d313-b513-281a-c5ad" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
+            <entryLink id="1471-cc6c-b1c6-411f" name="New EntryLink" hidden="false" collective="false" targetId="d313-b513-281a-c5ad" type="selectionEntry">
               <modifiers>
-                <modifier type="set" field="points" value="5">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
+                <modifier type="set" field="points" value="5"/>
               </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c597-45a0-0d3d-5faf" type="max"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="5199-e559-8f26-0f02" name="Paragon Blade" hidden="false" targetId="99f1-e166-4deb-ab11" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
+            <entryLink id="5199-e559-8f26-0f02" name="Paragon Blade" hidden="false" collective="false" targetId="99f1-e166-4deb-ab11" type="selectionEntry">
               <modifiers>
-                <modifier type="set" field="points" value="20">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
+                <modifier type="set" field="points" value="20"/>
               </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1fa9-c8c3-34b2-323a" type="max"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="7539-7e45-e4ac-5e94" name="Divining Blades" hidden="false" targetId="7d90-3f3d-50e1-e295" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
+            <entryLink id="7539-7e45-e4ac-5e94" name="Divining Blades" hidden="false" collective="false" targetId="7d90-3f3d-50e1-e295" type="selectionEntry">
               <modifiers>
-                <modifier type="set" field="points" value="50">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
+                <modifier type="set" field="points" value="50"/>
                 <modifier type="set" field="hidden" value="false">
-                  <repeats/>
                   <conditions>
                     <condition field="selections" scope="26dd-4eb2-fe70-ea73" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="56a8-62a7-0270-e718" type="equalTo"/>
                   </conditions>
-                  <conditionGroups/>
                 </modifier>
               </modifiers>
-              <constraints/>
-              <categoryLinks/>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="984c-b58f-0d00-0d9a" name="Exchange Bolt Pistol for:" hidden="false" collective="false" defaultSelectionEntryId="7d4b-2292-9d7a-bdcd">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="022f-5cbc-7872-0eaa" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2c56-3621-2c61-a326" type="min"/>
           </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="796f-f25f-a2ed-ad21" name="New EntryLink" hidden="false" targetId="5f1c-b6c2-0caa-f462" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
+            <entryLink id="796f-f25f-a2ed-ad21" name="New EntryLink" hidden="false" collective="false" targetId="5f1c-b6c2-0caa-f462" type="selectionEntry">
               <modifiers>
-                <modifier type="set" field="points" value="10">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
+                <modifier type="set" field="points" value="10"/>
               </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a226-861f-9549-efb9" type="max"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="7d4b-2292-9d7a-bdcd" name="New EntryLink" hidden="false" targetId="f727-c9c2-83d0-3984" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="7d4b-2292-9d7a-bdcd" name="New EntryLink" hidden="false" collective="false" targetId="f727-c9c2-83d0-3984" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6dbd-8238-5dc5-11e1" type="max"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="b889-6d5f-f2d4-b8ad" name="New EntryLink" hidden="false" targetId="af7d-23e9-3a57-57aa" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
+            <entryLink id="b889-6d5f-f2d4-b8ad" name="New EntryLink" hidden="false" collective="false" targetId="af7d-23e9-3a57-57aa" type="selectionEntry">
               <modifiers>
-                <modifier type="set" field="points" value="5">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
+                <modifier type="set" field="points" value="5"/>
               </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="30e5-7ab4-3cfb-4f48" type="max"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="5864-751b-41f8-d935" name="New EntryLink" hidden="false" targetId="0319-8f8d-ab88-efa5" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
+            <entryLink id="5864-751b-41f8-d935" name="New EntryLink" hidden="false" collective="false" targetId="0319-8f8d-ab88-efa5" type="selectionEntry">
               <modifiers>
-                <modifier type="set" field="points" value="5">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
+                <modifier type="set" field="points" value="5"/>
               </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9b11-8977-501e-77ef" type="max"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="803e-4214-b73c-6267" name="New EntryLink" hidden="false" targetId="a598-a02a-d502-adf4" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
+            <entryLink id="803e-4214-b73c-6267" name="New EntryLink" hidden="false" collective="false" targetId="a598-a02a-d502-adf4" type="selectionEntry">
               <modifiers>
-                <modifier type="set" field="points" value="15">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
+                <modifier type="set" field="points" value="15"/>
               </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2eb2-c495-8c8f-c4bc" type="max"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="2d0f-444e-6667-1321" name="Upgrade one weapon to be Master-Crafted" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0589-e2fc-a667-9015" type="max"/>
           </constraints>
-          <categoryLinks/>
           <selectionEntries>
             <selectionEntry id="0fe7-a966-be3c-87e8" name="Bolt Pistol Group" hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
               <infoLinks>
-                <infoLink id="b702-45c8-445c-7fbf" name="New InfoLink" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
+                <infoLink id="b702-45c8-445c-7fbf" name="New InfoLink" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule"/>
               </infoLinks>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
               <costs>
-                <cost name="pts" costTypeId="points" value="10.0"/>
+                <cost name="pts" typeId="points" value="10.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="521f-30c0-8171-a330" name="Execution Blade Group" hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
               <infoLinks>
-                <infoLink id="12a1-d75a-c3c1-d20b" name="New InfoLink" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
+                <infoLink id="12a1-d75a-c3c1-d20b" name="New InfoLink" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule"/>
               </infoLinks>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
               <costs>
-                <cost name="pts" costTypeId="points" value="10.0"/>
+                <cost name="pts" typeId="points" value="10.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
-          <selectionEntryGroups/>
-          <entryLinks/>
         </selectionEntryGroup>
         <selectionEntryGroup id="56a8-62a7-0270-e718" name="Psyarkana" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
           <modifiers>
             <modifier type="set" field="hidden" value="true">
-              <repeats/>
               <conditions>
                 <condition field="selections" scope="26dd-4eb2-fe70-ea73" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7539-7e45-e4ac-5e94" type="equalTo"/>
               </conditions>
-              <conditionGroups/>
             </modifier>
             <modifier type="set" field="a56c-cf7f-db3d-2b83" value="0">
-              <repeats/>
               <conditions>
                 <condition field="selections" scope="26dd-4eb2-fe70-ea73" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7539-7e45-e4ac-5e94" type="equalTo"/>
               </conditions>
-              <conditionGroups/>
             </modifier>
           </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a56c-cf7f-db3d-2b83" type="max"/>
           </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="aa2c-6362-8284-7b85" name="Icon of the Blazing Sun" hidden="false" targetId="b2fe-de24-0c45-9b4d" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
+            <entryLink id="aa2c-6362-8284-7b85" name="Icon of the Blazing Sun" hidden="false" collective="false" targetId="b2fe-de24-0c45-9b4d" type="selectionEntry">
               <modifiers>
-                <modifier type="set" field="hidden" value="false">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
+                <modifier type="set" field="hidden" value="false"/>
               </modifiers>
-              <constraints/>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="8152-525c-4a64-3ae4" name="Terminal Lucidity Injectors" hidden="false" targetId="66e2-6760-fb6a-edc3" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
+            <entryLink id="8152-525c-4a64-3ae4" name="Terminal Lucidity Injectors" hidden="false" collective="false" targetId="66e2-6760-fb6a-edc3" type="selectionEntry">
               <modifiers>
-                <modifier type="set" field="hidden" value="false">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
+                <modifier type="set" field="hidden" value="false"/>
               </modifiers>
-              <constraints/>
-              <categoryLinks/>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="6f18-18dd-5665-115a" name="New EntryLink" hidden="false" targetId="c81a-0cf2-1986-9f3b" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
+        <entryLink id="6f18-18dd-5665-115a" name="New EntryLink" hidden="false" collective="false" targetId="c81a-0cf2-1986-9f3b" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cc00-4352-c1cb-1e2b" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="430e-cd84-9ddc-b4a4" type="min"/>
           </constraints>
-          <categoryLinks/>
         </entryLink>
-        <entryLink id="7b17-c07b-0e9a-2c33" name="New EntryLink" hidden="false" targetId="e5f6-cd68-595a-306c" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="95b4-1d37-fc2f-fc35" name="New EntryLink" hidden="false" targetId="9e07-f5e7-b880-2bd5" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="9473-4c1c-821f-845f" name="Warlord" hidden="false" targetId="bef2-c1b8-bbe1-eab5" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
+        <entryLink id="7b17-c07b-0e9a-2c33" name="New EntryLink" hidden="false" collective="false" targetId="e5f6-cd68-595a-306c" type="selectionEntry"/>
+        <entryLink id="95b4-1d37-fc2f-fc35" name="New EntryLink" hidden="false" collective="false" targetId="9e07-f5e7-b880-2bd5" type="selectionEntry"/>
+        <entryLink id="9473-4c1c-821f-845f" name="Warlord" hidden="false" collective="false" targetId="bef2-c1b8-bbe1-eab5" type="selectionEntry"/>
       </entryLinks>
       <costs>
-        <cost name="pts" costTypeId="points" value="75.0"/>
+        <cost name="pts" typeId="points" value="75.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="1ebb-ff7d-d5f8-ee60" name="Sisters of Silence Excruciatus Cadre" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="67c3-fa78-a56d-9736" name="New InfoLink" hidden="false" targetId="584d-e540-7fdd-92c9" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="3f86-07e4-30f1-a86d" name="New InfoLink" hidden="false" targetId="4648-cbf1-884b-d7b4" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="44fe-cbbb-2018-0929" name="New InfoLink" hidden="false" targetId="97d7-d358-141a-8579" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="9dcb-776a-2f31-410e" name="New InfoLink" hidden="false" targetId="a225-e39b-3699-c8f8" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="0991-f499-6b27-629b" name="New InfoLink" hidden="false" targetId="8fd8-2be9-519b-1b68" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="b97f-cbcc-da16-87d6" name="New InfoLink" hidden="false" targetId="7e19-5042-d0cb-0d82" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="b382-9044-f6f7-5cda" name="New InfoLink" hidden="false" targetId="05b9-9f16-29f9-9dad" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="b853-ada8-985a-fcec" name="New InfoLink" hidden="false" targetId="4771-b711-0e74-3aee" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
       <modifiers>
         <modifier type="set" field="1ff9-e3c4-c2d0-94e9" value="0.0">
-          <repeats/>
-          <conditions/>
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
                 <condition field="points" scope="force" value="500.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="any" type="greaterThan"/>
                 <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="657a-bc81-4ae3-8a5b" type="instanceOf"/>
               </conditions>
-              <conditionGroups/>
             </conditionGroup>
           </conditionGroups>
         </modifier>
@@ -3527,1293 +1597,630 @@
       <constraints>
         <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="1ff9-e3c4-c2d0-94e9" type="max"/>
       </constraints>
-      <categoryLinks/>
+      <infoLinks>
+        <infoLink id="67c3-fa78-a56d-9736" name="New InfoLink" hidden="false" targetId="584d-e540-7fdd-92c9" type="rule"/>
+        <infoLink id="3f86-07e4-30f1-a86d" name="New InfoLink" hidden="false" targetId="4648-cbf1-884b-d7b4" type="rule"/>
+        <infoLink id="44fe-cbbb-2018-0929" name="New InfoLink" hidden="false" targetId="97d7-d358-141a-8579" type="rule"/>
+        <infoLink id="9dcb-776a-2f31-410e" name="New InfoLink" hidden="false" targetId="a225-e39b-3699-c8f8" type="rule"/>
+        <infoLink id="0991-f499-6b27-629b" name="New InfoLink" hidden="false" targetId="8fd8-2be9-519b-1b68" type="rule"/>
+        <infoLink id="b97f-cbcc-da16-87d6" name="New InfoLink" hidden="false" targetId="7e19-5042-d0cb-0d82" type="rule"/>
+        <infoLink id="b382-9044-f6f7-5cda" name="New InfoLink" hidden="false" targetId="05b9-9f16-29f9-9dad" type="rule"/>
+        <infoLink id="b853-ada8-985a-fcec" name="New InfoLink" hidden="false" targetId="4771-b711-0e74-3aee" type="rule"/>
+      </infoLinks>
       <selectionEntries>
         <selectionEntry id="c694-a760-8c54-631b" name="Silent Judge" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="eee1-4453-f5d8-5549" name="New InfoLink" hidden="false" targetId="58f8-6083-45f3-44e6" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1f5d-18c3-ccf6-6cd9" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1da8-7c8e-14d6-da6a" type="max"/>
           </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
+          <infoLinks>
+            <infoLink id="eee1-4453-f5d8-5549" name="New InfoLink" hidden="false" targetId="58f8-6083-45f3-44e6" type="profile"/>
+          </infoLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="6a2e-638c-2dc7-7464" name="Exchange Power Weapon for:" hidden="false" collective="false" defaultSelectionEntryId="c153-8038-d7cf-9515">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5c79-4924-7d3e-71fc" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fb72-7d06-bb82-af08" type="max"/>
               </constraints>
-              <categoryLinks/>
               <selectionEntries>
                 <selectionEntry id="e824-931b-8cea-f4eb" name="Power Axe" hidden="false" collective="false" type="upgrade">
-                  <profiles/>
-                  <rules/>
                   <infoLinks>
-                    <infoLink id="18c4-c8aa-617e-dbcb" name="New InfoLink" hidden="false" targetId="b3af-1eca-6629-4894" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
+                    <infoLink id="18c4-c8aa-617e-dbcb" name="New InfoLink" hidden="false" targetId="b3af-1eca-6629-4894" type="profile"/>
                   </infoLinks>
-                  <modifiers/>
-                  <constraints/>
-                  <categoryLinks/>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
                   <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
+                    <cost name="pts" typeId="points" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="8564-b4d4-c971-7f3b" name="Power Lance" hidden="false" collective="false" type="upgrade">
-                  <profiles/>
-                  <rules/>
                   <infoLinks>
-                    <infoLink id="54e3-46b1-8494-4581" name="New InfoLink" hidden="false" targetId="fdd4-9bf3-da9d-5479" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
+                    <infoLink id="54e3-46b1-8494-4581" name="New InfoLink" hidden="false" targetId="fdd4-9bf3-da9d-5479" type="profile"/>
                   </infoLinks>
-                  <modifiers/>
-                  <constraints/>
-                  <categoryLinks/>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
                   <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
+                    <cost name="pts" typeId="points" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="9d50-de98-06c9-c9df" name="Power Maul" hidden="false" collective="false" type="upgrade">
-                  <profiles/>
-                  <rules/>
                   <infoLinks>
-                    <infoLink id="7dac-9ad0-701c-c402" name="New InfoLink" hidden="false" targetId="6bbe-f2c1-78e2-da59" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
+                    <infoLink id="7dac-9ad0-701c-c402" name="New InfoLink" hidden="false" targetId="6bbe-f2c1-78e2-da59" type="profile"/>
                   </infoLinks>
-                  <modifiers/>
-                  <constraints/>
-                  <categoryLinks/>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
                   <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
+                    <cost name="pts" typeId="points" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="c153-8038-d7cf-9515" name="Power Sword" hidden="false" collective="false" type="upgrade">
-                  <profiles/>
-                  <rules/>
                   <infoLinks>
-                    <infoLink id="2ddc-b1b1-5845-a07b" name="New InfoLink" hidden="false" targetId="038e-23ec-4886-8b00" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
+                    <infoLink id="2ddc-b1b1-5845-a07b" name="New InfoLink" hidden="false" targetId="038e-23ec-4886-8b00" type="profile"/>
                   </infoLinks>
-                  <modifiers/>
-                  <constraints/>
-                  <categoryLinks/>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
                   <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
+                    <cost name="pts" typeId="points" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
-              <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="a60e-19dd-6010-665a" name="New EntryLink" hidden="false" targetId="e006-9328-106d-5c6a" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
+                <entryLink id="a60e-19dd-6010-665a" name="New EntryLink" hidden="false" collective="false" targetId="e006-9328-106d-5c6a" type="selectionEntry">
                   <modifiers>
-                    <modifier type="set" field="points" value="5">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
+                    <modifier type="set" field="points" value="5"/>
                   </modifiers>
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e140-c006-08fa-701f" type="max"/>
                   </constraints>
-                  <categoryLinks/>
                 </entryLink>
-                <entryLink id="56d6-61bc-4ff5-07e8" name="New EntryLink" hidden="false" targetId="1812-dcf0-818a-5491" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
+                <entryLink id="56d6-61bc-4ff5-07e8" name="New EntryLink" hidden="false" collective="false" targetId="1812-dcf0-818a-5491" type="selectionEntry">
                   <modifiers>
-                    <modifier type="set" field="points" value="10">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
+                    <modifier type="set" field="points" value="10"/>
                   </modifiers>
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f6c8-6aca-dbde-3e5a" type="max"/>
                   </constraints>
-                  <categoryLinks/>
                 </entryLink>
-                <entryLink id="b23b-3bc8-cb3f-6e78" name="New EntryLink" hidden="false" targetId="1f4e-6106-2d51-ba0b" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
+                <entryLink id="b23b-3bc8-cb3f-6e78" name="New EntryLink" hidden="false" collective="false" targetId="1f4e-6106-2d51-ba0b" type="selectionEntry">
                   <modifiers>
-                    <modifier type="set" field="points" value="5">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
+                    <modifier type="set" field="points" value="5"/>
                   </modifiers>
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cd13-10ce-0285-64bb" type="max"/>
                   </constraints>
-                  <categoryLinks/>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="27f3-a507-04c1-ff8d" name="Exchange Bolt Pistol for:" hidden="false" collective="false" defaultSelectionEntryId="c10c-3701-add7-e559">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="773b-55fd-b2b0-ad6c" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b7bd-dc5f-2c74-6920" type="max"/>
               </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="c10c-3701-add7-e559" name="New EntryLink" hidden="false" targetId="f727-c9c2-83d0-3984" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
+                <entryLink id="c10c-3701-add7-e559" name="New EntryLink" hidden="false" collective="false" targetId="f727-c9c2-83d0-3984" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e36-969a-9236-a8ec" type="max"/>
                   </constraints>
-                  <categoryLinks/>
                 </entryLink>
-                <entryLink id="5457-0e73-92fa-8906" name="New EntryLink" hidden="false" targetId="af7d-23e9-3a57-57aa" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
+                <entryLink id="5457-0e73-92fa-8906" name="New EntryLink" hidden="false" collective="false" targetId="af7d-23e9-3a57-57aa" type="selectionEntry">
                   <modifiers>
-                    <modifier type="set" field="points" value="5">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
+                    <modifier type="set" field="points" value="5"/>
                   </modifiers>
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c331-6c0c-196b-be5e" type="max"/>
                   </constraints>
-                  <categoryLinks/>
                 </entryLink>
-                <entryLink id="ac87-3ea9-934a-b53b" name="New EntryLink" hidden="false" targetId="a598-a02a-d502-adf4" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
+                <entryLink id="ac87-3ea9-934a-b53b" name="New EntryLink" hidden="false" collective="false" targetId="a598-a02a-d502-adf4" type="selectionEntry">
                   <modifiers>
-                    <modifier type="set" field="points" value="15">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
+                    <modifier type="set" field="points" value="15"/>
                   </modifiers>
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="75a2-a214-6d19-430b" type="max"/>
                   </constraints>
-                  <categoryLinks/>
                 </entryLink>
-                <entryLink id="a197-9ba4-f2d0-ff38" name="New EntryLink" hidden="false" targetId="a1bd-37d2-4ee5-6e4b" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
+                <entryLink id="a197-9ba4-f2d0-ff38" name="New EntryLink" hidden="false" collective="false" targetId="a1bd-37d2-4ee5-6e4b" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="02b7-77d5-4dd2-b941" type="max"/>
                   </constraints>
-                  <categoryLinks/>
                 </entryLink>
-                <entryLink id="bbdc-f88d-f740-5d89" name="New EntryLink" hidden="false" targetId="0319-8f8d-ab88-efa5" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
+                <entryLink id="bbdc-f88d-f740-5d89" name="New EntryLink" hidden="false" collective="false" targetId="0319-8f8d-ab88-efa5" type="selectionEntry">
                   <modifiers>
-                    <modifier type="set" field="points" value="5">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
+                    <modifier type="set" field="points" value="5"/>
                   </modifiers>
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9117-8db3-19f7-ef52" type="max"/>
                   </constraints>
-                  <categoryLinks/>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks>
-            <entryLink id="7063-888c-4ca3-f7f5" name="New EntryLink" hidden="false" targetId="aba8-92ff-b2a8-ad1e" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="7063-888c-4ca3-f7f5" name="New EntryLink" hidden="false" collective="false" targetId="aba8-92ff-b2a8-ad1e" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6584-086a-c2d3-2cb8" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2512-a18c-0f70-0024" type="max"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="68a7-1e32-cacf-495b" name="New EntryLink" hidden="false" targetId="568a-a7c1-0176-81fc" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="68a7-1e32-cacf-495b" name="New EntryLink" hidden="false" collective="false" targetId="568a-a7c1-0176-81fc" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bad7-27d6-0b3c-b342" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d006-2e9f-7535-7539" type="max"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="a438-3cf7-2e80-b74a" name="New EntryLink" hidden="false" targetId="e5f6-cd68-595a-306c" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="a438-3cf7-2e80-b74a" name="New EntryLink" hidden="false" collective="false" targetId="e5f6-cd68-595a-306c" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b40d-d83a-a300-d01f" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0fdd-a6c9-e941-3146" type="max"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="6087-7ce8-4337-c364" name="New EntryLink" hidden="false" targetId="e8f5-fd9d-1891-93d3" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="6087-7ce8-4337-c364" name="New EntryLink" hidden="false" collective="false" targetId="e8f5-fd9d-1891-93d3" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="660f-2bd9-e433-b06e" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="89a6-c81b-a2f2-9d07" type="max"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="d03e-59c5-5581-fb69" name="New EntryLink" hidden="false" targetId="011a-b751-e773-6b90" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="d03e-59c5-5581-fb69" name="New EntryLink" hidden="false" collective="false" targetId="011a-b751-e773-6b90" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0670-75f0-0168-4fe3" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ad58-fc74-3aa3-c98b" type="max"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="fc4d-e84c-8367-89f3" name="New EntryLink" hidden="false" targetId="0319-8f8d-ab88-efa5" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="fc4d-e84c-8367-89f3" name="New EntryLink" hidden="false" collective="false" targetId="0319-8f8d-ab88-efa5" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="977b-8bb0-e3d9-ee58" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6cf0-4bf3-4617-439e" type="min"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="ac2b-a584-a81e-3d1f" name="Questora" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="4aca-d5e5-8866-0c0b" name="New InfoLink" hidden="false" targetId="c39c-b1bf-bf79-1452" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="07bc-7ee2-5ac3-e215" type="max"/>
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ec26-82a7-a8f3-5e0d" type="min"/>
           </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
+          <infoLinks>
+            <infoLink id="4aca-d5e5-8866-0c0b" name="New InfoLink" hidden="false" targetId="c39c-b1bf-bf79-1452" type="profile"/>
+          </infoLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="0df1-a8b3-39f0-2bb4" name="May Exchange CCW for:" hidden="false" collective="false" defaultSelectionEntryId="c45e-5226-10a5-720f">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8f6b-44e6-9a81-cb75" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8657-f7cd-f589-0416" type="min"/>
               </constraints>
-              <categoryLinks/>
               <selectionEntries>
                 <selectionEntry id="9656-4f29-5c88-57a0" name="Power Weapon" hidden="false" collective="false" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9d88-544b-f1b6-9708" type="max"/>
                   </constraints>
-                  <categoryLinks/>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
                   <entryLinks>
-                    <entryLink id="d42d-a0ab-dc29-3ce9" name="New EntryLink" hidden="false" targetId="7a9d-499d-e939-23a3" type="selectionEntryGroup">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
+                    <entryLink id="d42d-a0ab-dc29-3ce9" name="New EntryLink" hidden="false" collective="false" targetId="7a9d-499d-e939-23a3" type="selectionEntryGroup">
                       <constraints>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a628-e985-a25f-5820" type="min"/>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ca8f-185f-7a08-5f51" type="max"/>
                       </constraints>
-                      <categoryLinks/>
                     </entryLink>
                   </entryLinks>
                   <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
+                    <cost name="pts" typeId="points" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
-              <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="c45e-5226-10a5-720f" name="New EntryLink" hidden="false" targetId="81d2-94da-550c-1dd3" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
+                <entryLink id="c45e-5226-10a5-720f" name="New EntryLink" hidden="false" collective="false" targetId="81d2-94da-550c-1dd3" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="58bf-a79b-6e8b-a73e" type="max"/>
                   </constraints>
-                  <categoryLinks/>
                 </entryLink>
-                <entryLink id="5a45-4521-72d2-1bab" name="New EntryLink" hidden="false" targetId="2dbb-47ce-c902-cc3d" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
+                <entryLink id="5a45-4521-72d2-1bab" name="New EntryLink" hidden="false" collective="false" targetId="2dbb-47ce-c902-cc3d" type="selectionEntry">
                   <modifiers>
-                    <modifier type="set" field="points" value="5">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
+                    <modifier type="set" field="points" value="5"/>
                   </modifiers>
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5e90-be79-4963-8e10" type="max"/>
                   </constraints>
-                  <categoryLinks/>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="7a17-d0d9-4b80-329c" name="May Exchange Assault Needler for:" hidden="false" collective="false" defaultSelectionEntryId="5b3e-b760-f0f5-9db0">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f6e3-13f5-7503-20c5" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3bd8-5ab0-404b-76e9" type="min"/>
               </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="5b3e-b760-f0f5-9db0" name="New EntryLink" hidden="false" targetId="f833-5eba-9592-4940" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
+                <entryLink id="5b3e-b760-f0f5-9db0" name="New EntryLink" hidden="false" collective="false" targetId="f833-5eba-9592-4940" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="599e-2a5d-605f-181e" type="max"/>
                   </constraints>
-                  <categoryLinks/>
                 </entryLink>
-                <entryLink id="cda7-524f-5ce5-e5ce" name="New EntryLink" hidden="false" targetId="0319-8f8d-ab88-efa5" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
+                <entryLink id="cda7-524f-5ce5-e5ce" name="New EntryLink" hidden="false" collective="false" targetId="0319-8f8d-ab88-efa5" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f203-71fd-4b71-d2e0" type="max"/>
                   </constraints>
-                  <categoryLinks/>
                 </entryLink>
-                <entryLink id="033b-5070-178a-6df2" name="New EntryLink" hidden="false" targetId="a1bd-37d2-4ee5-6e4b" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
+                <entryLink id="033b-5070-178a-6df2" name="New EntryLink" hidden="false" collective="false" targetId="a1bd-37d2-4ee5-6e4b" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9afc-6287-e32f-d8b7" type="max"/>
                   </constraints>
-                  <categoryLinks/>
                 </entryLink>
-                <entryLink id="655f-56f4-ef9f-ec2b" name="New EntryLink" hidden="false" targetId="c783-b082-5cb9-888e" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
+                <entryLink id="655f-56f4-ef9f-ec2b" name="New EntryLink" hidden="false" collective="false" targetId="c783-b082-5cb9-888e" type="selectionEntry">
                   <modifiers>
-                    <modifier type="set" field="points" value="10">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
+                    <modifier type="set" field="points" value="10"/>
                   </modifiers>
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7cab-b3ab-daaf-7248" type="max"/>
                   </constraints>
-                  <categoryLinks/>
                 </entryLink>
-                <entryLink id="f52b-13e7-244a-0999" name="New EntryLink" hidden="false" targetId="4099-02e6-ddf0-4100" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
+                <entryLink id="f52b-13e7-244a-0999" name="New EntryLink" hidden="false" collective="false" targetId="4099-02e6-ddf0-4100" type="selectionEntry">
                   <modifiers>
-                    <modifier type="set" field="points" value="5">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
+                    <modifier type="set" field="points" value="5"/>
                   </modifiers>
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2ec0-a692-4e45-47bc" type="max"/>
                   </constraints>
-                  <categoryLinks/>
                 </entryLink>
-                <entryLink id="5d3d-e3a8-fdb3-c0ab" name="New EntryLink" hidden="false" targetId="ac1f-421a-2070-02d2" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
+                <entryLink id="5d3d-e3a8-fdb3-c0ab" name="New EntryLink" hidden="false" collective="false" targetId="ac1f-421a-2070-02d2" type="selectionEntry">
                   <modifiers>
-                    <modifier type="set" field="points" value="15">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
+                    <modifier type="set" field="points" value="15"/>
                   </modifiers>
                   <constraints>
                     <constraint field="selections" scope="1ebb-ff7d-d5f8-ee60" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f2a6-5b31-2251-79ff" type="max"/>
                   </constraints>
-                  <categoryLinks/>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks>
-            <entryLink id="0459-aad1-629c-96d6" name="New EntryLink" hidden="false" targetId="568a-a7c1-0176-81fc" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="0459-aad1-629c-96d6" name="New EntryLink" hidden="false" collective="false" targetId="568a-a7c1-0176-81fc" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ef4e-2d85-5486-d8d6" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2c2e-1c2f-c9c4-815d" type="max"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="c581-93cf-5a08-ffa0" name="New EntryLink" hidden="false" targetId="f727-c9c2-83d0-3984" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="c581-93cf-5a08-ffa0" name="New EntryLink" hidden="false" collective="false" targetId="f727-c9c2-83d0-3984" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="102a-62f5-be13-9c38" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="26f0-4617-c6df-94fe" type="max"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="e7ec-fccc-e43c-4631" name="New EntryLink" hidden="false" targetId="e5f6-cd68-595a-306c" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="e7ec-fccc-e43c-4631" name="New EntryLink" hidden="false" collective="false" targetId="e5f6-cd68-595a-306c" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c3b5-f035-4d8a-5cfa" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="33c9-ff8d-4b9a-cf95" type="max"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="4c3d-269a-7cf8-9bf2" name="New EntryLink" hidden="false" targetId="aba8-92ff-b2a8-ad1e" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="4c3d-269a-7cf8-9bf2" name="New EntryLink" hidden="false" collective="false" targetId="aba8-92ff-b2a8-ad1e" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7af0-9545-53d7-0bbc" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="552e-fd5c-0782-6630" type="max"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
-      <selectionEntryGroups/>
       <entryLinks>
-        <entryLink id="bb91-7ce2-3421-08e3" name="Sisters of Silence Dedicated Transport" hidden="false" targetId="90bd-22e7-9326-3298" type="selectionEntryGroup">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
+        <entryLink id="bb91-7ce2-3421-08e3" name="Sisters of Silence Dedicated Transport" hidden="false" collective="false" targetId="90bd-22e7-9326-3298" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" costTypeId="points" value="100.0"/>
+        <cost name="pts" typeId="points" value="100.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="38a5-b278-eb49-3779" name="Constantin Valdor" book="HH8: Malevolence" page="266" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
+    <selectionEntry id="38a5-b278-eb49-3779" name="Constantin Valdor" publicationId="a30a-7522-pubN77499" page="266" hidden="false" collective="false" type="upgrade">
       <infoLinks>
-        <infoLink id="cf34-3f56-617c-5c89" name="Preternatural Skill" hidden="false" targetId="ce23-8050-129e-4371" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="f114-cb2e-0cf2-095f" name="The Sodality" hidden="false" targetId="c49a-b905-f536-8810" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="2a3b-f56c-9931-4a00" name="Inviolable Psyche" hidden="false" targetId="41a9-bbe8-d024-4813" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="1b90-7831-7913-982d" name="New InfoLink" hidden="false" targetId="2b06-29a6-641a-b22e" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="1eeb-0197-3832-ae5b" name="New InfoLink" hidden="false" targetId="4771-b711-0e74-3aee" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="ce1c-02dd-0531-4aec" name="New InfoLink" hidden="false" targetId="3e0b-be9f-b7eb-8c5e" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="d338-3500-c5c2-606a" name="New InfoLink" hidden="false" targetId="3ad4-1c37-d60b-1a4e" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="777d-907c-6d83-d8d4" name="Precision Strikes" hidden="false" targetId="a080-af1b-fb2e-4860" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="921d-d0fd-fd76-bf79" name="New InfoLink" hidden="false" targetId="0900-71d5-1937-aa96" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="dbb8-01cd-78cd-38a9" name="Bulky" hidden="false" targetId="38d5-b6eb-bda8-2497" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="9cb8-35c8-1d20-250f" name="New InfoLink" hidden="false" targetId="dc70-e199-5525-e78c" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="4bab-e4e3-ddd9-7d43" name="Constantin Valdor" hidden="false" targetId="cdc5-87f0-cf6d-b250" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
+        <infoLink id="cf34-3f56-617c-5c89" name="Preternatural Skill" hidden="false" targetId="ce23-8050-129e-4371" type="rule"/>
+        <infoLink id="f114-cb2e-0cf2-095f" name="The Sodality" hidden="false" targetId="c49a-b905-f536-8810" type="rule"/>
+        <infoLink id="2a3b-f56c-9931-4a00" name="Inviolable Psyche" hidden="false" targetId="41a9-bbe8-d024-4813" type="rule"/>
+        <infoLink id="1b90-7831-7913-982d" name="New InfoLink" hidden="false" targetId="2b06-29a6-641a-b22e" type="rule"/>
+        <infoLink id="1eeb-0197-3832-ae5b" name="New InfoLink" hidden="false" targetId="4771-b711-0e74-3aee" type="rule"/>
+        <infoLink id="ce1c-02dd-0531-4aec" name="New InfoLink" hidden="false" targetId="3e0b-be9f-b7eb-8c5e" type="rule"/>
+        <infoLink id="d338-3500-c5c2-606a" name="New InfoLink" hidden="false" targetId="3ad4-1c37-d60b-1a4e" type="rule"/>
+        <infoLink id="777d-907c-6d83-d8d4" name="Precision Strikes" hidden="false" targetId="a080-af1b-fb2e-4860" type="rule"/>
+        <infoLink id="921d-d0fd-fd76-bf79" name="New InfoLink" hidden="false" targetId="0900-71d5-1937-aa96" type="rule"/>
+        <infoLink id="dbb8-01cd-78cd-38a9" name="Bulky" hidden="false" targetId="38d5-b6eb-bda8-2497" type="rule"/>
+        <infoLink id="9cb8-35c8-1d20-250f" name="New InfoLink" hidden="false" targetId="dc70-e199-5525-e78c" type="rule"/>
+        <infoLink id="4bab-e4e3-ddd9-7d43" name="Constantin Valdor" hidden="false" targetId="cdc5-87f0-cf6d-b250" type="profile"/>
       </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
       <selectionEntries>
         <selectionEntry id="2926-8f43-4f60-f18f" name="Warlord" hidden="false" collective="false" type="upgrade">
-          <profiles/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ec17-55bc-f608-7b9e" type="max"/>
+          </constraints>
           <rules>
             <rule id="78e5-f535-4232-0b90" name="The Shadow of the Throne" hidden="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
-                  <repeats/>
                   <conditions>
                     <condition field="selections" scope="38a5-b278-eb49-3779" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7142-5637-eee3-884e" type="equalTo"/>
                   </conditions>
-                  <conditionGroups/>
                 </modifier>
               </modifiers>
               <description>If Constantin Valdor is your Warlord he may re-roll attempts to seize the initiative in missions where this is a factor. Additionally, if Constantin Valdor is your Warlord he gains the Teleportation Transponders item of wargear and may also grant one unit with the Legio Custodes special rule Teleportation Transponders at no additional cost.</description>
             </rule>
           </rules>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ec17-55bc-f608-7b9e" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="7142-5637-eee3-884e" name="Warlord" hidden="false" targetId="bef2-c1b8-bbe1-eab5" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="7142-5637-eee3-884e" name="Warlord" hidden="false" collective="false" targetId="bef2-c1b8-bbe1-eab5" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b7ca-9872-ceaf-4fdb" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5756-0f55-9ff6-5ebc" type="max"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="636a-99b5-1e62-eb2d" name="Teleportation Transponders" hidden="true" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="26f9-2ea8-1c9c-c76c" name="Teleportation Transponder" hidden="false" targetId="ccdd-40a2-abb2-09a3" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
           <modifiers>
             <modifier type="set" field="hidden" value="false">
-              <repeats/>
               <conditions>
                 <condition field="selections" scope="38a5-b278-eb49-3779" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2926-8f43-4f60-f18f" type="equalTo"/>
               </conditions>
-              <conditionGroups/>
             </modifier>
             <modifier type="set" field="234c-3c66-2d13-7c53" value="1">
-              <repeats/>
               <conditions>
                 <condition field="selections" scope="38a5-b278-eb49-3779" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2926-8f43-4f60-f18f" type="equalTo"/>
               </conditions>
-              <conditionGroups/>
             </modifier>
             <modifier type="set" field="d5cb-462e-3c50-ddb1" value="1">
-              <repeats/>
               <conditions>
                 <condition field="selections" scope="38a5-b278-eb49-3779" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2926-8f43-4f60-f18f" type="equalTo"/>
               </conditions>
-              <conditionGroups/>
             </modifier>
           </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="234c-3c66-2d13-7c53" type="max"/>
             <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d5cb-462e-3c50-ddb1" type="min"/>
           </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
+          <infoLinks>
+            <infoLink id="26f9-2ea8-1c9c-c76c" name="Teleportation Transponder" hidden="false" targetId="ccdd-40a2-abb2-09a3" type="profile"/>
+          </infoLinks>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
-      <selectionEntryGroups/>
       <entryLinks>
-        <entryLink id="a63c-030a-ec81-1619" name="Custodian Armour" hidden="false" targetId="2c5a-1976-04e4-e277" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
+        <entryLink id="a63c-030a-ec81-1619" name="Custodian Armour" hidden="false" collective="false" targetId="2c5a-1976-04e4-e277" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5a02-c105-b282-bfc5" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="52e5-b154-c741-48d4" type="max"/>
           </constraints>
-          <categoryLinks/>
         </entryLink>
-        <entryLink id="6544-c06a-bed8-7561" name="Digital Lasers" hidden="false" targetId="155f-54a6-8ca9-27f5" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
+        <entryLink id="6544-c06a-bed8-7561" name="Digital Lasers" hidden="false" collective="false" targetId="155f-54a6-8ca9-27f5" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c915-d3a5-3d08-8a95" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c74d-c66d-0a4e-3437" type="max"/>
           </constraints>
-          <categoryLinks/>
         </entryLink>
-        <entryLink id="285b-ceac-8ab3-8962" name="Plasma + Krak Grenades" hidden="false" targetId="42e2-2cc0-6353-4d47" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
+        <entryLink id="285b-ceac-8ab3-8962" name="Plasma + Krak Grenades" hidden="false" collective="false" targetId="42e2-2cc0-6353-4d47" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b6d5-731f-c7fb-ed58" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7c9b-cee8-8723-2078" type="max"/>
           </constraints>
-          <categoryLinks/>
         </entryLink>
-        <entryLink id="4db0-48d0-6146-e8bf" name="The Apollonian Spear" hidden="false" targetId="d89b-6ac9-335a-44c2" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
+        <entryLink id="4db0-48d0-6146-e8bf" name="The Apollonian Spear" hidden="false" collective="false" targetId="d89b-6ac9-335a-44c2" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="41ac-f9c3-641d-77f7" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1543-5885-9c88-afc5" type="max"/>
           </constraints>
-          <categoryLinks/>
         </entryLink>
-        <entryLink id="ff4e-2d22-ca9d-a0c4" name="New EntryLink" hidden="false" targetId="c60c-dfd9-c5b8-50d1" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
+        <entryLink id="ff4e-2d22-ca9d-a0c4" name="New EntryLink" hidden="false" collective="false" targetId="c60c-dfd9-c5b8-50d1" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7f59-247b-d5ad-d501" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f8da-43aa-9921-22d5" type="max"/>
           </constraints>
-          <categoryLinks/>
         </entryLink>
-        <entryLink id="a24d-1e89-6e07-3274" name="Arae-Shrikes" hidden="false" targetId="be4a-0e91-0f1f-4c1d" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
+        <entryLink id="a24d-1e89-6e07-3274" name="Arae-Shrikes" hidden="false" collective="false" targetId="be4a-0e91-0f1f-4c1d" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7f09-fbaa-8beb-8f21" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2a30-b639-8355-1ac1" type="max"/>
           </constraints>
-          <categoryLinks/>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="pts" costTypeId="points" value="325.0"/>
+        <cost name="pts" typeId="points" value="325.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="cc00-5542-b66c-07ee" name="Jenetia Krole" hidden="false" collective="false" type="upgrade">
-      <profiles/>
       <rules>
         <rule id="a598-c90b-1e9e-8988" name="The Laurels of Victory" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
           <modifiers>
             <modifier type="set" field="hidden" value="true">
-              <repeats/>
               <conditions>
                 <condition field="selections" scope="cc00-5542-b66c-07ee" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a6e4-0697-7bd2-6ed2" type="equalTo"/>
               </conditions>
-              <conditionGroups/>
             </modifier>
           </modifiers>
           <description>If Jenetia Krole is your Warlord, you may opt to reroll the dice to Sieze the Initiative in missions where this is relevent, and you may also dive D3 of your Infantry units the Scouts special rule.</description>
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="989f-34aa-4c14-fcb8" name="New InfoLink" hidden="false" targetId="97d7-d358-141a-8579" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="adeb-35e2-7f16-7aaf" name="New InfoLink" hidden="false" targetId="a080-af1b-fb2e-4860" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="29fb-ac8f-6f49-3b8a" name="New InfoLink" hidden="false" targetId="988c-d4d0-9418-1165" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="e450-8d71-ddf2-0878" name="New InfoLink" hidden="false" targetId="4dd2-fcb0-de6a-5b70" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="6641-a455-704b-ccf6" name="New InfoLink" hidden="false" targetId="584d-e540-7fdd-92c9" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="baa1-7d9c-50c0-2061" name="New InfoLink" hidden="false" targetId="c793-7756-3669-827c" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="da64-fa68-bfc4-279d" name="New InfoLink" hidden="false" targetId="3ad4-1c37-d60b-1a4e" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="3dc3-e63e-7d0c-7056" name="New InfoLink" hidden="false" targetId="3e0b-be9f-b7eb-8c5e" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="6d97-30b2-db72-3e5d" name="New InfoLink" hidden="false" targetId="05b9-9f16-29f9-9dad" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="d165-8059-0871-d6d9" name="New InfoLink" hidden="false" targetId="11c2-8160-f8a0-fa51" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
+        <infoLink id="989f-34aa-4c14-fcb8" name="New InfoLink" hidden="false" targetId="97d7-d358-141a-8579" type="rule"/>
+        <infoLink id="adeb-35e2-7f16-7aaf" name="New InfoLink" hidden="false" targetId="a080-af1b-fb2e-4860" type="rule"/>
+        <infoLink id="29fb-ac8f-6f49-3b8a" name="New InfoLink" hidden="false" targetId="988c-d4d0-9418-1165" type="rule"/>
+        <infoLink id="e450-8d71-ddf2-0878" name="New InfoLink" hidden="false" targetId="4dd2-fcb0-de6a-5b70" type="rule"/>
+        <infoLink id="6641-a455-704b-ccf6" name="New InfoLink" hidden="false" targetId="584d-e540-7fdd-92c9" type="rule"/>
+        <infoLink id="baa1-7d9c-50c0-2061" name="New InfoLink" hidden="false" targetId="c793-7756-3669-827c" type="rule"/>
+        <infoLink id="da64-fa68-bfc4-279d" name="New InfoLink" hidden="false" targetId="3ad4-1c37-d60b-1a4e" type="rule"/>
+        <infoLink id="3dc3-e63e-7d0c-7056" name="New InfoLink" hidden="false" targetId="3e0b-be9f-b7eb-8c5e" type="rule"/>
+        <infoLink id="6d97-30b2-db72-3e5d" name="New InfoLink" hidden="false" targetId="05b9-9f16-29f9-9dad" type="rule"/>
+        <infoLink id="d165-8059-0871-d6d9" name="New InfoLink" hidden="false" targetId="11c2-8160-f8a0-fa51" type="profile"/>
       </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
       <entryLinks>
-        <entryLink id="7d41-adb4-4760-5def" name="New EntryLink" hidden="false" targetId="9e07-f5e7-b880-2bd5" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
+        <entryLink id="7d41-adb4-4760-5def" name="New EntryLink" hidden="false" collective="false" targetId="9e07-f5e7-b880-2bd5" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="27f9-29e3-024b-1d46" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b0b3-34c3-ab73-c78c" type="max"/>
           </constraints>
-          <categoryLinks/>
         </entryLink>
-        <entryLink id="c360-58fb-527b-6d8b" name="New EntryLink" hidden="false" targetId="273a-86b2-05d1-228c" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
+        <entryLink id="c360-58fb-527b-6d8b" name="New EntryLink" hidden="false" collective="false" targetId="273a-86b2-05d1-228c" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8343-69ed-987d-0528" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1b69-b438-8ddc-e953" type="max"/>
           </constraints>
-          <categoryLinks/>
         </entryLink>
-        <entryLink id="99ae-7ebb-68f9-6b1f" name="New EntryLink" hidden="false" targetId="5f1c-b6c2-0caa-f462" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
+        <entryLink id="99ae-7ebb-68f9-6b1f" name="New EntryLink" hidden="false" collective="false" targetId="5f1c-b6c2-0caa-f462" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9780-4d5e-f083-0b9e" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="301a-7d3c-af74-c085" type="max"/>
           </constraints>
-          <categoryLinks/>
         </entryLink>
-        <entryLink id="048b-5052-2841-3d29" name="Frag, Krak, and Psyk-Out Grenades" hidden="false" targetId="e5f6-cd68-595a-306c" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
+        <entryLink id="048b-5052-2841-3d29" name="Frag, Krak, and Psyk-Out Grenades" hidden="false" collective="false" targetId="e5f6-cd68-595a-306c" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0a27-f798-f70d-1dea" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="60f7-627f-d765-40fc" type="max"/>
           </constraints>
-          <categoryLinks/>
         </entryLink>
-        <entryLink id="0bbc-7f7c-bd4b-5044" name="New EntryLink" hidden="false" targetId="c81a-0cf2-1986-9f3b" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
+        <entryLink id="0bbc-7f7c-bd4b-5044" name="New EntryLink" hidden="false" collective="false" targetId="c81a-0cf2-1986-9f3b" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c091-6b72-c650-1489" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="95a1-2ffe-4f8f-0f8c" type="max"/>
           </constraints>
-          <categoryLinks/>
         </entryLink>
-        <entryLink id="a6e4-0697-7bd2-6ed2" name="Warlord" hidden="false" targetId="bef2-c1b8-bbe1-eab5" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
+        <entryLink id="a6e4-0697-7bd2-6ed2" name="Warlord" hidden="false" collective="false" targetId="bef2-c1b8-bbe1-eab5" type="selectionEntry"/>
       </entryLinks>
       <costs>
-        <cost name="pts" costTypeId="points" value="150.0"/>
+        <cost name="pts" typeId="points" value="150.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="6ced-0f69-b659-41da" name="Legio Custodes Aquilon Terminator Squad" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
       <infoLinks>
-        <infoLink id="2338-a096-d26d-88a9" name="New InfoLink" hidden="false" targetId="38d5-b6eb-bda8-2497" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="4f93-49c6-3dba-e017" name="New InfoLink" hidden="false" targetId="2b06-29a6-641a-b22e" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
+        <infoLink id="2338-a096-d26d-88a9" name="New InfoLink" hidden="false" targetId="38d5-b6eb-bda8-2497" type="rule"/>
+        <infoLink id="4f93-49c6-3dba-e017" name="New InfoLink" hidden="false" targetId="2b06-29a6-641a-b22e" type="rule"/>
       </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
       <selectionEntries>
         <selectionEntry id="292d-3014-ca2e-eaf1" name="Aquilon Terminator" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="eac1-a220-ea5f-eb46" name="Aquilon Terminator" hidden="false" targetId="b2b1-a620-b8da-15a0" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3db9-b814-6c6a-fbdb" type="min"/>
             <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="84da-58c1-5c94-36bd" type="max"/>
           </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
+          <infoLinks>
+            <infoLink id="eac1-a220-ea5f-eb46" name="Aquilon Terminator" hidden="false" targetId="b2b1-a620-b8da-15a0" type="profile"/>
+          </infoLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="1db5-7372-a3b1-c0ce" name="Solerite Power Gauntlet" hidden="false" collective="false" defaultSelectionEntryId="147c-3eab-542c-1d6c">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2414-fa2c-4704-f202" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1f00-6ec0-485e-e5c9" type="min"/>
               </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="147c-3eab-542c-1d6c" name="Solerite Power Gauntlet" hidden="false" targetId="8ba6-041a-ff23-98f6" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <categoryLinks/>
-                </entryLink>
-                <entryLink id="770d-39a7-2d17-48c2" name="Solerite Power Talon" hidden="false" targetId="cb99-fafa-3e9d-035e" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <categoryLinks/>
-                </entryLink>
+                <entryLink id="147c-3eab-542c-1d6c" name="Solerite Power Gauntlet" hidden="false" collective="false" targetId="8ba6-041a-ff23-98f6" type="selectionEntry"/>
+                <entryLink id="770d-39a7-2d17-48c2" name="Solerite Power Talon" hidden="false" collective="false" targetId="cb99-fafa-3e9d-035e" type="selectionEntry"/>
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="fc5a-9e7d-d4a9-2755" name="Lastrum Pattern Storm Bolter" hidden="false" collective="false" defaultSelectionEntryId="2ada-6911-a187-35a8">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e27f-8b75-d2ba-6085" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="44a6-5ffa-d697-ef89" type="min"/>
               </constraints>
-              <categoryLinks/>
               <selectionEntries>
                 <selectionEntry id="5962-87f8-4be7-24fc" name="Twin-Linked Adrathic Destructor" hidden="false" collective="false" type="upgrade">
-                  <profiles/>
-                  <rules/>
                   <infoLinks>
-                    <infoLink id="8cd0-50e9-9723-80a5" name="New InfoLink" hidden="false" targetId="10a8-8d89-0bec-3e21" type="rule">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                    <infoLink id="53c8-8183-eb97-d22d" name="New InfoLink" hidden="false" targetId="0351-af54-349e-1fd3" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
+                    <infoLink id="8cd0-50e9-9723-80a5" name="New InfoLink" hidden="false" targetId="10a8-8d89-0bec-3e21" type="rule"/>
+                    <infoLink id="53c8-8183-eb97-d22d" name="New InfoLink" hidden="false" targetId="0351-af54-349e-1fd3" type="profile"/>
                   </infoLinks>
-                  <modifiers/>
-                  <constraints/>
-                  <categoryLinks/>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
                   <costs>
-                    <cost name="pts" costTypeId="points" value="15.0"/>
+                    <cost name="pts" typeId="points" value="15.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
-              <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="2ada-6911-a187-35a8" name="New EntryLink" hidden="false" targetId="2693-afa7-96a3-150a" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <categoryLinks/>
-                </entryLink>
-                <entryLink id="6e42-a4a7-b5d0-2a42" name="New EntryLink" hidden="false" targetId="af24-638f-cd0d-5d2d" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
+                <entryLink id="2ada-6911-a187-35a8" name="New EntryLink" hidden="false" collective="false" targetId="2693-afa7-96a3-150a" type="selectionEntry"/>
+                <entryLink id="6e42-a4a7-b5d0-2a42" name="New EntryLink" hidden="false" collective="false" targetId="af24-638f-cd0d-5d2d" type="selectionEntry">
                   <modifiers>
-                    <modifier type="set" field="points" value="15">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
+                    <modifier type="set" field="points" value="15"/>
                   </modifiers>
-                  <constraints/>
-                  <categoryLinks/>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks>
-            <entryLink id="81f4-74ee-e023-55a7" name="New EntryLink" hidden="false" targetId="6e95-2ae6-4dd8-c24b" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="81f4-74ee-e023-55a7" name="New EntryLink" hidden="false" collective="false" targetId="6e95-2ae6-4dd8-c24b" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aa22-7607-2bfb-d11a" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="36e0-6760-af35-1b55" type="min"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="pts" costTypeId="points" value="75.0"/>
+            <cost name="pts" typeId="points" value="75.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="1988-6c68-32eb-08ef" name="Entire squad may be equipped with:" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="27da-6c37-ea40-c395" name="Arae-Shrikes" hidden="false" targetId="be4a-0e91-0f1f-4c1d" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
+            <entryLink id="27da-6c37-ea40-c395" name="Arae-Shrikes" hidden="false" collective="false" targetId="be4a-0e91-0f1f-4c1d" type="selectionEntry">
               <modifiers>
                 <modifier type="increment" field="points" value="15">
                   <repeats>
                     <repeat field="selections" scope="6ced-0f69-b659-41da" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="292d-3014-ca2e-eaf1" repeats="1" roundUp="false"/>
                   </repeats>
-                  <conditions/>
-                  <conditionGroups/>
                 </modifier>
               </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7b81-3b6f-e3cd-e8a5" type="max"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="bf92-5cb4-a9f0-8496" name="Teleportation Transponders" hidden="false" targetId="81f8-eb55-e1fd-c90a" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
+            <entryLink id="bf92-5cb4-a9f0-8496" name="Teleportation Transponders" hidden="false" collective="false" targetId="81f8-eb55-e1fd-c90a" type="selectionEntry">
               <modifiers>
                 <modifier type="increment" field="points" value="5">
                   <repeats>
                     <repeat field="selections" scope="6ced-0f69-b659-41da" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="292d-3014-ca2e-eaf1" repeats="1" roundUp="false"/>
                   </repeats>
-                  <conditions/>
-                  <conditionGroups/>
                 </modifier>
               </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3c68-c133-5d0b-57c3" type="max"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="a11a-5607-fba9-c546" name="Teleportation Transponders" hidden="false" targetId="7d72-4429-d25c-54f3" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
+            <entryLink id="a11a-5607-fba9-c546" name="Teleportation Transponders" hidden="false" collective="false" targetId="7d72-4429-d25c-54f3" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="e5cc-9a82-291b-884a" name="Legio Custodes" hidden="false" targetId="a502-5799-a2f4-310b" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
+        <entryLink id="e5cc-9a82-291b-884a" name="Legio Custodes" hidden="false" collective="false" targetId="a502-5799-a2f4-310b" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1c99-cb38-2a60-1cca" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="057c-686c-f233-6462" type="min"/>
           </constraints>
-          <categoryLinks/>
         </entryLink>
-        <entryLink id="02a4-3158-a5e5-aeb8" name="Legio Custodes Dedicated Transport" hidden="false" targetId="c43b-5c09-9eae-27ba" type="selectionEntryGroup">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
+        <entryLink id="02a4-3158-a5e5-aeb8" name="Legio Custodes Dedicated Transport" hidden="false" collective="false" targetId="c43b-5c09-9eae-27ba" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
-              <repeats/>
               <conditions>
                 <condition field="selections" scope="6ced-0f69-b659-41da" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="292d-3014-ca2e-eaf1" type="greaterThan"/>
               </conditions>
-              <conditionGroups/>
             </modifier>
           </modifiers>
-          <constraints/>
-          <categoryLinks/>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="pts" costTypeId="points" value="30.0"/>
+        <cost name="pts" typeId="points" value="30.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="d290-734d-18b9-e387" name="Legio Custodes Hetaeron Guard Squad" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
       <infoLinks>
-        <infoLink id="36c6-17fc-4c9a-cf98" name="New InfoLink" hidden="false" targetId="38d5-b6eb-bda8-2497" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="def4-7a3c-839b-c526" name="New InfoLink" hidden="false" targetId="2b06-29a6-641a-b22e" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="8f50-c6ae-dca3-2a5c" name="New InfoLink" hidden="false" targetId="0900-71d5-1937-aa96" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
+        <infoLink id="36c6-17fc-4c9a-cf98" name="New InfoLink" hidden="false" targetId="38d5-b6eb-bda8-2497" type="rule"/>
+        <infoLink id="def4-7a3c-839b-c526" name="New InfoLink" hidden="false" targetId="2b06-29a6-641a-b22e" type="rule"/>
+        <infoLink id="8f50-c6ae-dca3-2a5c" name="New InfoLink" hidden="false" targetId="0900-71d5-1937-aa96" type="rule"/>
       </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
       <selectionEntries>
         <selectionEntry id="dc96-2155-7060-2d58" name="Hetaeron Guard" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="3af0-a71e-77f1-50d4" name="New InfoLink" hidden="false" targetId="074e-25bb-c644-f4bc" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b031-0823-a8bb-de6e" type="min"/>
             <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6fae-1676-c873-77d6" type="max"/>
           </constraints>
-          <categoryLinks/>
+          <infoLinks>
+            <infoLink id="3af0-a71e-77f1-50d4" name="New InfoLink" hidden="false" targetId="074e-25bb-c644-f4bc" type="profile"/>
+          </infoLinks>
           <selectionEntries>
             <selectionEntry id="2b8b-3081-9aa9-bb93" name="May Take a Praesidium Shield" hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="e949-af8d-2d7f-aa9c" name="New InfoLink" hidden="false" targetId="8801-24fc-bb8c-ef86" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
-                  <repeats/>
-                  <conditions/>
                   <conditionGroups>
                     <conditionGroup type="or">
                       <conditions>
                         <condition field="selections" scope="dc96-2155-7060-2d58" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="65d7-a925-2f18-c452" type="equalTo"/>
                         <condition field="selections" scope="dc96-2155-7060-2d58" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ead9-3236-e39f-2e83" type="equalTo"/>
                       </conditions>
-                      <conditionGroups/>
                     </conditionGroup>
                   </conditionGroups>
                 </modifier>
@@ -4821,2410 +2228,1134 @@
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="441d-8ef0-ef2a-82b1" type="max"/>
               </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
+              <infoLinks>
+                <infoLink id="e949-af8d-2d7f-aa9c" name="New InfoLink" hidden="false" targetId="8801-24fc-bb8c-ef86" type="profile"/>
+              </infoLinks>
               <costs>
-                <cost name="pts" costTypeId="points" value="10.0"/>
+                <cost name="pts" typeId="points" value="10.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
           <selectionEntryGroups>
             <selectionEntryGroup id="2015-e681-2dc6-f853" name="May Replace his Guardian Spear with:" hidden="false" collective="false" defaultSelectionEntryId="e858-d4f4-e1b7-27b8">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b494-3c1e-d435-00f4" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ddbf-7949-bb4d-bd82" type="min"/>
               </constraints>
-              <categoryLinks/>
               <selectionEntries>
                 <selectionEntry id="ead9-3236-e39f-2e83" name="Magisterium Vexilla and a Master-Crafted Power Weapon" hidden="false" collective="false" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
                   <modifiers>
                     <modifier type="set" field="a2cd-6062-932a-3cdd" value="0.0">
-                      <repeats/>
                       <conditions>
                         <condition field="selections" scope="d290-734d-18b9-e387" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="65d7-a925-2f18-c452" type="equalTo"/>
                       </conditions>
-                      <conditionGroups/>
                     </modifier>
                   </modifiers>
                   <constraints>
                     <constraint field="selections" scope="d290-734d-18b9-e387" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a2cd-6062-932a-3cdd" type="max"/>
                   </constraints>
-                  <categoryLinks/>
-                  <selectionEntries/>
                   <selectionEntryGroups>
                     <selectionEntryGroup id="009e-d756-2c22-3ab8" name="Power Weapon" hidden="false" collective="false" defaultSelectionEntryId="f623-1182-367d-5046">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
                       <constraints>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="455e-c313-d379-c769" type="max"/>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9607-80fa-cea2-8681" type="min"/>
                       </constraints>
-                      <categoryLinks/>
                       <selectionEntries>
                         <selectionEntry id="f623-1182-367d-5046" name="Power Sword" hidden="false" collective="false" type="upgrade">
-                          <profiles/>
-                          <rules/>
                           <infoLinks>
-                            <infoLink id="9ddf-193a-4b9c-0aec" name="New InfoLink" hidden="false" targetId="038e-23ec-4886-8b00" type="profile">
-                              <profiles/>
-                              <rules/>
-                              <infoLinks/>
-                              <modifiers/>
-                            </infoLink>
-                            <infoLink id="327b-ab81-53ec-7195" name="New InfoLink" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule">
-                              <profiles/>
-                              <rules/>
-                              <infoLinks/>
-                              <modifiers/>
-                            </infoLink>
+                            <infoLink id="9ddf-193a-4b9c-0aec" name="New InfoLink" hidden="false" targetId="038e-23ec-4886-8b00" type="profile"/>
+                            <infoLink id="327b-ab81-53ec-7195" name="New InfoLink" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule"/>
                           </infoLinks>
-                          <modifiers/>
-                          <constraints/>
-                          <categoryLinks/>
-                          <selectionEntries/>
-                          <selectionEntryGroups/>
-                          <entryLinks/>
                           <costs>
-                            <cost name="pts" costTypeId="points" value="0.0"/>
+                            <cost name="pts" typeId="points" value="0.0"/>
                           </costs>
                         </selectionEntry>
                         <selectionEntry id="43f9-3391-c2f9-286e" name="Power Lance" hidden="false" collective="false" type="upgrade">
-                          <profiles/>
-                          <rules/>
                           <infoLinks>
-                            <infoLink id="d8f8-3f50-32d7-0003" name="New InfoLink" hidden="false" targetId="fdd4-9bf3-da9d-5479" type="profile">
-                              <profiles/>
-                              <rules/>
-                              <infoLinks/>
-                              <modifiers/>
-                            </infoLink>
-                            <infoLink id="46fb-1162-7be4-81b2" name="New InfoLink" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule">
-                              <profiles/>
-                              <rules/>
-                              <infoLinks/>
-                              <modifiers/>
-                            </infoLink>
+                            <infoLink id="d8f8-3f50-32d7-0003" name="New InfoLink" hidden="false" targetId="fdd4-9bf3-da9d-5479" type="profile"/>
+                            <infoLink id="46fb-1162-7be4-81b2" name="New InfoLink" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule"/>
                           </infoLinks>
-                          <modifiers/>
-                          <constraints/>
-                          <categoryLinks/>
-                          <selectionEntries/>
-                          <selectionEntryGroups/>
-                          <entryLinks/>
                           <costs>
-                            <cost name="pts" costTypeId="points" value="0.0"/>
+                            <cost name="pts" typeId="points" value="0.0"/>
                           </costs>
                         </selectionEntry>
                         <selectionEntry id="739e-2a47-3907-03ef" name="Power Maul" hidden="false" collective="false" type="upgrade">
-                          <profiles/>
-                          <rules/>
                           <infoLinks>
-                            <infoLink id="38b4-21e4-1171-c57a" name="New InfoLink" hidden="false" targetId="6bbe-f2c1-78e2-da59" type="profile">
-                              <profiles/>
-                              <rules/>
-                              <infoLinks/>
-                              <modifiers/>
-                            </infoLink>
-                            <infoLink id="3019-e0f5-402a-1a63" name="New InfoLink" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule">
-                              <profiles/>
-                              <rules/>
-                              <infoLinks/>
-                              <modifiers/>
-                            </infoLink>
+                            <infoLink id="38b4-21e4-1171-c57a" name="New InfoLink" hidden="false" targetId="6bbe-f2c1-78e2-da59" type="profile"/>
+                            <infoLink id="3019-e0f5-402a-1a63" name="New InfoLink" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule"/>
                           </infoLinks>
-                          <modifiers/>
-                          <constraints/>
-                          <categoryLinks/>
-                          <selectionEntries/>
-                          <selectionEntryGroups/>
-                          <entryLinks/>
                           <costs>
-                            <cost name="pts" costTypeId="points" value="0.0"/>
+                            <cost name="pts" typeId="points" value="0.0"/>
                           </costs>
                         </selectionEntry>
                         <selectionEntry id="947f-8d17-6959-907c" name="Power Axe" hidden="false" collective="false" type="upgrade">
-                          <profiles/>
-                          <rules/>
                           <infoLinks>
-                            <infoLink id="b47d-3632-e66d-1aa8" name="New InfoLink" hidden="false" targetId="b3af-1eca-6629-4894" type="profile">
-                              <profiles/>
-                              <rules/>
-                              <infoLinks/>
-                              <modifiers/>
-                            </infoLink>
-                            <infoLink id="2bdd-53d2-fc8c-83c6" name="New InfoLink" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule">
-                              <profiles/>
-                              <rules/>
-                              <infoLinks/>
-                              <modifiers/>
-                            </infoLink>
+                            <infoLink id="b47d-3632-e66d-1aa8" name="New InfoLink" hidden="false" targetId="b3af-1eca-6629-4894" type="profile"/>
+                            <infoLink id="2bdd-53d2-fc8c-83c6" name="New InfoLink" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule"/>
                           </infoLinks>
-                          <modifiers/>
-                          <constraints/>
-                          <categoryLinks/>
-                          <selectionEntries/>
-                          <selectionEntryGroups/>
-                          <entryLinks/>
                           <costs>
-                            <cost name="pts" costTypeId="points" value="0.0"/>
+                            <cost name="pts" typeId="points" value="0.0"/>
                           </costs>
                         </selectionEntry>
                       </selectionEntries>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
                     </selectionEntryGroup>
                   </selectionEntryGroups>
                   <entryLinks>
-                    <entryLink id="6d9a-6a66-142f-9d76" name="Magisterium Vexilla" hidden="false" targetId="b7c1-be91-5d72-c763" type="selectionEntry">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
+                    <entryLink id="6d9a-6a66-142f-9d76" name="Magisterium Vexilla" hidden="false" collective="false" targetId="b7c1-be91-5d72-c763" type="selectionEntry">
                       <constraints>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b6c4-a0ea-3700-10c7" type="max"/>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9e3a-bde8-6940-1449" type="min"/>
                       </constraints>
-                      <categoryLinks/>
                     </entryLink>
                   </entryLinks>
                   <costs>
-                    <cost name="pts" costTypeId="points" value="15.0"/>
+                    <cost name="pts" typeId="points" value="15.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="65d7-a925-2f18-c452" name="Magisterium Vexilla and a Sentinel Warblade" hidden="false" collective="false" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
                   <modifiers>
                     <modifier type="set" field="7aee-317c-941a-fcac" value="0.0">
-                      <repeats/>
                       <conditions>
                         <condition field="selections" scope="d290-734d-18b9-e387" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ead9-3236-e39f-2e83" type="equalTo"/>
                       </conditions>
-                      <conditionGroups/>
                     </modifier>
                   </modifiers>
                   <constraints>
                     <constraint field="selections" scope="d290-734d-18b9-e387" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7aee-317c-941a-fcac" type="max"/>
                   </constraints>
-                  <categoryLinks/>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
                   <entryLinks>
-                    <entryLink id="a1db-f58d-333b-eabf" name="New EntryLink" hidden="false" targetId="0caf-31e2-cd7b-a4dd" type="selectionEntry">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
+                    <entryLink id="a1db-f58d-333b-eabf" name="New EntryLink" hidden="false" collective="false" targetId="0caf-31e2-cd7b-a4dd" type="selectionEntry">
                       <constraints>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6d38-070f-4dba-736b" type="max"/>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="82de-8b34-025a-ca2d" type="min"/>
                       </constraints>
-                      <categoryLinks/>
                     </entryLink>
-                    <entryLink id="0263-56ac-c7c8-9242" name="New EntryLink" hidden="false" targetId="b7c1-be91-5d72-c763" type="selectionEntry">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
+                    <entryLink id="0263-56ac-c7c8-9242" name="New EntryLink" hidden="false" collective="false" targetId="b7c1-be91-5d72-c763" type="selectionEntry">
                       <constraints>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7a6c-b18e-82a2-c956" type="max"/>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a017-abbc-efb3-23d1" type="min"/>
                       </constraints>
-                      <categoryLinks/>
                     </entryLink>
                   </entryLinks>
                   <costs>
-                    <cost name="pts" costTypeId="points" value="20.0"/>
+                    <cost name="pts" typeId="points" value="20.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
-              <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="e858-d4f4-e1b7-27b8" name="Guardian Spear" hidden="false" targetId="dc9c-fe1d-8c26-fb07" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
+                <entryLink id="e858-d4f4-e1b7-27b8" name="Guardian Spear" hidden="false" collective="false" targetId="dc9c-fe1d-8c26-fb07" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0274-a935-add3-523e" type="max"/>
                   </constraints>
-                  <categoryLinks/>
                 </entryLink>
-                <entryLink id="673b-7aa5-76b4-afe7" name="New EntryLink" hidden="false" targetId="4af1-fc20-e881-7ad9" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
+                <entryLink id="673b-7aa5-76b4-afe7" name="New EntryLink" hidden="false" collective="false" targetId="4af1-fc20-e881-7ad9" type="selectionEntry">
                   <modifiers>
-                    <modifier type="set" field="points" value="15">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
+                    <modifier type="set" field="points" value="15"/>
                   </modifiers>
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ee71-41d8-2ae6-2df6" type="max"/>
                   </constraints>
-                  <categoryLinks/>
                 </entryLink>
-                <entryLink id="ed10-348b-8ade-578e" name="New EntryLink" hidden="false" targetId="0179-aa55-899c-aa0b" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
+                <entryLink id="ed10-348b-8ade-578e" name="New EntryLink" hidden="false" collective="false" targetId="0179-aa55-899c-aa0b" type="selectionEntry">
                   <modifiers>
-                    <modifier type="set" field="points" value="10">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
+                    <modifier type="set" field="points" value="10"/>
                   </modifiers>
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6075-c60e-6563-5850" type="max"/>
                   </constraints>
-                  <categoryLinks/>
                 </entryLink>
-                <entryLink id="3e3f-dedf-af60-d5e7" name="New EntryLink" hidden="false" targetId="0caf-31e2-cd7b-a4dd" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <categoryLinks/>
-                </entryLink>
-                <entryLink id="f17a-3126-d440-c019" name="New EntryLink" hidden="false" targetId="cb99-fafa-3e9d-035e" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
+                <entryLink id="3e3f-dedf-af60-d5e7" name="New EntryLink" hidden="false" collective="false" targetId="0caf-31e2-cd7b-a4dd" type="selectionEntry"/>
+                <entryLink id="f17a-3126-d440-c019" name="New EntryLink" hidden="false" collective="false" targetId="cb99-fafa-3e9d-035e" type="selectionEntry">
                   <modifiers>
-                    <modifier type="set" field="points" value="10">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
+                    <modifier type="set" field="points" value="10"/>
                   </modifiers>
-                  <constraints/>
-                  <categoryLinks/>
                 </entryLink>
-                <entryLink id="e8fc-3dd5-b752-fdca" name="New EntryLink" hidden="false" targetId="8ba6-041a-ff23-98f6" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
+                <entryLink id="e8fc-3dd5-b752-fdca" name="New EntryLink" hidden="false" collective="false" targetId="8ba6-041a-ff23-98f6" type="selectionEntry">
                   <modifiers>
-                    <modifier type="set" field="points" value="15">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
+                    <modifier type="set" field="points" value="15"/>
                   </modifiers>
-                  <constraints/>
-                  <categoryLinks/>
                 </entryLink>
-                <entryLink id="f38c-bd8f-b9ee-4538" name="Paragon Blade" hidden="false" targetId="99f1-e166-4deb-ab11" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
+                <entryLink id="f38c-bd8f-b9ee-4538" name="Paragon Blade" hidden="false" collective="false" targetId="99f1-e166-4deb-ab11" type="selectionEntry">
                   <modifiers>
-                    <modifier type="set" field="points" value="25">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
+                    <modifier type="set" field="points" value="25"/>
                   </modifiers>
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b551-3ab5-e222-4e59" type="max"/>
                   </constraints>
-                  <categoryLinks/>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks>
-            <entryLink id="71bb-02b9-fda8-7c37" name="New EntryLink" hidden="false" targetId="2c5a-1976-04e4-e277" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="71bb-02b9-fda8-7c37" name="New EntryLink" hidden="false" collective="false" targetId="2c5a-1976-04e4-e277" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7296-fde3-0484-136e" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bb02-521e-8591-a731" type="max"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="d8fb-bc19-eed9-f883" name="New EntryLink" hidden="false" targetId="011a-b751-e773-6b90" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="d8fb-bc19-eed9-f883" name="New EntryLink" hidden="false" collective="false" targetId="011a-b751-e773-6b90" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5e57-f41e-4afd-0bce" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7ce9-9e1e-f127-d427" type="max"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="087d-bbe7-3165-9263" name="Plasma + Krak Grenades" hidden="false" targetId="42e2-2cc0-6353-4d47" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="087d-bbe7-3165-9263" name="Plasma + Krak Grenades" hidden="false" collective="false" targetId="42e2-2cc0-6353-4d47" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="498b-31e0-5cdc-30d6" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ea69-9a5e-96c9-5bb9" type="max"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="pts" costTypeId="points" value="70.0"/>
+            <cost name="pts" typeId="points" value="70.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="3031-ee5d-34ec-ee7d" name="Entire squad may be equipped with:" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="15d9-e051-b423-6d2c" name="Melta bombs" hidden="false" targetId="648a-e853-bb44-9cee" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
+            <entryLink id="15d9-e051-b423-6d2c" name="Melta bombs" hidden="false" collective="false" targetId="648a-e853-bb44-9cee" type="selectionEntry">
               <modifiers>
                 <modifier type="increment" field="points" value="5">
                   <repeats>
                     <repeat field="selections" scope="d290-734d-18b9-e387" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dc96-2155-7060-2d58" repeats="1" roundUp="false"/>
                   </repeats>
-                  <conditions/>
-                  <conditionGroups/>
                 </modifier>
               </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4c4a-1768-32e9-b11c" type="max"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="72fd-7abe-3f0d-1fb6" name="Arae-Shrikes" hidden="false" targetId="be4a-0e91-0f1f-4c1d" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
+            <entryLink id="72fd-7abe-3f0d-1fb6" name="Arae-Shrikes" hidden="false" collective="false" targetId="be4a-0e91-0f1f-4c1d" type="selectionEntry">
               <modifiers>
                 <modifier type="increment" field="points" value="15">
                   <repeats>
                     <repeat field="selections" scope="d290-734d-18b9-e387" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dc96-2155-7060-2d58" repeats="1" roundUp="false"/>
                   </repeats>
-                  <conditions/>
-                  <conditionGroups/>
                 </modifier>
               </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="82e1-254c-8145-c328" type="max"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="a65e-68f8-5758-65fe" name="New EntryLink" hidden="false" targetId="81f8-eb55-e1fd-c90a" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
+            <entryLink id="a65e-68f8-5758-65fe" name="New EntryLink" hidden="false" collective="false" targetId="81f8-eb55-e1fd-c90a" type="selectionEntry">
               <modifiers>
                 <modifier type="increment" field="points" value="5">
                   <repeats>
                     <repeat field="selections" scope="d290-734d-18b9-e387" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dc96-2155-7060-2d58" repeats="1" roundUp="false"/>
                   </repeats>
-                  <conditions/>
-                  <conditionGroups/>
                 </modifier>
               </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ee76-f93a-d827-7da9" type="max"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="4b09-5e5a-947b-c13d" name="Teleportation Transponders" hidden="false" targetId="7d72-4429-d25c-54f3" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
+            <entryLink id="4b09-5e5a-947b-c13d" name="Teleportation Transponders" hidden="false" collective="false" targetId="7d72-4429-d25c-54f3" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="9b6e-269d-b90f-6c50" name="New EntryLink" hidden="false" targetId="a502-5799-a2f4-310b" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
+        <entryLink id="9b6e-269d-b90f-6c50" name="New EntryLink" hidden="false" collective="false" targetId="a502-5799-a2f4-310b" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="22d4-5aa6-3ef0-f21a" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c07c-0eae-f3d2-bbc3" type="min"/>
           </constraints>
-          <categoryLinks/>
         </entryLink>
-        <entryLink id="dbf1-a23d-a901-4947" name="New EntryLink" hidden="false" targetId="c43b-5c09-9eae-27ba" type="selectionEntryGroup">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
+        <entryLink id="dbf1-a23d-a901-4947" name="New EntryLink" hidden="false" collective="false" targetId="c43b-5c09-9eae-27ba" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
-              <repeats/>
               <conditions>
                 <condition field="selections" scope="d290-734d-18b9-e387" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="dc96-2155-7060-2d58" type="greaterThan"/>
               </conditions>
-              <conditionGroups/>
             </modifier>
           </modifiers>
-          <constraints/>
-          <categoryLinks/>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="pts" costTypeId="points" value="40.0"/>
+        <cost name="pts" typeId="points" value="40.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="95b0-bc7c-b477-069b" name="Legio Custodes Contemptor-Achillus Dreadnought" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
       <infoLinks>
-        <infoLink id="06ee-92e6-c7a9-bab3" name="New InfoLink" hidden="false" targetId="6329-c318-322f-3690" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="b3f8-7d3a-e7c0-ad7f" name="New InfoLink" hidden="false" targetId="6875-ee73-2a85-6a97" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="2be2-6fd8-9149-5bbf" name="New InfoLink" hidden="false" targetId="0900-71d5-1937-aa96" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="e8ad-bb08-8e88-3e25" name="New InfoLink" hidden="false" targetId="6d06-5ea0-9a17-ca97" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="b3af-3a22-ff96-5629" name="New InfoLink" hidden="false" targetId="69e5-fc02-1f9d-63c2" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="1833-dcab-6b7d-26a8" name="New InfoLink" hidden="false" targetId="79c7-90f6-b453-e799" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="54c7-0ce0-a7b1-ac19" name="Refractor Field" hidden="false" targetId="4845-0bfe-2c22-883f" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="0b98-3911-ffbf-9830" name="New InfoLink" hidden="false" targetId="9bb4-3833-5343-0dd9" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
+        <infoLink id="06ee-92e6-c7a9-bab3" name="New InfoLink" hidden="false" targetId="6329-c318-322f-3690" type="profile"/>
+        <infoLink id="b3f8-7d3a-e7c0-ad7f" name="New InfoLink" hidden="false" targetId="6875-ee73-2a85-6a97" type="profile"/>
+        <infoLink id="2be2-6fd8-9149-5bbf" name="New InfoLink" hidden="false" targetId="0900-71d5-1937-aa96" type="rule"/>
+        <infoLink id="e8ad-bb08-8e88-3e25" name="New InfoLink" hidden="false" targetId="6d06-5ea0-9a17-ca97" type="rule"/>
+        <infoLink id="b3af-3a22-ff96-5629" name="New InfoLink" hidden="false" targetId="69e5-fc02-1f9d-63c2" type="rule"/>
+        <infoLink id="1833-dcab-6b7d-26a8" name="New InfoLink" hidden="false" targetId="79c7-90f6-b453-e799" type="profile"/>
+        <infoLink id="54c7-0ce0-a7b1-ac19" name="Refractor Field" hidden="false" targetId="4845-0bfe-2c22-883f" type="profile"/>
+        <infoLink id="0b98-3911-ffbf-9830" name="New InfoLink" hidden="false" targetId="9bb4-3833-5343-0dd9" type="profile"/>
       </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
       <selectionEntries>
         <selectionEntry id="dc75-d782-32ec-f1d8" name="Two Dreadnought Close Combat Weapons" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0307-ecbe-c7ec-24b8" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9925-b195-bb51-8838" type="max"/>
           </constraints>
-          <categoryLinks/>
           <selectionEntries>
             <selectionEntry id="104b-9f75-5fb7-c715" name="Dreadnought Close Combat weapon" hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="a204-191e-9686-1547" name="New InfoLink" hidden="false" targetId="3b26-3098-155f-0e58" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bfc8-0831-2d50-90f6" type="max"/>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dc62-a51e-0cce-128c" type="min"/>
               </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
+              <infoLinks>
+                <infoLink id="a204-191e-9686-1547" name="New InfoLink" hidden="false" targetId="3b26-3098-155f-0e58" type="profile"/>
+              </infoLinks>
               <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
+                <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
           <selectionEntryGroups>
             <selectionEntryGroup id="cd45-748b-80f0-0572" name="Inbuilt Lastrum Storm Bolters" hidden="false" collective="false" defaultSelectionEntryId="405f-7ff7-fb16-f07f">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eec8-d802-54a8-ffab" type="max"/>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8f82-f4e6-d65e-eac9" type="min"/>
               </constraints>
-              <categoryLinks/>
               <selectionEntries>
                 <selectionEntry id="9c30-a280-51da-f944" name="Twin-Linked Adrathic Destructor" hidden="false" collective="false" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="c5fd-4ad9-8b4f-607d" name="Twin-linked" hidden="false" targetId="10a8-8d89-0bec-3e21" type="rule">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                    <infoLink id="24f6-a21f-ed1e-91c2" name="Adrathic Destructor" hidden="false" targetId="0351-af54-349e-1fd3" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
                   <constraints>
                     <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="429b-bae0-0edc-3943" type="max"/>
                   </constraints>
-                  <categoryLinks/>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
+                  <infoLinks>
+                    <infoLink id="c5fd-4ad9-8b4f-607d" name="Twin-linked" hidden="false" targetId="10a8-8d89-0bec-3e21" type="rule"/>
+                    <infoLink id="24f6-a21f-ed1e-91c2" name="Adrathic Destructor" hidden="false" targetId="0351-af54-349e-1fd3" type="profile"/>
+                  </infoLinks>
                   <costs>
-                    <cost name="pts" costTypeId="points" value="15.0"/>
+                    <cost name="pts" typeId="points" value="15.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
-              <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="405f-7ff7-fb16-f07f" name="New EntryLink" hidden="false" targetId="2693-afa7-96a3-150a" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
+                <entryLink id="405f-7ff7-fb16-f07f" name="New EntryLink" hidden="false" collective="false" targetId="2693-afa7-96a3-150a" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b696-d3a2-af88-0fb0" type="max"/>
                   </constraints>
-                  <categoryLinks/>
                 </entryLink>
-                <entryLink id="070e-ba24-64cb-36b4" name="Infernus Incinerator" hidden="false" targetId="a52a-cf67-2fb7-1cf5" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
+                <entryLink id="070e-ba24-64cb-36b4" name="Infernus Incinerator" hidden="false" collective="false" targetId="a52a-cf67-2fb7-1cf5" type="selectionEntry">
                   <modifiers>
-                    <modifier type="set" field="points" value="5">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
+                    <modifier type="set" field="points" value="5"/>
                   </modifiers>
                   <constraints>
                     <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1f62-1b64-a717-f24e" type="max"/>
                   </constraints>
-                  <categoryLinks/>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
-          <entryLinks/>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="d61d-834b-3e6c-f057" name="May Take a Achillus Dreadspear with inbuilt Corvae Las-Pulser" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="ad0d-3c8c-08d3-00aa" name="New InfoLink" hidden="false" targetId="5076-87fe-92aa-f4a9" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="0655-9f6a-ba37-0ee6" name="Achillus Dreadspear" hidden="false" targetId="d87d-0686-d02f-ed9c" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="ac6f-73c7-01eb-01ea" name="Impaling" hidden="false" targetId="8507-1dbf-2690-2157" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="8b01-e592-6a7c-1fc9" name="New InfoLink" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0c38-f283-9112-0bc3" type="max"/>
           </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
+          <infoLinks>
+            <infoLink id="ad0d-3c8c-08d3-00aa" name="New InfoLink" hidden="false" targetId="5076-87fe-92aa-f4a9" type="profile"/>
+            <infoLink id="0655-9f6a-ba37-0ee6" name="Achillus Dreadspear" hidden="false" targetId="d87d-0686-d02f-ed9c" type="profile"/>
+            <infoLink id="ac6f-73c7-01eb-01ea" name="Impaling" hidden="false" targetId="8507-1dbf-2690-2157" type="rule"/>
+            <infoLink id="8b01-e592-6a7c-1fc9" name="New InfoLink" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule"/>
+          </infoLinks>
           <costs>
-            <cost name="pts" costTypeId="points" value="60.0"/>
+            <cost name="pts" typeId="points" value="60.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
-      <selectionEntryGroups/>
-      <entryLinks/>
       <costs>
-        <cost name="pts" costTypeId="points" value="215.0"/>
+        <cost name="pts" typeId="points" value="215.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="52aa-6b05-24b3-d283" name="Legio Custodes Coronus Grav-Carrier" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
       <infoLinks>
-        <infoLink id="e1c7-5859-b421-a94c" name="New InfoLink" hidden="false" targetId="d0b7-ed3f-25c8-1e63" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="c688-9996-9714-4fd5" name="New InfoLink" hidden="false" targetId="0ac1-dfc1-295b-50a6" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="6e0b-c6a7-4ee7-ef65" name="New InfoLink" hidden="false" targetId="d219-2314-4834-c054" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="f3ab-46e5-f3fa-95dd" name="New InfoLink" hidden="false" targetId="de18-25a0-504b-74be" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="68ea-bd55-2e31-a356" name="New InfoLink" hidden="false" targetId="1254-9285-e876-010d" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="f4b0-9572-f331-95b0" name="Coronus Grav-Carrier" hidden="false" targetId="fb44-2178-c180-a450" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="34b2-68c4-f7c7-f6af" name="Coronus Grav-Carrier" hidden="false" targetId="e63f-762a-dde4-4c66" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
+        <infoLink id="e1c7-5859-b421-a94c" name="New InfoLink" hidden="false" targetId="d0b7-ed3f-25c8-1e63" type="rule"/>
+        <infoLink id="c688-9996-9714-4fd5" name="New InfoLink" hidden="false" targetId="0ac1-dfc1-295b-50a6" type="rule"/>
+        <infoLink id="6e0b-c6a7-4ee7-ef65" name="New InfoLink" hidden="false" targetId="d219-2314-4834-c054" type="rule"/>
+        <infoLink id="f3ab-46e5-f3fa-95dd" name="New InfoLink" hidden="false" targetId="de18-25a0-504b-74be" type="rule"/>
+        <infoLink id="68ea-bd55-2e31-a356" name="New InfoLink" hidden="false" targetId="1254-9285-e876-010d" type="rule"/>
+        <infoLink id="f4b0-9572-f331-95b0" name="Coronus Grav-Carrier" hidden="false" targetId="fb44-2178-c180-a450" type="profile"/>
+        <infoLink id="34b2-68c4-f7c7-f6af" name="Coronus Grav-Carrier" hidden="false" targetId="e63f-762a-dde4-4c66" type="profile"/>
       </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
       <selectionEntries>
         <selectionEntry id="5be0-5093-ebf4-d943" name="Twin-Linked Lastrum Bolt Cannon" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="92ec-6053-6a8b-d087" name="New InfoLink" hidden="false" targetId="10a8-8d89-0bec-3e21" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5cf0-65d7-21d6-04f2" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6a70-bfcf-79ae-2dff" type="min"/>
           </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
+          <infoLinks>
+            <infoLink id="92ec-6053-6a8b-d087" name="New InfoLink" hidden="false" targetId="10a8-8d89-0bec-3e21" type="rule"/>
+          </infoLinks>
           <entryLinks>
-            <entryLink id="0d56-3db8-ec74-d0d9" name="New EntryLink" hidden="false" targetId="e854-b201-250d-5b1b" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="0d56-3db8-ec74-d0d9" name="New EntryLink" hidden="false" collective="false" targetId="e854-b201-250d-5b1b" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1650-5bc6-faee-3745" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="571b-cfac-3397-7720" type="min"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="37a0-222f-3e30-5879" name="Twin-Linked Arachnus Blaze Cannon" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="6d05-4639-6ea6-7b8b" name="New InfoLink" hidden="false" targetId="10a8-8d89-0bec-3e21" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="db4d-5b0d-29a1-2a74" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e137-31c5-63df-4b5e" type="min"/>
           </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
+          <infoLinks>
+            <infoLink id="6d05-4639-6ea6-7b8b" name="New InfoLink" hidden="false" targetId="10a8-8d89-0bec-3e21" type="rule"/>
+          </infoLinks>
           <entryLinks>
-            <entryLink id="4544-3a82-2293-5ae4" name="Arachnus Blaze Cannon" hidden="false" targetId="b33a-20a1-ddf9-38b5" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
+            <entryLink id="4544-3a82-2293-5ae4" name="Arachnus Blaze Cannon" hidden="false" collective="false" targetId="b33a-20a1-ddf9-38b5" type="selectionEntry">
               <modifiers>
-                <modifier type="set" field="name" value="Twin-Linked Arachnus Blaze Cannon">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
+                <modifier type="set" field="name" value="Twin-Linked Arachnus Blaze Cannon"/>
               </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="23c9-233a-7f50-7fe8" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8e11-ca73-68f1-fe1f" type="min"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="7d90-476d-a820-05d2" name="May take one of the Following:" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
           <selectionEntries>
             <selectionEntry id="ffd9-f8f3-12ce-a29f" name="Armoured Ceramite" hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="97b6-da94-7393-dbe5" name="New InfoLink" hidden="false" targetId="3138-683d-a9a0-570d" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4190-c0c2-2ffe-d181" type="max"/>
               </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
+              <infoLinks>
+                <infoLink id="97b6-da94-7393-dbe5" name="New InfoLink" hidden="false" targetId="3138-683d-a9a0-570d" type="rule"/>
+              </infoLinks>
               <costs>
-                <cost name="pts" costTypeId="points" value="20.0"/>
+                <cost name="pts" typeId="points" value="20.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="73e7-f83e-412a-6304" name="Searchlight" hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="66f3-b6dc-a634-be83" name="New InfoLink" hidden="false" targetId="9bb4-3833-5343-0dd9" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5b60-a890-4f96-aeca" type="max"/>
               </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
+              <infoLinks>
+                <infoLink id="66f3-b6dc-a634-be83" name="New InfoLink" hidden="false" targetId="9bb4-3833-5343-0dd9" type="profile"/>
+              </infoLinks>
               <costs>
-                <cost name="pts" costTypeId="points" value="1.0"/>
+                <cost name="pts" typeId="points" value="1.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2d99-1020-1c1f-421b" name="Extra Armour" hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="c432-9536-387a-c78d" name="New InfoLink" hidden="false" targetId="5283-9b50-3dcd-78e4" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="91f0-11aa-07c3-8fc5" type="max"/>
               </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
+              <infoLinks>
+                <infoLink id="c432-9536-387a-c78d" name="New InfoLink" hidden="false" targetId="5283-9b50-3dcd-78e4" type="rule"/>
+              </infoLinks>
               <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
+                <cost name="pts" typeId="points" value="5.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
-          <selectionEntryGroups/>
-          <entryLinks/>
         </selectionEntryGroup>
       </selectionEntryGroups>
-      <entryLinks/>
       <costs>
-        <cost name="pts" costTypeId="points" value="175.0"/>
+        <cost name="pts" typeId="points" value="175.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="fdd2-62b7-2df5-5793" name="Sisters of Silence Kharon Pattern Acquisitor" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
       <infoLinks>
-        <infoLink id="713f-df63-7891-a74e" name="Kharon Pattern Acquisitor" hidden="false" targetId="78ef-cbfb-dbf3-a6ae" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="81d1-ba63-ceb1-74e3" name="Kharon Pattern Acquisitor" hidden="false" targetId="a514-a6f2-c616-52d2" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="51bd-4320-6468-925c" name="Smoke Launchers" hidden="false" targetId="6875-ee73-2a85-6a97" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="871d-f952-0c31-f7ed" name="Searchlight" hidden="false" targetId="9bb4-3833-5343-0dd9" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="9b16-77a2-4395-09e9" name="New InfoLink" hidden="false" targetId="d219-2314-4834-c054" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="dfc3-51d8-6348-daca" name="New InfoLink" hidden="false" targetId="45cf-653a-4ff6-f22d" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="b5d9-eb11-08d7-775c" name="New InfoLink" hidden="false" targetId="a369-8250-a683-e4d5" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="7233-7e71-cf38-25c8" name="New InfoLink" hidden="false" targetId="a225-e39b-3699-c8f8" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="2628-5326-3a9d-d92e" name="New InfoLink" hidden="false" targetId="3ca6-ef89-ab4d-85c8" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="815f-e4ad-3b77-caa9" name="New InfoLink" hidden="false" targetId="0d66-14c9-d2f4-708b" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="4944-b4c3-6e1a-9a69" name="New InfoLink" hidden="false" targetId="18d0-fdf0-c554-cb34" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
+        <infoLink id="713f-df63-7891-a74e" name="Kharon Pattern Acquisitor" hidden="false" targetId="78ef-cbfb-dbf3-a6ae" type="profile"/>
+        <infoLink id="81d1-ba63-ceb1-74e3" name="Kharon Pattern Acquisitor" hidden="false" targetId="a514-a6f2-c616-52d2" type="profile"/>
+        <infoLink id="51bd-4320-6468-925c" name="Smoke Launchers" hidden="false" targetId="6875-ee73-2a85-6a97" type="profile"/>
+        <infoLink id="871d-f952-0c31-f7ed" name="Searchlight" hidden="false" targetId="9bb4-3833-5343-0dd9" type="profile"/>
+        <infoLink id="9b16-77a2-4395-09e9" name="New InfoLink" hidden="false" targetId="d219-2314-4834-c054" type="rule"/>
+        <infoLink id="dfc3-51d8-6348-daca" name="New InfoLink" hidden="false" targetId="45cf-653a-4ff6-f22d" type="rule"/>
+        <infoLink id="b5d9-eb11-08d7-775c" name="New InfoLink" hidden="false" targetId="a369-8250-a683-e4d5" type="rule"/>
+        <infoLink id="7233-7e71-cf38-25c8" name="New InfoLink" hidden="false" targetId="a225-e39b-3699-c8f8" type="rule"/>
+        <infoLink id="2628-5326-3a9d-d92e" name="New InfoLink" hidden="false" targetId="3ca6-ef89-ab4d-85c8" type="rule"/>
+        <infoLink id="815f-e4ad-3b77-caa9" name="New InfoLink" hidden="false" targetId="0d66-14c9-d2f4-708b" type="rule"/>
+        <infoLink id="4944-b4c3-6e1a-9a69" name="New InfoLink" hidden="false" targetId="18d0-fdf0-c554-cb34" type="rule"/>
       </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
       <selectionEntries>
         <selectionEntry id="d103-ec57-4509-2617" name="Two Twin-Linked Missile Launchers" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="7206-23c2-bfbc-1226" name="New InfoLink" hidden="false" targetId="10a8-8d89-0bec-3e21" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="34c1-74e4-e04b-87c9" name="New InfoLink" hidden="false" targetId="1e33-d8ec-f833-b584" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="1069-fd81-cffb-7538" name="New InfoLink" hidden="false" targetId="40e6-c95c-7c8d-cf02" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="6deb-793b-8bd9-5337" name="New InfoLink" hidden="false" targetId="fab0-4815-efaa-a613" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c744-79c8-3da2-2e1e" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bcc9-4473-614d-a045" type="min"/>
           </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
+          <infoLinks>
+            <infoLink id="7206-23c2-bfbc-1226" name="New InfoLink" hidden="false" targetId="10a8-8d89-0bec-3e21" type="rule"/>
+            <infoLink id="34c1-74e4-e04b-87c9" name="New InfoLink" hidden="false" targetId="1e33-d8ec-f833-b584" type="profile"/>
+            <infoLink id="1069-fd81-cffb-7538" name="New InfoLink" hidden="false" targetId="40e6-c95c-7c8d-cf02" type="profile"/>
+            <infoLink id="6deb-793b-8bd9-5337" name="New InfoLink" hidden="false" targetId="fab0-4815-efaa-a613" type="profile"/>
+          </infoLinks>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="b060-0799-88fc-42ec" name="May take one of the Following:" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
           <selectionEntries>
             <selectionEntry id="4594-bd5e-b3f6-ebea" name="Armoured Ceramite" hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="cc8e-1199-91d9-1489" name="New InfoLink" hidden="false" targetId="3138-683d-a9a0-570d" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5250-bd43-559b-52b5" type="max"/>
               </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
+              <infoLinks>
+                <infoLink id="cc8e-1199-91d9-1489" name="New InfoLink" hidden="false" targetId="3138-683d-a9a0-570d" type="rule"/>
+              </infoLinks>
               <costs>
-                <cost name="pts" costTypeId="points" value="20.0"/>
+                <cost name="pts" typeId="points" value="20.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1689-084a-6726-c2a2" name="Extra Armour" hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="8615-75cc-63a2-2f78" name="New InfoLink" hidden="false" targetId="5283-9b50-3dcd-78e4" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5dd6-b431-c7fc-af8e" type="max"/>
               </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
+              <infoLinks>
+                <infoLink id="8615-75cc-63a2-2f78" name="New InfoLink" hidden="false" targetId="5283-9b50-3dcd-78e4" type="rule"/>
+              </infoLinks>
               <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
+                <cost name="pts" typeId="points" value="5.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
-          <selectionEntryGroups/>
-          <entryLinks/>
         </selectionEntryGroup>
         <selectionEntryGroup id="6991-ccb1-40e8-a929" name="Hellion Pattern Cannon Array" hidden="false" collective="false" defaultSelectionEntryId="bb20-18ca-d5f6-a0dd">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="adb6-ebdd-3199-2d1a" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7c18-8cac-6704-3b2a" type="min"/>
           </constraints>
-          <categoryLinks/>
           <selectionEntries>
             <selectionEntry id="bb20-18ca-d5f6-a0dd" name="Hellion Pattern Cannon Array" hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="1691-5c02-da79-6764" name="New InfoLink" hidden="false" targetId="a538-26b1-51ac-5277" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="6804-f64f-0026-5af5" name="New InfoLink" hidden="false" targetId="f624-f475-e5ec-0dfa" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="5548-98f7-1678-a5be" name="New InfoLink" hidden="false" targetId="10a8-8d89-0bec-3e21" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fe53-8c27-8301-e262" type="max"/>
               </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
+              <infoLinks>
+                <infoLink id="1691-5c02-da79-6764" name="New InfoLink" hidden="false" targetId="a538-26b1-51ac-5277" type="profile"/>
+                <infoLink id="6804-f64f-0026-5af5" name="New InfoLink" hidden="false" targetId="f624-f475-e5ec-0dfa" type="rule"/>
+                <infoLink id="5548-98f7-1678-a5be" name="New InfoLink" hidden="false" targetId="10a8-8d89-0bec-3e21" type="rule"/>
+              </infoLinks>
               <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
+                <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="459b-caf5-0703-cff5" name="Twin-Linked Multi-Melta" hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="e865-6c3d-7ae5-214e" name="New InfoLink" hidden="false" targetId="4fc7-8b16-afe4-dad3" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="0d2d-0962-4e28-fcd9" name="New InfoLink" hidden="false" targetId="10a8-8d89-0bec-3e21" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d247-f3c6-0ab0-379b" type="max"/>
               </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
+              <infoLinks>
+                <infoLink id="e865-6c3d-7ae5-214e" name="New InfoLink" hidden="false" targetId="4fc7-8b16-afe4-dad3" type="profile"/>
+                <infoLink id="0d2d-0962-4e28-fcd9" name="New InfoLink" hidden="false" targetId="10a8-8d89-0bec-3e21" type="rule"/>
+              </infoLinks>
               <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
+                <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
-          <selectionEntryGroups/>
-          <entryLinks/>
         </selectionEntryGroup>
         <selectionEntryGroup id="457a-85c3-7ffd-1445" name="Psyarkana" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="33e5-b04f-1a8d-e0b3" type="max"/>
           </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="70bd-595d-2cf6-a6be" name="Armatus Necrotechnica" hidden="false" targetId="e78c-d1a1-c20f-dae8" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
+            <entryLink id="70bd-595d-2cf6-a6be" name="Armatus Necrotechnica" hidden="false" collective="false" targetId="e78c-d1a1-c20f-dae8" type="selectionEntry">
               <modifiers>
-                <modifier type="set" field="hidden" value="false">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
+                <modifier type="set" field="hidden" value="false"/>
               </modifiers>
-              <constraints/>
-              <categoryLinks/>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
-      <entryLinks/>
       <costs>
-        <cost name="pts" costTypeId="points" value="125.0"/>
+        <cost name="pts" typeId="points" value="125.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="17c2-d576-4704-9d48" name="Sisters of Silence Persuer Cadre" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
       <infoLinks>
-        <infoLink id="cea0-fc16-6a0d-810f" name="New InfoLink" hidden="false" targetId="97d7-d358-141a-8579" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="9deb-84d4-67a9-025b" name="New InfoLink" hidden="false" targetId="69e5-fc02-1f9d-63c2" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="457a-bcea-3e8c-c02c" name="New InfoLink" hidden="false" targetId="6d06-5ea0-9a17-ca97" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="cfce-2478-13f7-155e" name="com" hidden="false" targetId="05b9-9f16-29f9-9dad" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="8c7a-a893-21ee-6f41" name="New InfoLink" hidden="false" targetId="584d-e540-7fdd-92c9" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
+        <infoLink id="cea0-fc16-6a0d-810f" name="New InfoLink" hidden="false" targetId="97d7-d358-141a-8579" type="rule"/>
+        <infoLink id="9deb-84d4-67a9-025b" name="New InfoLink" hidden="false" targetId="69e5-fc02-1f9d-63c2" type="rule"/>
+        <infoLink id="457a-bcea-3e8c-c02c" name="New InfoLink" hidden="false" targetId="6d06-5ea0-9a17-ca97" type="rule"/>
+        <infoLink id="cfce-2478-13f7-155e" name="com" hidden="false" targetId="05b9-9f16-29f9-9dad" type="rule"/>
+        <infoLink id="8c7a-a893-21ee-6f41" name="New InfoLink" hidden="false" targetId="584d-e540-7fdd-92c9" type="rule"/>
       </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
       <selectionEntries>
         <selectionEntry id="e60c-e36b-7357-b3d5" name="Pursuer Mistress" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="0e0a-3c82-9cc1-1206" name="New InfoLink" hidden="false" targetId="4c14-8e91-08e2-b6c8" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e962-643f-d5c0-a72d" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e1b0-40d2-1126-3b01" type="min"/>
           </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
+          <infoLinks>
+            <infoLink id="0e0a-3c82-9cc1-1206" name="New InfoLink" hidden="false" targetId="4c14-8e91-08e2-b6c8" type="profile"/>
+          </infoLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="bb0b-f2d4-657b-e065" name="May take any of the Following:" hidden="false" collective="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="5454-ce80-d153-c1f2" name="New EntryLink" hidden="false" targetId="7a9d-499d-e939-23a3" type="selectionEntryGroup">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
+                <entryLink id="5454-ce80-d153-c1f2" name="New EntryLink" hidden="false" collective="false" targetId="7a9d-499d-e939-23a3" type="selectionEntryGroup">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="39f8-6717-5def-c777" type="max"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="88b9-9ce5-7ebc-e288" type="max"/>
                   </constraints>
-                  <categoryLinks/>
                 </entryLink>
-                <entryLink id="d2f9-01a8-d54d-5102" name="New EntryLink" hidden="false" targetId="0319-8f8d-ab88-efa5" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
+                <entryLink id="d2f9-01a8-d54d-5102" name="New EntryLink" hidden="false" collective="false" targetId="0319-8f8d-ab88-efa5" type="selectionEntry">
                   <modifiers>
-                    <modifier type="set" field="points" value="5">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
+                    <modifier type="set" field="points" value="5"/>
                   </modifiers>
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f944-ef92-d93b-6f65" type="max"/>
                   </constraints>
-                  <categoryLinks/>
                 </entryLink>
-                <entryLink id="c329-fc13-98e1-9b8e" name="New EntryLink" hidden="false" targetId="2dbb-47ce-c902-cc3d" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
+                <entryLink id="c329-fc13-98e1-9b8e" name="New EntryLink" hidden="false" collective="false" targetId="2dbb-47ce-c902-cc3d" type="selectionEntry">
                   <modifiers>
-                    <modifier type="set" field="points" value="5">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
+                    <modifier type="set" field="points" value="5"/>
                   </modifiers>
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1776-5434-ccbc-cfc7" type="max"/>
                   </constraints>
-                  <categoryLinks/>
                 </entryLink>
-                <entryLink id="d758-53e4-a24e-bfcb" name="New EntryLink" hidden="false" targetId="a598-a02a-d502-adf4" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
+                <entryLink id="d758-53e4-a24e-bfcb" name="New EntryLink" hidden="false" collective="false" targetId="a598-a02a-d502-adf4" type="selectionEntry">
                   <modifiers>
-                    <modifier type="set" field="points" value="15">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
+                    <modifier type="set" field="points" value="15"/>
                   </modifiers>
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f6ec-c76f-ee3b-69fd" type="max"/>
                   </constraints>
-                  <categoryLinks/>
                 </entryLink>
-                <entryLink id="9b6e-ad8a-3efc-e0d6" name="New EntryLink" hidden="false" targetId="af7d-23e9-3a57-57aa" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
+                <entryLink id="9b6e-ad8a-3efc-e0d6" name="New EntryLink" hidden="false" collective="false" targetId="af7d-23e9-3a57-57aa" type="selectionEntry">
                   <modifiers>
-                    <modifier type="set" field="points" value="5">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
+                    <modifier type="set" field="points" value="5"/>
                   </modifiers>
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f3db-a44a-9363-ff75" type="max"/>
                   </constraints>
-                  <categoryLinks/>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks>
-            <entryLink id="9907-0367-293c-52ec" name="New EntryLink" hidden="false" targetId="9ee5-e80d-e9cf-92c8" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="9907-0367-293c-52ec" name="New EntryLink" hidden="false" collective="false" targetId="9ee5-e80d-e9cf-92c8" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7573-cd17-fa7f-9c54" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="389d-5484-80d6-6016" type="min"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="e4ad-b00d-4a96-41d8" name="New EntryLink" hidden="false" targetId="90c3-7aa4-3fe9-a6ad" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="e4ad-b00d-4a96-41d8" name="New EntryLink" hidden="false" collective="false" targetId="90c3-7aa4-3fe9-a6ad" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="150b-adc2-c71b-cbb9" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b05b-24f1-8dd4-5ff4" type="max"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="1551-b785-c0a5-b717" name="New EntryLink" hidden="false" targetId="ecac-2dbb-8602-74e5" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="1551-b785-c0a5-b717" name="New EntryLink" hidden="false" collective="false" targetId="ecac-2dbb-8602-74e5" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf8a-a479-2aaa-87ed" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6ccb-6934-6557-f21e" type="max"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="038f-0561-ca3e-7ee7" name="New EntryLink" hidden="false" targetId="3dd5-816b-3d03-fa8e" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="038f-0561-ca3e-7ee7" name="New EntryLink" hidden="false" collective="false" targetId="3dd5-816b-3d03-fa8e" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b650-a301-d55b-1523" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f33e-be49-0d11-fc9e" type="max"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="pts" costTypeId="points" value="15.0"/>
+            <cost name="pts" typeId="points" value="15.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="bae3-35dc-a017-f960" name="Pursuers" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="993b-a6d0-e8fa-efd2" name="New InfoLink" hidden="false" targetId="7afd-4f57-4ff4-6545" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="18f7-5087-8868-474d" type="max"/>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8755-559a-0de3-1708" type="min"/>
           </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
+          <infoLinks>
+            <infoLink id="993b-a6d0-e8fa-efd2" name="New InfoLink" hidden="false" targetId="7afd-4f57-4ff4-6545" type="profile"/>
+          </infoLinks>
           <entryLinks>
-            <entryLink id="ed69-6021-57a5-db34" name="New EntryLink" hidden="false" targetId="9ee5-e80d-e9cf-92c8" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="ed69-6021-57a5-db34" name="New EntryLink" hidden="false" collective="false" targetId="9ee5-e80d-e9cf-92c8" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="715d-8422-38d9-19af" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d3aa-31a7-3f17-b193" type="max"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="69f2-5483-ef5a-12dc" name="New EntryLink" hidden="false" targetId="ecac-2dbb-8602-74e5" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="69f2-5483-ef5a-12dc" name="New EntryLink" hidden="false" collective="false" targetId="ecac-2dbb-8602-74e5" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0ec7-894a-be09-e62b" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bc22-f0ac-b709-ac0f" type="max"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="7146-7382-0095-11d4" name="New EntryLink" hidden="false" targetId="3dd5-816b-3d03-fa8e" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="7146-7382-0095-11d4" name="New EntryLink" hidden="false" collective="false" targetId="3dd5-816b-3d03-fa8e" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="24ef-bd9b-801f-7bce" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a608-4b4e-31c0-fc70" type="max"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="c006-4894-a33e-58f8" name="New EntryLink" hidden="false" targetId="90c3-7aa4-3fe9-a6ad" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="c006-4894-a33e-58f8" name="New EntryLink" hidden="false" collective="false" targetId="90c3-7aa4-3fe9-a6ad" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d09b-d010-499f-2999" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="533d-2777-858e-b91e" type="max"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="pts" costTypeId="points" value="10.0"/>
+            <cost name="pts" typeId="points" value="10.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="17ba-acd7-7692-3fdd" name="3-6 Beasts:" hidden="false" collective="false" defaultSelectionEntryId="5d0b-9941-66a3-c657">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c4b2-40a6-b03e-fd55" type="max"/>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="90e4-8225-5ec9-abb0" type="min"/>
           </constraints>
-          <categoryLinks/>
           <selectionEntries>
             <selectionEntry id="6f86-521d-ead0-c631" name="Cyber-Jackals" hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="3044-da76-1d9c-285d" name="New InfoLink" hidden="false" targetId="9bdd-5ec7-8dd6-63c0" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="bba7-1aa6-b1d1-04fa" name="New InfoLink" hidden="false" targetId="988c-d4d0-9418-1165" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="d44b-7117-0e78-0a9e" name="New InfoLink" hidden="false" targetId="0f2e-5714-931f-e35c" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
               <constraints>
                 <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9041-48c7-8e84-c53b" type="max"/>
               </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
+              <infoLinks>
+                <infoLink id="3044-da76-1d9c-285d" name="New InfoLink" hidden="false" targetId="9bdd-5ec7-8dd6-63c0" type="rule"/>
+                <infoLink id="bba7-1aa6-b1d1-04fa" name="New InfoLink" hidden="false" targetId="988c-d4d0-9418-1165" type="rule"/>
+                <infoLink id="d44b-7117-0e78-0a9e" name="New InfoLink" hidden="false" targetId="0f2e-5714-931f-e35c" type="profile"/>
+              </infoLinks>
               <selectionEntryGroups>
                 <selectionEntryGroup id="d518-3b65-35de-853c" name="One in Three may be equipped with the Following:" hidden="false" collective="false">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
                   <modifiers>
                     <modifier type="increment" field="9fa7-c308-e918-173d" value="1">
-                      <repeats/>
                       <conditions>
                         <condition field="selections" scope="17c2-d576-4704-9d48" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6f86-521d-ead0-c631" type="equalTo"/>
                       </conditions>
-                      <conditionGroups/>
                     </modifier>
                   </modifiers>
                   <constraints>
                     <constraint field="selections" scope="17c2-d576-4704-9d48" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9fa7-c308-e918-173d" type="max"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2fc6-3edb-6577-21b2" type="max"/>
                   </constraints>
-                  <categoryLinks/>
                   <selectionEntries>
                     <selectionEntry id="e168-e92a-1373-04e4" name="Flamer" hidden="false" collective="false" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="0c10-575a-836b-590a" name="New InfoLink" hidden="false" targetId="3a71-7de1-1948-3655" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
                       <constraints>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="779c-2d75-5b46-0d61" type="max"/>
                       </constraints>
-                      <categoryLinks/>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
+                      <infoLinks>
+                        <infoLink id="0c10-575a-836b-590a" name="New InfoLink" hidden="false" targetId="3a71-7de1-1948-3655" type="profile"/>
+                      </infoLinks>
                       <costs>
-                        <cost name="pts" costTypeId="points" value="15.0"/>
+                        <cost name="pts" typeId="points" value="15.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="c3e4-1d27-5047-591d" name="Meltagun" hidden="false" collective="false" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks>
-                        <infoLink id="6ccc-75a4-891c-0c17" name="New InfoLink" hidden="false" targetId="8ae4-74e5-7700-3804" type="profile">
-                          <profiles/>
-                          <rules/>
-                          <infoLinks/>
-                          <modifiers/>
-                        </infoLink>
-                      </infoLinks>
-                      <modifiers/>
                       <constraints>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b9cc-d17f-8aae-f2ce" type="max"/>
                       </constraints>
-                      <categoryLinks/>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
+                      <infoLinks>
+                        <infoLink id="6ccc-75a4-891c-0c17" name="New InfoLink" hidden="false" targetId="8ae4-74e5-7700-3804" type="profile"/>
+                      </infoLinks>
                       <costs>
-                        <cost name="pts" costTypeId="points" value="20.0"/>
+                        <cost name="pts" typeId="points" value="20.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
                 </selectionEntryGroup>
               </selectionEntryGroups>
-              <entryLinks/>
               <costs>
-                <cost name="pts" costTypeId="points" value="15.0"/>
+                <cost name="pts" typeId="points" value="15.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5d0b-9941-66a3-c657" name="Steeltalon Wing" hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="8bf1-02ec-86bd-d209" name="New InfoLink" hidden="false" targetId="7dae-4d12-baba-e529" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers>
-                    <modifier type="set" field="name" value="Blind (Close combat attacks)">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                </infoLink>
-                <infoLink id="938c-b19c-2254-e3cd" name="New InfoLink" hidden="false" targetId="b355-edee-f44f-11f3" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
               <constraints>
                 <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="11bc-caed-07d7-3a26" type="max"/>
               </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
+              <infoLinks>
+                <infoLink id="8bf1-02ec-86bd-d209" name="New InfoLink" hidden="false" targetId="7dae-4d12-baba-e529" type="rule">
+                  <modifiers>
+                    <modifier type="set" field="name" value="Blind (Close combat attacks)"/>
+                  </modifiers>
+                </infoLink>
+                <infoLink id="938c-b19c-2254-e3cd" name="New InfoLink" hidden="false" targetId="b355-edee-f44f-11f3" type="profile"/>
+              </infoLinks>
               <costs>
-                <cost name="pts" costTypeId="points" value="10.0"/>
+                <cost name="pts" typeId="points" value="10.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
-          <selectionEntryGroups/>
-          <entryLinks/>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="be32-1364-0313-8168" name="New EntryLink" hidden="false" targetId="90bd-22e7-9326-3298" type="selectionEntryGroup">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="9cc3-a328-5e91-68df" name="New EntryLink" hidden="false" targetId="dc16-2d58-276a-ae27" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
+        <entryLink id="be32-1364-0313-8168" name="New EntryLink" hidden="false" collective="false" targetId="90bd-22e7-9326-3298" type="selectionEntryGroup"/>
+        <entryLink id="9cc3-a328-5e91-68df" name="New EntryLink" hidden="false" collective="false" targetId="dc16-2d58-276a-ae27" type="selectionEntry"/>
       </entryLinks>
       <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="e5cb-9892-6a0d-9c40" name="Legio Custodes Agamatus Jetbike Squadron" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
       <infoLinks>
-        <infoLink id="9840-e429-8afd-7754" name="Deep Strike" hidden="false" targetId="d219-2314-4834-c054" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="3e00-2c01-ebd5-c171" name="New InfoLink" hidden="false" targetId="38ff-a919-70c4-aec4" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="86ef-100f-89de-d4e6" name="New InfoLink" hidden="false" targetId="a2af-e9d4-78d6-07c7" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
+        <infoLink id="9840-e429-8afd-7754" name="Deep Strike" hidden="false" targetId="d219-2314-4834-c054" type="rule"/>
+        <infoLink id="3e00-2c01-ebd5-c171" name="New InfoLink" hidden="false" targetId="38ff-a919-70c4-aec4" type="rule"/>
+        <infoLink id="86ef-100f-89de-d4e6" name="New InfoLink" hidden="false" targetId="a2af-e9d4-78d6-07c7" type="rule"/>
       </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
       <selectionEntries>
         <selectionEntry id="81fa-3004-feda-6090" name="Custodian Agamatus" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="8e4f-d856-6060-dfb1" name="Gyrfalcon Jetbike" hidden="false" targetId="634b-5e08-5355-c8d1" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="ca05-4f8e-8851-736c" name="Custodian Agamatus" hidden="false" targetId="dcf0-ff9a-7712-e3e1" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="dde3-8d94-0c47-d4e0" name="Power Lance" hidden="false" targetId="fdd4-9bf3-da9d-5479" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="45ac-757b-bc95-cb2e" name="Refractor Field" hidden="false" targetId="4845-0bfe-2c22-883f" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dd4f-22e8-abd6-225f" type="min"/>
             <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5602-e490-e3e7-b883" type="max"/>
           </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
+          <infoLinks>
+            <infoLink id="8e4f-d856-6060-dfb1" name="Gyrfalcon Jetbike" hidden="false" targetId="634b-5e08-5355-c8d1" type="profile"/>
+            <infoLink id="ca05-4f8e-8851-736c" name="Custodian Agamatus" hidden="false" targetId="dcf0-ff9a-7712-e3e1" type="profile"/>
+            <infoLink id="dde3-8d94-0c47-d4e0" name="Power Lance" hidden="false" targetId="fdd4-9bf3-da9d-5479" type="profile"/>
+            <infoLink id="45ac-757b-bc95-cb2e" name="Refractor Field" hidden="false" targetId="4845-0bfe-2c22-883f" type="profile"/>
+          </infoLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="b639-adda-f26b-dbfe" name="May upgrade Lastrum Bolt Cannon with:" hidden="false" collective="false" defaultSelectionEntryId="d283-b20b-48ec-6c76">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="13cc-4202-240c-c5a1" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b042-3d0a-7340-1bf5" type="min"/>
               </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="25a9-fc08-010d-996b" name="Corve Las-Pulser" hidden="false" targetId="25ca-4b92-d195-cd5e" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
+                <entryLink id="25a9-fc08-010d-996b" name="Corve Las-Pulser" hidden="false" collective="false" targetId="25ca-4b92-d195-cd5e" type="selectionEntry">
                   <modifiers>
-                    <modifier type="set" field="points" value="35">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                    <modifier type="set" field="name" value="Twin-Linked Corve Las-Pulser">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
+                    <modifier type="set" field="points" value="35"/>
+                    <modifier type="set" field="name" value="Twin-Linked Corve Las-Pulser"/>
                   </modifiers>
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cccf-72aa-2f22-ed60" type="max"/>
                   </constraints>
-                  <categoryLinks/>
                 </entryLink>
-                <entryLink id="fb15-ad11-7529-d684" name="Adrathic Devastator" hidden="false" targetId="b163-a4b3-0fd8-6f08" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
+                <entryLink id="fb15-ad11-7529-d684" name="Adrathic Devastator" hidden="false" collective="false" targetId="b163-a4b3-0fd8-6f08" type="selectionEntry">
                   <modifiers>
-                    <modifier type="set" field="points" value="15">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
+                    <modifier type="set" field="points" value="15"/>
                   </modifiers>
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="354d-a089-0f10-9748" type="max"/>
                   </constraints>
-                  <categoryLinks/>
                 </entryLink>
-                <entryLink id="d283-b20b-48ec-6c76" name="Lastrum Bolt Cannon" hidden="false" targetId="e854-b201-250d-5b1b" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
+                <entryLink id="d283-b20b-48ec-6c76" name="Lastrum Bolt Cannon" hidden="false" collective="false" targetId="e854-b201-250d-5b1b" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="848d-84f3-4ed8-e6d2" type="max"/>
                   </constraints>
-                  <categoryLinks/>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks>
-            <entryLink id="dbf3-723a-b9df-d3d8" name="Custodian Armour" hidden="false" targetId="2c5a-1976-04e4-e277" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="dbf3-723a-b9df-d3d8" name="Custodian Armour" hidden="false" collective="false" targetId="2c5a-1976-04e4-e277" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6cee-cb5c-efe6-19bc" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="63ea-32d2-a865-6d58" type="min"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="5c4b-5856-d714-133b" name="Plasma + Krak Grenades" hidden="false" targetId="42e2-2cc0-6353-4d47" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="5c4b-5856-d714-133b" name="Plasma + Krak Grenades" hidden="false" collective="false" targetId="42e2-2cc0-6353-4d47" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2fb7-8f5a-d560-cf6a" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2e3c-0828-d5b3-0bee" type="max"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="pts" costTypeId="points" value="75.0"/>
+            <cost name="pts" typeId="points" value="75.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="1cbf-f7ed-4c58-e95c" name="Entire squad may be equipped with:" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="7061-7f23-e405-157a" name="New EntryLink" hidden="false" targetId="648a-e853-bb44-9cee" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
+            <entryLink id="7061-7f23-e405-157a" name="New EntryLink" hidden="false" collective="false" targetId="648a-e853-bb44-9cee" type="selectionEntry">
               <modifiers>
                 <modifier type="increment" field="points" value="5">
                   <repeats>
                     <repeat field="selections" scope="e5cb-9892-6a0d-9c40" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="81fa-3004-feda-6090" repeats="1" roundUp="false"/>
                   </repeats>
-                  <conditions/>
-                  <conditionGroups/>
                 </modifier>
               </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2cb5-b281-c118-10cf" type="max"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="2e20-21cb-06d6-5aed" name="Teleportation Transponders" hidden="false" targetId="7d72-4429-d25c-54f3" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
+            <entryLink id="2e20-21cb-06d6-5aed" name="Teleportation Transponders" hidden="false" collective="false" targetId="7d72-4429-d25c-54f3" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="ac93-30cb-817f-1ff7" name="Legio Custodes" hidden="false" targetId="a502-5799-a2f4-310b" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
+        <entryLink id="ac93-30cb-817f-1ff7" name="Legio Custodes" hidden="false" collective="false" targetId="a502-5799-a2f4-310b" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2b7f-7b4e-b074-d308" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4092-4626-3dda-81ae" type="min"/>
           </constraints>
-          <categoryLinks/>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="5ef4-118e-6aba-94a9" name="Legio Custodes Pallas Grav-Attack Squadron" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
       <selectionEntries>
         <selectionEntry id="8236-3482-4a71-71ec" name="Pallas Grav-Attack" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="6864-0ab8-f79e-c3b9" name="Grav-backwash" hidden="false" targetId="1254-9285-e876-010d" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="0b94-8bba-19b0-8c69" name="Flare Shield" hidden="false" targetId="cb4a-644f-bd8d-7d97" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="cc35-992f-3d9d-2136" name="New InfoLink" hidden="false" targetId="de18-25a0-504b-74be" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="76ff-3be7-0eb2-08de" name="New InfoLink" hidden="false" targetId="d219-2314-4834-c054" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="c58d-335c-b0e6-0147" name="New InfoLink" hidden="false" targetId="0ac1-dfc1-295b-50a6" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="8820-165f-5199-fbc6" name="Pallas Grav-Attack" hidden="false" targetId="a222-27fb-496a-dc5e" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6a5b-d3de-21c5-440e" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3c05-ab3d-44ed-cc0a" type="min"/>
           </constraints>
-          <categoryLinks/>
+          <infoLinks>
+            <infoLink id="6864-0ab8-f79e-c3b9" name="Grav-backwash" hidden="false" targetId="1254-9285-e876-010d" type="rule"/>
+            <infoLink id="0b94-8bba-19b0-8c69" name="Flare Shield" hidden="false" targetId="cb4a-644f-bd8d-7d97" type="profile"/>
+            <infoLink id="cc35-992f-3d9d-2136" name="New InfoLink" hidden="false" targetId="de18-25a0-504b-74be" type="rule"/>
+            <infoLink id="76ff-3be7-0eb2-08de" name="New InfoLink" hidden="false" targetId="d219-2314-4834-c054" type="rule"/>
+            <infoLink id="c58d-335c-b0e6-0147" name="New InfoLink" hidden="false" targetId="0ac1-dfc1-295b-50a6" type="rule"/>
+            <infoLink id="8820-165f-5199-fbc6" name="Pallas Grav-Attack" hidden="false" targetId="a222-27fb-496a-dc5e" type="profile"/>
+          </infoLinks>
           <selectionEntries>
             <selectionEntry id="1e9d-d797-c886-da01" name="Searchlight" hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="2eac-ed30-5375-6051" name="New InfoLink" hidden="false" targetId="9bb4-3833-5343-0dd9" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a3b3-dc96-ca1f-bf69" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cc4f-a6dc-0d4c-f8ad" type="min"/>
               </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
+              <infoLinks>
+                <infoLink id="2eac-ed30-5375-6051" name="New InfoLink" hidden="false" targetId="9bb4-3833-5343-0dd9" type="profile"/>
+              </infoLinks>
               <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
+                <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
           <selectionEntryGroups>
             <selectionEntryGroup id="1287-0bef-21bd-8393" name="May take the following:" hidden="false" collective="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
               <selectionEntries>
                 <selectionEntry id="a17b-a006-a179-5cd2" name="Extra Armour" hidden="false" collective="false" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="50ad-14dc-4372-299d" name="New InfoLink" hidden="false" targetId="5283-9b50-3dcd-78e4" type="rule">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1c76-cf88-eda5-6b6f" type="max"/>
                   </constraints>
-                  <categoryLinks/>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
+                  <infoLinks>
+                    <infoLink id="50ad-14dc-4372-299d" name="New InfoLink" hidden="false" targetId="5283-9b50-3dcd-78e4" type="rule"/>
+                  </infoLinks>
                   <costs>
-                    <cost name="pts" costTypeId="points" value="5.0"/>
+                    <cost name="pts" typeId="points" value="5.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
-              <selectionEntryGroups/>
-              <entryLinks/>
             </selectionEntryGroup>
             <selectionEntryGroup id="3996-8917-9bf8-d5a2" name="May exchange it&apos;s Twin-Linked Arachnus Blaze Cannon with:" hidden="false" collective="false" defaultSelectionEntryId="4896-60b8-f27d-d852">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0486-bcd4-1176-907d" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7e66-09ad-2f6e-49a2" type="min"/>
               </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="4896-60b8-f27d-d852" name="Arachnus Blaze Cannon" hidden="false" targetId="b33a-20a1-ddf9-38b5" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
+                <entryLink id="4896-60b8-f27d-d852" name="Arachnus Blaze Cannon" hidden="false" collective="false" targetId="b33a-20a1-ddf9-38b5" type="selectionEntry">
                   <modifiers>
-                    <modifier type="set" field="name" value="Twin-Linked Arachnus Blaze Cannon">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
+                    <modifier type="set" field="name" value="Twin-Linked Arachnus Blaze Cannon"/>
                   </modifiers>
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="da81-9120-df99-33c7" type="max"/>
                   </constraints>
-                  <categoryLinks/>
                 </entryLink>
-                <entryLink id="d4ee-a83b-0163-4898" name="Adrathic Devastator" hidden="false" targetId="b163-a4b3-0fd8-6f08" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
+                <entryLink id="d4ee-a83b-0163-4898" name="Adrathic Devastator" hidden="false" collective="false" targetId="b163-a4b3-0fd8-6f08" type="selectionEntry">
                   <modifiers>
-                    <modifier type="set" field="name" value="Twin-Linked Adrathic Devastator">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                    <modifier type="set" field="points" value="20">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
+                    <modifier type="set" field="name" value="Twin-Linked Adrathic Devastator"/>
+                    <modifier type="set" field="points" value="20"/>
                   </modifiers>
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4581-e5d0-3e60-ae21" type="max"/>
                   </constraints>
-                  <categoryLinks/>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
-          <entryLinks/>
           <costs>
-            <cost name="pts" costTypeId="points" value="95.0"/>
+            <cost name="pts" typeId="points" value="95.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
-      <selectionEntryGroups/>
-      <entryLinks/>
       <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="08a1-0907-5ed0-2a6c" name="Sisters of Silence Seeker Cadre" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
       <infoLinks>
-        <infoLink id="8d2e-2a74-669a-622d" name="New InfoLink" hidden="false" targetId="584d-e540-7fdd-92c9" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="150e-edf9-debc-4da2" name="com" hidden="false" targetId="05b9-9f16-29f9-9dad" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="12d5-2189-b257-c1d6" name="" hidden="false" targetId="97d7-d358-141a-8579" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
+        <infoLink id="8d2e-2a74-669a-622d" name="New InfoLink" hidden="false" targetId="584d-e540-7fdd-92c9" type="rule"/>
+        <infoLink id="150e-edf9-debc-4da2" name="com" hidden="false" targetId="05b9-9f16-29f9-9dad" type="rule"/>
+        <infoLink id="12d5-2189-b257-c1d6" name="" hidden="false" targetId="97d7-d358-141a-8579" type="rule"/>
       </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
       <selectionEntries>
         <selectionEntry id="c9fc-4070-c8d4-a1fd" name="Seeker Mistress" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="84fe-bde7-9d72-8cdd" name="New InfoLink" hidden="false" targetId="d18b-f29b-a2b1-d194" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dcaf-20ff-f7d1-80cc" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="341a-5304-9a3b-1ec5" type="min"/>
           </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
+          <infoLinks>
+            <infoLink id="84fe-bde7-9d72-8cdd" name="New InfoLink" hidden="false" targetId="d18b-f29b-a2b1-d194" type="profile"/>
+          </infoLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="6a38-cb0f-955a-9bbb" name="May take any of the following:" hidden="false" collective="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="2b3f-f1e8-1029-92f7" name="New EntryLink" hidden="false" targetId="2dbb-47ce-c902-cc3d" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
+                <entryLink id="2b3f-f1e8-1029-92f7" name="New EntryLink" hidden="false" collective="false" targetId="2dbb-47ce-c902-cc3d" type="selectionEntry">
                   <modifiers>
-                    <modifier type="set" field="points" value="5">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
+                    <modifier type="set" field="points" value="5"/>
                   </modifiers>
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7720-df04-caf7-008b" type="max"/>
                   </constraints>
-                  <categoryLinks/>
                 </entryLink>
-                <entryLink id="aada-c4b0-46f0-5d92" name="New EntryLink" hidden="false" targetId="a598-a02a-d502-adf4" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
+                <entryLink id="aada-c4b0-46f0-5d92" name="New EntryLink" hidden="false" collective="false" targetId="a598-a02a-d502-adf4" type="selectionEntry">
                   <modifiers>
-                    <modifier type="set" field="points" value="15">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
+                    <modifier type="set" field="points" value="15"/>
                   </modifiers>
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fdfb-ad26-169e-7c4f" type="max"/>
                   </constraints>
-                  <categoryLinks/>
                 </entryLink>
-                <entryLink id="d70f-94b0-ed24-aa59" name="New EntryLink" hidden="false" targetId="0319-8f8d-ab88-efa5" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
+                <entryLink id="d70f-94b0-ed24-aa59" name="New EntryLink" hidden="false" collective="false" targetId="0319-8f8d-ab88-efa5" type="selectionEntry">
                   <modifiers>
-                    <modifier type="set" field="points" value="5">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
+                    <modifier type="set" field="points" value="5"/>
                   </modifiers>
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3568-d02b-2f71-0586" type="max"/>
                   </constraints>
-                  <categoryLinks/>
                 </entryLink>
-                <entryLink id="ffad-733d-9398-bd26" name="New EntryLink" hidden="false" targetId="7a9d-499d-e939-23a3" type="selectionEntryGroup">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
+                <entryLink id="ffad-733d-9398-bd26" name="New EntryLink" hidden="false" collective="false" targetId="7a9d-499d-e939-23a3" type="selectionEntryGroup">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a1a3-6e8d-cc53-bd67" type="max"/>
                   </constraints>
-                  <categoryLinks/>
                 </entryLink>
-                <entryLink id="6071-7662-0cb8-63fe" name="New EntryLink" hidden="false" targetId="af7d-23e9-3a57-57aa" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
+                <entryLink id="6071-7662-0cb8-63fe" name="New EntryLink" hidden="false" collective="false" targetId="af7d-23e9-3a57-57aa" type="selectionEntry">
                   <modifiers>
-                    <modifier type="set" field="points" value="5">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
+                    <modifier type="set" field="points" value="5"/>
                   </modifiers>
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c7d6-759d-efa7-d485" type="max"/>
                   </constraints>
-                  <categoryLinks/>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks>
-            <entryLink id="ac7d-9a74-ba54-1d74" name="New EntryLink" hidden="false" targetId="90c3-7aa4-3fe9-a6ad" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="ac7d-9a74-ba54-1d74" name="New EntryLink" hidden="false" collective="false" targetId="90c3-7aa4-3fe9-a6ad" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5c0e-9959-276d-fe00" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9b01-fa27-ab4e-f60c" type="min"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="2f16-7b60-173c-a57a" name="New EntryLink" hidden="false" targetId="ecac-2dbb-8602-74e5" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="2f16-7b60-173c-a57a" name="New EntryLink" hidden="false" collective="false" targetId="ecac-2dbb-8602-74e5" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9b74-5a19-74b7-fc9f" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d591-9a7d-0fe7-8d90" type="min"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="8fee-f7ef-c458-72ec" name="New EntryLink" hidden="false" targetId="3dd5-816b-3d03-fa8e" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="8fee-f7ef-c458-72ec" name="New EntryLink" hidden="false" collective="false" targetId="3dd5-816b-3d03-fa8e" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fe25-9394-6ec3-d58e" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ec71-a87e-c4ac-8ce6" type="min"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="pts" costTypeId="points" value="45.0"/>
+            <cost name="pts" typeId="points" value="45.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="b08a-cc0a-fcde-a695" name="Seekers" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="5de2-3817-e4c4-9cd6" name="New InfoLink" hidden="false" targetId="0ee6-f79c-ff88-7773" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
           <modifiers>
             <modifier type="decrement" field="e234-939a-8cc9-a660" value="1">
               <repeats>
                 <repeat field="selections" scope="08a1-0907-5ed0-2a6c" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ac71-e300-0442-d8de" repeats="1" roundUp="false"/>
               </repeats>
-              <conditions/>
-              <conditionGroups/>
             </modifier>
             <modifier type="decrement" field="3bc5-d4de-8c97-f17c" value="1">
               <repeats>
                 <repeat field="selections" scope="08a1-0907-5ed0-2a6c" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ac71-e300-0442-d8de" repeats="1" roundUp="false"/>
               </repeats>
-              <conditions/>
-              <conditionGroups/>
             </modifier>
           </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e234-939a-8cc9-a660" type="min"/>
             <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3bc5-d4de-8c97-f17c" type="max"/>
           </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
+          <infoLinks>
+            <infoLink id="5de2-3817-e4c4-9cd6" name="New InfoLink" hidden="false" targetId="0ee6-f79c-ff88-7773" type="profile"/>
+          </infoLinks>
           <entryLinks>
-            <entryLink id="4e48-4785-00c2-5423" name="New EntryLink" hidden="false" targetId="3dd5-816b-3d03-fa8e" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="4e48-4785-00c2-5423" name="New EntryLink" hidden="false" collective="false" targetId="3dd5-816b-3d03-fa8e" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6df9-b50f-a266-b804" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fb1d-7116-b971-9aa5" type="min"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="cc79-d10a-0bd6-554a" name="New EntryLink" hidden="false" targetId="ecac-2dbb-8602-74e5" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="cc79-d10a-0bd6-554a" name="New EntryLink" hidden="false" collective="false" targetId="ecac-2dbb-8602-74e5" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="64c7-4116-c4d2-e1d3" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e71e-5437-e5ed-1a7f" type="min"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="9808-6a6c-5239-f2b1" name="New EntryLink" hidden="false" targetId="90c3-7aa4-3fe9-a6ad" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="9808-6a6c-5239-f2b1" name="New EntryLink" hidden="false" collective="false" targetId="90c3-7aa4-3fe9-a6ad" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8dff-d8e4-ba84-5e4a" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f47b-b00c-a81b-68c2" type="min"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="pts" costTypeId="points" value="10.0"/>
+            <cost name="pts" typeId="points" value="10.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="ac71-e300-0442-d8de" name="Seeker w/ Breaching Charge" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="797a-8fa0-6f1f-3ae5" name="New InfoLink" hidden="false" targetId="0ee6-f79c-ff88-7773" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2b08-e9fa-2a7d-4d24" type="max"/>
           </constraints>
-          <categoryLinks/>
+          <infoLinks>
+            <infoLink id="797a-8fa0-6f1f-3ae5" name="New InfoLink" hidden="false" targetId="0ee6-f79c-ff88-7773" type="profile"/>
+          </infoLinks>
           <selectionEntries>
             <selectionEntry id="e22b-47e3-f419-eab2" name="Breaching Charge" hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="eb3f-c5ad-5f34-010f" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9039-940d-1a88-f4f2" type="max"/>
               </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
               <costs>
-                <cost name="pts" costTypeId="points" value="10.0"/>
+                <cost name="pts" typeId="points" value="10.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
-          <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="2165-1b72-aad1-8db0" name="New EntryLink" hidden="false" targetId="9ee5-e80d-e9cf-92c8" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="2165-1b72-aad1-8db0" name="New EntryLink" hidden="false" collective="false" targetId="9ee5-e80d-e9cf-92c8" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6305-e530-1213-d3f9" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9d4d-9dc8-c3d0-3b85" type="min"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="342b-0da1-ecb3-2c65" name="New EntryLink" hidden="false" targetId="30c9-6a17-3e08-a83d" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="342b-0da1-ecb3-2c65" name="New EntryLink" hidden="false" collective="false" targetId="30c9-6a17-3e08-a83d" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8aa8-7537-82d8-151a" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d04d-2f6a-8844-81e5" type="min"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="69bb-fefd-9982-e14a" name="fra" hidden="false" targetId="ecac-2dbb-8602-74e5" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="69bb-fefd-9982-e14a" name="fra" hidden="false" collective="false" targetId="ecac-2dbb-8602-74e5" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b0fe-56f8-a88b-8e50" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5224-0fd4-5f25-f085" type="min"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="15d3-d81e-7543-54d1" name="New EntryLink" hidden="false" targetId="3dd5-816b-3d03-fa8e" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="15d3-d81e-7543-54d1" name="New EntryLink" hidden="false" collective="false" targetId="3dd5-816b-3d03-fa8e" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="49e2-be05-9628-fa76" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="77e1-1b4a-a4ce-6a0f" type="min"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="pts" costTypeId="points" value="10.0"/>
+            <cost name="pts" typeId="points" value="10.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="a513-8a1d-0a57-ce6c" name="Seeker Weapons" hidden="false" collective="false" defaultSelectionEntryId="cd3a-da95-d9ab-493c">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="926e-2ccd-1347-867d" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8d54-2241-cfcc-6c7a" type="min"/>
           </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="cd3a-da95-d9ab-493c" name="New EntryLink" hidden="false" targetId="cf19-156c-1aa3-daa0" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="cd3a-da95-d9ab-493c" name="New EntryLink" hidden="false" collective="false" targetId="cf19-156c-1aa3-daa0" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9f75-f84c-44ae-1fd5" type="max"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="fb31-6183-9d08-ee69" name="New EntryLink" hidden="false" targetId="4f36-1f24-0152-73d0" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
+            <entryLink id="fb31-6183-9d08-ee69" name="New EntryLink" hidden="false" collective="false" targetId="4f36-1f24-0152-73d0" type="selectionEntry">
               <modifiers>
                 <modifier type="increment" field="points" value="5">
                   <repeats>
@@ -7232,2118 +3363,1021 @@
                     <repeat field="selections" scope="08a1-0907-5ed0-2a6c" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ac71-e300-0442-d8de" repeats="1" roundUp="false"/>
                     <repeat field="selections" scope="08a1-0907-5ed0-2a6c" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c9fc-4070-c8d4-a1fd" repeats="1" roundUp="false"/>
                   </repeats>
-                  <conditions/>
-                  <conditionGroups/>
                 </modifier>
               </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="003a-c53c-7b69-302b" type="max"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="5142-4844-b812-0a84" name="New EntryLink" hidden="false" targetId="90bd-22e7-9326-3298" type="selectionEntryGroup">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="41f6-7915-1a23-aa05" name="New EntryLink" hidden="false" targetId="dc16-2d58-276a-ae27" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
+        <entryLink id="5142-4844-b812-0a84" name="New EntryLink" hidden="false" collective="false" targetId="90bd-22e7-9326-3298" type="selectionEntryGroup"/>
+        <entryLink id="41f6-7915-1a23-aa05" name="New EntryLink" hidden="false" collective="false" targetId="dc16-2d58-276a-ae27" type="selectionEntry"/>
       </entryLinks>
       <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="5f2c-6d5f-60a2-c648" name="Legio Custodes Sagittarum Guard Squad" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
       <selectionEntries>
         <selectionEntry id="19e0-ce3f-6d10-c15c" name="Sagittarum Guard" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="1854-bc19-7e21-91ef" name="New InfoLink" hidden="false" targetId="38d5-b6eb-bda8-2497" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="7b99-6e1e-07f5-5cbe" name="New InfoLink" hidden="false" targetId="2b06-29a6-641a-b22e" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e9e8-e8e4-ebef-6d65" type="min"/>
             <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed16-d8d4-8ae5-c68b" type="max"/>
           </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
+          <infoLinks>
+            <infoLink id="1854-bc19-7e21-91ef" name="New InfoLink" hidden="false" targetId="38d5-b6eb-bda8-2497" type="rule"/>
+            <infoLink id="7b99-6e1e-07f5-5cbe" name="New InfoLink" hidden="false" targetId="2b06-29a6-641a-b22e" type="rule"/>
+          </infoLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="c4c1-8a75-caec-e060" name="Adrastus Bolt Caliver" hidden="false" collective="false" defaultSelectionEntryId="ab86-49db-c7b4-7aa4">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8a07-5a04-a72c-8bc1" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fc39-e911-3d16-9136" type="min"/>
               </constraints>
-              <categoryLinks/>
               <selectionEntries>
                 <selectionEntry id="ab86-49db-c7b4-7aa4" name="Adrastus Bolt Caliver" hidden="false" collective="false" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b49c-03c1-f9cd-d62c" type="max"/>
                   </constraints>
-                  <categoryLinks/>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
                   <entryLinks>
-                    <entryLink id="344f-ea9d-57da-3513" name="New EntryLink" hidden="false" targetId="f1b0-99e2-cc9c-8e09" type="selectionEntry">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
+                    <entryLink id="344f-ea9d-57da-3513" name="New EntryLink" hidden="false" collective="false" targetId="f1b0-99e2-cc9c-8e09" type="selectionEntry">
                       <constraints>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3287-0fc3-860c-8820" type="max"/>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9a0a-c4f0-604a-da10" type="min"/>
                       </constraints>
-                      <categoryLinks/>
                     </entryLink>
                   </entryLinks>
                   <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
+                    <cost name="pts" typeId="points" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="3ecd-b207-0c49-4ed1" name="One member may replace their Adrastus Bolt Caliver with:" hidden="false" collective="false" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="14e1-e5d1-1682-2d7d" type="max"/>
                     <constraint field="selections" scope="5f2c-6d5f-60a2-c648" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="2a55-be49-024b-0520" type="max"/>
                   </constraints>
-                  <categoryLinks/>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
                   <entryLinks>
-                    <entryLink id="64e3-65e8-3b01-0419" name="Adrathic Destructor" hidden="false" targetId="ac1f-421a-2070-02d2" type="selectionEntry">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
+                    <entryLink id="64e3-65e8-3b01-0419" name="Adrathic Destructor" hidden="false" collective="false" targetId="ac1f-421a-2070-02d2" type="selectionEntry">
                       <constraints>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9c71-c456-1c3e-a6ad" type="max"/>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="36cb-bb77-fe1e-fb61" type="min"/>
                       </constraints>
-                      <categoryLinks/>
                     </entryLink>
-                    <entryLink id="d6b4-2529-ea7e-3023" name="Magisterium Vexilla" hidden="false" targetId="b7c1-be91-5d72-c763" type="selectionEntry">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
+                    <entryLink id="d6b4-2529-ea7e-3023" name="Magisterium Vexilla" hidden="false" collective="false" targetId="b7c1-be91-5d72-c763" type="selectionEntry">
                       <constraints>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="42d8-3dcd-3f51-a371" type="max"/>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3620-0ce4-d403-9400" type="min"/>
                       </constraints>
-                      <categoryLinks/>
                     </entryLink>
                   </entryLinks>
                   <costs>
-                    <cost name="pts" costTypeId="points" value="10.0"/>
+                    <cost name="pts" typeId="points" value="10.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
-              <selectionEntryGroups/>
-              <entryLinks/>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks>
-            <entryLink id="2af6-a6bc-ed6d-e731" name="New EntryLink" hidden="false" targetId="2c5a-1976-04e4-e277" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="2af6-a6bc-ed6d-e731" name="New EntryLink" hidden="false" collective="false" targetId="2c5a-1976-04e4-e277" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e322-262c-921e-ae76" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1f49-974c-b87c-0400" type="min"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="d09f-0576-d0ca-8644" name="Plasma + Krak Grenades" hidden="false" targetId="42e2-2cc0-6353-4d47" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="d09f-0576-d0ca-8644" name="Plasma + Krak Grenades" hidden="false" collective="false" targetId="42e2-2cc0-6353-4d47" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9670-8fd3-5d70-7244" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="77b5-f07d-66ea-0530" type="min"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="a9ad-4f02-e529-49f0" name="Refractor Feild" hidden="false" targetId="011a-b751-e773-6b90" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="a9ad-4f02-e529-49f0" name="Refractor Feild" hidden="false" collective="false" targetId="011a-b751-e773-6b90" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c75d-da8c-e5de-0550" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="05ca-927f-6675-4932" type="min"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="bca0-57c3-3162-6d1a" name="New EntryLink" hidden="false" targetId="a502-5799-a2f4-310b" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="bca0-57c3-3162-6d1a" name="New EntryLink" hidden="false" collective="false" targetId="a502-5799-a2f4-310b" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="942c-51b7-3467-f7dc" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="988e-b6f6-0c47-480d" type="min"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="pts" costTypeId="points" value="60.0"/>
+            <cost name="pts" typeId="points" value="60.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="3d85-f3f4-90be-5e1f" name="Entire squad may be equipped with:" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="e7e0-227a-c1d8-2b42" name="New EntryLink" hidden="false" targetId="648a-e853-bb44-9cee" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
+            <entryLink id="e7e0-227a-c1d8-2b42" name="New EntryLink" hidden="false" collective="false" targetId="648a-e853-bb44-9cee" type="selectionEntry">
               <modifiers>
                 <modifier type="increment" field="points" value="5">
                   <repeats>
                     <repeat field="selections" scope="5f2c-6d5f-60a2-c648" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="19e0-ce3f-6d10-c15c" repeats="1" roundUp="false"/>
                   </repeats>
-                  <conditions/>
-                  <conditionGroups/>
                 </modifier>
               </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="09de-711b-ead9-2189" type="max"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="ec8d-f204-938e-9fcf" name="Arae-Shrikes" hidden="false" targetId="be4a-0e91-0f1f-4c1d" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
+            <entryLink id="ec8d-f204-938e-9fcf" name="Arae-Shrikes" hidden="false" collective="false" targetId="be4a-0e91-0f1f-4c1d" type="selectionEntry">
               <modifiers>
                 <modifier type="increment" field="points" value="15">
                   <repeats>
                     <repeat field="selections" scope="5f2c-6d5f-60a2-c648" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="19e0-ce3f-6d10-c15c" repeats="1" roundUp="false"/>
                   </repeats>
-                  <conditions/>
-                  <conditionGroups/>
                 </modifier>
-                <modifier type="set" field="hidden" value="true">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
+                <modifier type="set" field="hidden" value="true"/>
               </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ee7-43d3-3487-5f1d" type="max"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="3dbf-b3b3-8d11-8323" name="Teleportation Transponders" hidden="false" targetId="81f8-eb55-e1fd-c90a" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
+            <entryLink id="3dbf-b3b3-8d11-8323" name="Teleportation Transponders" hidden="false" collective="false" targetId="81f8-eb55-e1fd-c90a" type="selectionEntry">
               <modifiers>
                 <modifier type="increment" field="points" value="5">
                   <repeats>
                     <repeat field="selections" scope="5f2c-6d5f-60a2-c648" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="19e0-ce3f-6d10-c15c" repeats="1" roundUp="false"/>
                   </repeats>
-                  <conditions/>
-                  <conditionGroups/>
                 </modifier>
               </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="752f-38e8-bfe1-7111" type="max"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="21d8-c0a9-bbd8-c511" name="Teleportation Transponders" hidden="false" targetId="7d72-4429-d25c-54f3" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="9be6-e474-75b9-75a7" name="Solerite Power Gauntlet" hidden="false" targetId="8ba6-041a-ff23-98f6" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
+            <entryLink id="21d8-c0a9-bbd8-c511" name="Teleportation Transponders" hidden="false" collective="false" targetId="7d72-4429-d25c-54f3" type="selectionEntry"/>
+            <entryLink id="9be6-e474-75b9-75a7" name="Solerite Power Gauntlet" hidden="false" collective="false" targetId="8ba6-041a-ff23-98f6" type="selectionEntry">
               <modifiers>
                 <modifier type="increment" field="points" value="15">
                   <repeats>
                     <repeat field="selections" scope="5f2c-6d5f-60a2-c648" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="19e0-ce3f-6d10-c15c" repeats="1" roundUp="false"/>
                   </repeats>
-                  <conditions/>
-                  <conditionGroups/>
                 </modifier>
               </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bd97-6752-90a7-dfc6" type="max"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="20a7-d431-92bc-97c7" name="New EntryLink" hidden="false" targetId="c43b-5c09-9eae-27ba" type="selectionEntryGroup">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
+        <entryLink id="20a7-d431-92bc-97c7" name="New EntryLink" hidden="false" collective="false" targetId="c43b-5c09-9eae-27ba" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
-              <repeats/>
               <conditions>
                 <condition field="selections" scope="5f2c-6d5f-60a2-c648" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="19e0-ce3f-6d10-c15c" type="greaterThan"/>
               </conditions>
-              <conditionGroups/>
             </modifier>
           </modifiers>
-          <constraints/>
-          <categoryLinks/>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="pts" costTypeId="points" value="5.0"/>
+        <cost name="pts" typeId="points" value="5.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="335e-a873-5aa2-19e0" name="Legio Custodes Contemptor-Galatus Dreadnought" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
       <infoLinks>
-        <infoLink id="fc19-b1ed-4626-7aa0" name="New InfoLink" hidden="false" targetId="69e5-fc02-1f9d-63c2" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="5a23-e549-8432-77f9" name="New InfoLink" hidden="false" targetId="6d06-5ea0-9a17-ca97" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="9582-c203-28ed-0050" name="New InfoLink" hidden="false" targetId="0900-71d5-1937-aa96" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="62d3-b774-21b0-3b2f" name="New InfoLink" hidden="false" targetId="6875-ee73-2a85-6a97" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="e0f5-de7e-2c92-f99f" name="New InfoLink" hidden="false" targetId="5283-9b50-3dcd-78e4" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="a7e7-7b01-1e64-9a6d" name="New InfoLink" hidden="false" targetId="9bb4-3833-5343-0dd9" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="dd6f-c4d4-2ad2-3e8c" name="Contemptor-Galatus Dreadnought" hidden="false" targetId="0b06-b727-909f-9126" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
+        <infoLink id="fc19-b1ed-4626-7aa0" name="New InfoLink" hidden="false" targetId="69e5-fc02-1f9d-63c2" type="rule"/>
+        <infoLink id="5a23-e549-8432-77f9" name="New InfoLink" hidden="false" targetId="6d06-5ea0-9a17-ca97" type="rule"/>
+        <infoLink id="9582-c203-28ed-0050" name="New InfoLink" hidden="false" targetId="0900-71d5-1937-aa96" type="rule"/>
+        <infoLink id="62d3-b774-21b0-3b2f" name="New InfoLink" hidden="false" targetId="6875-ee73-2a85-6a97" type="profile"/>
+        <infoLink id="e0f5-de7e-2c92-f99f" name="New InfoLink" hidden="false" targetId="5283-9b50-3dcd-78e4" type="rule"/>
+        <infoLink id="a7e7-7b01-1e64-9a6d" name="New InfoLink" hidden="false" targetId="9bb4-3833-5343-0dd9" type="profile"/>
+        <infoLink id="dd6f-c4d4-2ad2-3e8c" name="Contemptor-Galatus Dreadnought" hidden="false" targetId="0b06-b727-909f-9126" type="profile"/>
       </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
       <selectionEntries>
         <selectionEntry id="69d9-8b97-d367-0c22" name="Galatus Warblade with inbuilt Twin-Linked Infernus Incinerator" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="6e5b-b6eb-9c56-adb2" name="Infernus Incinerator" hidden="false" targetId="20a0-9b92-39e5-592b" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="set" field="name" value="Twin-Linked Infernus Incinerator">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </infoLink>
-            <infoLink id="2131-46bf-a083-cac5" name="Galatus Warblade" hidden="false" targetId="5a99-1a1a-7c69-3613" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="e785-1e24-e230-2a44" name="New InfoLink" hidden="false" targetId="10a8-8d89-0bec-3e21" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="dc27-565b-4491-9a16" name="New InfoLink" hidden="false" targetId="0ba8-83bc-74c1-43c2" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="1916-745e-3480-b869" name="New InfoLink" hidden="false" targetId="89da-0cb5-bee4-8ec2" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fa5d-5226-ba36-a2ef" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="624b-99f6-85c5-62a1" type="min"/>
           </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
+          <infoLinks>
+            <infoLink id="6e5b-b6eb-9c56-adb2" name="Infernus Incinerator" hidden="false" targetId="20a0-9b92-39e5-592b" type="profile">
+              <modifiers>
+                <modifier type="set" field="name" value="Twin-Linked Infernus Incinerator"/>
+              </modifiers>
+            </infoLink>
+            <infoLink id="2131-46bf-a083-cac5" name="Galatus Warblade" hidden="false" targetId="5a99-1a1a-7c69-3613" type="profile"/>
+            <infoLink id="e785-1e24-e230-2a44" name="New InfoLink" hidden="false" targetId="10a8-8d89-0bec-3e21" type="rule"/>
+            <infoLink id="dc27-565b-4491-9a16" name="New InfoLink" hidden="false" targetId="0ba8-83bc-74c1-43c2" type="rule"/>
+            <infoLink id="1916-745e-3480-b869" name="New InfoLink" hidden="false" targetId="89da-0cb5-bee4-8ec2" type="rule"/>
+          </infoLinks>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="4bfc-eaf8-31e0-29f2" name="Dreadnought Praesidium Shield" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="77ee-1702-5d4b-5e9e" name="Dreadnought Praesidium Shield" hidden="false" targetId="767b-d879-1e5f-bc94" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9468-4d75-f961-123e" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="12bb-cd7a-ac80-f9a8" type="min"/>
           </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
+          <infoLinks>
+            <infoLink id="77ee-1702-5d4b-5e9e" name="Dreadnought Praesidium Shield" hidden="false" targetId="767b-d879-1e5f-bc94" type="profile"/>
+          </infoLinks>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
-      <selectionEntryGroups/>
       <entryLinks>
-        <entryLink id="a178-b009-41df-6ee4" name="New EntryLink" hidden="false" targetId="011a-b751-e773-6b90" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
+        <entryLink id="a178-b009-41df-6ee4" name="New EntryLink" hidden="false" collective="false" targetId="011a-b751-e773-6b90" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0cb6-f399-b772-6798" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6288-eddb-7c8c-07d6" type="min"/>
           </constraints>
-          <categoryLinks/>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="pts" costTypeId="points" value="250.0"/>
+        <cost name="pts" typeId="points" value="250.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="a502-5799-a2f4-310b" name="Legio Custodes" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
       <infoLinks>
-        <infoLink id="63c4-c9dd-a70a-015a" name="Preternatural Skill" hidden="false" targetId="eabf-f2b0-71f8-0f72" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="7f40-2a9b-838c-84e8" name="The Sodality" hidden="false" targetId="c49a-b905-f536-8810" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="340e-98dc-db85-94a2" name="Inviolable Psyche" hidden="false" targetId="41a9-bbe8-d024-4813" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
+        <infoLink id="63c4-c9dd-a70a-015a" name="Preternatural Skill" hidden="false" targetId="eabf-f2b0-71f8-0f72" type="rule"/>
+        <infoLink id="7f40-2a9b-838c-84e8" name="The Sodality" hidden="false" targetId="c49a-b905-f536-8810" type="rule"/>
+        <infoLink id="340e-98dc-db85-94a2" name="Inviolable Psyche" hidden="false" targetId="41a9-bbe8-d024-4813" type="rule"/>
       </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
       <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="80ba-e9bc-4e45-0c8f" name="Sisters of Silence Oblivion Knight Cadre" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
       <selectionEntries>
         <selectionEntry id="4296-476d-bbcf-5191" name="Raptor Guard Cadre" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
           <modifiers>
             <modifier type="set" field="hidden" value="true">
-              <repeats/>
               <conditions>
                 <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="de59-9a90-c4b5-5469" type="equalTo"/>
               </conditions>
-              <conditionGroups/>
             </modifier>
           </modifiers>
           <constraints>
             <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c53f-341c-487e-44f8" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7a0a-0c0f-4699-e863" type="max"/>
           </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
           <costs>
-            <cost name="pts" costTypeId="points" value="20.0"/>
+            <cost name="pts" typeId="points" value="20.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="444b-a3d1-00f9-4e44" name="Oblivion Knight" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="29e9-5c22-f215-16d3" name="New InfoLink" hidden="false" targetId="c75a-ed2c-71e8-996e" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="set" field="575323232344415441232323" value="5">
-                  <repeats/>
-                  <conditions>
-                    <condition field="selections" scope="80ba-e9bc-4e45-0c8f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4296-476d-bbcf-5191" type="equalTo"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </infoLink>
-            <infoLink id="be4b-918a-20f0-8eb8" name="New InfoLink" hidden="false" targetId="c793-7756-3669-827c" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="89a0-ffff-a70c-d775" name="New InfoLink" hidden="false" targetId="584d-e540-7fdd-92c9" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="b11f-cc9d-5c79-8463" name="fan" hidden="false" targetId="97d7-d358-141a-8579" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="564a-673f-aa4f-3110" name="Preci" hidden="false" targetId="a080-af1b-fb2e-4860" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="225a-a97f-9405-3b80" name="New InfoLink" hidden="false" targetId="05b9-9f16-29f9-9dad" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d81e-d460-184d-a333" type="max"/>
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6e0a-9872-efe0-ce7a" type="min"/>
           </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
+          <infoLinks>
+            <infoLink id="29e9-5c22-f215-16d3" name="New InfoLink" hidden="false" targetId="c75a-ed2c-71e8-996e" type="profile">
+              <modifiers>
+                <modifier type="set" field="575323232344415441232323" value="5">
+                  <conditions>
+                    <condition field="selections" scope="80ba-e9bc-4e45-0c8f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4296-476d-bbcf-5191" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </infoLink>
+            <infoLink id="be4b-918a-20f0-8eb8" name="New InfoLink" hidden="false" targetId="c793-7756-3669-827c" type="rule"/>
+            <infoLink id="89a0-ffff-a70c-d775" name="New InfoLink" hidden="false" targetId="584d-e540-7fdd-92c9" type="rule"/>
+            <infoLink id="b11f-cc9d-5c79-8463" name="fan" hidden="false" targetId="97d7-d358-141a-8579" type="rule"/>
+            <infoLink id="564a-673f-aa4f-3110" name="Preci" hidden="false" targetId="a080-af1b-fb2e-4860" type="rule"/>
+            <infoLink id="225a-a97f-9405-3b80" name="New InfoLink" hidden="false" targetId="05b9-9f16-29f9-9dad" type="rule"/>
+          </infoLinks>
           <entryLinks>
-            <entryLink id="7c23-a91a-66b5-af57" name="New EntryLink" hidden="false" targetId="9ee5-e80d-e9cf-92c8" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="7c23-a91a-66b5-af57" name="New EntryLink" hidden="false" collective="false" targetId="9ee5-e80d-e9cf-92c8" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="da2d-69c9-f0a9-11c5" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4a23-af0c-2f7c-3b60" type="min"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="6620-ec15-4c37-f9dd" name="New EntryLink" hidden="false" targetId="ecac-2dbb-8602-74e5" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="6620-ec15-4c37-f9dd" name="New EntryLink" hidden="false" collective="false" targetId="ecac-2dbb-8602-74e5" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af43-43a5-d2f5-a760" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4165-0fb3-1cb3-fb00" type="min"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="0dcb-8174-d0cd-f5e4" name="New EntryLink" hidden="false" targetId="3dd5-816b-3d03-fa8e" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="0dcb-8174-d0cd-f5e4" name="New EntryLink" hidden="false" collective="false" targetId="3dd5-816b-3d03-fa8e" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9178-e2a2-1de9-3b8a" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="42e7-dc54-1226-5343" type="min"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="b2ac-8686-7315-f308" name="" hidden="false" targetId="956d-1d22-964f-61f6" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="b2ac-8686-7315-f308" name="" hidden="false" collective="false" targetId="956d-1d22-964f-61f6" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="db84-2910-c10f-9da8" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ec35-ba4a-b5a5-b953" type="min"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="pts" costTypeId="points" value="13.0"/>
+            <cost name="pts" typeId="points" value="13.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="018b-b46e-b425-4cc8" name="Oblivion Knight Mistress" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="a3db-afc5-dbbb-da57" name="New InfoLink" hidden="false" targetId="619b-fd43-fe72-e4dd" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="set" field="575323232344415441232323" value="5">
-                  <repeats/>
-                  <conditions>
-                    <condition field="selections" scope="80ba-e9bc-4e45-0c8f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4296-476d-bbcf-5191" type="equalTo"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </infoLink>
-            <infoLink id="4319-e0d2-e716-3d92" name="New InfoLink" hidden="false" targetId="05b9-9f16-29f9-9dad" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="7a0a-ad48-db6e-fc62" name="New InfoLink" hidden="false" targetId="c793-7756-3669-827c" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="357b-bcd4-f34e-733f" name="fan" hidden="false" targetId="97d7-d358-141a-8579" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="5b23-6a15-ce06-880b" name="Preci" hidden="false" targetId="a080-af1b-fb2e-4860" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="9e09-2885-fe0c-d48a" name="New InfoLink" hidden="false" targetId="584d-e540-7fdd-92c9" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7f4f-2c02-bcc7-4a13" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3b2b-6a3c-1ba1-48fd" type="min"/>
           </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
+          <infoLinks>
+            <infoLink id="a3db-afc5-dbbb-da57" name="New InfoLink" hidden="false" targetId="619b-fd43-fe72-e4dd" type="profile">
+              <modifiers>
+                <modifier type="set" field="575323232344415441232323" value="5">
+                  <conditions>
+                    <condition field="selections" scope="80ba-e9bc-4e45-0c8f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4296-476d-bbcf-5191" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </infoLink>
+            <infoLink id="4319-e0d2-e716-3d92" name="New InfoLink" hidden="false" targetId="05b9-9f16-29f9-9dad" type="rule"/>
+            <infoLink id="7a0a-ad48-db6e-fc62" name="New InfoLink" hidden="false" targetId="c793-7756-3669-827c" type="rule"/>
+            <infoLink id="357b-bcd4-f34e-733f" name="fan" hidden="false" targetId="97d7-d358-141a-8579" type="rule"/>
+            <infoLink id="5b23-6a15-ce06-880b" name="Preci" hidden="false" targetId="a080-af1b-fb2e-4860" type="rule"/>
+            <infoLink id="9e09-2885-fe0c-d48a" name="New InfoLink" hidden="false" targetId="584d-e540-7fdd-92c9" type="rule"/>
+          </infoLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="863f-6be1-2eee-b8d2" name="May Replace Execution Blade with:" hidden="false" collective="false" defaultSelectionEntryId="9650-4ee2-3c43-d55c">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="801f-8723-b9a2-5f9c" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="588c-2d68-070b-201a" type="min"/>
               </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="9650-4ee2-3c43-d55c" name="New EntryLink" hidden="false" targetId="1812-dcf0-818a-5491" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
+                <entryLink id="9650-4ee2-3c43-d55c" name="New EntryLink" hidden="false" collective="false" targetId="1812-dcf0-818a-5491" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ca7-46ad-3bcb-b795" type="max"/>
                   </constraints>
-                  <categoryLinks/>
                 </entryLink>
-                <entryLink id="bf4e-cd1d-9d2a-e725" name="New EntryLink" hidden="false" targetId="d313-b513-281a-c5ad" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
+                <entryLink id="bf4e-cd1d-9d2a-e725" name="New EntryLink" hidden="false" collective="false" targetId="d313-b513-281a-c5ad" type="selectionEntry">
                   <modifiers>
-                    <modifier type="set" field="points" value="5">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
+                    <modifier type="set" field="points" value="5"/>
                   </modifiers>
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9992-8a7f-7ee3-5107" type="max"/>
                   </constraints>
-                  <categoryLinks/>
                 </entryLink>
-                <entryLink id="c2bf-bea9-846b-585b" name="New EntryLink" hidden="false" targetId="e006-9328-106d-5c6a" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
+                <entryLink id="c2bf-bea9-846b-585b" name="New EntryLink" hidden="false" collective="false" targetId="e006-9328-106d-5c6a" type="selectionEntry">
                   <modifiers>
-                    <modifier type="set" field="points" value="10">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
+                    <modifier type="set" field="points" value="10"/>
                   </modifiers>
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="35c9-281e-f2ba-dd07" type="max"/>
                   </constraints>
-                  <categoryLinks/>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="6bd3-bb9d-068d-7c1f" name="May Exchange Bolt Pistol For:" hidden="false" collective="false" defaultSelectionEntryId="3c40-2db5-a9b0-4301">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5d15-9a26-a5e4-7e13" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a11-02b5-ecad-5ccf" type="min"/>
               </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="3c40-2db5-a9b0-4301" name="New EntryLink" hidden="false" targetId="f727-c9c2-83d0-3984" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
+                <entryLink id="3c40-2db5-a9b0-4301" name="New EntryLink" hidden="false" collective="false" targetId="f727-c9c2-83d0-3984" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5197-35ae-2e31-5274" type="max"/>
                   </constraints>
-                  <categoryLinks/>
                 </entryLink>
-                <entryLink id="edc7-820c-3f4b-eb4c" name="New EntryLink" hidden="false" targetId="af7d-23e9-3a57-57aa" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
+                <entryLink id="edc7-820c-3f4b-eb4c" name="New EntryLink" hidden="false" collective="false" targetId="af7d-23e9-3a57-57aa" type="selectionEntry">
                   <modifiers>
-                    <modifier type="set" field="points" value="5">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
+                    <modifier type="set" field="points" value="5"/>
                   </modifiers>
-                  <constraints/>
-                  <categoryLinks/>
                 </entryLink>
-                <entryLink id="6709-e175-0da9-f621" name="New EntryLink" hidden="false" targetId="a598-a02a-d502-adf4" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
+                <entryLink id="6709-e175-0da9-f621" name="New EntryLink" hidden="false" collective="false" targetId="a598-a02a-d502-adf4" type="selectionEntry">
                   <modifiers>
-                    <modifier type="set" field="points" value="15">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
+                    <modifier type="set" field="points" value="15"/>
                   </modifiers>
-                  <constraints/>
-                  <categoryLinks/>
                 </entryLink>
-                <entryLink id="271a-6044-c52b-48b0" name="New EntryLink" hidden="false" targetId="0319-8f8d-ab88-efa5" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
+                <entryLink id="271a-6044-c52b-48b0" name="New EntryLink" hidden="false" collective="false" targetId="0319-8f8d-ab88-efa5" type="selectionEntry">
                   <modifiers>
-                    <modifier type="set" field="points" value="5">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
+                    <modifier type="set" field="points" value="5"/>
                   </modifiers>
-                  <constraints/>
-                  <categoryLinks/>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks>
-            <entryLink id="dbdb-606c-1cb5-6571" name="New EntryLink" hidden="false" targetId="e5f6-cd68-595a-306c" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="dbdb-606c-1cb5-6571" name="New EntryLink" hidden="false" collective="false" targetId="e5f6-cd68-595a-306c" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="31fc-f1d7-c4e5-eb0e" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7fba-8020-4525-36ad" type="min"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="e215-ac0c-bf86-c49c" name="New EntryLink" hidden="false" targetId="fad2-42fa-1e2d-0b88" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="e215-ac0c-bf86-c49c" name="New EntryLink" hidden="false" collective="false" targetId="fad2-42fa-1e2d-0b88" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7422-5716-d79e-5345" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="82cd-3d87-1d17-5dcf" type="min"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="7f7f-e2ac-8a82-2ba7" name="New EntryLink" hidden="false" targetId="aba8-92ff-b2a8-ad1e" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="7f7f-e2ac-8a82-2ba7" name="New EntryLink" hidden="false" collective="false" targetId="aba8-92ff-b2a8-ad1e" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4dee-6a9a-f1f4-0181" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b562-581f-45de-5c99" type="min"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="pts" costTypeId="points" value="33.0"/>
+            <cost name="pts" typeId="points" value="33.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="d7c4-0c06-2307-0347" name="Oblivion Knight Weapons" hidden="false" collective="false" defaultSelectionEntryId="0c79-902c-8d43-b536">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b9a3-8f35-939b-eba2" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="01a4-5352-d01f-e2fb" type="min"/>
           </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="0c79-902c-8d43-b536" name="New EntryLink" hidden="false" targetId="30c9-6a17-3e08-a83d" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="0c79-902c-8d43-b536" name="New EntryLink" hidden="false" collective="false" targetId="30c9-6a17-3e08-a83d" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="700a-0eed-d1ef-99e3" type="max"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="bde1-19d5-2b05-849c" name="New EntryLink" hidden="false" targetId="e473-0d6d-b922-9dc2" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
+            <entryLink id="bde1-19d5-2b05-849c" name="New EntryLink" hidden="false" collective="false" targetId="e473-0d6d-b922-9dc2" type="selectionEntry">
               <modifiers>
                 <modifier type="increment" field="points" value="5">
                   <repeats>
                     <repeat field="selections" scope="80ba-e9bc-4e45-0c8f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="444b-a3d1-00f9-4e44" repeats="1" roundUp="false"/>
                   </repeats>
-                  <conditions/>
-                  <conditionGroups/>
                 </modifier>
               </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="35ce-e7ae-8769-cf07" type="max"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="18d5-d1c5-9fed-9e13" name="New EntryLink" hidden="false" targetId="dc16-2d58-276a-ae27" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="b09f-7efe-8568-225a" name="New EntryLink" hidden="false" targetId="90bd-22e7-9326-3298" type="selectionEntryGroup">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
+        <entryLink id="18d5-d1c5-9fed-9e13" name="New EntryLink" hidden="false" collective="false" targetId="dc16-2d58-276a-ae27" type="selectionEntry"/>
+        <entryLink id="b09f-7efe-8568-225a" name="New EntryLink" hidden="false" collective="false" targetId="90bd-22e7-9326-3298" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="9ee5-e80d-e9cf-92c8" name="Bolt Pistol" hidden="false" collective="true" type="upgrade">
-      <profiles/>
-      <rules/>
       <infoLinks>
-        <infoLink id="6215-7880-248e-0991" name="New InfoLink" hidden="false" targetId="ec83-0776-ef74-9cc2" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
+        <infoLink id="6215-7880-248e-0991" name="New InfoLink" hidden="false" targetId="ec83-0776-ef74-9cc2" type="profile"/>
       </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
       <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8797-9df7-d8b5-d6ac" name="Boltgun" hidden="false" collective="true" type="upgrade">
-      <profiles/>
-      <rules/>
       <infoLinks>
-        <infoLink id="62ee-b036-32d3-3957" name="New InfoLink" hidden="false" targetId="09fd-8af1-a6b1-51f7" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
+        <infoLink id="62ee-b036-32d3-3957" name="New InfoLink" hidden="false" targetId="09fd-8af1-a6b1-51f7" type="profile"/>
       </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
       <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="90c3-7aa4-3fe9-a6ad" name="Close Combat Weapon" hidden="false" collective="true" type="upgrade">
-      <profiles/>
-      <rules/>
       <infoLinks>
-        <infoLink id="bae0-24df-f9c4-16de" name="New InfoLink" hidden="false" targetId="730c-b70b-1e8f-f2e9" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
+        <infoLink id="bae0-24df-f9c4-16de" name="New InfoLink" hidden="false" targetId="730c-b70b-1e8f-f2e9" type="profile"/>
       </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
       <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="30c9-6a17-3e08-a83d" name="Execution Blade" hidden="false" collective="true" type="upgrade">
-      <profiles/>
-      <rules/>
       <infoLinks>
-        <infoLink id="5bc3-df21-1486-ed7c" name="New InfoLink" hidden="false" targetId="514e-dfe7-e9a4-17a7" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="030b-97c3-ea7c-efd8" name="due" hidden="false" targetId="eddf-f5b5-0ec0-e1bb" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="15a5-ab60-8f4d-5b6b" name="New InfoLink" hidden="false" targetId="e8e8-bbc9-fb47-e91b" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="a1e3-62fd-c633-80d8" name="New InfoLink" hidden="false" targetId="b11c-0ef4-af6b-d96f" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
+        <infoLink id="5bc3-df21-1486-ed7c" name="New InfoLink" hidden="false" targetId="514e-dfe7-e9a4-17a7" type="rule"/>
+        <infoLink id="030b-97c3-ea7c-efd8" name="due" hidden="false" targetId="eddf-f5b5-0ec0-e1bb" type="rule"/>
+        <infoLink id="15a5-ab60-8f4d-5b6b" name="New InfoLink" hidden="false" targetId="e8e8-bbc9-fb47-e91b" type="profile"/>
+        <infoLink id="a1e3-62fd-c633-80d8" name="New InfoLink" hidden="false" targetId="b11c-0ef4-af6b-d96f" type="rule"/>
       </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
       <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="ecac-2dbb-8602-74e5" name="Frag, Krak, and Psyk-Out Grenades" hidden="false" collective="true" type="upgrade">
-      <profiles/>
-      <rules/>
       <infoLinks>
-        <infoLink id="6319-78fd-85f4-11d2" name="New InfoLink" hidden="false" targetId="d890-1b84-bbd9-12d3" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="d51b-cd30-639c-80b1" name="New InfoLink" hidden="false" targetId="d9f7-775b-1047-f335" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="f73f-e366-8c0e-1790" name="New InfoLink" hidden="false" targetId="9430-a4d5-6f01-57e2" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="4903-096e-8fee-35a9" name="New InfoLink" hidden="false" targetId="a234-e343-fb57-423f" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
+        <infoLink id="6319-78fd-85f4-11d2" name="New InfoLink" hidden="false" targetId="d890-1b84-bbd9-12d3" type="profile"/>
+        <infoLink id="d51b-cd30-639c-80b1" name="New InfoLink" hidden="false" targetId="d9f7-775b-1047-f335" type="profile"/>
+        <infoLink id="f73f-e366-8c0e-1790" name="New InfoLink" hidden="false" targetId="9430-a4d5-6f01-57e2" type="rule"/>
+        <infoLink id="4903-096e-8fee-35a9" name="New InfoLink" hidden="false" targetId="a234-e343-fb57-423f" type="profile"/>
       </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
       <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="e473-0d6d-b922-9dc2" name="Power Axe" hidden="false" collective="true" type="upgrade">
-      <profiles/>
-      <rules/>
       <infoLinks>
-        <infoLink id="6735-f615-8fe8-fa1f" name="New InfoLink" hidden="false" targetId="b3af-1eca-6629-4894" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
+        <infoLink id="6735-f615-8fe8-fa1f" name="New InfoLink" hidden="false" targetId="b3af-1eca-6629-4894" type="profile"/>
       </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
       <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="956d-1d22-964f-61f6" name="Voidsheen Cloak" hidden="false" collective="true" type="upgrade">
-      <profiles/>
-      <rules/>
       <infoLinks>
-        <infoLink id="cf82-6587-5a93-2734" name="New InfoLink" hidden="false" targetId="3cfc-cfdc-a578-923e" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
+        <infoLink id="cf82-6587-5a93-2734" name="New InfoLink" hidden="false" targetId="3cfc-cfdc-a578-923e" type="rule"/>
       </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
       <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="3dd5-816b-3d03-fa8e" name="Vratine Armour" hidden="false" collective="true" type="upgrade">
-      <profiles/>
-      <rules/>
       <infoLinks>
-        <infoLink id="3c69-c470-eb4b-bb85" name="New InfoLink" hidden="false" targetId="d7f5-8d27-73ca-2c52" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
+        <infoLink id="3c69-c470-eb4b-bb85" name="New InfoLink" hidden="false" targetId="d7f5-8d27-73ca-2c52" type="profile"/>
       </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
       <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="2547-40ab-cb22-90a2" name="Sisters of Silence Prosecutor Cadre" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
       <infoLinks>
-        <infoLink id="eeab-c6b4-e7f0-39ba" name="New InfoLink" hidden="false" targetId="05b9-9f16-29f9-9dad" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="0285-673e-a46a-d916" name="New InfoLink" hidden="false" targetId="97d7-d358-141a-8579" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="5b7a-cd6f-8816-a8da" name="New InfoLink" hidden="false" targetId="584d-e540-7fdd-92c9" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
+        <infoLink id="eeab-c6b4-e7f0-39ba" name="New InfoLink" hidden="false" targetId="05b9-9f16-29f9-9dad" type="rule"/>
+        <infoLink id="0285-673e-a46a-d916" name="New InfoLink" hidden="false" targetId="97d7-d358-141a-8579" type="rule"/>
+        <infoLink id="5b7a-cd6f-8816-a8da" name="New InfoLink" hidden="false" targetId="584d-e540-7fdd-92c9" type="rule"/>
       </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
       <selectionEntries>
         <selectionEntry id="3230-5d28-c87c-cd84" name="Prosecutors" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="09eb-8ad9-1887-a79c" name="New InfoLink" hidden="false" targetId="0478-968b-221a-4d91" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
           <modifiers>
             <modifier type="decrement" field="bac4-1271-5c3c-bc52" value="1">
               <repeats>
                 <repeat field="selections" scope="2547-40ab-cb22-90a2" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8930-1e80-89bd-5aed" repeats="1" roundUp="false"/>
               </repeats>
-              <conditions/>
-              <conditionGroups/>
             </modifier>
             <modifier type="decrement" field="30e4-a5bc-a491-617b" value="1">
               <repeats>
                 <repeat field="selections" scope="2547-40ab-cb22-90a2" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8930-1e80-89bd-5aed" repeats="1" roundUp="false"/>
               </repeats>
-              <conditions/>
-              <conditionGroups/>
             </modifier>
           </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="30e4-a5bc-a491-617b" type="min"/>
             <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bac4-1271-5c3c-bc52" type="max"/>
           </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
+          <infoLinks>
+            <infoLink id="09eb-8ad9-1887-a79c" name="New InfoLink" hidden="false" targetId="0478-968b-221a-4d91" type="profile"/>
+          </infoLinks>
           <entryLinks>
-            <entryLink id="5977-c2f2-abc0-96b8" name="New EntryLink" hidden="false" targetId="3dd5-816b-3d03-fa8e" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="5977-c2f2-abc0-96b8" name="New EntryLink" hidden="false" collective="false" targetId="3dd5-816b-3d03-fa8e" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c269-4284-bb86-d717" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cf49-91de-df8b-867b" type="min"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="c812-dca6-25e5-1fc7" name="New EntryLink" hidden="false" targetId="ecac-2dbb-8602-74e5" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="c812-dca6-25e5-1fc7" name="New EntryLink" hidden="false" collective="false" targetId="ecac-2dbb-8602-74e5" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="621d-de70-6d03-9989" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dec3-3062-6c3e-8d20" type="min"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="b01b-d84a-719b-2be7" name="New EntryLink" hidden="false" targetId="90c3-7aa4-3fe9-a6ad" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="b01b-d84a-719b-2be7" name="New EntryLink" hidden="false" collective="false" targetId="90c3-7aa4-3fe9-a6ad" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c7ec-f3d6-dd2c-b679" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8388-e98f-feb4-9f92" type="min"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="pts" costTypeId="points" value="10.0"/>
+            <cost name="pts" typeId="points" value="10.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="1c36-44a7-bc5a-bd44" name="Prosecutor Mistress" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="ea89-a309-935c-094d" name="New InfoLink" hidden="false" targetId="4c13-7e48-ffef-d350" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b635-1bd1-c26f-0d26" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f577-6568-43f5-d424" type="min"/>
           </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
+          <infoLinks>
+            <infoLink id="ea89-a309-935c-094d" name="New InfoLink" hidden="false" targetId="4c13-7e48-ffef-d350" type="profile"/>
+          </infoLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="4699-df8d-02ea-d60b" name="May take any of the following:" hidden="false" collective="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="70c6-a877-4d6a-24b8" name="New EntryLink" hidden="false" targetId="2dbb-47ce-c902-cc3d" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
+                <entryLink id="70c6-a877-4d6a-24b8" name="New EntryLink" hidden="false" collective="false" targetId="2dbb-47ce-c902-cc3d" type="selectionEntry">
                   <modifiers>
-                    <modifier type="set" field="points" value="5">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
+                    <modifier type="set" field="points" value="5"/>
                   </modifiers>
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3286-6dde-5b40-90cd" type="max"/>
                   </constraints>
-                  <categoryLinks/>
                 </entryLink>
-                <entryLink id="8bd2-5099-64f3-1e62" name="New EntryLink" hidden="false" targetId="a598-a02a-d502-adf4" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
+                <entryLink id="8bd2-5099-64f3-1e62" name="New EntryLink" hidden="false" collective="false" targetId="a598-a02a-d502-adf4" type="selectionEntry">
                   <modifiers>
-                    <modifier type="set" field="points" value="15">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
+                    <modifier type="set" field="points" value="15"/>
                   </modifiers>
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5be6-874a-73fb-65a0" type="max"/>
                   </constraints>
-                  <categoryLinks/>
                 </entryLink>
-                <entryLink id="54ff-2eeb-39c4-69b6" name="New EntryLink" hidden="false" targetId="0319-8f8d-ab88-efa5" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
+                <entryLink id="54ff-2eeb-39c4-69b6" name="New EntryLink" hidden="false" collective="false" targetId="0319-8f8d-ab88-efa5" type="selectionEntry">
                   <modifiers>
-                    <modifier type="set" field="points" value="5">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
+                    <modifier type="set" field="points" value="5"/>
                   </modifiers>
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="33ff-05e0-c2d1-f651" type="max"/>
                   </constraints>
-                  <categoryLinks/>
                 </entryLink>
-                <entryLink id="21f2-6ce2-12c4-d566" name="New EntryLink" hidden="false" targetId="7a9d-499d-e939-23a3" type="selectionEntryGroup">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
+                <entryLink id="21f2-6ce2-12c4-d566" name="New EntryLink" hidden="false" collective="false" targetId="7a9d-499d-e939-23a3" type="selectionEntryGroup">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2a20-9404-37d1-5a0c" type="max"/>
                   </constraints>
-                  <categoryLinks/>
                 </entryLink>
-                <entryLink id="847a-4071-2e21-92bd" name="New EntryLink" hidden="false" targetId="af7d-23e9-3a57-57aa" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
+                <entryLink id="847a-4071-2e21-92bd" name="New EntryLink" hidden="false" collective="false" targetId="af7d-23e9-3a57-57aa" type="selectionEntry">
                   <modifiers>
-                    <modifier type="set" field="points" value="5">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
+                    <modifier type="set" field="points" value="5"/>
                   </modifiers>
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e2bb-dc9d-a05f-8ac7" type="max"/>
                   </constraints>
-                  <categoryLinks/>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks>
-            <entryLink id="020f-3f99-b842-010f" name="New EntryLink" hidden="false" targetId="90c3-7aa4-3fe9-a6ad" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="020f-3f99-b842-010f" name="New EntryLink" hidden="false" collective="false" targetId="90c3-7aa4-3fe9-a6ad" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0c45-b48a-72a6-df3e" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2660-a7e9-54d1-18af" type="min"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="3f71-1086-a661-d1ba" name="New EntryLink" hidden="false" targetId="ecac-2dbb-8602-74e5" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="3f71-1086-a661-d1ba" name="New EntryLink" hidden="false" collective="false" targetId="ecac-2dbb-8602-74e5" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6589-35c5-0ae8-3f48" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b88f-15e9-3a1b-6123" type="min"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="66ff-166d-c39b-f0b9" name="New EntryLink" hidden="false" targetId="3dd5-816b-3d03-fa8e" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="66ff-166d-c39b-f0b9" name="New EntryLink" hidden="false" collective="false" targetId="3dd5-816b-3d03-fa8e" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e02b-37f3-0641-cf14" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="be56-1721-7067-30be" type="min"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="pts" costTypeId="points" value="25.0"/>
+            <cost name="pts" typeId="points" value="25.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="8930-1e80-89bd-5aed" name="Prosecutors w/ Special Equipment" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="6ffb-5960-6da8-7cc9" name="New InfoLink" hidden="false" targetId="0478-968b-221a-4d91" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cb50-72d4-5d41-2b17" type="min"/>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="833a-065a-6de6-df1b" type="max"/>
           </constraints>
-          <categoryLinks/>
+          <infoLinks>
+            <infoLink id="6ffb-5960-6da8-7cc9" name="New InfoLink" hidden="false" targetId="0478-968b-221a-4d91" type="profile"/>
+          </infoLinks>
           <selectionEntries>
             <selectionEntry id="76f4-8757-2855-c0ed" name="Nuncio-Vox" hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="9fc6-6691-99ed-e309" name="New InfoLink" hidden="false" targetId="2a0e-e1f0-5ea0-5799" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
               <constraints>
                 <constraint field="selections" scope="2547-40ab-cb22-90a2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c78f-49e5-57a2-03a9" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9177-e97a-d033-c987" type="max"/>
               </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
+              <infoLinks>
+                <infoLink id="9fc6-6691-99ed-e309" name="New InfoLink" hidden="false" targetId="2a0e-e1f0-5ea0-5799" type="profile"/>
+              </infoLinks>
               <costs>
-                <cost name="pts" costTypeId="points" value="10.0"/>
+                <cost name="pts" typeId="points" value="10.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d1df-8a72-8b0b-c67e" name="Breaching Charge" hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
               <constraints>
                 <constraint field="selections" scope="2547-40ab-cb22-90a2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1c9f-334b-fa21-408d" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="61d3-f43f-d78a-8158" type="max"/>
               </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
               <costs>
-                <cost name="pts" costTypeId="points" value="10.0"/>
+                <cost name="pts" typeId="points" value="10.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
-          <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="e8bf-8376-795e-fca2" name="New EntryLink" hidden="false" targetId="ecac-2dbb-8602-74e5" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="e8bf-8376-795e-fca2" name="New EntryLink" hidden="false" collective="false" targetId="ecac-2dbb-8602-74e5" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d18d-417a-ee9c-b8f7" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e2b7-f936-0f99-1754" type="min"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="e9a8-46f8-5319-0158" name="New EntryLink" hidden="false" targetId="90c3-7aa4-3fe9-a6ad" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="e9a8-46f8-5319-0158" name="New EntryLink" hidden="false" collective="false" targetId="90c3-7aa4-3fe9-a6ad" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="87be-26e7-302f-1d88" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="51e5-5450-02fa-78c7" type="min"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="a183-ab29-d96b-f798" name="New EntryLink" hidden="false" targetId="3dd5-816b-3d03-fa8e" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="a183-ab29-d96b-f798" name="New EntryLink" hidden="false" collective="false" targetId="3dd5-816b-3d03-fa8e" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0db1-e3e9-abdb-4b34" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f3f1-b9e3-6525-5a70" type="min"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="pts" costTypeId="points" value="10.0"/>
+            <cost name="pts" typeId="points" value="10.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="bc46-bdb5-b632-669e" name="Prosecutor Weapons" hidden="false" collective="false" defaultSelectionEntryId="f05f-ee9e-4dd1-725a">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1d79-daa2-1afb-5e30" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d846-7eb6-317b-0ab8" type="min"/>
           </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="72f4-a4f3-b079-2c0d" name="New EntryLink" hidden="false" targetId="9ee5-e80d-e9cf-92c8" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
+            <entryLink id="72f4-a4f3-b079-2c0d" name="New EntryLink" hidden="false" collective="false" targetId="9ee5-e80d-e9cf-92c8" type="selectionEntry">
               <modifiers>
-                <modifier type="set" field="name" value="Two Bolt Pistols">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
+                <modifier type="set" field="name" value="Two Bolt Pistols"/>
               </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ff0b-ee89-f1df-471c" type="max"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="f05f-ee9e-4dd1-725a" name="New EntryLink" hidden="false" targetId="8797-9df7-d8b5-d6ac" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="f05f-ee9e-4dd1-725a" name="New EntryLink" hidden="false" collective="false" targetId="8797-9df7-d8b5-d6ac" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5c22-ab85-fe1e-cca5" type="max"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="6b58-ae1a-4b28-79f5" name="New EntryLink" hidden="false" targetId="dc16-2d58-276a-ae27" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="81cd-ce33-c917-f793" name="New EntryLink" hidden="false" targetId="90bd-22e7-9326-3298" type="selectionEntryGroup">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
+        <entryLink id="6b58-ae1a-4b28-79f5" name="New EntryLink" hidden="false" collective="false" targetId="dc16-2d58-276a-ae27" type="selectionEntry"/>
+        <entryLink id="81cd-ce33-c917-f793" name="New EntryLink" hidden="false" collective="false" targetId="90bd-22e7-9326-3298" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="7017-b303-200f-730b" name="Sisters of Silence Vigilator Cadre" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
       <infoLinks>
-        <infoLink id="b196-7d3e-c2ad-afd2" name="New InfoLink" hidden="false" targetId="05b9-9f16-29f9-9dad" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="3a5d-f5dd-fbdb-0e1a" name="New InfoLink" hidden="false" targetId="584d-e540-7fdd-92c9" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="1a0c-0c6a-5d60-db3f" name="" hidden="false" targetId="97d7-d358-141a-8579" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="a72e-0742-1641-1e91" name="New InfoLink" hidden="false" targetId="9e6d-607b-824f-30ea" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
+        <infoLink id="b196-7d3e-c2ad-afd2" name="New InfoLink" hidden="false" targetId="05b9-9f16-29f9-9dad" type="rule"/>
+        <infoLink id="3a5d-f5dd-fbdb-0e1a" name="New InfoLink" hidden="false" targetId="584d-e540-7fdd-92c9" type="rule"/>
+        <infoLink id="1a0c-0c6a-5d60-db3f" name="" hidden="false" targetId="97d7-d358-141a-8579" type="rule"/>
+        <infoLink id="a72e-0742-1641-1e91" name="New InfoLink" hidden="false" targetId="9e6d-607b-824f-30ea" type="rule"/>
       </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
       <selectionEntries>
         <selectionEntry id="fcd4-d99f-6309-de2e" name="Vigilator" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="1020-a800-b8dd-f884" name="New InfoLink" hidden="false" targetId="84d2-df3c-0971-52b2" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
           <modifiers>
             <modifier type="decrement" field="6885-f288-2ef8-97b0" value="1">
               <repeats>
                 <repeat field="selections" scope="7017-b303-200f-730b" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="43fe-849e-c031-a64e" repeats="1" roundUp="false"/>
               </repeats>
-              <conditions/>
-              <conditionGroups/>
             </modifier>
             <modifier type="decrement" field="edaa-8dfa-ba93-c8e2" value="1">
               <repeats>
                 <repeat field="selections" scope="7017-b303-200f-730b" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="43fe-849e-c031-a64e" repeats="1" roundUp="false"/>
               </repeats>
-              <conditions/>
-              <conditionGroups/>
             </modifier>
           </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6885-f288-2ef8-97b0" type="max"/>
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="edaa-8dfa-ba93-c8e2" type="min"/>
           </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
+          <infoLinks>
+            <infoLink id="1020-a800-b8dd-f884" name="New InfoLink" hidden="false" targetId="84d2-df3c-0971-52b2" type="profile"/>
+          </infoLinks>
           <entryLinks>
-            <entryLink id="a86e-a407-a208-fc4c" name="New EntryLink" hidden="false" targetId="ecac-2dbb-8602-74e5" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="a86e-a407-a208-fc4c" name="New EntryLink" hidden="false" collective="false" targetId="ecac-2dbb-8602-74e5" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="17fa-f5d2-8353-a698" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="667f-c7e4-75fd-2d3c" type="min"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="b2f8-8d53-3d4a-f70f" name="New EntryLink" hidden="false" targetId="3dd5-816b-3d03-fa8e" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="b2f8-8d53-3d4a-f70f" name="New EntryLink" hidden="false" collective="false" targetId="3dd5-816b-3d03-fa8e" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1027-deb4-bf38-fba3" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2437-5bb9-f825-f8b6" type="min"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="420f-d6ee-85ce-bb46" name="New EntryLink" hidden="false" targetId="30c9-6a17-3e08-a83d" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="420f-d6ee-85ce-bb46" name="New EntryLink" hidden="false" collective="false" targetId="30c9-6a17-3e08-a83d" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="911f-3b19-6ee6-e8be" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="be2b-c0c5-54e4-a5ad" type="min"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="a046-43fd-3e2b-e7f4" name="New EntryLink" hidden="false" targetId="9ee5-e80d-e9cf-92c8" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="a046-43fd-3e2b-e7f4" name="New EntryLink" hidden="false" collective="false" targetId="9ee5-e80d-e9cf-92c8" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dc30-44c0-7da5-5333" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="86a7-7c66-6c85-2500" type="min"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="pts" costTypeId="points" value="12.0"/>
+            <cost name="pts" typeId="points" value="12.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="ff92-0d54-1940-fc5f" name="Vigilator Mistress" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="9d47-1e9d-25d5-4402" name="New InfoLink" hidden="false" targetId="516a-af98-8713-2632" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2d20-753e-467e-8a13" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="127d-5309-03c4-6718" type="min"/>
           </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
+          <infoLinks>
+            <infoLink id="9d47-1e9d-25d5-4402" name="New InfoLink" hidden="false" targetId="516a-af98-8713-2632" type="profile"/>
+          </infoLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="b2bd-3449-6221-3142" name="May replace Bolt Pistol with:" hidden="false" collective="false" defaultSelectionEntryId="37f6-3eb6-714e-863b">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c186-61fc-bfce-7c98" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d0a2-a410-783f-4ff9" type="max"/>
               </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="37f6-3eb6-714e-863b" name="New EntryLink" hidden="false" targetId="f727-c9c2-83d0-3984" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
+                <entryLink id="37f6-3eb6-714e-863b" name="New EntryLink" hidden="false" collective="false" targetId="f727-c9c2-83d0-3984" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aca7-c664-a3ba-1f4f" type="max"/>
                   </constraints>
-                  <categoryLinks/>
                 </entryLink>
-                <entryLink id="68ec-87bb-e3eb-f86d" name="New EntryLink" hidden="false" targetId="af7d-23e9-3a57-57aa" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
+                <entryLink id="68ec-87bb-e3eb-f86d" name="New EntryLink" hidden="false" collective="false" targetId="af7d-23e9-3a57-57aa" type="selectionEntry">
                   <modifiers>
-                    <modifier type="set" field="points" value="5">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
+                    <modifier type="set" field="points" value="5"/>
                   </modifiers>
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="77ff-116f-818d-8425" type="max"/>
                   </constraints>
-                  <categoryLinks/>
                 </entryLink>
-                <entryLink id="85c7-5046-dfc1-8474" name="New EntryLink" hidden="false" targetId="a598-a02a-d502-adf4" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
+                <entryLink id="85c7-5046-dfc1-8474" name="New EntryLink" hidden="false" collective="false" targetId="a598-a02a-d502-adf4" type="selectionEntry">
                   <modifiers>
-                    <modifier type="set" field="points" value="15">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
+                    <modifier type="set" field="points" value="15"/>
                   </modifiers>
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cf6e-b273-9e61-df62" type="max"/>
                   </constraints>
-                  <categoryLinks/>
                 </entryLink>
-                <entryLink id="1e88-f804-e57a-e2cc" name="New EntryLink" hidden="false" targetId="0319-8f8d-ab88-efa5" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
+                <entryLink id="1e88-f804-e57a-e2cc" name="New EntryLink" hidden="false" collective="false" targetId="0319-8f8d-ab88-efa5" type="selectionEntry">
                   <modifiers>
-                    <modifier type="set" field="points" value="5">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
+                    <modifier type="set" field="points" value="5"/>
                   </modifiers>
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="32f0-eca5-98e2-7ba8" type="max"/>
                   </constraints>
-                  <categoryLinks/>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="8d17-f2dc-c911-6951" name="May replace Execution Blade with:" hidden="false" collective="false" defaultSelectionEntryId="60d2-0f19-4dae-bb80">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="12d5-6dd0-6225-8356" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b8b0-0b05-88af-0973" type="max"/>
               </constraints>
-              <categoryLinks/>
               <selectionEntries>
                 <selectionEntry id="e0ad-3da5-0fd4-46bf" name="Power Axe" hidden="false" collective="false" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="f2d3-e6fb-2b70-c41f" name="New InfoLink" hidden="false" targetId="b3af-1eca-6629-4894" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
                   <modifiers>
-                    <modifier type="set" field="points" value="5">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
+                    <modifier type="set" field="points" value="5"/>
                   </modifiers>
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4a91-dfe9-c5e9-dfde" type="max"/>
                   </constraints>
-                  <categoryLinks/>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
+                  <infoLinks>
+                    <infoLink id="f2d3-e6fb-2b70-c41f" name="New InfoLink" hidden="false" targetId="b3af-1eca-6629-4894" type="profile"/>
+                  </infoLinks>
                   <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
+                    <cost name="pts" typeId="points" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="ab7b-841d-6a0b-fa3b" name="Power Lance" hidden="false" collective="false" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="47a3-5cde-583b-edf5" name="New InfoLink" hidden="false" targetId="fdd4-9bf3-da9d-5479" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
                   <modifiers>
-                    <modifier type="set" field="points" value="5">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
+                    <modifier type="set" field="points" value="5"/>
                   </modifiers>
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fe83-e5f9-61ad-41b8" type="max"/>
                   </constraints>
-                  <categoryLinks/>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
+                  <infoLinks>
+                    <infoLink id="47a3-5cde-583b-edf5" name="New InfoLink" hidden="false" targetId="fdd4-9bf3-da9d-5479" type="profile"/>
+                  </infoLinks>
                   <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
+                    <cost name="pts" typeId="points" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="e4c8-26a8-661a-38da" name="Power Maul" hidden="false" collective="false" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="a875-7192-976e-90b6" name="New InfoLink" hidden="false" targetId="6bbe-f2c1-78e2-da59" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
                   <modifiers>
-                    <modifier type="set" field="points" value="5">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
+                    <modifier type="set" field="points" value="5"/>
                   </modifiers>
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d0fb-3d7b-dcbb-88e4" type="max"/>
                   </constraints>
-                  <categoryLinks/>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
+                  <infoLinks>
+                    <infoLink id="a875-7192-976e-90b6" name="New InfoLink" hidden="false" targetId="6bbe-f2c1-78e2-da59" type="profile"/>
+                  </infoLinks>
                   <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
+                    <cost name="pts" typeId="points" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="c524-4b2e-2143-a130" name="Power Sword" hidden="false" collective="false" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="80cc-87d3-ff47-e5bc" name="New InfoLink" hidden="false" targetId="038e-23ec-4886-8b00" type="profile">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
                   <modifiers>
-                    <modifier type="set" field="points" value="5">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
+                    <modifier type="set" field="points" value="5"/>
                   </modifiers>
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d6dc-946e-df54-6926" type="max"/>
                   </constraints>
-                  <categoryLinks/>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
+                  <infoLinks>
+                    <infoLink id="80cc-87d3-ff47-e5bc" name="New InfoLink" hidden="false" targetId="038e-23ec-4886-8b00" type="profile"/>
+                  </infoLinks>
                   <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
+                    <cost name="pts" typeId="points" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
-              <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="60d2-0f19-4dae-bb80" name="New EntryLink" hidden="false" targetId="1812-dcf0-818a-5491" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
+                <entryLink id="60d2-0f19-4dae-bb80" name="New EntryLink" hidden="false" collective="false" targetId="1812-dcf0-818a-5491" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f8ff-97c8-4f06-6450" type="max"/>
                   </constraints>
-                  <categoryLinks/>
                 </entryLink>
-                <entryLink id="f727-b459-e5a5-1b01" name="New EntryLink" hidden="false" targetId="e006-9328-106d-5c6a" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
+                <entryLink id="f727-b459-e5a5-1b01" name="New EntryLink" hidden="false" collective="false" targetId="e006-9328-106d-5c6a" type="selectionEntry">
                   <modifiers>
-                    <modifier type="set" field="points" value="10">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
+                    <modifier type="set" field="points" value="10"/>
                   </modifiers>
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cd5b-c597-a738-35bb" type="max"/>
                   </constraints>
-                  <categoryLinks/>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks>
-            <entryLink id="0449-fbf8-4376-6700" name="New EntryLink" hidden="false" targetId="e5f6-cd68-595a-306c" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="0449-fbf8-4376-6700" name="New EntryLink" hidden="false" collective="false" targetId="e5f6-cd68-595a-306c" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a78f-e662-9b74-d8e6" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="abde-c299-9a71-45c1" type="min"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="b64d-0d17-5a16-3338" name="New EntryLink" hidden="false" targetId="aba8-92ff-b2a8-ad1e" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="b64d-0d17-5a16-3338" name="New EntryLink" hidden="false" collective="false" targetId="aba8-92ff-b2a8-ad1e" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6e48-0892-5736-9b50" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6e5c-a344-17ac-57ee" type="min"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="pts" costTypeId="points" value="37.0"/>
+            <cost name="pts" typeId="points" value="37.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="43fe-849e-c031-a64e" name="Vigilator w/ Breaching Charge" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="2ddb-48d1-5735-1ed6" name="New InfoLink" hidden="false" targetId="84d2-df3c-0971-52b2" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4783-609f-c012-39da" type="max"/>
           </constraints>
-          <categoryLinks/>
+          <infoLinks>
+            <infoLink id="2ddb-48d1-5735-1ed6" name="New InfoLink" hidden="false" targetId="84d2-df3c-0971-52b2" type="profile"/>
+          </infoLinks>
           <selectionEntries>
             <selectionEntry id="7c13-59b8-12e5-1623" name="Breaching Charge" hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="efeb-1e5f-3408-d787" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1770-1f4a-eeea-16ec" type="max"/>
               </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
               <costs>
-                <cost name="pts" costTypeId="points" value="10.0"/>
+                <cost name="pts" typeId="points" value="10.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
-          <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="768a-3e36-d047-27a0" name="New EntryLink" hidden="false" targetId="9ee5-e80d-e9cf-92c8" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="768a-3e36-d047-27a0" name="New EntryLink" hidden="false" collective="false" targetId="9ee5-e80d-e9cf-92c8" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a99-6612-59ce-dc8c" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="91a4-cbf5-d959-2cbe" type="min"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="f80b-0775-2924-2b9b" name="New EntryLink" hidden="false" targetId="30c9-6a17-3e08-a83d" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="f80b-0775-2924-2b9b" name="New EntryLink" hidden="false" collective="false" targetId="30c9-6a17-3e08-a83d" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="127d-981e-cdb3-a0dd" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="258a-d81b-2a73-bc39" type="min"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="cbc4-48fc-8dcf-9a34" name="fra" hidden="false" targetId="ecac-2dbb-8602-74e5" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="cbc4-48fc-8dcf-9a34" name="fra" hidden="false" collective="false" targetId="ecac-2dbb-8602-74e5" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="26eb-ca07-f2e5-17f2" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ac54-c6f4-c051-6429" type="min"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="9932-2595-dad0-c135" name="New EntryLink" hidden="false" targetId="3dd5-816b-3d03-fa8e" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="9932-2595-dad0-c135" name="New EntryLink" hidden="false" collective="false" targetId="3dd5-816b-3d03-fa8e" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9450-7833-d676-8892" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9111-4400-4b84-0814" type="min"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="pts" costTypeId="points" value="12.0"/>
+            <cost name="pts" typeId="points" value="12.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
-      <selectionEntryGroups/>
       <entryLinks>
-        <entryLink id="6a7d-49b5-1500-355e" name="New EntryLink" hidden="false" targetId="dc16-2d58-276a-ae27" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="2413-88ea-923d-a525" name="New EntryLink" hidden="false" targetId="90bd-22e7-9326-3298" type="selectionEntryGroup">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
+        <entryLink id="6a7d-49b5-1500-355e" name="New EntryLink" hidden="false" collective="false" targetId="dc16-2d58-276a-ae27" type="selectionEntry"/>
+        <entryLink id="2413-88ea-923d-a525" name="New EntryLink" hidden="false" collective="false" targetId="90bd-22e7-9326-3298" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="cf19-156c-1aa3-daa0" name="Flamer" hidden="false" collective="true" type="upgrade">
-      <profiles/>
-      <rules/>
       <infoLinks>
-        <infoLink id="ab4a-9c20-4e69-4f96" name="New InfoLink" hidden="false" targetId="3a71-7de1-1948-3655" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
+        <infoLink id="ab4a-9c20-4e69-4f96" name="New InfoLink" hidden="false" targetId="3a71-7de1-1948-3655" type="profile"/>
       </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
       <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="4f36-1f24-0152-73d0" name="Grenade Launcher" hidden="false" collective="true" type="upgrade">
-      <profiles/>
-      <rules/>
       <infoLinks>
-        <infoLink id="22a0-15de-1905-8df7" name="New InfoLink" hidden="false" targetId="d9f7-775b-1047-f335" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="2a74-55ee-cc17-637e" name="New InfoLink" hidden="false" targetId="d890-1b84-bbd9-12d3" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="b02e-3d3b-3e33-6e5f" name="New InfoLink" hidden="false" targetId="432e-7f24-6937-aa48" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
+        <infoLink id="22a0-15de-1905-8df7" name="New InfoLink" hidden="false" targetId="d9f7-775b-1047-f335" type="profile"/>
+        <infoLink id="2a74-55ee-cc17-637e" name="New InfoLink" hidden="false" targetId="d890-1b84-bbd9-12d3" type="profile"/>
+        <infoLink id="b02e-3d3b-3e33-6e5f" name="New InfoLink" hidden="false" targetId="432e-7f24-6937-aa48" type="profile"/>
       </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
       <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="dc16-2d58-276a-ae27" name="Company Cadre Choice" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
       <modifiers>
         <modifier type="increment" field="34d4-cfaf-ca68-2b7a" value="1">
           <repeats>
@@ -9351,8 +4385,6 @@
             <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cc00-5542-b66c-07ee" repeats="3" roundUp="false"/>
             <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="26dd-4eb2-fe70-ea73" repeats="3" roundUp="false"/>
           </repeats>
-          <conditions/>
-          <conditionGroups/>
         </modifier>
       </modifiers>
       <constraints>
@@ -9360,3641 +4392,1493 @@
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="81a9-733e-6f95-fcb9" type="max"/>
         <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="34d4-cfaf-ca68-2b7a" type="max"/>
       </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
       <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="5804-0f3c-116f-46e2" name="Legio Custodes Telemon Heavy Dreadnought" hidden="false" collective="false" type="upgrade">
       <profiles>
-        <profile id="0dd1-7b8c-1e91-3fc7" name="Multi-Layer Refractor Field" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323" profileTypeName="Wargear Item">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
+        <profile id="0dd1-7b8c-1e91-3fc7" name="Multi-Layer Refractor Field" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
           <characteristics>
-            <characteristic name="Description" characteristicTypeId="4465736372697074696f6e23232344415441232323" value="A multi-layer refractor field confers a 4+ Invulnerable save, increasing to 3+ against weapons with the Blast special rule or that use a template of any kind."/>
+            <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">A multi-layer refractor field confers a 4+ Invulnerable save, increasing to 3+ against weapons with the Blast special rule or that use a template of any kind.</characteristic>
           </characteristics>
         </profile>
-        <profile id="cdb5-2a5b-0741-7958" name="Telemon Dreadnought" hidden="false" profileTypeId="57616c6b657223232344415441232323" profileTypeName="Walker">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
+        <profile id="cdb5-2a5b-0741-7958" name="Telemon Dreadnought" hidden="false" typeId="57616c6b657223232344415441232323" typeName="Walker">
           <characteristics>
-            <characteristic name="WS" characteristicTypeId="575323232344415441232323" value="6"/>
-            <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="5"/>
-            <characteristic name="S" characteristicTypeId="5323232344415441232323" value="9"/>
-            <characteristic name="Front" characteristicTypeId="46726f6e7423232344415441232323" value="13"/>
-            <characteristic name="Side" characteristicTypeId="5369646523232344415441232323" value="13"/>
-            <characteristic name="Rear" characteristicTypeId="5265617223232344415441232323" value="12"/>
-            <characteristic name="I" characteristicTypeId="4923232344415441232323" value="5"/>
-            <characteristic name="A" characteristicTypeId="4123232344415441232323" value="4"/>
-            <characteristic name="HP" characteristicTypeId="485023232344415441232323" value="4"/>
-            <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Vehicle (Walker, Character)"/>
+            <characteristic name="WS" typeId="575323232344415441232323">6</characteristic>
+            <characteristic name="BS" typeId="425323232344415441232323">5</characteristic>
+            <characteristic name="S" typeId="5323232344415441232323">9</characteristic>
+            <characteristic name="Front" typeId="46726f6e7423232344415441232323">13</characteristic>
+            <characteristic name="Side" typeId="5369646523232344415441232323">13</characteristic>
+            <characteristic name="Rear" typeId="5265617223232344415441232323">12</characteristic>
+            <characteristic name="I" typeId="4923232344415441232323">5</characteristic>
+            <characteristic name="A" typeId="4123232344415441232323">4</characteristic>
+            <characteristic name="HP" typeId="485023232344415441232323">4</characteristic>
+            <characteristic name="Type" typeId="5479706523232344415441232323">Vehicle (Walker, Character)</characteristic>
           </characteristics>
         </profile>
       </profiles>
       <rules>
         <rule id="802a-1662-3078-108d" name="Indomitable Charge" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
           <description>When charging, this model inflicts D6 Hammer of Wrath hits rather than just one.</description>
         </rule>
         <rule id="bd41-2f34-d305-65e3" name="Unyielding Sentinel" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
           <description>If this model suffers a penetrating hit, two dice must be rolled to determine the result
 on the Vehicle Damage table and the highest roll discarded before the final results are
 decided.</description>
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="24dc-5340-d47d-8553" name="Smoke Launchers" hidden="false" targetId="6875-ee73-2a85-6a97" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="a64c-1d2a-8262-4c89" name="Move Through Cover" hidden="false" targetId="6d06-5ea0-9a17-ca97" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="ded8-3bdf-83fa-3d74" name="Extra Armour" hidden="false" targetId="79c7-90f6-b453-e799" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="b75b-29a0-1060-3549" name="Searchlight" hidden="false" targetId="9bb4-3833-5343-0dd9" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="6ca0-5e67-332f-7c83" name="Armoured Ceramite" hidden="false" targetId="874d-45cf-6007-a1de" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
+        <infoLink id="24dc-5340-d47d-8553" name="Smoke Launchers" hidden="false" targetId="6875-ee73-2a85-6a97" type="profile"/>
+        <infoLink id="a64c-1d2a-8262-4c89" name="Move Through Cover" hidden="false" targetId="6d06-5ea0-9a17-ca97" type="rule"/>
+        <infoLink id="ded8-3bdf-83fa-3d74" name="Extra Armour" hidden="false" targetId="79c7-90f6-b453-e799" type="profile"/>
+        <infoLink id="b75b-29a0-1060-3549" name="Searchlight" hidden="false" targetId="9bb4-3833-5343-0dd9" type="profile"/>
+        <infoLink id="6ca0-5e67-332f-7c83" name="Armoured Ceramite" hidden="false" targetId="874d-45cf-6007-a1de" type="profile"/>
       </infoLinks>
-      <modifiers/>
-      <constraints/>
       <categoryLinks>
-        <categoryLink id="4ec8-82c0-be2a-9601" name="New CategoryLink" hidden="false" targetId="486561767920537570706f727423232344415441232323" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
+        <categoryLink id="4ec8-82c0-be2a-9601" name="New CategoryLink" hidden="false" targetId="486561767920537570706f727423232344415441232323" primary="true"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="e5a8-ae9a-44fc-f885" name="Torso-mounted Spiculus Bolt Launcher" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f6c8-7f92-4e5b-c134" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d9f4-ecfb-0231-173f" type="min"/>
+          </constraints>
           <profiles>
-            <profile id="3aef-1ea5-ebdb-be73" name="Spiculus Bolt Launcher" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <profile id="3aef-1ea5-ebdb-be73" name="Spiculus Bolt Launcher" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
               <characteristics>
-                <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="48&quot;"/>
-                <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="5"/>
-                <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="4"/>
-                <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 5, Rending, Volley Fire"/>
+                <characteristic name="Range" typeId="52616e676523232344415441232323">48&quot;</characteristic>
+                <characteristic name="Strength" typeId="537472656e67746823232344415441232323">5</characteristic>
+                <characteristic name="AP" typeId="415023232344415441232323">4</characteristic>
+                <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 5, Rending, Volley Fire</characteristic>
               </characteristics>
             </profile>
           </profiles>
           <rules>
             <rule id="b4fc-473d-abe7-889e" name="Volley Fire" hidden="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
               <description>If the bearer does not move in the Movement phase, it may double the number of shots fired by this weapon. Note that the Relentless special rule does not allow models to move and claim the benefit of this special rule.</description>
             </rule>
           </rules>
           <infoLinks>
-            <infoLink id="8b2c-7d57-c2ab-5ca8" name="Rending" hidden="false" targetId="8269-2cd6-9236-16e7" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
+            <infoLink id="8b2c-7d57-c2ab-5ca8" name="Rending" hidden="false" targetId="8269-2cd6-9236-16e7" type="rule"/>
           </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f6c8-7f92-4e5b-c134" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d9f4-ecfb-0231-173f" type="min"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
-      <selectionEntryGroups/>
       <entryLinks>
-        <entryLink id="2df4-2788-fe21-ea71" name="Telemon Caestus" hidden="false" targetId="d870-726f-9486-5438" type="selectionEntryGroup">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="77ec-7797-2e2a-3795" name="Telemon Caestus" hidden="false" targetId="d870-726f-9486-5438" type="selectionEntryGroup">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
+        <entryLink id="2df4-2788-fe21-ea71" name="Telemon Caestus" hidden="false" collective="false" targetId="d870-726f-9486-5438" type="selectionEntryGroup"/>
+        <entryLink id="77ec-7797-2e2a-3795" name="Telemon Caestus" hidden="false" collective="false" targetId="d870-726f-9486-5438" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" costTypeId="points" value="320.0"/>
+        <cost name="pts" typeId="points" value="320.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="8594-6f9f-c58d-440d" name="Orion Assault Dropship" book="" hidden="false" collective="false" type="unit">
+    <selectionEntry id="8594-6f9f-c58d-440d" name="Orion Assault Dropship" hidden="false" collective="false" type="unit">
       <profiles>
-        <profile id="7e6c-26d8-68c5-b552" name="Orion Assault Dropship" hidden="false" profileTypeId="56656869636c6523232344415441232323" profileTypeName="Vehicle">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
+        <profile id="7e6c-26d8-68c5-b552" name="Orion Assault Dropship" hidden="false" typeId="56656869636c6523232344415441232323" typeName="Vehicle">
           <characteristics>
-            <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="5"/>
-            <characteristic name="Front" characteristicTypeId="46726f6e7423232344415441232323" value="13"/>
-            <characteristic name="Side" characteristicTypeId="5369646523232344415441232323" value="12"/>
-            <characteristic name="Rear" characteristicTypeId="5265617223232344415441232323" value="11"/>
-            <characteristic name="HP" characteristicTypeId="485023232344415441232323" value="7"/>
-            <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Super-heavy Flyer (Hover, Transport)"/>
+            <characteristic name="BS" typeId="425323232344415441232323">5</characteristic>
+            <characteristic name="Front" typeId="46726f6e7423232344415441232323">13</characteristic>
+            <characteristic name="Side" typeId="5369646523232344415441232323">12</characteristic>
+            <characteristic name="Rear" typeId="5265617223232344415441232323">11</characteristic>
+            <characteristic name="HP" typeId="485023232344415441232323">7</characteristic>
+            <characteristic name="Type" typeId="5479706523232344415441232323">Super-heavy Flyer (Hover, Transport)</characteristic>
           </characteristics>
         </profile>
-        <profile id="7ee3-dea7-8bc2-0013" name="Orion Assault Dropship (Transport)" hidden="false" profileTypeId="307d-047f-ca13-706b" profileTypeName="Transport">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
+        <profile id="7ee3-dea7-8bc2-0013" name="Orion Assault Dropship (Transport)" hidden="false" typeId="307d-047f-ca13-706b" typeName="Transport">
           <characteristics>
-            <characteristic name="Capacity" characteristicTypeId="8285-4205-b6cd-8473" value="24. May include a single Contemptor-Achillus Dreadnought or Contemptor-Galatus Dreadnought (counting as 10 models each)."/>
-            <characteristic name="Fire Points" characteristicTypeId="b270-a7f9-22b2-3702" value="None"/>
-            <characteristic name="Access Points" characteristicTypeId="d17b-0342-b1dc-b8e7" value="One access ramp on the rear of the fuselage."/>
+            <characteristic name="Capacity" typeId="8285-4205-b6cd-8473">24. May include a single Contemptor-Achillus Dreadnought or Contemptor-Galatus Dreadnought (counting as 10 models each).</characteristic>
+            <characteristic name="Fire Points" typeId="b270-a7f9-22b2-3702">None</characteristic>
+            <characteristic name="Access Points" typeId="d17b-0342-b1dc-b8e7">One access ramp on the rear of the fuselage.</characteristic>
           </characteristics>
         </profile>
       </profiles>
-      <rules/>
       <infoLinks>
-        <infoLink id="a5f2-903a-5bb1-2ae1" name="Extra Armour" hidden="false" targetId="5283-9b50-3dcd-78e4" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="c874-1e29-dbdd-a8d3" name="Assault Vehicle" hidden="false" targetId="45cf-653a-4ff6-f22d" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="c639-4c38-4d68-7dfe" name="Grav-backwash" hidden="false" targetId="1254-9285-e876-010d" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="b532-2bdc-a230-1aaa" name="Deep Strike" hidden="false" targetId="d219-2314-4834-c054" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="d5e4-db8d-4ea2-f1cc" name="Armoured Ceramite" hidden="false" targetId="3138-683d-a9a0-570d" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
+        <infoLink id="a5f2-903a-5bb1-2ae1" name="Extra Armour" hidden="false" targetId="5283-9b50-3dcd-78e4" type="rule"/>
+        <infoLink id="c874-1e29-dbdd-a8d3" name="Assault Vehicle" hidden="false" targetId="45cf-653a-4ff6-f22d" type="rule"/>
+        <infoLink id="c639-4c38-4d68-7dfe" name="Grav-backwash" hidden="false" targetId="1254-9285-e876-010d" type="rule"/>
+        <infoLink id="b532-2bdc-a230-1aaa" name="Deep Strike" hidden="false" targetId="d219-2314-4834-c054" type="rule"/>
+        <infoLink id="d5e4-db8d-4ea2-f1cc" name="Armoured Ceramite" hidden="false" targetId="3138-683d-a9a0-570d" type="rule"/>
       </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
       <selectionEntries>
         <selectionEntry id="4247-e61e-0be7-5d54" name="Macro Arae-shrike" hidden="false" collective="false" type="upgrade">
-          <profiles>
-            <profile id="1102-3cb0-9e67-dfbc" name="Arae-shrike (Interception Interference)" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323" profileTypeName="Wargear Item">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="Description" characteristicTypeId="4465736372697074696f6e23232344415441232323" value="When this model enters the battlefield, and any enemy units declare the use of the Interceptor special rule to fire upon it, the intercepting player must roll a D6 for each unit that is attempting Interceptor fire after all such attacks have been declared. If any dice results in a 3 or less then that unit may not make an Interceptor attack that turn, but may fire as normal in its next Shooting phase."/>
-              </characteristics>
-            </profile>
-          </profiles>
-          <rules/>
-          <infoLinks>
-            <infoLink id="77ff-072c-e502-5c31" name="Arae-Shrikes (Deep Strike Interference)" hidden="false" targetId="b429-19fb-4cf4-1e2e" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="e91b-4e48-a04e-ac58" name="Arae-Shrikes (Targeting Interference)" hidden="false" targetId="f0c1-9ee8-4740-54f9" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e6d9-8740-32d7-8556" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="56c8-60ce-363a-9e25" type="min"/>
           </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="0cef-111e-949a-cdf5" name="Eclipse Shield" hidden="false" collective="false" type="upgrade">
           <profiles>
-            <profile id="ba5e-302a-a313-bc11" name="Eclipse Shield" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323" profileTypeName="Wargear Item">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <profile id="1102-3cb0-9e67-dfbc" name="Arae-shrike (Interception Interference)" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
               <characteristics>
-                <characteristic name="Description" characteristicTypeId="4465736372697074696f6e23232344415441232323" value="An eclipse field operates against shooting attacks that strike the Orion’s Front arc. It reduces the Strength of attacks by weapons with the Template or Blast type by -2 and the Strength of other shooting attacks by -1. If a shooting attack targeting the Orion’s Front arc inflicts a glancing hit or penetrating hit from any weapon attack then the Orion immediately gains the Shrouded special rule against all subsequent shooting attacks targeting it in the Front arc during the same phase. An eclipse shield has no effect on close combat attacks or attacks inflicted by the Destroyer special rule."/>
+                <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">When this model enters the battlefield, and any enemy units declare the use of the Interceptor special rule to fire upon it, the intercepting player must roll a D6 for each unit that is attempting Interceptor fire after all such attacks have been declared. If any dice results in a 3 or less then that unit may not make an Interceptor attack that turn, but may fire as normal in its next Shooting phase.</characteristic>
               </characteristics>
             </profile>
           </profiles>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
+          <infoLinks>
+            <infoLink id="77ff-072c-e502-5c31" name="Arae-Shrikes (Deep Strike Interference)" hidden="false" targetId="b429-19fb-4cf4-1e2e" type="profile"/>
+            <infoLink id="e91b-4e48-a04e-ac58" name="Arae-Shrikes (Targeting Interference)" hidden="false" targetId="f0c1-9ee8-4740-54f9" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="0cef-111e-949a-cdf5" name="Eclipse Shield" hidden="false" collective="false" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fd78-10b3-f54e-6f14" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ffaa-b004-e2b2-6ccb" type="max"/>
           </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="e76a-312e-d30b-5533" name="Spiculus Heavy Bolt Launcher" hidden="false" collective="false" type="upgrade">
           <profiles>
-            <profile id="846f-8e05-696a-46c7" name="Spiculus Heavy Bolt Launcher" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <profile id="ba5e-302a-a313-bc11" name="Eclipse Shield" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
               <characteristics>
-                <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="48&quot;"/>
-                <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="7"/>
-                <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="4"/>
-                <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 3, Rending"/>
+                <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">An eclipse field operates against shooting attacks that strike the Orion’s Front arc. It reduces the Strength of attacks by weapons with the Template or Blast type by -2 and the Strength of other shooting attacks by -1. If a shooting attack targeting the Orion’s Front arc inflicts a glancing hit or penetrating hit from any weapon attack then the Orion immediately gains the Shrouded special rule against all subsequent shooting attacks targeting it in the Front arc during the same phase. An eclipse shield has no effect on close combat attacks or attacks inflicted by the Destroyer special rule.</characteristic>
               </characteristics>
             </profile>
           </profiles>
-          <rules/>
-          <infoLinks>
-            <infoLink id="d3fa-0fab-bc59-8088" name="Rending" hidden="false" targetId="8269-2cd6-9236-16e7" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="e76a-312e-d30b-5533" name="Spiculus Heavy Bolt Launcher" hidden="false" collective="false" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8401-42fc-829e-9e48" type="max"/>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fec5-8cf0-2f28-9bcf" type="min"/>
           </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
+          <profiles>
+            <profile id="846f-8e05-696a-46c7" name="Spiculus Heavy Bolt Launcher" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="52616e676523232344415441232323">48&quot;</characteristic>
+                <characteristic name="Strength" typeId="537472656e67746823232344415441232323">7</characteristic>
+                <characteristic name="AP" typeId="415023232344415441232323">4</characteristic>
+                <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 3, Rending</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="d3fa-0fab-bc59-8088" name="Rending" hidden="false" targetId="8269-2cd6-9236-16e7" type="rule"/>
+          </infoLinks>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
-      <selectionEntryGroups/>
       <entryLinks>
-        <entryLink id="370f-f593-58d0-e2fd" name="Arachnus Heavy Blaze cannon" hidden="false" targetId="9cee-6cf2-e0af-4002" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
+        <entryLink id="370f-f593-58d0-e2fd" name="Arachnus Heavy Blaze cannon" hidden="false" collective="false" targetId="9cee-6cf2-e0af-4002" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f98e-a211-fac2-d7c3" type="max"/>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="071f-06a5-2294-032a" type="min"/>
           </constraints>
-          <categoryLinks/>
         </entryLink>
-        <entryLink id="2e94-d64a-3862-4eb4" name="Lastrum Bolt Cannon" hidden="false" targetId="e854-b201-250d-5b1b" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
+        <entryLink id="2e94-d64a-3862-4eb4" name="Lastrum Bolt Cannon" hidden="false" collective="false" targetId="e854-b201-250d-5b1b" type="selectionEntry">
           <modifiers>
-            <modifier type="set" field="name" value="Nose-mounted Twin-Linked Lastrum bolt cannon">
-              <repeats/>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
+            <modifier type="set" field="name" value="Nose-mounted Twin-Linked Lastrum bolt cannon"/>
           </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0b03-5fa5-c8aa-c5df" type="max"/>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="96ff-9c1a-00a5-aac5" type="min"/>
           </constraints>
-          <categoryLinks/>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="pts" costTypeId="points" value="615.0"/>
+        <cost name="pts" typeId="points" value="615.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="bef2-c1b8-bbe1-eab5" name="Warlord" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1e94-d65a-de11-c02f" type="max"/>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5d44-9436-c09c-779f" type="max"/>
       </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
       <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="7d72-4429-d25c-54f3" name="Teleportation Transponders" hidden="true" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="33ac-48ea-560f-4d33" name="Teleportation Transponder" hidden="false" targetId="ccdd-40a2-abb2-09a3" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
       <modifiers>
         <modifier type="set" field="hidden" value="false">
-          <repeats/>
           <conditions>
             <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="2926-8f43-4f60-f18f" type="equalTo"/>
           </conditions>
-          <conditionGroups/>
         </modifier>
       </modifiers>
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7241-91e3-9270-7ca9" type="max"/>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4473-7567-f8ff-5281" type="max"/>
       </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
+      <infoLinks>
+        <infoLink id="33ac-48ea-560f-4d33" name="Teleportation Transponder" hidden="false" targetId="ccdd-40a2-abb2-09a3" type="profile"/>
+      </infoLinks>
       <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="702e-27bd-4148-e4e5" name="Legio Custodes Venatari Squad" book="FW Download" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
+    <selectionEntry id="702e-27bd-4148-e4e5" name="Legio Custodes Venatari Squad" publicationId="a30a-7522-pubN94337" hidden="false" collective="false" type="upgrade">
       <infoLinks>
-        <infoLink id="7a14-cab3-a31f-d4b1" name="Bulky" hidden="false" targetId="38d5-b6eb-bda8-2497" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="d1cd-897f-a852-586c" name="Crusader" hidden="false" targetId="2b06-29a6-641a-b22e" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="0343-a60c-128b-5321" name="Fleet" hidden="false" targetId="69e5-fc02-1f9d-63c2" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="79d8-3d93-4ce1-4071" name="Move Through Cover" hidden="false" targetId="6d06-5ea0-9a17-ca97" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
+        <infoLink id="7a14-cab3-a31f-d4b1" name="Bulky" hidden="false" targetId="38d5-b6eb-bda8-2497" type="rule"/>
+        <infoLink id="d1cd-897f-a852-586c" name="Crusader" hidden="false" targetId="2b06-29a6-641a-b22e" type="rule"/>
+        <infoLink id="0343-a60c-128b-5321" name="Fleet" hidden="false" targetId="69e5-fc02-1f9d-63c2" type="rule"/>
+        <infoLink id="79d8-3d93-4ce1-4071" name="Move Through Cover" hidden="false" targetId="6d06-5ea0-9a17-ca97" type="rule"/>
       </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
       <selectionEntries>
         <selectionEntry id="517b-051c-5f6c-b86a" name="Venatari" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="88b0-771f-6e49-043f" name="Custodian Venatari" hidden="false" targetId="11d9-f1a7-f2de-8ffa" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7228-487b-516e-15e9" type="min"/>
             <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ad5e-a8fb-0de7-d892" type="max"/>
           </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
+          <infoLinks>
+            <infoLink id="88b0-771f-6e49-043f" name="Custodian Venatari" hidden="false" targetId="11d9-f1a7-f2de-8ffa" type="profile"/>
+          </infoLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="f53c-ad3c-d292-e6d4" name="May Replace Archaeotech Kinetic Destroyer &amp; Tarsus Buckler with" hidden="false" collective="false" defaultSelectionEntryId="b294-3593-41f9-86a4">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2766-5a22-ef59-6fce" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="08f0-d2bf-aaba-b4ef" type="min"/>
               </constraints>
-              <categoryLinks/>
               <selectionEntries>
                 <selectionEntry id="b294-3593-41f9-86a4" name="Archaeotech Kinetic Destroyer &amp; Tarsus Buckler" hidden="false" collective="false" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <categoryLinks/>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
                   <entryLinks>
-                    <entryLink id="bb00-e4c7-211f-12e1" name="Archaeotech Kinetic Destroyer" hidden="false" targetId="c632-2ff7-8629-e8fc" type="selectionEntry">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints/>
-                      <categoryLinks/>
-                    </entryLink>
-                    <entryLink id="ecf9-8c49-64b7-30c9" name="Tarsus Buckler" hidden="false" targetId="27dc-deb9-9379-eb10" type="selectionEntry">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints/>
-                      <categoryLinks/>
-                    </entryLink>
+                    <entryLink id="bb00-e4c7-211f-12e1" name="Archaeotech Kinetic Destroyer" hidden="false" collective="false" targetId="c632-2ff7-8629-e8fc" type="selectionEntry"/>
+                    <entryLink id="ecf9-8c49-64b7-30c9" name="Tarsus Buckler" hidden="false" collective="false" targetId="27dc-deb9-9379-eb10" type="selectionEntry"/>
                   </entryLinks>
                   <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
+                    <cost name="pts" typeId="points" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
-              <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="c3c0-11c8-5386-8035" name="Venatari Lance" hidden="false" targetId="c8bb-78c1-0ffc-0a1a" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
+                <entryLink id="c3c0-11c8-5386-8035" name="Venatari Lance" hidden="false" collective="false" targetId="c8bb-78c1-0ffc-0a1a" type="selectionEntry">
                   <modifiers>
-                    <modifier type="set" field="points" value="10">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
+                    <modifier type="set" field="points" value="10"/>
                   </modifiers>
-                  <constraints/>
-                  <categoryLinks/>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks>
-            <entryLink id="5cd7-f5bc-aa20-4573" name="Custodian Jump Harness" hidden="false" targetId="19b9-4cf5-d024-132d" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="5cd7-f5bc-aa20-4573" name="Custodian Jump Harness" hidden="false" collective="false" targetId="19b9-4cf5-d024-132d" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="43f0-7d2e-c854-b0b1" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2632-1e73-ef99-4ca5" type="max"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="f891-e8dc-c152-845e" name="Refractor Feild" hidden="false" targetId="011a-b751-e773-6b90" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="f891-e8dc-c152-845e" name="Refractor Feild" hidden="false" collective="false" targetId="011a-b751-e773-6b90" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f6a1-ec8a-f815-9f63" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2bf9-3ce3-97cf-c8cd" type="max"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
-            <entryLink id="6da5-cc1f-678c-bd5c" name="Plasma + Krak Grenades" hidden="false" targetId="42e2-2cc0-6353-4d47" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <entryLink id="6da5-cc1f-678c-bd5c" name="Plasma + Krak Grenades" hidden="false" collective="false" targetId="42e2-2cc0-6353-4d47" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="86d3-2d3b-dcd9-b08f" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c8be-3822-00b5-5f7d" type="max"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="pts" costTypeId="points" value="65.0"/>
+            <cost name="pts" typeId="points" value="65.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="417c-2d09-9e00-5c5a" name="Entire squad may be equipped with:" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="cec1-4e26-6240-6f23" name="Melta bombs" hidden="false" targetId="648a-e853-bb44-9cee" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
+            <entryLink id="cec1-4e26-6240-6f23" name="Melta bombs" hidden="false" collective="false" targetId="648a-e853-bb44-9cee" type="selectionEntry">
               <modifiers>
                 <modifier type="increment" field="points" value="5">
                   <repeats>
                     <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="517b-051c-5f6c-b86a" repeats="1" roundUp="false"/>
                   </repeats>
-                  <conditions/>
-                  <conditionGroups/>
                 </modifier>
               </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7c8c-2402-00ea-4b71" type="max"/>
               </constraints>
-              <categoryLinks/>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="e55c-9688-faae-2e73" name="Legio Custodes" hidden="false" targetId="a502-5799-a2f4-310b" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
+        <entryLink id="e55c-9688-faae-2e73" name="Legio Custodes" hidden="false" collective="false" targetId="a502-5799-a2f4-310b" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="238d-4fed-dd44-d6ca" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="60e3-1a3c-803b-1ee2" type="min"/>
           </constraints>
-          <categoryLinks/>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="pts" costTypeId="points" value="15.0"/>
+        <cost name="pts" typeId="points" value="15.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="dc85-086f-2a21-9002" name="Ares Gunship" book="HH8" page="286" hidden="false" collective="false" type="unit">
+    <selectionEntry id="dc85-086f-2a21-9002" name="Ares Gunship" publicationId="a30a-7522-pubN94931" page="286" hidden="false" collective="false" type="unit">
       <profiles>
-        <profile id="56a6-7db0-83ed-1efa" name="Ares Gunship" hidden="false" profileTypeId="56656869636c6523232344415441232323" profileTypeName="Vehicle">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
+        <profile id="56a6-7db0-83ed-1efa" name="Ares Gunship" hidden="false" typeId="56656869636c6523232344415441232323" typeName="Vehicle">
           <characteristics>
-            <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="5"/>
-            <characteristic name="Front" characteristicTypeId="46726f6e7423232344415441232323" value="13"/>
-            <characteristic name="Side" characteristicTypeId="5369646523232344415441232323" value="12"/>
-            <characteristic name="Rear" characteristicTypeId="5265617223232344415441232323" value="10"/>
-            <characteristic name="HP" characteristicTypeId="485023232344415441232323" value="7"/>
-            <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Super-heavy Flyer (Hover)"/>
+            <characteristic name="BS" typeId="425323232344415441232323">5</characteristic>
+            <characteristic name="Front" typeId="46726f6e7423232344415441232323">13</characteristic>
+            <characteristic name="Side" typeId="5369646523232344415441232323">12</characteristic>
+            <characteristic name="Rear" typeId="5265617223232344415441232323">10</characteristic>
+            <characteristic name="HP" typeId="485023232344415441232323">7</characteristic>
+            <characteristic name="Type" typeId="5479706523232344415441232323">Super-heavy Flyer (Hover)</characteristic>
           </characteristics>
         </profile>
       </profiles>
       <rules>
-        <rule id="0fc8-8907-18c5-4bcc" name="Exposed Arachnus-Capacitors" book="HH8" page="287" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
+        <rule id="0fc8-8907-18c5-4bcc" name="Exposed Arachnus-Capacitors" publicationId="a30a-7522-pubN94931" page="287" hidden="false">
           <description>Contrary to the usual rules for Super-heavy Flayers, shuold the Ares Gunship suffer a penetrating hit from its Rare arc which results in an Exploses! result on the Cehicle Damage table, roll a D6. On a 5+ the Ares Gunship Immediately loses all of its remaining Hull points and suffers Catastrophic Damage.</description>
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="1c31-aeff-f024-b832" name="Extra Armour" hidden="false" targetId="5283-9b50-3dcd-78e4" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="43e6-9a73-7db0-5b45" name="Grav-backwash" hidden="false" targetId="1254-9285-e876-010d" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="48af-c909-df68-7f2c" name="Deep Strike" hidden="false" targetId="d219-2314-4834-c054" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="2170-334b-47f9-ca8a" name="Armoured Ceramite" hidden="false" targetId="3138-683d-a9a0-570d" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
+        <infoLink id="1c31-aeff-f024-b832" name="Extra Armour" hidden="false" targetId="5283-9b50-3dcd-78e4" type="rule"/>
+        <infoLink id="43e6-9a73-7db0-5b45" name="Grav-backwash" hidden="false" targetId="1254-9285-e876-010d" type="rule"/>
+        <infoLink id="48af-c909-df68-7f2c" name="Deep Strike" hidden="false" targetId="d219-2314-4834-c054" type="rule"/>
+        <infoLink id="2170-334b-47f9-ca8a" name="Armoured Ceramite" hidden="false" targetId="3138-683d-a9a0-570d" type="rule"/>
       </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
       <selectionEntries>
         <selectionEntry id="61e7-7e45-be48-42aa" name="Macro Arae-shrike" hidden="false" collective="false" type="upgrade">
-          <profiles>
-            <profile id="a95a-fc26-8dd8-7eb9" name="Arae-shrike (Interception Interference)" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323" profileTypeName="Wargear Item">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="Description" characteristicTypeId="4465736372697074696f6e23232344415441232323" value="When this model enters the battlefield, and any enemy units declare the use of the Interceptor special rule to fire upon it, the intercepting player must roll a D6 for each unit that is attempting Interceptor fire after all such attacks have been declared. If any dice results in a 3 or less then that unit may not make an Interceptor attack that turn, but may fire as normal in its next Shooting phase."/>
-              </characteristics>
-            </profile>
-          </profiles>
-          <rules/>
-          <infoLinks>
-            <infoLink id="7094-57c3-1c57-a45e" name="Arae-Shrikes (Deep Strike Interference)" hidden="false" targetId="b429-19fb-4cf4-1e2e" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="c3a6-041d-9cd0-1236" name="Arae-Shrikes (Targeting Interference)" hidden="false" targetId="f0c1-9ee8-4740-54f9" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1444-c178-69f4-f0f9" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="80f8-6360-8da6-c714" type="min"/>
           </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="e744-45d0-091d-88d8" name="Eclipse Shield" hidden="false" collective="false" type="upgrade">
           <profiles>
-            <profile id="d89c-4d63-9770-3c6c" name="Eclipse Shield" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323" profileTypeName="Wargear Item">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <profile id="a95a-fc26-8dd8-7eb9" name="Arae-shrike (Interception Interference)" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
               <characteristics>
-                <characteristic name="Description" characteristicTypeId="4465736372697074696f6e23232344415441232323" value="An eclipse field operates against shooting attacks that strike the Orion’s Front arc. It reduces the Strength of attacks by weapons with the Template or Blast type by -2 and the Strength of other shooting attacks by -1. If a shooting attack targeting the Orion’s Front arc inflicts a glancing hit or penetrating hit from any weapon attack then the Orion immediately gains the Shrouded special rule against all subsequent shooting attacks targeting it in the Front arc during the same phase. An eclipse shield has no effect on close combat attacks or attacks inflicted by the Destroyer special rule."/>
+                <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">When this model enters the battlefield, and any enemy units declare the use of the Interceptor special rule to fire upon it, the intercepting player must roll a D6 for each unit that is attempting Interceptor fire after all such attacks have been declared. If any dice results in a 3 or less then that unit may not make an Interceptor attack that turn, but may fire as normal in its next Shooting phase.</characteristic>
               </characteristics>
             </profile>
           </profiles>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
+          <infoLinks>
+            <infoLink id="7094-57c3-1c57-a45e" name="Arae-Shrikes (Deep Strike Interference)" hidden="false" targetId="b429-19fb-4cf4-1e2e" type="profile"/>
+            <infoLink id="c3a6-041d-9cd0-1236" name="Arae-Shrikes (Targeting Interference)" hidden="false" targetId="f0c1-9ee8-4740-54f9" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="e744-45d0-091d-88d8" name="Eclipse Shield" hidden="false" collective="false" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b710-7bc0-efdf-dbc1" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5be5-b7fc-8e60-9303" type="max"/>
           </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="6332-6774-13cb-2e9a" name="Arachnus Magna-Blaze Cannon" book="HH8" page="287" hidden="false" collective="false" type="upgrade">
           <profiles>
-            <profile id="99aa-6807-bbf4-9461" name="Arachnus Magna-Blaze Cannon (Concentrated Blast)" book="HH8" page="287" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <profile id="d89c-4d63-9770-3c6c" name="Eclipse Shield" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
               <characteristics>
-                <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="72&quot;"/>
-                <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="10"/>
-                <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="1"/>
-                <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Primary Weapon 2, Exoshock*, Master-Crafted, Armourbane, Instant Death"/>
+                <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">An eclipse field operates against shooting attacks that strike the Orion’s Front arc. It reduces the Strength of attacks by weapons with the Template or Blast type by -2 and the Strength of other shooting attacks by -1. If a shooting attack targeting the Orion’s Front arc inflicts a glancing hit or penetrating hit from any weapon attack then the Orion immediately gains the Shrouded special rule against all subsequent shooting attacks targeting it in the Front arc during the same phase. An eclipse shield has no effect on close combat attacks or attacks inflicted by the Destroyer special rule.</characteristic>
               </characteristics>
             </profile>
-            <profile id="f52e-8352-8e92-00d1" name="Arachnus Magna-Blaze Cannon (Burst Fire)" book="HH8" page="287" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="6332-6774-13cb-2e9a" name="Arachnus Magna-Blaze Cannon" publicationId="a30a-7522-pubN94931" page="287" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c2e1-ed77-9e41-eac1" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="10b3-0801-b4cb-06b6" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="99aa-6807-bbf4-9461" name="Arachnus Magna-Blaze Cannon (Concentrated Blast)" publicationId="a30a-7522-pubN94931" page="287" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
               <characteristics>
-                <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="48&quot;"/>
-                <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="8"/>
-                <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="2"/>
-                <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 2, Large Blast (5&quot;)"/>
+                <characteristic name="Range" typeId="52616e676523232344415441232323">72&quot;</characteristic>
+                <characteristic name="Strength" typeId="537472656e67746823232344415441232323">10</characteristic>
+                <characteristic name="AP" typeId="415023232344415441232323">1</characteristic>
+                <characteristic name="Type" typeId="5479706523232344415441232323">Primary Weapon 2, Exoshock*, Master-Crafted, Armourbane, Instant Death</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="f52e-8352-8e92-00d1" name="Arachnus Magna-Blaze Cannon (Burst Fire)" publicationId="a30a-7522-pubN94931" page="287" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="52616e676523232344415441232323">48&quot;</characteristic>
+                <characteristic name="Strength" typeId="537472656e67746823232344415441232323">8</characteristic>
+                <characteristic name="AP" typeId="415023232344415441232323">2</characteristic>
+                <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 2, Large Blast (5&quot;)</characteristic>
               </characteristics>
             </profile>
           </profiles>
           <rules>
             <rule id="ac98-f33e-fbcd-0785" name="Exoshock*" hidden="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
               <description>If this wepon scores a penetrating hit on a target, roll a D6. on a roll of a 4+, a second automatic penetrating hit is inflicted on the same target, against which cover saves may not be taken.
 *In the case of the Ares Magna Blaze Cannon. only a single additional penetrading hit can be caused, which is resolved on the Vehicle Damage table.</description>
             </rule>
           </rules>
           <infoLinks>
-            <infoLink id="f09c-22ff-fb78-1f64" name="Master-crafted" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="0ab7-4cda-ffe2-e0ed" name="Armourbane" hidden="false" targetId="e182-50cd-0867-9a8d" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="62a9-39fa-6add-4534" name="Instant Death" hidden="false" targetId="fbf1-6913-ff9f-5a4f" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
+            <infoLink id="f09c-22ff-fb78-1f64" name="Master-crafted" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule"/>
+            <infoLink id="0ab7-4cda-ffe2-e0ed" name="Armourbane" hidden="false" targetId="e182-50cd-0867-9a8d" type="rule"/>
+            <infoLink id="62a9-39fa-6add-4534" name="Instant Death" hidden="false" targetId="fbf1-6913-ff9f-5a4f" type="rule"/>
           </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c2e1-ed77-9e41-eac1" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="10b3-0801-b4cb-06b6" type="min"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="e79a-6ed4-583d-f294" name="Two Infernus Firebomb Cluster" hidden="false" collective="false" type="upgrade">
-          <profiles>
-            <profile id="d266-057a-a6f2-12da" name="Infernus Firebomb Cluster" book="HH8" page="287" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="-"/>
-                <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="5"/>
-                <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="4"/>
-                <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Bomb 3, Large Blast (5&quot;), Ignores Cover Saves, One Use"/>
-              </characteristics>
-            </profile>
-          </profiles>
-          <rules/>
-          <infoLinks>
-            <infoLink id="e43e-e695-94ed-f238" name="Ignores Cover" hidden="false" targetId="acf2-681d-4188-94d7" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="e246-1b8c-9df4-93a4" name="One Use Only/One Shot Only" hidden="false" targetId="3789-00ab-3f47-eb36" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dcaa-9d4b-71a0-898c" type="max"/>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0266-c0a0-0879-7a5f" type="min"/>
           </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
+          <profiles>
+            <profile id="d266-057a-a6f2-12da" name="Infernus Firebomb Cluster" publicationId="a30a-7522-pubN94931" page="287" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
+                <characteristic name="Strength" typeId="537472656e67746823232344415441232323">5</characteristic>
+                <characteristic name="AP" typeId="415023232344415441232323">4</characteristic>
+                <characteristic name="Type" typeId="5479706523232344415441232323">Bomb 3, Large Blast (5&quot;), Ignores Cover Saves, One Use</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="e43e-e695-94ed-f238" name="Ignores Cover" hidden="false" targetId="acf2-681d-4188-94d7" type="rule"/>
+            <infoLink id="e246-1b8c-9df4-93a4" name="One Use Only/One Shot Only" hidden="false" targetId="3789-00ab-3f47-eb36" type="rule"/>
+          </infoLinks>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
-      <selectionEntryGroups/>
       <entryLinks>
-        <entryLink id="7f99-b9d6-4482-1b8c" name="Arachnus Heavy Blaze cannon" hidden="false" targetId="9cee-6cf2-e0af-4002" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
+        <entryLink id="7f99-b9d6-4482-1b8c" name="Arachnus Heavy Blaze cannon" hidden="false" collective="false" targetId="9cee-6cf2-e0af-4002" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dd1e-5aa7-43c4-9c96" type="max"/>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c9d9-05aa-ef30-c13a" type="min"/>
           </constraints>
-          <categoryLinks/>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="pts" costTypeId="points" value="640.0"/>
+        <cost name="pts" typeId="points" value="640.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="7d90-3f3d-50e1-e295" name="Divining Blades" hidden="true" collective="false" type="upgrade">
-      <profiles>
-        <profile id="8b29-ca65-a6fb-1439" name="Divining Blades" book="HH8" page="306" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="Melee"/>
-            <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="+2"/>
-            <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="1"/>
-            <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Melee, Instant Death, Master-Crafted, Psy-Lash, Two Handed."/>
-          </characteristics>
-        </profile>
-      </profiles>
-      <rules/>
-      <infoLinks>
-        <infoLink id="aed5-5736-9831-3af1" name="Instant Death" hidden="false" targetId="fbf1-6913-ff9f-5a4f" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="0749-f2b5-64f7-a15b" name="Master-crafted" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="6853-1967-c819-6181" name="Psy-Lash" hidden="false" targetId="6f38-4691-2eda-8e1b" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="ae1e-574a-9cfe-7508" name="Two-Handed" hidden="false" targetId="b11c-0ef4-af6b-d96f" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="aa18-3d76-d619-9546" type="max"/>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="991e-4b2a-5ebf-ad74" type="max"/>
       </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
+      <profiles>
+        <profile id="8b29-ca65-a6fb-1439" name="Divining Blades" publicationId="a30a-7522-pubN94931" page="306" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="52616e676523232344415441232323">Melee</characteristic>
+            <characteristic name="Strength" typeId="537472656e67746823232344415441232323">+2</characteristic>
+            <characteristic name="AP" typeId="415023232344415441232323">1</characteristic>
+            <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Instant Death, Master-Crafted, Psy-Lash, Two Handed.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="aed5-5736-9831-3af1" name="Instant Death" hidden="false" targetId="fbf1-6913-ff9f-5a4f" type="rule"/>
+        <infoLink id="0749-f2b5-64f7-a15b" name="Master-crafted" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule"/>
+        <infoLink id="6853-1967-c819-6181" name="Psy-Lash" hidden="false" targetId="6f38-4691-2eda-8e1b" type="rule"/>
+        <infoLink id="ae1e-574a-9cfe-7508" name="Two-Handed" hidden="false" targetId="b11c-0ef4-af6b-d96f" type="rule"/>
+      </infoLinks>
       <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup id="986b-441b-bff6-b09f" name="Wargear" hidden="false" collective="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
       <selectionEntries>
-        <selectionEntry id="a521-ee67-6936-d9b2" name="Praesidium Shield" book="HH7" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="d4dc-99fb-8665-78cc" name="Praesidium Shield" hidden="false" targetId="8801-24fc-bb8c-ef86" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
+        <selectionEntry id="a521-ee67-6936-d9b2" name="Praesidium Shield" publicationId="a30a-7522-pubN95872" hidden="false" collective="false" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf60-6690-dbe8-e081" type="max"/>
           </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
+          <infoLinks>
+            <infoLink id="d4dc-99fb-8665-78cc" name="Praesidium Shield" hidden="false" targetId="8801-24fc-bb8c-ef86" type="profile"/>
+          </infoLinks>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="81f8-eb55-e1fd-c90a" name="Teleportation Transponders" book="HH7" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
+        <selectionEntry id="81f8-eb55-e1fd-c90a" name="Teleportation Transponders" publicationId="a30a-7522-pubN95872" hidden="false" collective="false" type="upgrade">
           <infoLinks>
-            <infoLink id="f0d1-589f-37af-ae38" name="Teleportation Transponder" hidden="false" targetId="ccdd-40a2-abb2-09a3" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
+            <infoLink id="f0d1-589f-37af-ae38" name="Teleportation Transponder" hidden="false" targetId="ccdd-40a2-abb2-09a3" type="profile"/>
           </infoLinks>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="011a-b751-e773-6b90" name="Refractor Feild" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
           <infoLinks>
-            <infoLink id="5250-699f-a073-d16f" name="New InfoLink" hidden="false" targetId="4845-0bfe-2c22-883f" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
+            <infoLink id="5250-699f-a073-d16f" name="New InfoLink" hidden="false" targetId="4845-0bfe-2c22-883f" type="profile"/>
           </infoLinks>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="c60c-dfd9-c5b8-50d1" name="Iron Halo" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
           <infoLinks>
-            <infoLink id="49b1-6f24-3e38-5397" name="New InfoLink" hidden="false" targetId="e8d9-eb1e-3e42-09b1" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
+            <infoLink id="49b1-6f24-3e38-5397" name="New InfoLink" hidden="false" targetId="e8d9-eb1e-3e42-09b1" type="profile"/>
           </infoLinks>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="b7c1-be91-5d72-c763" name="Magisterium Vexilla" book="HH7" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
+        <selectionEntry id="b7c1-be91-5d72-c763" name="Magisterium Vexilla" publicationId="a30a-7522-pubN95872" hidden="false" collective="false" type="upgrade">
           <infoLinks>
-            <infoLink id="631b-0da4-3458-792f" name="Magesterium Vexilla" hidden="false" targetId="74a8-38a9-870a-f02d" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
+            <infoLink id="631b-0da4-3458-792f" name="Magesterium Vexilla" hidden="false" targetId="74a8-38a9-870a-f02d" type="profile"/>
           </infoLinks>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="be4a-0e91-0f1f-4c1d" name="Arae-Shrikes" book="HH7" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
+        <selectionEntry id="be4a-0e91-0f1f-4c1d" name="Arae-Shrikes" publicationId="a30a-7522-pubN95872" hidden="false" collective="false" type="upgrade">
           <infoLinks>
-            <infoLink id="d1d3-d247-0e19-c049" name="Arae-Shrikes (Deep Strike Interference)" hidden="false" targetId="b429-19fb-4cf4-1e2e" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="4e56-c9ab-1686-d4c8" name="Arae-Shrikes (Targeting Interference)" hidden="false" targetId="f0c1-9ee8-4740-54f9" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
+            <infoLink id="d1d3-d247-0e19-c049" name="Arae-Shrikes (Deep Strike Interference)" hidden="false" targetId="b429-19fb-4cf4-1e2e" type="profile"/>
+            <infoLink id="4e56-c9ab-1686-d4c8" name="Arae-Shrikes (Targeting Interference)" hidden="false" targetId="f0c1-9ee8-4740-54f9" type="profile"/>
           </infoLinks>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="42e2-2cc0-6353-4d47" name="Plasma + Krak Grenades" book="HH7" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
+        <selectionEntry id="42e2-2cc0-6353-4d47" name="Plasma + Krak Grenades" publicationId="a30a-7522-pubN95872" hidden="false" collective="false" type="upgrade">
           <infoLinks>
-            <infoLink id="cec2-cbf0-7874-0f36" name="New InfoLink" hidden="false" targetId="d9f7-775b-1047-f335" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="c600-66fb-51ef-43a0" name="New InfoLink" hidden="false" targetId="7b4d-1c91-ab33-1b12" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="d109-b31e-e4f6-5b48" name="New InfoLink" hidden="false" targetId="0d78-e15c-74f6-5701" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
+            <infoLink id="cec2-cbf0-7874-0f36" name="New InfoLink" hidden="false" targetId="d9f7-775b-1047-f335" type="profile"/>
+            <infoLink id="c600-66fb-51ef-43a0" name="New InfoLink" hidden="false" targetId="7b4d-1c91-ab33-1b12" type="profile"/>
+            <infoLink id="d109-b31e-e4f6-5b48" name="New InfoLink" hidden="false" targetId="0d78-e15c-74f6-5701" type="rule"/>
           </infoLinks>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="648a-e853-bb44-9cee" name="Melta bombs" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
           <infoLinks>
-            <infoLink id="5da3-9638-ef38-4d9f" name="New InfoLink" hidden="false" targetId="a1d8-f9f3-865a-9faf" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
+            <infoLink id="5da3-9638-ef38-4d9f" name="New InfoLink" hidden="false" targetId="a1d8-f9f3-865a-9faf" type="profile"/>
           </infoLinks>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="5f1c-b6c2-0caa-f462" name="Archaeotech Pistol" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
           <infoLinks>
-            <infoLink id="8f7d-14c7-f292-4ce7" name="New InfoLink" hidden="false" targetId="cf65-5d4c-24a3-92d2" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
+            <infoLink id="8f7d-14c7-f292-4ce7" name="New InfoLink" hidden="false" targetId="cf65-5d4c-24a3-92d2" type="profile"/>
           </infoLinks>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="155f-54a6-8ca9-27f5" name="Digital Lasers" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
           <infoLinks>
-            <infoLink id="3d48-abba-5177-87ec" name="New InfoLink" hidden="false" targetId="1a12-3c84-f5a6-1c48" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
+            <infoLink id="3d48-abba-5177-87ec" name="New InfoLink" hidden="false" targetId="1a12-3c84-f5a6-1c48" type="profile"/>
           </infoLinks>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="9d28-797b-ad71-c8ca" name="Cyber Familliar" book="HH7" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
+        <selectionEntry id="9d28-797b-ad71-c8ca" name="Cyber Familliar" publicationId="a30a-7522-pubN95872" hidden="false" collective="false" type="upgrade">
           <infoLinks>
-            <infoLink id="b86c-b6bb-6713-8f81" name="New InfoLink" hidden="false" targetId="379b-7755-6264-0849" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
+            <infoLink id="b86c-b6bb-6713-8f81" name="New InfoLink" hidden="false" targetId="379b-7755-6264-0849" type="profile"/>
           </infoLinks>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="f727-c9c2-83d0-3984" name="Bolt Pistol" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
           <infoLinks>
-            <infoLink id="32ee-6734-bbe2-e55f" name="New InfoLink" hidden="false" targetId="ec83-0776-ef74-9cc2" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
+            <infoLink id="32ee-6734-bbe2-e55f" name="New InfoLink" hidden="false" targetId="ec83-0776-ef74-9cc2" type="profile"/>
           </infoLinks>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="af7d-23e9-3a57-57aa" name="Hand Flamer" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
           <infoLinks>
-            <infoLink id="df8f-a663-c95c-e77b" name="New InfoLink" hidden="false" targetId="21b6-668e-d5ef-a8da" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
+            <infoLink id="df8f-a663-c95c-e77b" name="New InfoLink" hidden="false" targetId="21b6-668e-d5ef-a8da" type="profile"/>
           </infoLinks>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="a598-a02a-d502-adf4" name="Plasma Pistol" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
           <infoLinks>
-            <infoLink id="3512-a7b4-28c1-8131" name="New InfoLink" hidden="false" targetId="f9fd-36be-dc19-401f" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
+            <infoLink id="3512-a7b4-28c1-8131" name="New InfoLink" hidden="false" targetId="f9fd-36be-dc19-401f" type="profile"/>
           </infoLinks>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="99f1-e166-4deb-ab11" name="Paragon Blade" page="0" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d2e2-3e58-0edc-6511" type="max"/>
+          </constraints>
           <profiles>
-            <profile id="8419-0715-b38f-8b3f" name="Paragon Blade" book="HH1: Betrayal" page="235" hidden="false" profileTypeId="576561706f6e23232344415441232323">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <profile id="8419-0715-b38f-8b3f" name="Paragon Blade" publicationId="a30a-7522-pubN96662" page="235" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
               <characteristics>
-                <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="-"/>
-                <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="+1"/>
-                <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="2"/>
-                <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Melee, Murderous Strike, Specialist Weapon"/>
+                <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
+                <characteristic name="Strength" typeId="537472656e67746823232344415441232323">+1</characteristic>
+                <characteristic name="AP" typeId="415023232344415441232323">2</characteristic>
+                <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Murderous Strike, Specialist Weapon</characteristic>
               </characteristics>
             </profile>
           </profiles>
           <rules>
             <rule id="32c0-4401-bc92-7474" name="Murderous Strike" page="0" hidden="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
               <description>Causes Instant Death on a To Wound roll of 6</description>
             </rule>
           </rules>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d2e2-3e58-0edc-6511" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
           <costs>
-            <cost name="pts" costTypeId="points" value="20.0"/>
+            <cost name="pts" typeId="points" value="20.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="e8f5-fd9d-1891-93d3" name="Nuncio-Vox" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
           <infoLinks>
-            <infoLink id="5874-98f1-4956-ff70" name="New InfoLink" hidden="false" targetId="2a0e-e1f0-5ea0-5799" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
+            <infoLink id="5874-98f1-4956-ff70" name="New InfoLink" hidden="false" targetId="2a0e-e1f0-5ea0-5799" type="profile"/>
           </infoLinks>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="2dbb-47ce-c902-cc3d" name="Charnabal Sabre" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
           <infoLinks>
-            <infoLink id="3101-c36a-5f13-5eac" name="New InfoLink" hidden="false" targetId="896c-9540-49b4-1d08" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="0b23-81d8-ae16-3a1c" name="New InfoLink" hidden="false" targetId="eddf-f5b5-0ec0-e1bb" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
+            <infoLink id="3101-c36a-5f13-5eac" name="New InfoLink" hidden="false" targetId="896c-9540-49b4-1d08" type="profile"/>
+            <infoLink id="0b23-81d8-ae16-3a1c" name="New InfoLink" hidden="false" targetId="eddf-f5b5-0ec0-e1bb" type="rule"/>
           </infoLinks>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="c783-b082-5cb9-888e" name="Flamer with Compression Tanks" book="HH7" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
+        <selectionEntry id="c783-b082-5cb9-888e" name="Flamer with Compression Tanks" publicationId="a30a-7522-pubN95872" hidden="false" collective="false" type="upgrade">
           <infoLinks>
-            <infoLink id="6f64-4c2b-1c34-3181" name="New InfoLink" hidden="false" targetId="3a71-7de1-1948-3655" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="b4c0-df3a-9eaa-1910" name="New InfoLink" hidden="false" targetId="3eed-1fde-941e-af2d" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
+            <infoLink id="6f64-4c2b-1c34-3181" name="New InfoLink" hidden="false" targetId="3a71-7de1-1948-3655" type="profile"/>
+            <infoLink id="b4c0-df3a-9eaa-1910" name="New InfoLink" hidden="false" targetId="3eed-1fde-941e-af2d" type="rule"/>
           </infoLinks>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="1f4e-6106-2d51-ba0b" name="Power Fist" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
           <infoLinks>
-            <infoLink id="c22c-ee03-0144-23af" name="New InfoLink" hidden="false" targetId="4ddd-399c-d71c-4ac1" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
+            <infoLink id="c22c-ee03-0144-23af" name="New InfoLink" hidden="false" targetId="4ddd-399c-d71c-4ac1" type="profile"/>
           </infoLinks>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="a920-a58e-a750-0a5c" name="Misericordia" book="HH7" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
+        <selectionEntry id="a920-a58e-a750-0a5c" name="Misericordia" publicationId="a30a-7522-pubN95872" hidden="false" collective="false" type="upgrade">
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="41e2-dfa6-69be-a6cb" name="Boltgun" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
           <infoLinks>
-            <infoLink id="e8d0-43ca-fcf3-6d88" name="New InfoLink" hidden="false" targetId="09fd-8af1-a6b1-51f7" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
+            <infoLink id="e8d0-43ca-fcf3-6d88" name="New InfoLink" hidden="false" targetId="09fd-8af1-a6b1-51f7" type="profile"/>
           </infoLinks>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
-      <selectionEntryGroups/>
-      <entryLinks/>
     </selectionEntryGroup>
     <selectionEntryGroup id="6d79-f204-10b7-08cf" name="Legio Custodes Battlefeild Support Weapons" hidden="false" collective="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
       <selectionEntries>
-        <selectionEntry id="d9f3-ece0-5749-021e" name="Illastus Accelerator Cannon" book="HH7" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
+        <selectionEntry id="d9f3-ece0-5749-021e" name="Illastus Accelerator Cannon" publicationId="a30a-7522-pubN95872" hidden="false" collective="false" type="upgrade">
           <infoLinks>
-            <infoLink id="e7cd-657e-49a9-a02d" name="Rapid Tracking" hidden="false" targetId="3996-018b-a7d9-a7b8" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="d17f-0502-f5ac-aa0e" name="Heliothermic Detonation" hidden="false" targetId="dd32-1791-4789-051f" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="a352-3b65-5812-946a" name="Illastus Accelerator Cannon" hidden="false" targetId="77bf-13f3-9413-a331" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="8d50-2789-d1d8-52ec" name="Rending" hidden="false" targetId="8269-2cd6-9236-16e7" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
+            <infoLink id="e7cd-657e-49a9-a02d" name="Rapid Tracking" hidden="false" targetId="3996-018b-a7d9-a7b8" type="rule"/>
+            <infoLink id="d17f-0502-f5ac-aa0e" name="Heliothermic Detonation" hidden="false" targetId="dd32-1791-4789-051f" type="rule"/>
+            <infoLink id="a352-3b65-5812-946a" name="Illastus Accelerator Cannon" hidden="false" targetId="77bf-13f3-9413-a331" type="profile"/>
+            <infoLink id="8d50-2789-d1d8-52ec" name="Rending" hidden="false" targetId="8269-2cd6-9236-16e7" type="rule"/>
           </infoLinks>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="af24-638f-cd0d-5d2d" name="Infernus Firepike" book="HH7" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
+        <selectionEntry id="af24-638f-cd0d-5d2d" name="Infernus Firepike" publicationId="a30a-7522-pubN95872" hidden="false" collective="false" type="upgrade">
           <infoLinks>
-            <infoLink id="2cc0-e060-e33f-c84e" name="New InfoLink" hidden="false" targetId="63ea-1d6c-119b-ccb1" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="e48a-e65b-72a7-ab1e" name="New InfoLink" hidden="false" targetId="5039-18f0-a9ed-0938" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
+            <infoLink id="2cc0-e060-e33f-c84e" name="New InfoLink" hidden="false" targetId="63ea-1d6c-119b-ccb1" type="profile"/>
+            <infoLink id="e48a-e65b-72a7-ab1e" name="New InfoLink" hidden="false" targetId="5039-18f0-a9ed-0938" type="rule"/>
           </infoLinks>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="a52a-cf67-2fb7-1cf5" name="Infernus Incinerator" book="HH7" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
+        <selectionEntry id="a52a-cf67-2fb7-1cf5" name="Infernus Incinerator" publicationId="a30a-7522-pubN95872" hidden="false" collective="false" type="upgrade">
           <infoLinks>
-            <infoLink id="d5e5-f390-c436-93b8" name="New InfoLink" hidden="false" targetId="20a0-9b92-39e5-592b" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
+            <infoLink id="d5e5-f390-c436-93b8" name="New InfoLink" hidden="false" targetId="20a0-9b92-39e5-592b" type="profile"/>
           </infoLinks>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="e8b1-f158-e1ab-ddfc" name="Proteus Las Lance" book="HH7" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
+        <selectionEntry id="e8b1-f158-e1ab-ddfc" name="Proteus Las Lance" publicationId="a30a-7522-pubN95872" hidden="false" collective="false" type="upgrade">
           <infoLinks>
-            <infoLink id="c59d-7b4f-6d8b-7b73" name="New InfoLink" hidden="false" targetId="1968-4e55-18f3-4c72" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="621d-5ed7-e889-7fd1" name="New InfoLink" hidden="false" targetId="98ed-3a29-c86b-455d" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
+            <infoLink id="c59d-7b4f-6d8b-7b73" name="New InfoLink" hidden="false" targetId="1968-4e55-18f3-4c72" type="profile"/>
+            <infoLink id="621d-5ed7-e889-7fd1" name="New InfoLink" hidden="false" targetId="98ed-3a29-c86b-455d" type="rule"/>
           </infoLinks>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="25ca-4b92-d195-cd5e" name="Corve Las-Pulser" book="HH7" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
+        <selectionEntry id="25ca-4b92-d195-cd5e" name="Corve Las-Pulser" publicationId="a30a-7522-pubN95872" hidden="false" collective="false" type="upgrade">
           <infoLinks>
-            <infoLink id="a384-5a88-2fe6-80a2" name="New InfoLink" hidden="false" targetId="5076-87fe-92aa-f4a9" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="a086-69ac-3ad0-222d" name="New InfoLink" hidden="false" targetId="2740-e6d7-076b-9d5c" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
+            <infoLink id="a384-5a88-2fe6-80a2" name="New InfoLink" hidden="false" targetId="5076-87fe-92aa-f4a9" type="profile"/>
+            <infoLink id="a086-69ac-3ad0-222d" name="New InfoLink" hidden="false" targetId="2740-e6d7-076b-9d5c" type="rule"/>
           </infoLinks>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="b33a-20a1-ddf9-38b5" name="Arachnus Blaze Cannon" book="HH7" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
+        <selectionEntry id="b33a-20a1-ddf9-38b5" name="Arachnus Blaze Cannon" publicationId="a30a-7522-pubN95872" hidden="false" collective="false" type="upgrade">
           <infoLinks>
-            <infoLink id="a9f3-7952-8e1f-14a7" name="Exoshock" hidden="false" targetId="2740-e6d7-076b-9d5c" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="2831-cd24-bbed-e6db" name="New InfoLink" hidden="false" targetId="458c-cc54-229f-324d" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="9a5d-40a4-af54-d6fa" name="New InfoLink" hidden="false" targetId="3e1e-6409-2b91-7534" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
+            <infoLink id="a9f3-7952-8e1f-14a7" name="Exoshock" hidden="false" targetId="2740-e6d7-076b-9d5c" type="rule"/>
+            <infoLink id="2831-cd24-bbed-e6db" name="New InfoLink" hidden="false" targetId="458c-cc54-229f-324d" type="profile"/>
+            <infoLink id="9a5d-40a4-af54-d6fa" name="New InfoLink" hidden="false" targetId="3e1e-6409-2b91-7534" type="profile"/>
           </infoLinks>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="9cee-6cf2-e0af-4002" name="Arachnus Heavy Blaze cannon" book="HH7" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
+        <selectionEntry id="9cee-6cf2-e0af-4002" name="Arachnus Heavy Blaze cannon" publicationId="a30a-7522-pubN95872" hidden="false" collective="false" type="upgrade">
           <infoLinks>
-            <infoLink id="c24c-4f89-6ab2-f803" name="Arachnus Heavy Blaze Cannon (Concentrated Blast)" hidden="false" targetId="9262-8169-5662-60de" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="b82a-b1d9-56a5-b4e7" name="Arachnus Heavy Blaze Cannon (Burst Fire)" hidden="false" targetId="e58e-67e0-e173-1f8b" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="d979-2634-1cae-44c7" name="New InfoLink" hidden="false" targetId="2740-e6d7-076b-9d5c" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
+            <infoLink id="c24c-4f89-6ab2-f803" name="Arachnus Heavy Blaze Cannon (Concentrated Blast)" hidden="false" targetId="9262-8169-5662-60de" type="profile"/>
+            <infoLink id="b82a-b1d9-56a5-b4e7" name="Arachnus Heavy Blaze Cannon (Burst Fire)" hidden="false" targetId="e58e-67e0-e173-1f8b" type="profile"/>
+            <infoLink id="d979-2634-1cae-44c7" name="New InfoLink" hidden="false" targetId="2740-e6d7-076b-9d5c" type="rule"/>
           </infoLinks>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
-      <selectionEntryGroups/>
-      <entryLinks/>
     </selectionEntryGroup>
     <selectionEntryGroup id="0f60-5d21-a0b9-4c6a" name="Armour" hidden="false" collective="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
       <selectionEntries>
         <selectionEntry id="6e95-2ae6-4dd8-c24b" name="Aquilon Pattern Terminator Armor" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="86ef-7588-7f40-2102" name="Aquillon Pattern Terminator Armour" hidden="false" targetId="0a62-df1f-aed7-fc07" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b2be-7d67-7bed-bf62" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4d88-51ef-6d43-1ae9" type="min"/>
           </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
+          <infoLinks>
+            <infoLink id="86ef-7588-7f40-2102" name="Aquillon Pattern Terminator Armour" hidden="false" targetId="0a62-df1f-aed7-fc07" type="profile"/>
+          </infoLinks>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="2c5a-1976-04e4-e277" name="Custodian Armour" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="98ee-218e-56ae-9862" name="Custodian Armour" hidden="false" targetId="f07e-858e-d637-e858" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="713b-3293-5140-a0da" name="Move Through Cover" hidden="false" targetId="6d06-5ea0-9a17-ca97" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bcd5-4aab-0cae-d224" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="adf8-e84b-ee09-99b7" type="min"/>
           </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
+          <infoLinks>
+            <infoLink id="98ee-218e-56ae-9862" name="Custodian Armour" hidden="false" targetId="f07e-858e-d637-e858" type="profile"/>
+            <infoLink id="713b-3293-5140-a0da" name="Move Through Cover" hidden="false" targetId="6d06-5ea0-9a17-ca97" type="rule"/>
+          </infoLinks>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="aba8-92ff-b2a8-ad1e" name="Vratine Armour" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="0fc6-39bd-7767-7b7b" name="New InfoLink" hidden="false" targetId="d7f5-8d27-73ca-2c52" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c3a8-959d-2e74-74d0" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="90e0-fb78-3fcb-71cd" type="min"/>
           </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
+          <infoLinks>
+            <infoLink id="0fc6-39bd-7767-7b7b" name="New InfoLink" hidden="false" targetId="d7f5-8d27-73ca-2c52" type="profile"/>
+          </infoLinks>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="9e07-f5e7-b880-2bd5" name="Artificer Armour" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="4b4e-b5a5-281d-9960" name="New InfoLink" hidden="false" targetId="4b6b-08cb-a956-0eb3" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2cb0-2b44-bc81-3f0f" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="20cc-b904-af29-7ac7" type="max"/>
           </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
+          <infoLinks>
+            <infoLink id="4b4e-b5a5-281d-9960" name="New InfoLink" hidden="false" targetId="4b6b-08cb-a956-0eb3" type="profile"/>
+          </infoLinks>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="19b9-4cf5-d024-132d" name="Custodian Jump Harness" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="dd67-98a7-e5e7-b9f9" name="Custodian Jump Harness" hidden="false" targetId="783e-c8f7-4312-98c7" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="5ccd-0d60-74e0-a879" name="Auramite Pinions" hidden="false" targetId="320e-ff0d-18d2-10f7" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3140-0b86-5da2-2f03" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2470-55ee-e333-b0b0" type="min"/>
           </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
+          <infoLinks>
+            <infoLink id="dd67-98a7-e5e7-b9f9" name="Custodian Jump Harness" hidden="false" targetId="783e-c8f7-4312-98c7" type="profile"/>
+            <infoLink id="5ccd-0d60-74e0-a879" name="Auramite Pinions" hidden="false" targetId="320e-ff0d-18d2-10f7" type="rule"/>
+          </infoLinks>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
-      <selectionEntryGroups/>
-      <entryLinks/>
     </selectionEntryGroup>
     <selectionEntryGroup id="1542-edf8-6c46-f146" name="Legio Custodes Ranged Weapons" hidden="false" collective="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
       <selectionEntries>
-        <selectionEntry id="ac1f-421a-2070-02d2" name="Adrathic Destructor" book="HH7" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
+        <selectionEntry id="ac1f-421a-2070-02d2" name="Adrathic Destructor" publicationId="a30a-7522-pubN95872" hidden="false" collective="false" type="upgrade">
           <infoLinks>
-            <infoLink id="413b-656f-3f94-4315" name="Adrathic Destructor" hidden="false" targetId="0351-af54-349e-1fd3" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="9f75-fea5-8d1d-d0fe" name="New InfoLink" hidden="false" targetId="fbf1-6913-ff9f-5a4f" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="2ec6-293c-30a4-2213" name="New InfoLink" hidden="false" targetId="e182-50cd-0867-9a8d" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="017b-3951-c0cc-4107" name="New InfoLink" hidden="false" targetId="f4fd-d519-4769-5510" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
+            <infoLink id="413b-656f-3f94-4315" name="Adrathic Destructor" hidden="false" targetId="0351-af54-349e-1fd3" type="profile"/>
+            <infoLink id="9f75-fea5-8d1d-d0fe" name="New InfoLink" hidden="false" targetId="fbf1-6913-ff9f-5a4f" type="rule"/>
+            <infoLink id="2ec6-293c-30a4-2213" name="New InfoLink" hidden="false" targetId="e182-50cd-0867-9a8d" type="rule"/>
+            <infoLink id="017b-3951-c0cc-4107" name="New InfoLink" hidden="false" targetId="f4fd-d519-4769-5510" type="rule"/>
           </infoLinks>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="f1b0-99e2-cc9c-8e09" name="Adrastus Bolt Caliver" book="HH7" hidden="false" collective="false" type="upgrade">
-          <profiles/>
+        <selectionEntry id="f1b0-99e2-cc9c-8e09" name="Adrastus Bolt Caliver" publicationId="a30a-7522-pubN95872" hidden="false" collective="false" type="upgrade">
           <rules>
             <rule id="c9b5-afc1-43dd-ab25" name="Combination Weapon" hidden="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
               <description>A model with an Adrastus Bolt Caliver can fire it either as a volley of bolter fire or a disintegration beam in the Shooting phase - you must declare which is used before any dice are rolled. If a unit is equipped with this weapon then the controlling player must decide and declare which mode is being used by each model, and the unit does not have to entirely fire on the same mode. Note that unlike conventional combi-weapons, the disintegration beam can be fired multiple times during the game.</description>
             </rule>
           </rules>
           <infoLinks>
-            <infoLink id="7c7e-653d-564a-e58b" name="Adrastus Bolt Caliver (Bolt Volley)" hidden="false" targetId="4209-a82b-d7a3-bdf1" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="e795-e9d0-3157-0cf8" name="Adrastus Bolt Caliver (Disintegration Beam)" hidden="false" targetId="c74d-90b4-32aa-e89f" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="6651-826e-bc43-bdbd" name="New InfoLink" hidden="false" targetId="fbf1-6913-ff9f-5a4f" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="0b32-0ee8-25ef-884b" name="New InfoLink" hidden="false" targetId="e182-50cd-0867-9a8d" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="52b0-0ef3-4169-0625" name="New InfoLink" hidden="false" targetId="f4fd-d519-4769-5510" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
+            <infoLink id="7c7e-653d-564a-e58b" name="Adrastus Bolt Caliver (Bolt Volley)" hidden="false" targetId="4209-a82b-d7a3-bdf1" type="profile"/>
+            <infoLink id="e795-e9d0-3157-0cf8" name="Adrastus Bolt Caliver (Disintegration Beam)" hidden="false" targetId="c74d-90b4-32aa-e89f" type="profile"/>
+            <infoLink id="6651-826e-bc43-bdbd" name="New InfoLink" hidden="false" targetId="fbf1-6913-ff9f-5a4f" type="rule"/>
+            <infoLink id="0b32-0ee8-25ef-884b" name="New InfoLink" hidden="false" targetId="e182-50cd-0867-9a8d" type="rule"/>
+            <infoLink id="52b0-0ef3-4169-0625" name="New InfoLink" hidden="false" targetId="f4fd-d519-4769-5510" type="rule"/>
           </infoLinks>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="b163-a4b3-0fd8-6f08" name="Adrathic Devastator" book="HH7" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
+        <selectionEntry id="b163-a4b3-0fd8-6f08" name="Adrathic Devastator" publicationId="a30a-7522-pubN95872" hidden="false" collective="false" type="upgrade">
           <infoLinks>
-            <infoLink id="6cab-7a95-d842-03d7" name="Adrathic Devastator" hidden="false" targetId="c984-c9d4-07c9-76e5" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="1d47-6bea-6833-a8fb" name="New InfoLink" hidden="false" targetId="fbf1-6913-ff9f-5a4f" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="a903-7ede-4db2-3ebb" name="New InfoLink" hidden="false" targetId="e182-50cd-0867-9a8d" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="41e6-4e4e-e420-4c00" name="New InfoLink" hidden="false" targetId="f4fd-d519-4769-5510" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
+            <infoLink id="6cab-7a95-d842-03d7" name="Adrathic Devastator" hidden="false" targetId="c984-c9d4-07c9-76e5" type="profile"/>
+            <infoLink id="1d47-6bea-6833-a8fb" name="New InfoLink" hidden="false" targetId="fbf1-6913-ff9f-5a4f" type="rule"/>
+            <infoLink id="a903-7ede-4db2-3ebb" name="New InfoLink" hidden="false" targetId="e182-50cd-0867-9a8d" type="rule"/>
+            <infoLink id="41e6-4e4e-e420-4c00" name="New InfoLink" hidden="false" targetId="f4fd-d519-4769-5510" type="rule"/>
           </infoLinks>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="05c1-76b8-f932-ab2c" name="Adrathic Exterminator" book="HH7" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
+        <selectionEntry id="05c1-76b8-f932-ab2c" name="Adrathic Exterminator" publicationId="a30a-7522-pubN95872" hidden="false" collective="false" type="upgrade">
           <infoLinks>
-            <infoLink id="8368-22fc-4a20-84de" name="Adrathic Exterminator" hidden="false" targetId="2320-260c-8e15-5599" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="7818-ce03-ffde-e89a" name="New InfoLink" hidden="false" targetId="fbf1-6913-ff9f-5a4f" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="e7ed-1caa-2d5c-e0b0" name="New InfoLink" hidden="false" targetId="e182-50cd-0867-9a8d" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="da04-1c0f-49a3-060a" name="New InfoLink" hidden="false" targetId="f4fd-d519-4769-5510" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
+            <infoLink id="8368-22fc-4a20-84de" name="Adrathic Exterminator" hidden="false" targetId="2320-260c-8e15-5599" type="profile"/>
+            <infoLink id="7818-ce03-ffde-e89a" name="New InfoLink" hidden="false" targetId="fbf1-6913-ff9f-5a4f" type="rule"/>
+            <infoLink id="e7ed-1caa-2d5c-e0b0" name="New InfoLink" hidden="false" targetId="e182-50cd-0867-9a8d" type="rule"/>
+            <infoLink id="da04-1c0f-49a3-060a" name="New InfoLink" hidden="false" targetId="f4fd-d519-4769-5510" type="rule"/>
           </infoLinks>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="e854-b201-250d-5b1b" name="Lastrum Bolt Cannon" book="HH7" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
+        <selectionEntry id="e854-b201-250d-5b1b" name="Lastrum Bolt Cannon" publicationId="a30a-7522-pubN95872" hidden="false" collective="false" type="upgrade">
           <infoLinks>
-            <infoLink id="d884-ac3e-7bbb-5a98" name="New InfoLink" hidden="false" targetId="6e09-5e34-f395-cd3d" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="2a88-f396-c9fa-a7b7" name="Heliothermic Detonation" hidden="false" targetId="dd32-1791-4789-051f" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
+            <infoLink id="d884-ac3e-7bbb-5a98" name="New InfoLink" hidden="false" targetId="6e09-5e34-f395-cd3d" type="profile"/>
+            <infoLink id="2a88-f396-c9fa-a7b7" name="Heliothermic Detonation" hidden="false" targetId="dd32-1791-4789-051f" type="rule"/>
           </infoLinks>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="2693-afa7-96a3-150a" name="Lastrum Storm Bolter" book="HH7" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
+        <selectionEntry id="2693-afa7-96a3-150a" name="Lastrum Storm Bolter" publicationId="a30a-7522-pubN95872" hidden="false" collective="false" type="upgrade">
           <infoLinks>
-            <infoLink id="0e30-b4e9-a250-57be" name="New InfoLink" hidden="false" targetId="2f59-72d5-423f-9303" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="e579-e18c-3fb8-47d1" name="New InfoLink" hidden="false" targetId="dd32-1791-4789-051f" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
+            <infoLink id="0e30-b4e9-a250-57be" name="New InfoLink" hidden="false" targetId="2f59-72d5-423f-9303" type="profile"/>
+            <infoLink id="e579-e18c-3fb8-47d1" name="New InfoLink" hidden="false" targetId="dd32-1791-4789-051f" type="rule"/>
           </infoLinks>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
-      <selectionEntryGroups/>
-      <entryLinks/>
     </selectionEntryGroup>
     <selectionEntryGroup id="0de7-4aa7-e7da-fe45" name="Legio Custodes Assault Weapons" hidden="false" collective="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
       <selectionEntries>
-        <selectionEntry id="dc9c-fe1d-8c26-fb07" name="Guardian Spear" book="HH7" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
+        <selectionEntry id="dc9c-fe1d-8c26-fb07" name="Guardian Spear" publicationId="a30a-7522-pubN95872" hidden="false" collective="false" type="upgrade">
           <infoLinks>
-            <infoLink id="34bd-ad22-dbbb-1678" name="New InfoLink" hidden="false" targetId="fecc-6269-d1e4-3d5a" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="86ff-9d76-0b8d-edb4" name="New InfoLink" hidden="false" targetId="6726-c0ae-28a4-744e" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="e93d-3c21-809a-d73b" name="New InfoLink" hidden="false" targetId="a37c-753a-33b4-8101" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="aba0-0e03-79e6-8f63" name="New InfoLink" hidden="false" targetId="7ee3-d437-bc44-3630" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
+            <infoLink id="34bd-ad22-dbbb-1678" name="New InfoLink" hidden="false" targetId="fecc-6269-d1e4-3d5a" type="profile"/>
+            <infoLink id="86ff-9d76-0b8d-edb4" name="New InfoLink" hidden="false" targetId="6726-c0ae-28a4-744e" type="profile"/>
+            <infoLink id="e93d-3c21-809a-d73b" name="New InfoLink" hidden="false" targetId="a37c-753a-33b4-8101" type="rule"/>
+            <infoLink id="aba0-0e03-79e6-8f63" name="New InfoLink" hidden="false" targetId="7ee3-d437-bc44-3630" type="rule"/>
           </infoLinks>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="0179-aa55-899c-aa0b" name="Adrasite Spear" book="HH7" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
+        <selectionEntry id="0179-aa55-899c-aa0b" name="Adrasite Spear" publicationId="a30a-7522-pubN95872" hidden="false" collective="false" type="upgrade">
           <infoLinks>
-            <infoLink id="2a7c-4446-cd28-8a50" name="Guardian Spear (Power Blade)" hidden="false" targetId="fecc-6269-d1e4-3d5a" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="9504-91af-7cae-e3ef" name="Adrathic Destructor" hidden="false" targetId="0351-af54-349e-1fd3" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="b92a-780d-28a9-63f9" name="Lightning Blows" hidden="false" targetId="a37c-753a-33b4-8101" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="1c5a-43e2-e7ff-4204" name="Specialist Weapon" hidden="false" targetId="7ee3-d437-bc44-3630" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="f37a-2235-cc24-38df" name="Instant Death" hidden="false" targetId="fbf1-6913-ff9f-5a4f" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="7039-b409-b369-6bd5" name="Armourbane" hidden="false" targetId="e182-50cd-0867-9a8d" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="99d9-2eb3-be67-407f" name="Gets Hot" hidden="false" targetId="f4fd-d519-4769-5510" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
+            <infoLink id="2a7c-4446-cd28-8a50" name="Guardian Spear (Power Blade)" hidden="false" targetId="fecc-6269-d1e4-3d5a" type="profile"/>
+            <infoLink id="9504-91af-7cae-e3ef" name="Adrathic Destructor" hidden="false" targetId="0351-af54-349e-1fd3" type="profile"/>
+            <infoLink id="b92a-780d-28a9-63f9" name="Lightning Blows" hidden="false" targetId="a37c-753a-33b4-8101" type="rule"/>
+            <infoLink id="1c5a-43e2-e7ff-4204" name="Specialist Weapon" hidden="false" targetId="7ee3-d437-bc44-3630" type="rule"/>
+            <infoLink id="f37a-2235-cc24-38df" name="Instant Death" hidden="false" targetId="fbf1-6913-ff9f-5a4f" type="rule"/>
+            <infoLink id="7039-b409-b369-6bd5" name="Armourbane" hidden="false" targetId="e182-50cd-0867-9a8d" type="rule"/>
+            <infoLink id="99d9-2eb3-be67-407f" name="Gets Hot" hidden="false" targetId="f4fd-d519-4769-5510" type="rule"/>
           </infoLinks>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="5111-6e79-1a9b-007a" name="Paragon Spear" book="HH7" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
+        <selectionEntry id="5111-6e79-1a9b-007a" name="Paragon Spear" publicationId="a30a-7522-pubN95872" hidden="false" collective="false" type="upgrade">
           <infoLinks>
             <infoLink id="77ad-efec-55bf-7301" name="Paragon Power Blade" hidden="false" targetId="3a85-e9c8-548f-9c71" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
               <modifiers>
-                <modifier type="set" field="5479706523232344415441232323" value="Melee, Lightning Blows, Murderous Strike, Specialist Weapon">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
+                <modifier type="set" field="5479706523232344415441232323" value="Melee, Lightning Blows, Murderous Strike, Specialist Weapon"/>
               </modifiers>
             </infoLink>
-            <infoLink id="eb47-500f-4f1e-ed49" name="Lightning Blows" hidden="false" targetId="a37c-753a-33b4-8101" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="30fc-70c3-5ac4-21a9" name="Specialist Weapon" hidden="false" targetId="7ee3-d437-bc44-3630" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="bda3-55dc-0edf-acea" name="Paragon Bolter" hidden="false" targetId="6f85-7ba6-232a-5938" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="4f9c-8cf6-3ce9-5234" name="Murderous Strike" hidden="false" targetId="9627-9c59-94d1-d76a" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
+            <infoLink id="eb47-500f-4f1e-ed49" name="Lightning Blows" hidden="false" targetId="a37c-753a-33b4-8101" type="rule"/>
+            <infoLink id="30fc-70c3-5ac4-21a9" name="Specialist Weapon" hidden="false" targetId="7ee3-d437-bc44-3630" type="rule"/>
+            <infoLink id="bda3-55dc-0edf-acea" name="Paragon Bolter" hidden="false" targetId="6f85-7ba6-232a-5938" type="profile"/>
+            <infoLink id="4f9c-8cf6-3ce9-5234" name="Murderous Strike" hidden="false" targetId="9627-9c59-94d1-d76a" type="rule"/>
           </infoLinks>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="4af1-fc20-e881-7ad9" name="Pyrithite Spear" book="HH7" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
+        <selectionEntry id="4af1-fc20-e881-7ad9" name="Pyrithite Spear" publicationId="a30a-7522-pubN95872" hidden="false" collective="false" type="upgrade">
           <infoLinks>
-            <infoLink id="01bf-5c79-177e-2937" name="Guardian Spear (Power Blade)" hidden="false" targetId="fecc-6269-d1e4-3d5a" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="2c35-1473-e920-a2a7" name="Melta Beam" hidden="false" targetId="a597-6272-58d2-7c84" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="e2ec-c879-4e64-2d4c" name="Lightning Blows" hidden="false" targetId="a37c-753a-33b4-8101" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="c151-eb09-0090-853b" name="Specialist Weapon" hidden="false" targetId="7ee3-d437-bc44-3630" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
+            <infoLink id="01bf-5c79-177e-2937" name="Guardian Spear (Power Blade)" hidden="false" targetId="fecc-6269-d1e4-3d5a" type="profile"/>
+            <infoLink id="2c35-1473-e920-a2a7" name="Melta Beam" hidden="false" targetId="a597-6272-58d2-7c84" type="profile"/>
+            <infoLink id="e2ec-c879-4e64-2d4c" name="Lightning Blows" hidden="false" targetId="a37c-753a-33b4-8101" type="rule"/>
+            <infoLink id="c151-eb09-0090-853b" name="Specialist Weapon" hidden="false" targetId="7ee3-d437-bc44-3630" type="rule"/>
           </infoLinks>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="0caf-31e2-cd7b-a4dd" name="Sentinel Warblade" book="HH7" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
+        <selectionEntry id="0caf-31e2-cd7b-a4dd" name="Sentinel Warblade" publicationId="a30a-7522-pubN95872" hidden="false" collective="false" type="upgrade">
           <infoLinks>
-            <infoLink id="7145-f375-8a48-8c3e" name="New InfoLink" hidden="false" targetId="d0e4-db08-9380-21f1" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="e137-4635-4e72-b03e" name="New InfoLink" hidden="false" targetId="8253-1a93-2972-6699" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="0379-8e05-d706-584e" name="re" hidden="false" targetId="8269-2cd6-9236-16e7" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="4d87-2a47-49ae-3feb" name="New InfoLink" hidden="false" targetId="7ee3-d437-bc44-3630" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="4f90-420f-f8e6-eb8d" name="h" hidden="false" targetId="3800-d4fb-7935-f2a9" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
+            <infoLink id="7145-f375-8a48-8c3e" name="New InfoLink" hidden="false" targetId="d0e4-db08-9380-21f1" type="profile"/>
+            <infoLink id="e137-4635-4e72-b03e" name="New InfoLink" hidden="false" targetId="8253-1a93-2972-6699" type="profile"/>
+            <infoLink id="0379-8e05-d706-584e" name="re" hidden="false" targetId="8269-2cd6-9236-16e7" type="rule"/>
+            <infoLink id="4d87-2a47-49ae-3feb" name="New InfoLink" hidden="false" targetId="7ee3-d437-bc44-3630" type="rule"/>
+            <infoLink id="4f90-420f-f8e6-eb8d" name="h" hidden="false" targetId="3800-d4fb-7935-f2a9" type="rule"/>
           </infoLinks>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="8ba6-041a-ff23-98f6" name="Solerite Power Gauntlet" book="HH7" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
+        <selectionEntry id="8ba6-041a-ff23-98f6" name="Solerite Power Gauntlet" publicationId="a30a-7522-pubN95872" hidden="false" collective="false" type="upgrade">
           <infoLinks>
-            <infoLink id="7adb-bf35-3881-0752" name="New InfoLink" hidden="false" targetId="1620-fda1-7c0c-8b64" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="66c2-b477-db91-9e83" name="New InfoLink" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="843a-2a2c-82b1-c2f8" name="New InfoLink" hidden="false" targetId="5eea-958c-d623-c3c9" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
+            <infoLink id="7adb-bf35-3881-0752" name="New InfoLink" hidden="false" targetId="1620-fda1-7c0c-8b64" type="profile"/>
+            <infoLink id="66c2-b477-db91-9e83" name="New InfoLink" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule"/>
+            <infoLink id="843a-2a2c-82b1-c2f8" name="New InfoLink" hidden="false" targetId="5eea-958c-d623-c3c9" type="rule"/>
           </infoLinks>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="cb99-fafa-3e9d-035e" name="Solerite Power Talon" book="HH7" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
+        <selectionEntry id="cb99-fafa-3e9d-035e" name="Solerite Power Talon" publicationId="a30a-7522-pubN95872" hidden="false" collective="false" type="upgrade">
           <infoLinks>
-            <infoLink id="0a47-ac3f-ef01-762c" name="New InfoLink" hidden="false" targetId="2ddd-f96f-86df-50ba" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="0a8e-9b6e-e9af-ba25" name="New InfoLink" hidden="false" targetId="7ee3-d437-bc44-3630" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="2020-646b-57a9-fc44" name="New InfoLink" hidden="false" targetId="89da-0cb5-bee4-8ec2" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="a96f-ccc2-5460-e292" name="New InfoLink" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
+            <infoLink id="0a47-ac3f-ef01-762c" name="New InfoLink" hidden="false" targetId="2ddd-f96f-86df-50ba" type="profile"/>
+            <infoLink id="0a8e-9b6e-e9af-ba25" name="New InfoLink" hidden="false" targetId="7ee3-d437-bc44-3630" type="rule"/>
+            <infoLink id="2020-646b-57a9-fc44" name="New InfoLink" hidden="false" targetId="89da-0cb5-bee4-8ec2" type="rule"/>
+            <infoLink id="a96f-ccc2-5460-e292" name="New InfoLink" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule"/>
           </infoLinks>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="81d2-94da-550c-1dd3" name="Close Combat Weapon" book="WH40k BRB" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
+        <selectionEntry id="81d2-94da-550c-1dd3" name="Close Combat Weapon" publicationId="a30a-7522-pubN99459" hidden="false" collective="false" type="upgrade">
           <infoLinks>
-            <infoLink id="996a-bed8-0566-6d7e" name="New InfoLink" hidden="false" targetId="730c-b70b-1e8f-f2e9" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
+            <infoLink id="996a-bed8-0566-6d7e" name="New InfoLink" hidden="false" targetId="730c-b70b-1e8f-f2e9" type="profile"/>
           </infoLinks>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="d89b-6ac9-335a-44c2" name="The Apollonian Spear" book="HH7" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
+        <selectionEntry id="d89b-6ac9-335a-44c2" name="The Apollonian Spear" publicationId="a30a-7522-pubN95872" hidden="false" collective="false" type="upgrade">
           <infoLinks>
-            <infoLink id="6117-ee15-8802-d5eb" name="New InfoLink" hidden="false" targetId="a37c-753a-33b4-8101" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="7996-0014-cda9-33e7" name="New InfoLink" hidden="false" targetId="7ee3-d437-bc44-3630" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="56ca-2ef7-1661-34d3" name="Molecular Severance" hidden="false" targetId="7a26-98f9-345e-e2c0" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="0790-a081-8e38-caa4" name="Hyper-Velocity Bolter" hidden="false" targetId="3912-42bf-2de6-6611" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="8d2d-dfa4-0bc3-709b" name="The Apollonian Spear Power Blade" hidden="false" targetId="7001-00aa-5d65-dbd8" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
+            <infoLink id="6117-ee15-8802-d5eb" name="New InfoLink" hidden="false" targetId="a37c-753a-33b4-8101" type="rule"/>
+            <infoLink id="7996-0014-cda9-33e7" name="New InfoLink" hidden="false" targetId="7ee3-d437-bc44-3630" type="rule"/>
+            <infoLink id="56ca-2ef7-1661-34d3" name="Molecular Severance" hidden="false" targetId="7a26-98f9-345e-e2c0" type="rule"/>
+            <infoLink id="0790-a081-8e38-caa4" name="Hyper-Velocity Bolter" hidden="false" targetId="3912-42bf-2de6-6611" type="profile"/>
+            <infoLink id="8d2d-dfa4-0bc3-709b" name="The Apollonian Spear Power Blade" hidden="false" targetId="7001-00aa-5d65-dbd8" type="profile"/>
           </infoLinks>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="c8bb-78c1-0ffc-0a1a" name="Venatari Lance" book="FW Download" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="c8bb-78c1-0ffc-0a1a" name="Venatari Lance" publicationId="a30a-7522-pubN94337" hidden="false" collective="false" type="upgrade">
           <profiles>
-            <profile id="febd-cc98-8da6-d4c9" name="Venatari Lance : Archaeotech Repeater" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <profile id="febd-cc98-8da6-d4c9" name="Venatari Lance : Archaeotech Repeater" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
               <characteristics>
-                <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="12&quot;"/>
-                <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="7"/>
-                <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="3"/>
-                <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Assualt 2, Master-Crafted"/>
+                <characteristic name="Range" typeId="52616e676523232344415441232323">12&quot;</characteristic>
+                <characteristic name="Strength" typeId="537472656e67746823232344415441232323">7</characteristic>
+                <characteristic name="AP" typeId="415023232344415441232323">3</characteristic>
+                <characteristic name="Type" typeId="5479706523232344415441232323">Assualt 2, Master-Crafted</characteristic>
               </characteristics>
             </profile>
-            <profile id="a4eb-545b-3e04-ca65" name="Venatari Lance : Power Blade" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <profile id="a4eb-545b-3e04-ca65" name="Venatari Lance : Power Blade" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
               <characteristics>
-                <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="Melee"/>
-                <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="As User/+1*"/>
-                <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="3/2*"/>
-                <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Melee, Lightning Blows, Two-Handed, Specialist Weapon. *Use the second profile if the model has charged this turn"/>
+                <characteristic name="Range" typeId="52616e676523232344415441232323">Melee</characteristic>
+                <characteristic name="Strength" typeId="537472656e67746823232344415441232323">As User/+1*</characteristic>
+                <characteristic name="AP" typeId="415023232344415441232323">3/2*</characteristic>
+                <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Lightning Blows, Two-Handed, Specialist Weapon. *Use the second profile if the model has charged this turn</characteristic>
               </characteristics>
             </profile>
           </profiles>
-          <rules/>
           <infoLinks>
-            <infoLink id="f618-c41c-5b99-68b6" name="Lightning Blows" hidden="false" targetId="a37c-753a-33b4-8101" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="f1e4-42a0-65ae-669a" name="Specialist Weapon" hidden="false" targetId="7ee3-d437-bc44-3630" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="f575-ece3-b9ef-8a55" name="Two-Handed" hidden="false" targetId="b11c-0ef4-af6b-d96f" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="fa51-1068-08e0-c2f4" name="Master-crafted" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
+            <infoLink id="f618-c41c-5b99-68b6" name="Lightning Blows" hidden="false" targetId="a37c-753a-33b4-8101" type="rule"/>
+            <infoLink id="f1e4-42a0-65ae-669a" name="Specialist Weapon" hidden="false" targetId="7ee3-d437-bc44-3630" type="rule"/>
+            <infoLink id="f575-ece3-b9ef-8a55" name="Two-Handed" hidden="false" targetId="b11c-0ef4-af6b-d96f" type="rule"/>
+            <infoLink id="fa51-1068-08e0-c2f4" name="Master-crafted" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule"/>
           </infoLinks>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="c632-2ff7-8629-e8fc" name="Archaeotech Kinetic Destroyer" hidden="false" collective="false" type="upgrade">
-          <profiles>
-            <profile id="f766-666e-5e9b-8dcc" name="Archaeotech Kinetic Destoryer" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="12&quot;"/>
-                <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="7"/>
-                <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="3"/>
-                <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Pistol, Master-Crafted, Fan Burst"/>
-              </characteristics>
-            </profile>
-          </profiles>
-          <rules/>
-          <infoLinks>
-            <infoLink id="df9d-6e5d-1f08-e8c8" name="Fan-Burst" hidden="false" targetId="bad5-67d0-2390-90f5" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0b5a-a363-52f8-31bc" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bafe-3424-7f67-7452" type="max"/>
           </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="27dc-deb9-9379-eb10" name="Tarsus Buckler" hidden="false" collective="false" type="upgrade">
           <profiles>
-            <profile id="9b9b-9bea-0c97-6a8f" name="Tarsus Buckler" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <profile id="f766-666e-5e9b-8dcc" name="Archaeotech Kinetic Destoryer" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
               <characteristics>
-                <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="Melee"/>
-                <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="+1"/>
-                <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="3"/>
-                <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Melee, Energy Nullifer"/>
+                <characteristic name="Range" typeId="52616e676523232344415441232323">12&quot;</characteristic>
+                <characteristic name="Strength" typeId="537472656e67746823232344415441232323">7</characteristic>
+                <characteristic name="AP" typeId="415023232344415441232323">3</characteristic>
+                <characteristic name="Type" typeId="5479706523232344415441232323">Pistol, Master-Crafted, Fan Burst</characteristic>
               </characteristics>
             </profile>
           </profiles>
-          <rules/>
           <infoLinks>
-            <infoLink id="8fb5-c38e-886e-f51e" name="Energy Nullifier" hidden="false" targetId="8fa4-a1c0-c588-34e6" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
+            <infoLink id="df9d-6e5d-1f08-e8c8" name="Fan-Burst" hidden="false" targetId="bad5-67d0-2390-90f5" type="rule"/>
           </infoLinks>
-          <modifiers/>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="27dc-deb9-9379-eb10" name="Tarsus Buckler" hidden="false" collective="false" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7698-8200-3303-ff9e" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d5bb-d8ed-7bbd-7fdc" type="min"/>
           </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
+          <profiles>
+            <profile id="9b9b-9bea-0c97-6a8f" name="Tarsus Buckler" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="52616e676523232344415441232323">Melee</characteristic>
+                <characteristic name="Strength" typeId="537472656e67746823232344415441232323">+1</characteristic>
+                <characteristic name="AP" typeId="415023232344415441232323">3</characteristic>
+                <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Energy Nullifer</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="8fb5-c38e-886e-f51e" name="Energy Nullifier" hidden="false" targetId="8fa4-a1c0-c588-34e6" type="rule"/>
+          </infoLinks>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
-      <selectionEntryGroups/>
-      <entryLinks/>
     </selectionEntryGroup>
     <selectionEntryGroup id="3476-549f-c1a1-67b3" name="Sisters of Silence Wargear" hidden="false" collective="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
       <selectionEntries>
-        <selectionEntry id="a088-a0e9-0612-f74f" name="Psyk-out Grenades" book="HH7" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
+        <selectionEntry id="a088-a0e9-0612-f74f" name="Psyk-out Grenades" publicationId="a30a-7522-pubN95872" hidden="false" collective="false" type="upgrade">
           <infoLinks>
-            <infoLink id="03b1-9e1b-67c9-caa0" name="New InfoLink" hidden="false" targetId="a234-e343-fb57-423f" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="e140-bced-2253-b633" name="New InfoLink" hidden="false" targetId="432e-7f24-6937-aa48" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="e23c-098a-88f1-ef85" name="New InfoLink" hidden="false" targetId="97a9-13e2-6a86-dae2" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
+            <infoLink id="03b1-9e1b-67c9-caa0" name="New InfoLink" hidden="false" targetId="a234-e343-fb57-423f" type="profile"/>
+            <infoLink id="e140-bced-2253-b633" name="New InfoLink" hidden="false" targetId="432e-7f24-6937-aa48" type="profile"/>
+            <infoLink id="e23c-098a-88f1-ef85" name="New InfoLink" hidden="false" targetId="97a9-13e2-6a86-dae2" type="rule"/>
           </infoLinks>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="1c06-89fd-9e8f-09d0" name="Psyk-out Missile" book="HH7" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
+        <selectionEntry id="1c06-89fd-9e8f-09d0" name="Psyk-out Missile" publicationId="a30a-7522-pubN95872" hidden="false" collective="false" type="upgrade">
           <infoLinks>
-            <infoLink id="c6ef-913e-b84a-657e" name="New InfoLink" hidden="false" targetId="fab0-4815-efaa-a613" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="934c-75ec-e47e-962f" name="New InfoLink" hidden="false" targetId="97a9-13e2-6a86-dae2" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="6205-1803-d93e-8281" name="New InfoLink" hidden="false" targetId="f624-f475-e5ec-0dfa" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
+            <infoLink id="c6ef-913e-b84a-657e" name="New InfoLink" hidden="false" targetId="fab0-4815-efaa-a613" type="profile"/>
+            <infoLink id="934c-75ec-e47e-962f" name="New InfoLink" hidden="false" targetId="97a9-13e2-6a86-dae2" type="rule"/>
+            <infoLink id="6205-1803-d93e-8281" name="New InfoLink" hidden="false" targetId="f624-f475-e5ec-0dfa" type="rule"/>
           </infoLinks>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="e006-9328-106d-5c6a" name="Proteus Neuro-Lash" book="HH7" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
+        <selectionEntry id="e006-9328-106d-5c6a" name="Proteus Neuro-Lash" publicationId="a30a-7522-pubN95872" hidden="false" collective="false" type="upgrade">
           <infoLinks>
-            <infoLink id="b7cc-5065-e306-7cc3" name="New InfoLink" hidden="false" targetId="626e-2455-feaf-032b" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="add6-6d71-9687-3c87" name="New InfoLink" hidden="false" targetId="ae06-63ec-f5ae-f8db" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="d497-74d3-6cd4-4a90" name="New InfoLink" hidden="false" targetId="2042-be09-f23c-fbb9" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="9d46-d80c-703a-0f6d" name="New InfoLink" hidden="false" targetId="b11c-0ef4-af6b-d96f" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
+            <infoLink id="b7cc-5065-e306-7cc3" name="New InfoLink" hidden="false" targetId="626e-2455-feaf-032b" type="rule"/>
+            <infoLink id="add6-6d71-9687-3c87" name="New InfoLink" hidden="false" targetId="ae06-63ec-f5ae-f8db" type="rule"/>
+            <infoLink id="d497-74d3-6cd4-4a90" name="New InfoLink" hidden="false" targetId="2042-be09-f23c-fbb9" type="profile"/>
+            <infoLink id="9d46-d80c-703a-0f6d" name="New InfoLink" hidden="false" targetId="b11c-0ef4-af6b-d96f" type="rule"/>
           </infoLinks>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="1812-dcf0-818a-5491" name="Execution Blade" book="HH7" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
+        <selectionEntry id="1812-dcf0-818a-5491" name="Execution Blade" publicationId="a30a-7522-pubN95872" hidden="false" collective="false" type="upgrade">
           <infoLinks>
-            <infoLink id="c8e0-5a42-4bd2-8ac7" name="New InfoLink" hidden="false" targetId="514e-dfe7-e9a4-17a7" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="9864-bd0c-8d74-b89c" name="due" hidden="false" targetId="eddf-f5b5-0ec0-e1bb" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="e3b4-c0d1-83b0-98f0" name="New InfoLink" hidden="false" targetId="e8e8-bbc9-fb47-e91b" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="b26a-c39f-3316-6995" name="New InfoLink" hidden="false" targetId="b11c-0ef4-af6b-d96f" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
+            <infoLink id="c8e0-5a42-4bd2-8ac7" name="New InfoLink" hidden="false" targetId="514e-dfe7-e9a4-17a7" type="rule"/>
+            <infoLink id="9864-bd0c-8d74-b89c" name="due" hidden="false" targetId="eddf-f5b5-0ec0-e1bb" type="rule"/>
+            <infoLink id="e3b4-c0d1-83b0-98f0" name="New InfoLink" hidden="false" targetId="e8e8-bbc9-fb47-e91b" type="profile"/>
+            <infoLink id="b26a-c39f-3316-6995" name="New InfoLink" hidden="false" targetId="b11c-0ef4-af6b-d96f" type="rule"/>
           </infoLinks>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="c81a-0cf2-1986-9f3b" name="Enhanced Voidsheen Cloak" book="HH7" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
+        <selectionEntry id="c81a-0cf2-1986-9f3b" name="Enhanced Voidsheen Cloak" publicationId="a30a-7522-pubN95872" hidden="false" collective="false" type="upgrade">
           <infoLinks>
-            <infoLink id="72c1-a354-d1e5-47b4" name="New InfoLink" hidden="false" targetId="71ff-3b5a-6f75-55fc" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
+            <infoLink id="72c1-a354-d1e5-47b4" name="New InfoLink" hidden="false" targetId="71ff-3b5a-6f75-55fc" type="rule"/>
           </infoLinks>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="e5f6-cd68-595a-306c" name="Frag, Krak, and Psyk-Out Grenades" book="HH7" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="42fe-b9e5-b239-72ff" name="New InfoLink" hidden="false" targetId="d890-1b84-bbd9-12d3" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="ff38-6873-8a19-a4bc" name="New InfoLink" hidden="false" targetId="d9f7-775b-1047-f335" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="cd92-b236-85bb-b75c" name="New InfoLink" hidden="false" targetId="9430-a4d5-6f01-57e2" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="2125-26e5-bf4d-9c84" name="New InfoLink" hidden="false" targetId="a234-e343-fb57-423f" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
+        <selectionEntry id="e5f6-cd68-595a-306c" name="Frag, Krak, and Psyk-Out Grenades" publicationId="a30a-7522-pubN95872" hidden="false" collective="false" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="907b-0c60-1a0c-9dd7" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9f76-332f-0469-0eb8" type="max"/>
           </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
+          <infoLinks>
+            <infoLink id="42fe-b9e5-b239-72ff" name="New InfoLink" hidden="false" targetId="d890-1b84-bbd9-12d3" type="profile"/>
+            <infoLink id="ff38-6873-8a19-a4bc" name="New InfoLink" hidden="false" targetId="d9f7-775b-1047-f335" type="profile"/>
+            <infoLink id="cd92-b236-85bb-b75c" name="New InfoLink" hidden="false" targetId="9430-a4d5-6f01-57e2" type="rule"/>
+            <infoLink id="2125-26e5-bf4d-9c84" name="New InfoLink" hidden="false" targetId="a234-e343-fb57-423f" type="profile"/>
+          </infoLinks>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="568a-a7c1-0176-81fc" name="Spectra Vestments" book="HH7" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
+        <selectionEntry id="568a-a7c1-0176-81fc" name="Spectra Vestments" publicationId="a30a-7522-pubN95872" hidden="false" collective="false" type="upgrade">
           <infoLinks>
-            <infoLink id="c089-880d-13a7-e6c2" name="New InfoLink" hidden="false" targetId="6a7d-c38d-c888-a1ac" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
+            <infoLink id="c089-880d-13a7-e6c2" name="New InfoLink" hidden="false" targetId="6a7d-c38d-c888-a1ac" type="rule"/>
           </infoLinks>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="273a-86b2-05d1-228c" name="The Sword of Oblivion" book="HH7" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
+        <selectionEntry id="273a-86b2-05d1-228c" name="The Sword of Oblivion" publicationId="a30a-7522-pubN95872" hidden="false" collective="false" type="upgrade">
           <infoLinks>
-            <infoLink id="00f5-c0c9-d918-2ab2" name="New InfoLink" hidden="false" targetId="eddf-f5b5-0ec0-e1bb" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="8144-8da1-5e46-e1e2" name="New InfoLink" hidden="false" targetId="9627-9c59-94d1-d76a" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="b851-8414-27f5-b26f" name="New InfoLink" hidden="false" targetId="69d5-d069-6768-2b5e" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="9cc0-e9df-536f-9914" name="New InfoLink" hidden="false" targetId="b11c-0ef4-af6b-d96f" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
+            <infoLink id="00f5-c0c9-d918-2ab2" name="New InfoLink" hidden="false" targetId="eddf-f5b5-0ec0-e1bb" type="rule"/>
+            <infoLink id="8144-8da1-5e46-e1e2" name="New InfoLink" hidden="false" targetId="9627-9c59-94d1-d76a" type="rule"/>
+            <infoLink id="b851-8414-27f5-b26f" name="New InfoLink" hidden="false" targetId="69d5-d069-6768-2b5e" type="profile"/>
+            <infoLink id="9cc0-e9df-536f-9914" name="New InfoLink" hidden="false" targetId="b11c-0ef4-af6b-d96f" type="rule"/>
           </infoLinks>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="fad2-42fa-1e2d-0b88" name="Voidsheen Cloak" book="HH7" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
+        <selectionEntry id="fad2-42fa-1e2d-0b88" name="Voidsheen Cloak" publicationId="a30a-7522-pubN95872" hidden="false" collective="false" type="upgrade">
           <infoLinks>
-            <infoLink id="bc33-bf62-e76e-dbfd" name="New InfoLink" hidden="false" targetId="3cfc-cfdc-a578-923e" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
+            <infoLink id="bc33-bf62-e76e-dbfd" name="New InfoLink" hidden="false" targetId="3cfc-cfdc-a578-923e" type="rule"/>
           </infoLinks>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
-      <selectionEntryGroups/>
-      <entryLinks/>
     </selectionEntryGroup>
     <selectionEntryGroup id="18d8-c9e2-b2ae-ad92" name="Sisters of Silence Ranged weapons" hidden="false" collective="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
       <selectionEntries>
-        <selectionEntry id="a1bd-37d2-4ee5-6e4b" name="Stake-Crossbow" book="HH7" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
+        <selectionEntry id="a1bd-37d2-4ee5-6e4b" name="Stake-Crossbow" publicationId="a30a-7522-pubN95872" hidden="false" collective="false" type="upgrade">
           <infoLinks>
-            <infoLink id="7967-0777-fad5-67c7" name="New InfoLink" hidden="false" targetId="97a9-13e2-6a86-dae2" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="05c1-4620-21ce-3db1" name="New InfoLink" hidden="false" targetId="a5ee-4cdc-5ced-c368" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
+            <infoLink id="7967-0777-fad5-67c7" name="New InfoLink" hidden="false" targetId="97a9-13e2-6a86-dae2" type="rule"/>
+            <infoLink id="05c1-4620-21ce-3db1" name="New InfoLink" hidden="false" targetId="a5ee-4cdc-5ced-c368" type="profile"/>
           </infoLinks>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="0319-8f8d-ab88-efa5" name="Needle Pistol" book="HH7" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
+        <selectionEntry id="0319-8f8d-ab88-efa5" name="Needle Pistol" publicationId="a30a-7522-pubN95872" hidden="false" collective="false" type="upgrade">
           <infoLinks>
-            <infoLink id="abdc-5517-84a6-e642" name="New InfoLink" hidden="false" targetId="2d80-e016-4c0b-9a22" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="8e26-44c9-7582-5b85" name="New InfoLink" hidden="false" targetId="8269-2cd6-9236-16e7" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="7c97-b4d3-8169-2f60" name="New InfoLink" hidden="false" targetId="a5ff-1cb1-bee4-d809" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
+            <infoLink id="abdc-5517-84a6-e642" name="New InfoLink" hidden="false" targetId="2d80-e016-4c0b-9a22" type="profile"/>
+            <infoLink id="8e26-44c9-7582-5b85" name="New InfoLink" hidden="false" targetId="8269-2cd6-9236-16e7" type="rule"/>
+            <infoLink id="7c97-b4d3-8169-2f60" name="New InfoLink" hidden="false" targetId="a5ff-1cb1-bee4-d809" type="rule"/>
           </infoLinks>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="f833-5eba-9592-4940" name="Assault Needler" book="HH7" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
+        <selectionEntry id="f833-5eba-9592-4940" name="Assault Needler" publicationId="a30a-7522-pubN95872" hidden="false" collective="false" type="upgrade">
           <infoLinks>
-            <infoLink id="b392-833f-0c20-bb64" name="New InfoLink" hidden="false" targetId="692f-190e-f395-a636" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="927d-6223-a74c-dddd" name="New InfoLink" hidden="false" targetId="8269-2cd6-9236-16e7" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="e757-8532-a401-5c38" name="New InfoLink" hidden="false" targetId="a5ff-1cb1-bee4-d809" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
+            <infoLink id="b392-833f-0c20-bb64" name="New InfoLink" hidden="false" targetId="692f-190e-f395-a636" type="profile"/>
+            <infoLink id="927d-6223-a74c-dddd" name="New InfoLink" hidden="false" targetId="8269-2cd6-9236-16e7" type="rule"/>
+            <infoLink id="e757-8532-a401-5c38" name="New InfoLink" hidden="false" targetId="a5ff-1cb1-bee4-d809" type="rule"/>
           </infoLinks>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="4099-02e6-ddf0-4100" name="Snare Gun" book="HH7" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
+        <selectionEntry id="4099-02e6-ddf0-4100" name="Snare Gun" publicationId="a30a-7522-pubN95872" hidden="false" collective="false" type="upgrade">
           <infoLinks>
-            <infoLink id="f020-985b-4c27-d35a" name="New InfoLink" hidden="false" targetId="380f-6582-bd5a-da17" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="58c9-3134-8ee1-f371" name="New InfoLink" hidden="false" targetId="a389-4914-28ac-3c24" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
+            <infoLink id="f020-985b-4c27-d35a" name="New InfoLink" hidden="false" targetId="380f-6582-bd5a-da17" type="rule"/>
+            <infoLink id="58c9-3134-8ee1-f371" name="New InfoLink" hidden="false" targetId="a389-4914-28ac-3c24" type="profile"/>
           </infoLinks>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
-      <selectionEntryGroups/>
       <entryLinks>
-        <entryLink id="7118-5706-3406-b9d8" name="New EntryLink" hidden="false" targetId="ac1f-421a-2070-02d2" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
+        <entryLink id="7118-5706-3406-b9d8" name="New EntryLink" hidden="false" collective="false" targetId="ac1f-421a-2070-02d2" type="selectionEntry"/>
       </entryLinks>
     </selectionEntryGroup>
     <selectionEntryGroup id="90bd-22e7-9326-3298" name="Sisters of Silence Dedicated Transport" hidden="false" collective="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d222-663f-7022-2f11" type="max"/>
       </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
       <entryLinks>
-        <entryLink id="0174-2a58-dee8-a98e" name="Sisters of Silence Kharon Pattern Acquisitor" hidden="false" targetId="fdd2-62b7-2df5-5793" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
+        <entryLink id="0174-2a58-dee8-a98e" name="Sisters of Silence Kharon Pattern Acquisitor" hidden="false" collective="false" targetId="fdd2-62b7-2df5-5793" type="selectionEntry"/>
       </entryLinks>
     </selectionEntryGroup>
     <selectionEntryGroup id="7a9d-499d-e939-23a3" name="Power Weapon" hidden="false" collective="false" defaultSelectionEntryId="d313-b513-281a-c5ad">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6d88-8faa-d3d7-49fb" type="max"/>
       </constraints>
-      <categoryLinks/>
       <selectionEntries>
         <selectionEntry id="19f3-c3be-1dde-f2a3" name="Power Sword" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="1c8d-fc5a-aba4-a438" name="New InfoLink" hidden="false" targetId="038e-23ec-4886-8b00" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
           <modifiers>
-            <modifier type="set" field="points" value="10">
-              <repeats/>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
+            <modifier type="set" field="points" value="10"/>
           </modifiers>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
+          <infoLinks>
+            <infoLink id="1c8d-fc5a-aba4-a438" name="New InfoLink" hidden="false" targetId="038e-23ec-4886-8b00" type="profile"/>
+          </infoLinks>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="8d2c-aefe-26a2-d00e" name="Power Lance" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="5055-4520-acd7-151c" name="New InfoLink" hidden="false" targetId="fdd4-9bf3-da9d-5479" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
           <modifiers>
-            <modifier type="set" field="points" value="10">
-              <repeats/>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
+            <modifier type="set" field="points" value="10"/>
           </modifiers>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
+          <infoLinks>
+            <infoLink id="5055-4520-acd7-151c" name="New InfoLink" hidden="false" targetId="fdd4-9bf3-da9d-5479" type="profile"/>
+          </infoLinks>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="44d9-a43f-ca9c-4692" name="Power Maul" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="0578-1797-7b04-fa69" name="New InfoLink" hidden="false" targetId="6bbe-f2c1-78e2-da59" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
           <modifiers>
-            <modifier type="set" field="points" value="10">
-              <repeats/>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
+            <modifier type="set" field="points" value="10"/>
           </modifiers>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
+          <infoLinks>
+            <infoLink id="0578-1797-7b04-fa69" name="New InfoLink" hidden="false" targetId="6bbe-f2c1-78e2-da59" type="profile"/>
+          </infoLinks>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="d313-b513-281a-c5ad" name="Power Axe" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="fa47-963e-9978-3be4" name="New InfoLink" hidden="false" targetId="b3af-1eca-6629-4894" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
           <modifiers>
-            <modifier type="set" field="points" value="10">
-              <repeats/>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
+            <modifier type="set" field="points" value="10"/>
           </modifiers>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
+          <infoLinks>
+            <infoLink id="fa47-963e-9978-3be4" name="New InfoLink" hidden="false" targetId="b3af-1eca-6629-4894" type="profile"/>
+          </infoLinks>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
-      <selectionEntryGroups/>
-      <entryLinks/>
     </selectionEntryGroup>
     <selectionEntryGroup id="c43b-5c09-9eae-27ba" name="Legio Custodes Dedicated Transport" hidden="false" collective="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="36aa-4b54-7733-0967" type="max"/>
       </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
       <entryLinks>
-        <entryLink id="e8fb-c8e2-06cf-8210" name="New EntryLink" hidden="false" targetId="52aa-6b05-24b3-d283" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
+        <entryLink id="e8fb-c8e2-06cf-8210" name="New EntryLink" hidden="false" collective="false" targetId="52aa-6b05-24b3-d283" type="selectionEntry"/>
       </entryLinks>
     </selectionEntryGroup>
     <selectionEntryGroup id="5527-f4ef-035b-11c2" name="Wargear" hidden="false" collective="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
       <selectionEntries>
         <selectionEntry id="b4ea-a586-86a9-02eb" name="Nuncio-vox" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="44af-c1bd-9c26-f6d2" name="New InfoLink" hidden="false" targetId="2a0e-e1f0-5ea0-5799" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8ccf-07cb-9064-9762" type="max"/>
           </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
+          <infoLinks>
+            <infoLink id="44af-c1bd-9c26-f6d2" name="New InfoLink" hidden="false" targetId="2a0e-e1f0-5ea0-5799" type="profile"/>
+          </infoLinks>
           <costs>
-            <cost name="pts" costTypeId="points" value="10.0"/>
+            <cost name="pts" typeId="points" value="10.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="91c7-90a8-a1ae-cde0" name="Legion Vexilla" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="76b0-0c2e-5e67-1cef" name="New InfoLink" hidden="false" targetId="d187-89fe-0b05-808e" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a592-1d66-c299-b987" type="max"/>
           </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
+          <infoLinks>
+            <infoLink id="76b0-0c2e-5e67-1cef" name="New InfoLink" hidden="false" targetId="d187-89fe-0b05-808e" type="profile"/>
+          </infoLinks>
           <costs>
-            <cost name="pts" costTypeId="points" value="10.0"/>
+            <cost name="pts" typeId="points" value="10.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="dd74-ccdb-9bc6-7069" name="Artificer Armour" hidden="false" collective="false" type="upgrade">
-          <profiles>
-            <profile id="c587-5d7f-6151-005d" name="Artificer Armour" book="LA:AODAL" page="131" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323" profileTypeName="Wargear Item">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="Description" characteristicTypeId="4465736372697074696f6e23232344415441232323" value="Artificer Armour confers a 2+ Armour save.  "/>
-              </characteristics>
-            </profile>
-          </profiles>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="535d-a0a7-ce4e-6ab5" type="max"/>
           </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="10.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="ab39-d41c-7f2d-a92b" name="Combat Shield" book="LA:AODAL" page="131" hidden="false" collective="false" type="upgrade">
           <profiles>
-            <profile id="96e4-a19a-7925-ebaa" name="Combat Shield" book="LA:AODAL" page="131" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323" profileTypeName="Wargear Item">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <profile id="c587-5d7f-6151-005d" name="Artificer Armour" publicationId="a30a-7522-pubN101730" page="131" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
               <characteristics>
-                <characteristic name="Description" characteristicTypeId="4465736372697074696f6e23232344415441232323" value="Combat shields and boarding shields confer a 6+ invulnerable save, increasing to 5+ in close combat."/>
+                <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Artificer Armour confers a 2+ Armour save.  </characteristic>
               </characteristics>
             </profile>
           </profiles>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
+          <costs>
+            <cost name="pts" typeId="points" value="10.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="ab39-d41c-7f2d-a92b" name="Combat Shield" publicationId="a30a-7522-pubN101730" page="131" hidden="false" collective="false" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8e0d-f89e-8c8d-2d29" type="max"/>
           </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
+          <profiles>
+            <profile id="96e4-a19a-7925-ebaa" name="Combat Shield" publicationId="a30a-7522-pubN101730" page="131" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
+              <characteristics>
+                <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Combat shields and boarding shields confer a 6+ invulnerable save, increasing to 5+ in close combat.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
           <costs>
-            <cost name="pts" costTypeId="points" value="5.0"/>
+            <cost name="pts" typeId="points" value="5.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="1c30-47c5-950a-e3df" name="Boarding Shield" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="58f6-30eb-0a45-56ea" name="New InfoLink" hidden="false" targetId="d978-1455-09f8-544f" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4f5f-b5eb-eb91-d212" type="max"/>
           </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
+          <infoLinks>
+            <infoLink id="58f6-30eb-0a45-56ea" name="New InfoLink" hidden="false" targetId="d978-1455-09f8-544f" type="profile"/>
+          </infoLinks>
           <costs>
-            <cost name="pts" costTypeId="points" value="10.0"/>
+            <cost name="pts" typeId="points" value="10.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="131a-f920-a4da-1196" name="Jump Pack" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="d3a7-f59c-affa-2304" name="New InfoLink" hidden="false" targetId="d219-2314-4834-c054" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="0f09-9044-0614-dbf4" name="New InfoLink" hidden="false" targetId="38d5-b6eb-bda8-2497" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="074a-533b-41ac-f2ae" name="New InfoLink" hidden="false" targetId="f095-0842-a6b1-5404" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="0cfb-ee3e-b966-8841" name="New InfoLink" hidden="false" targetId="8cb0-ff25-22a2-d480" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="bb9a-1adf-8c3d-0560" type="max"/>
             <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c90e-f674-9793-926a" type="min"/>
           </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
+          <infoLinks>
+            <infoLink id="d3a7-f59c-affa-2304" name="New InfoLink" hidden="false" targetId="d219-2314-4834-c054" type="rule"/>
+            <infoLink id="0f09-9044-0614-dbf4" name="New InfoLink" hidden="false" targetId="38d5-b6eb-bda8-2497" type="rule"/>
+            <infoLink id="074a-533b-41ac-f2ae" name="New InfoLink" hidden="false" targetId="f095-0842-a6b1-5404" type="profile"/>
+            <infoLink id="0cfb-ee3e-b966-8841" name="New InfoLink" hidden="false" targetId="8cb0-ff25-22a2-d480" type="rule"/>
+          </infoLinks>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="5b17-8f37-be37-1146" name="Space Marine Bike" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="cf4f-d466-52c5-f6a4" name="New InfoLink" hidden="false" targetId="09fd-8af1-a6b1-51f7" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="b6a7-352b-bfcc-7847" name="New InfoLink" hidden="false" targetId="0434-8c4b-9614-73dd" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="8825-4bbf-b997-9fe8" name="New InfoLink" hidden="false" targetId="3c7d-a1fa-c68b-caad" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="cc48-0356-5c73-39cd" name="New InfoLink" hidden="false" targetId="d3e5-b43d-a89c-3bd8" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="7571-dc8f-3214-7a41" name="New InfoLink" hidden="false" targetId="6f66-b417-6004-0916" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="0f00-b363-95d5-8e84" name="New InfoLink" hidden="false" targetId="abc9-8566-bb61-4b7c" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d441-c235-b1b9-eb8f" type="max"/>
             <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8c45-d376-3ee9-a6f7" type="min"/>
           </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
+          <infoLinks>
+            <infoLink id="cf4f-d466-52c5-f6a4" name="New InfoLink" hidden="false" targetId="09fd-8af1-a6b1-51f7" type="profile"/>
+            <infoLink id="b6a7-352b-bfcc-7847" name="New InfoLink" hidden="false" targetId="0434-8c4b-9614-73dd" type="profile"/>
+            <infoLink id="8825-4bbf-b997-9fe8" name="New InfoLink" hidden="false" targetId="3c7d-a1fa-c68b-caad" type="rule"/>
+            <infoLink id="cc48-0356-5c73-39cd" name="New InfoLink" hidden="false" targetId="d3e5-b43d-a89c-3bd8" type="rule"/>
+            <infoLink id="7571-dc8f-3214-7a41" name="New InfoLink" hidden="false" targetId="6f66-b417-6004-0916" type="rule"/>
+            <infoLink id="0f00-b363-95d5-8e84" name="New InfoLink" hidden="false" targetId="abc9-8566-bb61-4b7c" type="rule"/>
+          </infoLinks>
           <costs>
-            <cost name="pts" costTypeId="points" value="20.0"/>
+            <cost name="pts" typeId="points" value="20.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
-      <selectionEntryGroups/>
-      <entryLinks/>
     </selectionEntryGroup>
     <selectionEntryGroup id="d870-726f-9486-5438" name="Telemon Caestus" hidden="false" collective="false" defaultSelectionEntryId="f656-da4f-66d0-4c26">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="b1e6-f153-521a-5f66" type="min"/>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="1f9f-6c8b-d132-7b46" type="max"/>
       </constraints>
-      <categoryLinks/>
       <selectionEntries>
         <selectionEntry id="f656-da4f-66d0-4c26" name="Telemon Caestus" hidden="false" collective="false" type="upgrade">
           <profiles>
-            <profile id="2727-43a6-ee4f-8240" name="Telemon Caestus" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <profile id="2727-43a6-ee4f-8240" name="Telemon Caestus" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
               <characteristics>
-                <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="Melee"/>
-                <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="x2"/>
-                <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="2"/>
-                <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Melee, Shred, Murderous Strike"/>
+                <characteristic name="Range" typeId="52616e676523232344415441232323">Melee</characteristic>
+                <characteristic name="Strength" typeId="537472656e67746823232344415441232323">x2</characteristic>
+                <characteristic name="AP" typeId="415023232344415441232323">2</characteristic>
+                <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Shred, Murderous Strike</characteristic>
               </characteristics>
             </profile>
           </profiles>
-          <rules/>
           <infoLinks>
-            <infoLink id="bde3-baa7-86ed-2e49" name="Shred" hidden="false" targetId="89da-0cb5-bee4-8ec2" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="5298-ac4b-0700-9527" name="Murderous Strike" hidden="false" targetId="9627-9c59-94d1-d76a" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
+            <infoLink id="bde3-baa7-86ed-2e49" name="Shred" hidden="false" targetId="89da-0cb5-bee4-8ec2" type="rule"/>
+            <infoLink id="5298-ac4b-0700-9527" name="Murderous Strike" hidden="false" targetId="9627-9c59-94d1-d76a" type="rule"/>
           </infoLinks>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
           <selectionEntries>
             <selectionEntry id="0388-aed0-80c0-1f28" name="Proteus Plasma Projector" hidden="false" collective="false" type="upgrade">
-              <profiles>
-                <profile id="28c3-6280-268c-a95c" name="Proteus Plasma Projector" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <characteristics>
-                    <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="Template"/>
-                    <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="5"/>
-                    <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="2"/>
-                    <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Assault 1, Gets Hot"/>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <rules/>
-              <infoLinks>
-                <infoLink id="06c8-5cc4-f077-5dfc" name="Gets Hot" hidden="false" targetId="f4fd-d519-4769-5510" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bd94-37a7-16a7-d9e3" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7ed0-5dba-990c-f4e4" type="min"/>
               </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
+              <profiles>
+                <profile id="28c3-6280-268c-a95c" name="Proteus Plasma Projector" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="52616e676523232344415441232323">Template</characteristic>
+                    <characteristic name="Strength" typeId="537472656e67746823232344415441232323">5</characteristic>
+                    <characteristic name="AP" typeId="415023232344415441232323">2</characteristic>
+                    <characteristic name="Type" typeId="5479706523232344415441232323">Assault 1, Gets Hot</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink id="06c8-5cc4-f077-5dfc" name="Gets Hot" hidden="false" targetId="f4fd-d519-4769-5510" type="rule"/>
+              </infoLinks>
               <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
+                <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
-          <selectionEntryGroups/>
-          <entryLinks/>
           <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="edfc-5a45-95fd-1199" name="Arachnus Storm Cannon" hidden="false" collective="false" type="upgrade">
           <profiles>
-            <profile id="bce1-df07-92cb-f56c" name="Burst Fire" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <profile id="bce1-df07-92cb-f56c" name="Burst Fire" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
               <characteristics>
-                <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="48&quot;"/>
-                <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="7"/>
-                <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="3"/>
-                <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 7"/>
+                <characteristic name="Range" typeId="52616e676523232344415441232323">48&quot;</characteristic>
+                <characteristic name="Strength" typeId="537472656e67746823232344415441232323">7</characteristic>
+                <characteristic name="AP" typeId="415023232344415441232323">3</characteristic>
+                <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 7</characteristic>
               </characteristics>
             </profile>
-            <profile id="1f78-1c22-d195-698e" name="Concentrated Blast" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+            <profile id="1f78-1c22-d195-698e" name="Concentrated Blast" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
               <characteristics>
-                <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="72&quot;"/>
-                <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="9"/>
-                <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="1"/>
-                <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 2, Exo-Shock"/>
+                <characteristic name="Range" typeId="52616e676523232344415441232323">72&quot;</characteristic>
+                <characteristic name="Strength" typeId="537472656e67746823232344415441232323">9</characteristic>
+                <characteristic name="AP" typeId="415023232344415441232323">1</characteristic>
+                <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 2, Exo-Shock</characteristic>
               </characteristics>
             </profile>
           </profiles>
-          <rules/>
           <infoLinks>
-            <infoLink id="5b1f-f905-7f01-5ec8" name="Exoshock" hidden="false" targetId="2740-e6d7-076b-9d5c" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
+            <infoLink id="5b1f-f905-7f01-5ec8" name="Exoshock" hidden="false" targetId="2740-e6d7-076b-9d5c" type="rule"/>
           </infoLinks>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
           <costs>
-            <cost name="pts" costTypeId="points" value="40.0"/>
+            <cost name="pts" typeId="points" value="40.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="2d89-d9dd-f2a7-ebc4" name="Illastus Accelerator Culverin" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
           <infoLinks>
-            <infoLink id="44a3-7c01-9d03-cddf" name="Illastus Accelerator Culverin" hidden="false" targetId="bd4f-4ba1-a337-9b50" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="4269-f7ca-1fff-2f93" name="Heliothermic Detonation" hidden="false" targetId="dd32-1791-4789-051f" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="349e-d14d-23a9-df56" name="Rending" hidden="false" targetId="8269-2cd6-9236-16e7" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
+            <infoLink id="44a3-7c01-9d03-cddf" name="Illastus Accelerator Culverin" hidden="false" targetId="bd4f-4ba1-a337-9b50" type="profile"/>
+            <infoLink id="4269-f7ca-1fff-2f93" name="Heliothermic Detonation" hidden="false" targetId="dd32-1791-4789-051f" type="rule"/>
+            <infoLink id="349e-d14d-23a9-df56" name="Rending" hidden="false" targetId="8269-2cd6-9236-16e7" type="rule"/>
           </infoLinks>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
           <costs>
-            <cost name="pts" costTypeId="points" value="25.0"/>
+            <cost name="pts" typeId="points" value="25.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
-      <selectionEntryGroups/>
-      <entryLinks/>
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <sharedRules>
-    <rule id="1254-9285-e876-010d" name="Grav-backwash" book="HH7" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
+    <rule id="1254-9285-e876-010d" name="Grav-backwash" publicationId="a30a-7522-pubN95872" hidden="false">
       <description>Unless the vehicle has become Immobilised, attackers suffer a -2 To Hit it in assault.</description>
     </rule>
-    <rule id="41a9-bbe8-d024-4813" name="Inviolable Psyche" book="HH7" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
+    <rule id="41a9-bbe8-d024-4813" name="Inviolable Psyche" publicationId="a30a-7522-pubN95872" hidden="false">
       <description>A unit with this special rule is immune to Fear and Pinning test, and can re-roll failed Deny the Witch attempts. This unit does not suffer penalties to its LEadership when taking Morale checks.</description>
     </rule>
-    <rule id="ce23-8050-129e-4371" name="Preternatural Skill" book="HH7" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
+    <rule id="ce23-8050-129e-4371" name="Preternatural Skill" publicationId="a30a-7522-pubN95872" hidden="false">
       <description>Any model with this special rule gains a bonus of +1 to their Initiative in the Assault phase if their Weapon Skill is greater than that of the model(s) which they are fighting.</description>
     </rule>
-    <rule id="c49a-b905-f536-8810" name="The Sodality" book="HH7" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
+    <rule id="c49a-b905-f536-8810" name="The Sodality" publicationId="a30a-7522-pubN95872" hidden="false">
       <description>A unit composed entirely of models with this special rule has a coherency of 3&quot; instead of the usual 2&quot; and may always attempt to Regroup as an unmodified Leadership test regardless of casualties taken or any other effects.</description>
     </rule>
-    <rule id="a37c-753a-33b4-8101" name="Lightning Blows" book="HH7" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
+    <rule id="a37c-753a-33b4-8101" name="Lightning Blows" publicationId="a30a-7522-pubN95872" hidden="false">
       <description>Every roll of a 6 To Hit with this weapon generates another attack with the same weapon at the same Initiative step. These extra attacks do not themselves also generate additional attacks.</description>
     </rule>
-    <rule id="3800-d4fb-7935-f2a9" name="Hail of Fire" book="HH7" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
+    <rule id="3800-d4fb-7935-f2a9" name="Hail of Fire" publicationId="a30a-7522-pubN95872" hidden="false">
       <description>This weapon makes snap shots at BS2.</description>
     </rule>
-    <rule id="9627-9c59-94d1-d76a" name="Murderous Strike" book="HH7" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
+    <rule id="9627-9c59-94d1-d76a" name="Murderous Strike" publicationId="a30a-7522-pubN95872" hidden="false">
       <description>Attacks with this weapon cause Instant Death on a To Wound roll of 5 or 6. Roll any viable saves against thses Instant Death-causing wounds seperately to any other wounds the attack inflicts.</description>
     </rule>
-    <rule id="dd32-1791-4789-051f" name="Heliothermic Detonation" book="HH7" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
+    <rule id="dd32-1791-4789-051f" name="Heliothermic Detonation" publicationId="a30a-7522-pubN95872" hidden="false">
       <description>If any Target suffers one or more unsaved wounds from this weapon and is not slain, they must take an immediate Toughnes test. if this test is failed, they suffer Instant Death. in the case of a vehicle suffering a penetrating hit from this weapon, add +1 to the result that is rolled on the Vehicle Damage table.</description>
     </rule>
-    <rule id="3996-018b-a7d9-a7b8" name="Rapid Tracking" book="HH7" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
+    <rule id="3996-018b-a7d9-a7b8" name="Rapid Tracking" publicationId="a30a-7522-pubN95872" hidden="false">
       <description>Targets may not take Jink saves against damage from this weapon</description>
     </rule>
-    <rule id="2740-e6d7-076b-9d5c" name="Exoshock" book="HH7" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
+    <rule id="2740-e6d7-076b-9d5c" name="Exoshock" publicationId="a30a-7522-pubN95872" hidden="false">
       <description>If this wepon scores a penetrating hit on a target, roll a D6. on a roll of a 4+, a second automatic penetrating hit is inflicted on the same target, against which cover saves may not be taken.</description>
     </rule>
-    <rule id="584d-e540-7fdd-92c9" name="Psykic Anathema" book="HH7:Inferno" page="247" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
+    <rule id="584d-e540-7fdd-92c9" name="Psykic Anathema" publicationId="a30a-7522-pubN102882" page="247" hidden="false">
       <description>Models witht his rule ar eimmune to all psychic powers and cannot be affected by them. They also ignore any Telepathy Discipline Blessings on enemy units which would negatively affect the models which this rule. This does not extend to Transport Vehicles.
 
 All units with in 12&quot; of any model with this rul suffer -1 to their Leadership value increasing to -2 if the model is a Psyker. Models with Fearless or the Psychic Anathema are not subject to this effect. This affects friend and foe equally.
@@ -13005,1354 +5889,902 @@ All units with Daemon within 12&quot; of any model with this rule suffer -1 to t
 
 All models with psychic powers suffer a penalty to roll to manifest psychic powers when near any model with this rule. -1 within 12&quot;, increasting to -2 when in base contact.</description>
     </rule>
-    <rule id="c793-7756-3669-827c" name="Ex Oblivio" book="HH7:Inferno" page="247" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
+    <rule id="c793-7756-3669-827c" name="Ex Oblivio" publicationId="a30a-7522-pubN102882" page="247" hidden="false">
       <description>Psychi models or units of any kind within 6&quot; of models with tis rul at the start of their Psychic phase do not generate additional warp charge dice.
 
 If any Psyhic model is in base contact with a model that has this special rule at the start of any Psychic phase they must immediately make a Leadership text before Warp Charge is rulled for. If this test is failed they must immediately suffer Perils of the Warp at -1and may not use any psychic powers durung this phase should they survive this.</description>
     </rule>
-    <rule id="97d7-d358-141a-8579" name="Fanatic Disipline" book="HH7" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
+    <rule id="97d7-d358-141a-8579" name="Fanatic Disipline" publicationId="a30a-7522-pubN95872" hidden="false">
       <description>Models with this special rule are Fearless. In addition, they have Hatred (Psykers) special rule.</description>
     </rule>
-    <rule id="05b9-9f16-29f9-9dad" name="Company Cadre Structure" book="HH7" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
+    <rule id="05b9-9f16-29f9-9dad" name="Company Cadre Structure" publicationId="a30a-7522-pubN95872" hidden="false">
       <description>In order to field any units with the Company-Cadre special rule using the Talons of the Emperor army list, at least one HQ unit with this special rule must be part of this detachment for every 3 non-HQ units with the Company Cadre special rule in the same detachment.</description>
     </rule>
-    <rule id="6774-89d9-ba61-1071" name="Cadre Tactics" book="HH7" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
+    <rule id="6774-89d9-ba61-1071" name="Cadre Tactics" publicationId="a30a-7522-pubN95872" hidden="false">
       <description>One of the following additional benefits may be given to all units in the detachment with the Company-Cadre special rule.
 Infiltrate
 Crusader
 Stealth
 Overawe(+1 to the total score to determine the result of an assault)</description>
     </rule>
-    <rule id="97a9-13e2-6a86-dae2" name="Psi-Shock" book="HH7" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
+    <rule id="97a9-13e2-6a86-dae2" name="Psi-Shock" publicationId="a30a-7522-pubN95872" hidden="false">
       <description>If a unit containing at least one Psyker is hit by a weapon with the Psi-Shock special rule, one randomly determined Psyker model in that unit suffers Perils of the Warp in addition to any other damage.</description>
     </rule>
-    <rule id="626e-2455-feaf-032b" name="Electro-Arc" book="HH7" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
+    <rule id="626e-2455-feaf-032b" name="Electro-Arc" publicationId="a30a-7522-pubN95872" hidden="false">
       <description>Total all hits caused by weapons with this special rule durring an Assault phase, before making any To Wound rolls, then roll a single D6 for each of these hits. Any rolls of 3+ cause an additional hit at AP- with the Poisoned (4+)special rule.</description>
     </rule>
-    <rule id="ae06-63ec-f5ae-f8db" name="Sweeping Strikes" book="HH7" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
+    <rule id="ae06-63ec-f5ae-f8db" name="Sweeping Strikes" publicationId="a30a-7522-pubN95872" hidden="false">
       <description>The bearer may choose to use the number of enemy models within 3&quot; that are locked in combat with them instead of their Attacks score to determine the number of attacks they may make in any Assault phase.</description>
     </rule>
-    <rule id="514e-dfe7-e9a4-17a7" name="Piercing Cut" book="HH7" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
+    <rule id="514e-dfe7-e9a4-17a7" name="Piercing Cut" publicationId="a30a-7522-pubN95872" hidden="false">
       <description>To Hit rolls of 5 or 6 made for attacks with this weapon are resolved seperately at AP2</description>
     </rule>
-    <rule id="eddf-f5b5-0ec0-e1bb" name="Duellist&apos;s Edge" book="HH7" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
+    <rule id="eddf-f5b5-0ec0-e1bb" name="Duellist&apos;s Edge" publicationId="a30a-7522-pubN95872" hidden="false">
       <description>When fighting in a Challenge, the user of this weapon gains a +1 bonus to their Inititave value.</description>
     </rule>
-    <rule id="380f-6582-bd5a-da17" name="Snare" book="HH7" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
+    <rule id="380f-6582-bd5a-da17" name="Snare" publicationId="a30a-7522-pubN95872" hidden="false">
       <description>If this weapon inflicts a sucessful hit, it becomes D3 hits on the target unit. For each hit inflicted, the opposing player must make a Strength test. For each Strength test failed, the unit suffers a single wound with no armour saves allowed (Invulnerable saves may be taken as normal). This weapon has no effect on Gargantuan Creatures or Vehicles.</description>
     </rule>
-    <rule id="71ff-3b5a-6f75-55fc" name="Enhanced Voidsheen Cloak" book="HH7" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
+    <rule id="71ff-3b5a-6f75-55fc" name="Enhanced Voidsheen Cloak" publicationId="a30a-7522-pubN95872" hidden="false">
       <description>Provides the wearer with a 4++, which increases to a 3++ vs Template and Blast weapons</description>
     </rule>
-    <rule id="3eed-1fde-941e-af2d" name="Compression Tanks" book="HH7:Inferno" page="255" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
+    <rule id="3eed-1fde-941e-af2d" name="Compression Tanks" publicationId="a30a-7522-pubN102882" page="255" hidden="false">
       <description>Once per game, a model equipped with this wargear can use it, and their controlling player must declare its use before any rolls To Wound are made for this attack. When it is used, the flamer&apos;s Strenght is increated to 6. Once used in this manner the flamer cannot be used again at all for the rest of the game.</description>
     </rule>
-    <rule id="7e19-5042-d0cb-0d82" name="Instruments of Torment" book="HH7" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
+    <rule id="7e19-5042-d0cb-0d82" name="Instruments of Torment" publicationId="a30a-7522-pubN95872" hidden="false">
       <description>When in close compat with any character without any other models being present in the combat, all attacks made by a unit with this special rule carry the Instant Death special rule.</description>
     </rule>
-    <rule id="4648-cbf1-884b-d7b4" name="Witchfinders" book="HH7" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
+    <rule id="4648-cbf1-884b-d7b4" name="Witchfinders" publicationId="a30a-7522-pubN95872" hidden="false">
       <description>You may only take an Excruciatus Cadre as your Detachment&apos;s compulsory HQ choice if the Detachment costs 500pts or less in total.</description>
     </rule>
-    <rule id="8fd8-2be9-519b-1b68" name="Hatred (Psykers, Daemons)" book="HH7" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
+    <rule id="8fd8-2be9-519b-1b68" name="Hatred (Psykers, Daemons)" publicationId="a30a-7522-pubN95872" hidden="false">
       <description>This rule is often presented as Hatred (X) where X identifies a specific type of foe. If the special rule does not specify a type of foe, then the unit has Hatred against everyone. This can refer to a Faction, or a specific unit. For example, Hatred (Orks) means any model with the Ork Faction, whilst Hatred (Big Meks) means only Big Meks. A model striking a hated foe in close combat re-rolls all failed To Hit rolls during the first round of each close combat.</description>
     </rule>
-    <rule id="7a26-98f9-345e-e2c0" name="Molecular Severance" book="HH7" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
+    <rule id="7a26-98f9-345e-e2c0" name="Molecular Severance" publicationId="a30a-7522-pubN95872" hidden="false">
       <description>Any To Wound roll of a 4+ with this weapon inflicts Instand Death, or in the case of vehicles causes a penetrating hit regardless of the target&apos;s armour value. In addition, any sucessful invulnerable save taken againts this weapon must be re-rolled.</description>
     </rule>
-    <rule id="6a7d-c38d-c888-a1ac" name="Spectra-Vestments" book="HH7" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
+    <rule id="6a7d-c38d-c888-a1ac" name="Spectra-Vestments" publicationId="a30a-7522-pubN95872" hidden="false">
       <description>A model equipped with Spectra-Vestments imposes a -1 BS penalty on targets making shooting attacks againt them.</description>
     </rule>
-    <rule id="3cfc-cfdc-a578-923e" name="Voidsheen Cloak" book="HH7" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
+    <rule id="3cfc-cfdc-a578-923e" name="Voidsheen Cloak" publicationId="a30a-7522-pubN95872" hidden="false">
       <description>6++, increasing to a 4++ against Template and Blast weapons</description>
     </rule>
-    <rule id="8507-1dbf-2690-2157" name="Impaling" book="HH7" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
+    <rule id="8507-1dbf-2690-2157" name="Impaling" publicationId="a30a-7522-pubN95872" hidden="false">
       <description>In the assault phase on a turn in which this model has charged, To Hit rolls of 6 with this weapon are resolved as Destroyer Hits.</description>
     </rule>
-    <rule id="9e6d-607b-824f-30ea" name="Death Mark" book="HH7" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
+    <rule id="9e6d-607b-824f-30ea" name="Death Mark" publicationId="a30a-7522-pubN95872" hidden="false">
       <description>After both sides have deployed but before the game begins, if a Detachment contains any Vigilator Cadres, their controlling player must declare a single enemy Infantry unit or Independant Character as carrying the Death Mark this game. All Vigilator units in the Detachment gain the Preferred Enemy special rule when attacking this unit or Character.</description>
     </rule>
-    <rule id="3ca6-ef89-ab4d-85c8" name="Battle Auspex" book="HH7" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
+    <rule id="3ca6-ef89-ab4d-85c8" name="Battle Auspex" publicationId="a30a-7522-pubN95872" hidden="false">
       <description>The Kharon Pattern Acquisitor has the Night Vision special rule. In addition, it reduces the cover saves of enemy targets it fires on by -1.</description>
     </rule>
-    <rule id="a369-8250-a683-e4d5" name="Spectra-Distort Field" book="HH7" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
+    <rule id="a369-8250-a683-e4d5" name="Spectra-Distort Field" publicationId="a30a-7522-pubN95872" hidden="false">
       <description>A Model with a Spectra-Distort field has the stealth special rule. Furthermore, shooting attacks against it from more then 12&quot; away have a -1 BS penalty (Minimum 1)</description>
     </rule>
-    <rule id="18d0-fdf0-c554-cb34" name="Capture-Grid" book="HH7" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
+    <rule id="18d0-fdf0-c554-cb34" name="Capture-Grid" publicationId="a30a-7522-pubN95872" hidden="false">
       <description>When the Kharon Pattern Acquisitor makes a Tank Shock against an Infantry unit, it inflicts D6 Str 5 Hammer of Wrath attacks while doing so - these are made before any Death or Glory attempts</description>
     </rule>
-    <rule id="a2af-e9d4-78d6-07c7" name="Sweeping Fire" book="HH7" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
+    <rule id="a2af-e9d4-78d6-07c7" name="Sweeping Fire" publicationId="a30a-7522-pubN95872" hidden="false">
       <description>Members of the unit may fire once with each of their weapons in the Shooting phase</description>
     </rule>
     <rule id="320e-ff0d-18d2-10f7" name="Auramite Pinions" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
       <description>A Model with this special rule has an invulnerable save of 4+ when locked in close combat.</description>
     </rule>
     <rule id="bad5-67d0-2390-90f5" name="Fan-Burst" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
       <description>On the roll of a 6 To Hit, the bearer may make an extra shooting attack with this weapon (up to a miximum of six rolls To Hit)</description>
     </rule>
     <rule id="8fa4-a1c0-c588-34e6" name="Energy Nullifier" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
       <description>The AP value of any attack made agaisnt a model bearing wargear with the Energy Nullifier rule is reduced by 1 (for example, the attacks of a power sword striking a model equipped with a Tarsus buckler are resolved at AP 4 instead of AP 3).</description>
     </rule>
   </sharedRules>
   <sharedProfiles>
-    <profile id="d0e4-db08-9380-21f1" name="Sentinel Warblade (Bolt Caster)" book="HH7" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
+    <profile id="d0e4-db08-9380-21f1" name="Sentinel Warblade (Bolt Caster)" publicationId="a30a-7522-pubN95872" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
-        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="12&quot;"/>
-        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="4"/>
-        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="5"/>
-        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Assault 2, Hail of Fire"/>
+        <characteristic name="Range" typeId="52616e676523232344415441232323">12&quot;</characteristic>
+        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">4</characteristic>
+        <characteristic name="AP" typeId="415023232344415441232323">5</characteristic>
+        <characteristic name="Type" typeId="5479706523232344415441232323">Assault 2, Hail of Fire</characteristic>
       </characteristics>
     </profile>
-    <profile id="8253-1a93-2972-6699" name="Sentinel Warblade (Warblade)" book="HH7" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
+    <profile id="8253-1a93-2972-6699" name="Sentinel Warblade (Warblade)" publicationId="a30a-7522-pubN95872" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
-        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="Melee"/>
-        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="User"/>
-        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="3"/>
-        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Melee, Rending, Specialist Weapon"/>
+        <characteristic name="Range" typeId="52616e676523232344415441232323">Melee</characteristic>
+        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">User</characteristic>
+        <characteristic name="AP" typeId="415023232344415441232323">3</characteristic>
+        <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Rending, Specialist Weapon</characteristic>
       </characteristics>
     </profile>
-    <profile id="6726-c0ae-28a4-744e" name="Guardian Spear (Guardian Bolter)" book="HH7" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
+    <profile id="6726-c0ae-28a4-744e" name="Guardian Spear (Guardian Bolter)" publicationId="a30a-7522-pubN95872" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
-        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="18&quot;"/>
-        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="4"/>
-        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="4"/>
-        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Assault 2"/>
+        <characteristic name="Range" typeId="52616e676523232344415441232323">18&quot;</characteristic>
+        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">4</characteristic>
+        <characteristic name="AP" typeId="415023232344415441232323">4</characteristic>
+        <characteristic name="Type" typeId="5479706523232344415441232323">Assault 2</characteristic>
       </characteristics>
     </profile>
-    <profile id="fecc-6269-d1e4-3d5a" name="Guardian Spear (Power Blade)" book="HH7" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
+    <profile id="fecc-6269-d1e4-3d5a" name="Guardian Spear (Power Blade)" publicationId="a30a-7522-pubN95872" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
-        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="Melee"/>
-        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="User/+1*"/>
-        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="3/2*"/>
-        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Melee, Lightning Blows, Specialist Weapon"/>
+        <characteristic name="Range" typeId="52616e676523232344415441232323">Melee</characteristic>
+        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">User/+1*</characteristic>
+        <characteristic name="AP" typeId="415023232344415441232323">3/2*</characteristic>
+        <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Lightning Blows, Specialist Weapon</characteristic>
       </characteristics>
     </profile>
-    <profile id="f07e-858e-d637-e858" name="Custodian Armour" book="HH7" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323" profileTypeName="Wargear Item">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
+    <profile id="f07e-858e-d637-e858" name="Custodian Armour" publicationId="a30a-7522-pubN95872" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
       <characteristics>
-        <characteristic name="Description" characteristicTypeId="4465736372697074696f6e23232344415441232323" value="Custodian armour provides a 2+ armour save and confers the Move Through Cover special rule.  "/>
+        <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Custodian armour provides a 2+ armour save and confers the Move Through Cover special rule.  </characteristic>
       </characteristics>
     </profile>
-    <profile id="8801-24fc-bb8c-ef86" name="Praesidium Shield" book="HH7" page="" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323" profileTypeName="Wargear Item">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
+    <profile id="8801-24fc-bb8c-ef86" name="Praesidium Shield" publicationId="a30a-7522-pubN95872" page="" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
       <characteristics>
-        <characteristic name="Description" characteristicTypeId="4465736372697074696f6e23232344415441232323" value="A Praesidium Shield increases the invulnerable save of the bearer by 1 (e.g., a 5+ becomes a 4+), to a maximum of 3+. It also imposes a -1 penalty on To Hit rolls of opponents who direct their attacks against the model in the Assault phase, to a maximum of 6+. A model equipped with a Praesidium shield however cannot use a weapon with the Two-handed special rule, claim the benefit of an additional close combat weapon in assault or use the increased close combat profile when charging for a Guardian spear-type weapon."/>
+        <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">A Praesidium Shield increases the invulnerable save of the bearer by 1 (e.g., a 5+ becomes a 4+), to a maximum of 3+. It also imposes a -1 penalty on To Hit rolls of opponents who direct their attacks against the model in the Assault phase, to a maximum of 6+. A model equipped with a Praesidium shield however cannot use a weapon with the Two-handed special rule, claim the benefit of an additional close combat weapon in assault or use the increased close combat profile when charging for a Guardian spear-type weapon.</characteristic>
       </characteristics>
     </profile>
-    <profile id="0a62-df1f-aed7-fc07" name="Aquillon Pattern Terminator Armour" book="HH7" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323" profileTypeName="Wargear Item">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
+    <profile id="0a62-df1f-aed7-fc07" name="Aquillon Pattern Terminator Armour" publicationId="a30a-7522-pubN95872" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
       <characteristics>
-        <characteristic name="Description" characteristicTypeId="4465736372697074696f6e23232344415441232323" value="Aquilon Pattern Terminator Armour provides a 2+ armor save, a 4+ Invulnerable save, and the Hammer of Wrath special rule. A model equipped with Aquilon Pattern Terminator armour may fire Heavy and Salvo weapons, counting as stationary even if they moved in the previous movement phase. They may also charge after firing Rapid Fire, Heavy, or Salvo weapons. A model equipped with Aquilon pattern Terminator armour may not make Run moves, but may still fire overwatch and make Sweeping Advances."/>
+        <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Aquilon Pattern Terminator Armour provides a 2+ armor save, a 4+ Invulnerable save, and the Hammer of Wrath special rule. A model equipped with Aquilon Pattern Terminator armour may fire Heavy and Salvo weapons, counting as stationary even if they moved in the previous movement phase. They may also charge after firing Rapid Fire, Heavy, or Salvo weapons. A model equipped with Aquilon pattern Terminator armour may not make Run moves, but may still fire overwatch and make Sweeping Advances.</characteristic>
       </characteristics>
     </profile>
-    <profile id="ccdd-40a2-abb2-09a3" name="Teleportation Transponder" book="HH7" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323" profileTypeName="Wargear Item">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
+    <profile id="ccdd-40a2-abb2-09a3" name="Teleportation Transponder" publicationId="a30a-7522-pubN95872" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
       <characteristics>
-        <characteristic name="Description" characteristicTypeId="4465736372697074696f6e23232344415441232323" value="A unit comprising models that are all equipped with teleportation transponders gains the Deep Strike rule."/>
+        <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">A unit comprising models that are all equipped with teleportation transponders gains the Deep Strike rule.</characteristic>
       </characteristics>
     </profile>
-    <profile id="e8d9-eb1e-3e42-09b1" name="Iron Halo" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323" profileTypeName="Wargear Item">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
+    <profile id="e8d9-eb1e-3e42-09b1" name="Iron Halo" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
       <characteristics>
-        <characteristic name="Description" characteristicTypeId="4465736372697074696f6e23232344415441232323" value="4++"/>
+        <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">4++</characteristic>
       </characteristics>
     </profile>
-    <profile id="a660-c6dd-f169-e9f3" name="Refractor Feild" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323" profileTypeName="Wargear Item">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
+    <profile id="a660-c6dd-f169-e9f3" name="Refractor Feild" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
       <characteristics>
-        <characteristic name="Description" characteristicTypeId="4465736372697074696f6e23232344415441232323" value="5++"/>
+        <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">5++</characteristic>
       </characteristics>
     </profile>
-    <profile id="74a8-38a9-870a-f02d" name="Magesterium Vexilla" book="HH7" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323" profileTypeName="Wargear Item">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
+    <profile id="74a8-38a9-870a-f02d" name="Magesterium Vexilla" publicationId="a30a-7522-pubN95872" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
       <characteristics>
-        <characteristic name="Description" characteristicTypeId="4465736372697074696f6e23232344415441232323" value="A unit with the Magisterium Vexilla may re-roll failed Leadership tests and gains the Fear special rule. In addition, you may add +1 to the Wounds score calculated to see if any friendly unit with any models within 12&quot; of any magisterium Vaxilla wins a combat in the assault phase - this bonus only applies once."/>
+        <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">A unit with the Magisterium Vexilla may re-roll failed Leadership tests and gains the Fear special rule. In addition, you may add +1 to the Wounds score calculated to see if any friendly unit with any models within 12&quot; of any magisterium Vaxilla wins a combat in the assault phase - this bonus only applies once.</characteristic>
       </characteristics>
     </profile>
-    <profile id="b429-19fb-4cf4-1e2e" name="Arae-Shrikes (Deep Strike Interference)" book="HH7" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323" profileTypeName="Wargear Item">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
+    <profile id="b429-19fb-4cf4-1e2e" name="Arae-Shrikes (Deep Strike Interference)" publicationId="a30a-7522-pubN95872" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
       <characteristics>
-        <characteristic name="Description" characteristicTypeId="4465736372697074696f6e23232344415441232323" value="When an enemy unit attempts to land via Deep Strike within 12&quot; of a model equipped with an Arae-shrike, roll a D6 before they determine the result of their Deep Strike landing. On a 4+, the unit suffers a Deep Strike Mishap instead of landing – note that even models usually immune to Deep Strike Mishaps such as those that have Inertial Guidance systems or who do not usually scatter while Deep Striking are still subject to this effect."/>
+        <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">When an enemy unit attempts to land via Deep Strike within 12&quot; of a model equipped with an Arae-shrike, roll a D6 before they determine the result of their Deep Strike landing. On a 4+, the unit suffers a Deep Strike Mishap instead of landing – note that even models usually immune to Deep Strike Mishaps such as those that have Inertial Guidance systems or who do not usually scatter while Deep Striking are still subject to this effect.</characteristic>
       </characteristics>
     </profile>
-    <profile id="f0c1-9ee8-4740-54f9" name="Arae-Shrikes (Targeting Interference)" book="HH7" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323" profileTypeName="Wargear Item">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
+    <profile id="f0c1-9ee8-4740-54f9" name="Arae-Shrikes (Targeting Interference)" publicationId="a30a-7522-pubN95872" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
       <characteristics>
-        <characteristic name="Description" characteristicTypeId="4465736372697074696f6e23232344415441232323" value="When a unit containing one or more models with an Arae-shrike is targeted by a weapon with the Barrage type, the attacking player must roll an additional D6 for the weapon’s Scatter distance and pick the highest two results. A Hit on the Scatter dice remains a Hit however."/>
+        <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">When a unit containing one or more models with an Arae-shrike is targeted by a weapon with the Barrage type, the attacking player must roll an additional D6 for the weapon’s Scatter distance and pick the highest two results. A Hit on the Scatter dice remains a Hit however.</characteristic>
       </characteristics>
     </profile>
-    <profile id="a597-6272-58d2-7c84" name="Melta Beam" book="HH7" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
+    <profile id="a597-6272-58d2-7c84" name="Melta Beam" publicationId="a30a-7522-pubN95872" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
-        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="6&quot;"/>
-        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="8"/>
-        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="1"/>
-        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Assault 1, Melta"/>
+        <characteristic name="Range" typeId="52616e676523232344415441232323">6&quot;</characteristic>
+        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">8</characteristic>
+        <characteristic name="AP" typeId="415023232344415441232323">1</characteristic>
+        <characteristic name="Type" typeId="5479706523232344415441232323">Assault 1, Melta</characteristic>
       </characteristics>
     </profile>
-    <profile id="0351-af54-349e-1fd3" name="Adrathic Destructor" book="HH7" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
+    <profile id="0351-af54-349e-1fd3" name="Adrathic Destructor" publicationId="a30a-7522-pubN95872" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
-        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="12&quot;"/>
-        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="5"/>
-        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="2"/>
-        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Assault 1, Instant Death, Gets Hot, Armourbane"/>
+        <characteristic name="Range" typeId="52616e676523232344415441232323">12&quot;</characteristic>
+        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">5</characteristic>
+        <characteristic name="AP" typeId="415023232344415441232323">2</characteristic>
+        <characteristic name="Type" typeId="5479706523232344415441232323">Assault 1, Instant Death, Gets Hot, Armourbane</characteristic>
       </characteristics>
     </profile>
-    <profile id="6f85-7ba6-232a-5938" name="Paragon Bolter" book="HH7" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
+    <profile id="6f85-7ba6-232a-5938" name="Paragon Bolter" publicationId="a30a-7522-pubN95872" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
-        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="18&quot;"/>
-        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="5"/>
-        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="3"/>
-        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Assaut 2"/>
+        <characteristic name="Range" typeId="52616e676523232344415441232323">18&quot;</characteristic>
+        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">5</characteristic>
+        <characteristic name="AP" typeId="415023232344415441232323">3</characteristic>
+        <characteristic name="Type" typeId="5479706523232344415441232323">Assaut 2</characteristic>
       </characteristics>
     </profile>
-    <profile id="1620-fda1-7c0c-8b64" name="Solerite Power Gauntlet" book="HH7" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
+    <profile id="1620-fda1-7c0c-8b64" name="Solerite Power Gauntlet" publicationId="a30a-7522-pubN95872" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
-        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="-"/>
-        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="x2"/>
-        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="1"/>
-        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Melee, Master-Crafted, Unweildy"/>
+        <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
+        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">x2</characteristic>
+        <characteristic name="AP" typeId="415023232344415441232323">1</characteristic>
+        <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Master-Crafted, Unweildy</characteristic>
       </characteristics>
     </profile>
-    <profile id="2ddd-f96f-86df-50ba" name="Solerite Power Talons" book="HH7" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
+    <profile id="2ddd-f96f-86df-50ba" name="Solerite Power Talons" publicationId="a30a-7522-pubN95872" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
-        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="-"/>
-        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="+2"/>
-        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="3"/>
-        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Melee, Master-Crafted, Shred"/>
+        <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
+        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">+2</characteristic>
+        <characteristic name="AP" typeId="415023232344415441232323">3</characteristic>
+        <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Master-Crafted, Shred</characteristic>
       </characteristics>
     </profile>
-    <profile id="c984-c9d4-07c9-76e5" name="Adrathic Devastator" book="HH7" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
+    <profile id="c984-c9d4-07c9-76e5" name="Adrathic Devastator" publicationId="a30a-7522-pubN95872" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
-        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="18&quot;"/>
-        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="6"/>
-        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="2"/>
-        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 2, Instant Death, Armourbane, Gets Hot"/>
+        <characteristic name="Range" typeId="52616e676523232344415441232323">18&quot;</characteristic>
+        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">6</characteristic>
+        <characteristic name="AP" typeId="415023232344415441232323">2</characteristic>
+        <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 2, Instant Death, Armourbane, Gets Hot</characteristic>
       </characteristics>
     </profile>
-    <profile id="2320-260c-8e15-5599" name="Adrathic Exterminator" book="HH7" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
+    <profile id="2320-260c-8e15-5599" name="Adrathic Exterminator" publicationId="a30a-7522-pubN95872" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
-        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="36&quot;"/>
-        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="6"/>
-        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="2"/>
-        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 1, Blast (3&quot;), Instant Death, Armourbane, Gets Hot"/>
+        <characteristic name="Range" typeId="52616e676523232344415441232323">36&quot;</characteristic>
+        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">6</characteristic>
+        <characteristic name="AP" typeId="415023232344415441232323">2</characteristic>
+        <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 1, Blast (3&quot;), Instant Death, Armourbane, Gets Hot</characteristic>
       </characteristics>
     </profile>
-    <profile id="4209-a82b-d7a3-bdf1" name="Adrastus Bolt Caliver (Bolt Volley)" book="HH7" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
+    <profile id="4209-a82b-d7a3-bdf1" name="Adrastus Bolt Caliver (Bolt Volley)" publicationId="a30a-7522-pubN95872" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
-        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="30&quot;"/>
-        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="5"/>
-        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="4"/>
-        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Assault 3"/>
+        <characteristic name="Range" typeId="52616e676523232344415441232323">30&quot;</characteristic>
+        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">5</characteristic>
+        <characteristic name="AP" typeId="415023232344415441232323">4</characteristic>
+        <characteristic name="Type" typeId="5479706523232344415441232323">Assault 3</characteristic>
       </characteristics>
     </profile>
-    <profile id="c74d-90b4-32aa-e89f" name="Adrastus Bolt Caliver (Disintegration Beam)" book="HH7" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
+    <profile id="c74d-90b4-32aa-e89f" name="Adrastus Bolt Caliver (Disintegration Beam)" publicationId="a30a-7522-pubN95872" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
-        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="12&quot;"/>
-        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="5"/>
-        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="2"/>
-        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Assault 1, Instant Daeth, Armourbane, Gets Hot"/>
+        <characteristic name="Range" typeId="52616e676523232344415441232323">12&quot;</characteristic>
+        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">5</characteristic>
+        <characteristic name="AP" typeId="415023232344415441232323">2</characteristic>
+        <characteristic name="Type" typeId="5479706523232344415441232323">Assault 1, Instant Daeth, Armourbane, Gets Hot</characteristic>
       </characteristics>
     </profile>
-    <profile id="2f59-72d5-423f-9303" name="Lastrum Storm Bolter" book="HH7" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
+    <profile id="2f59-72d5-423f-9303" name="Lastrum Storm Bolter" publicationId="a30a-7522-pubN95872" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
-        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="24&quot;"/>
-        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="5"/>
-        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="4"/>
-        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Assault 2, Heilothermic Detonation"/>
+        <characteristic name="Range" typeId="52616e676523232344415441232323">24&quot;</characteristic>
+        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">5</characteristic>
+        <characteristic name="AP" typeId="415023232344415441232323">4</characteristic>
+        <characteristic name="Type" typeId="5479706523232344415441232323">Assault 2, Heilothermic Detonation</characteristic>
       </characteristics>
     </profile>
-    <profile id="6e09-5e34-f395-cd3d" name="Lastrum Bolt Cannon" book="HH7" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
+    <profile id="6e09-5e34-f395-cd3d" name="Lastrum Bolt Cannon" publicationId="a30a-7522-pubN95872" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
-        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="36&quot;"/>
-        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="6"/>
-        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="3"/>
-        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 3, Heliothermic Detonation"/>
+        <characteristic name="Range" typeId="52616e676523232344415441232323">36&quot;</characteristic>
+        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">6</characteristic>
+        <characteristic name="AP" typeId="415023232344415441232323">3</characteristic>
+        <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 3, Heliothermic Detonation</characteristic>
       </characteristics>
     </profile>
-    <profile id="77bf-13f3-9413-a331" name="Illastus Accelerator Cannon" book="HH7" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
+    <profile id="77bf-13f3-9413-a331" name="Illastus Accelerator Cannon" publicationId="a30a-7522-pubN95872" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
-        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="60&quot;"/>
-        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="7"/>
-        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="2"/>
-        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 3, Rending, Rapid Tracking, Heliothermic Detonation"/>
+        <characteristic name="Range" typeId="52616e676523232344415441232323">60&quot;</characteristic>
+        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">7</characteristic>
+        <characteristic name="AP" typeId="415023232344415441232323">2</characteristic>
+        <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 3, Rending, Rapid Tracking, Heliothermic Detonation</characteristic>
       </characteristics>
     </profile>
-    <profile id="20a0-9b92-39e5-592b" name="Infernus Incinerator" book="HH7" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
+    <profile id="20a0-9b92-39e5-592b" name="Infernus Incinerator" publicationId="a30a-7522-pubN95872" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
-        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="Template"/>
-        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="6"/>
-        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="4"/>
-        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 1"/>
+        <characteristic name="Range" typeId="52616e676523232344415441232323">Template</characteristic>
+        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">6</characteristic>
+        <characteristic name="AP" typeId="415023232344415441232323">4</characteristic>
+        <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 1</characteristic>
       </characteristics>
     </profile>
-    <profile id="63ea-1d6c-119b-ccb1" name="Infernum Firepike" book="HH7" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
+    <profile id="63ea-1d6c-119b-ccb1" name="Infernum Firepike" publicationId="a30a-7522-pubN95872" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
-        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="Template"/>
-        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="6"/>
-        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="6"/>
-        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 1, Torrent"/>
+        <characteristic name="Range" typeId="52616e676523232344415441232323">Template</characteristic>
+        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">6</characteristic>
+        <characteristic name="AP" typeId="415023232344415441232323">6</characteristic>
+        <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 1, Torrent</characteristic>
       </characteristics>
     </profile>
-    <profile id="1968-4e55-18f3-4c72" name="Proteus Las Lance" book="HH7" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
+    <profile id="1968-4e55-18f3-4c72" name="Proteus Las Lance" publicationId="a30a-7522-pubN95872" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
-        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="24&quot;"/>
-        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="7"/>
-        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="2"/>
-        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 2, Lance"/>
+        <characteristic name="Range" typeId="52616e676523232344415441232323">24&quot;</characteristic>
+        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">7</characteristic>
+        <characteristic name="AP" typeId="415023232344415441232323">2</characteristic>
+        <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 2, Lance</characteristic>
       </characteristics>
     </profile>
-    <profile id="5076-87fe-92aa-f4a9" name="Corve Las-Pulser" book="HH7" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
+    <profile id="5076-87fe-92aa-f4a9" name="Corve Las-Pulser" publicationId="a30a-7522-pubN95872" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
-        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="36&quot;"/>
-        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="9"/>
-        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="2"/>
-        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy D3"/>
+        <characteristic name="Range" typeId="52616e676523232344415441232323">36&quot;</characteristic>
+        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">9</characteristic>
+        <characteristic name="AP" typeId="415023232344415441232323">2</characteristic>
+        <characteristic name="Type" typeId="5479706523232344415441232323">Heavy D3</characteristic>
       </characteristics>
     </profile>
-    <profile id="458c-cc54-229f-324d" name="Arachnus Blaze Cannon (Concentrated Blast)" book="HH7" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
+    <profile id="458c-cc54-229f-324d" name="Arachnus Blaze Cannon (Concentrated Blast)" publicationId="a30a-7522-pubN95872" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
-        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="48&quot;"/>
-        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="8"/>
-        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="1"/>
-        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 1, Exoshock"/>
+        <characteristic name="Range" typeId="52616e676523232344415441232323">48&quot;</characteristic>
+        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">8</characteristic>
+        <characteristic name="AP" typeId="415023232344415441232323">1</characteristic>
+        <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 1, Exoshock</characteristic>
       </characteristics>
     </profile>
-    <profile id="3e1e-6409-2b91-7534" name="Arachnus Blaze Cannon (Burst Fire)" book="HH7" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
+    <profile id="3e1e-6409-2b91-7534" name="Arachnus Blaze Cannon (Burst Fire)" publicationId="a30a-7522-pubN95872" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
-        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="36&quot;"/>
-        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="6"/>
-        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="5"/>
-        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 3"/>
+        <characteristic name="Range" typeId="52616e676523232344415441232323">36&quot;</characteristic>
+        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">6</characteristic>
+        <characteristic name="AP" typeId="415023232344415441232323">5</characteristic>
+        <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 3</characteristic>
       </characteristics>
     </profile>
-    <profile id="9262-8169-5662-60de" name="Arachnus Heavy Blaze Cannon (Concentrated Blast)" book="HH7" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
+    <profile id="9262-8169-5662-60de" name="Arachnus Heavy Blaze Cannon (Concentrated Blast)" publicationId="a30a-7522-pubN95872" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
-        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="72&quot;"/>
-        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="10"/>
-        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="1"/>
-        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 1, Exoshock"/>
+        <characteristic name="Range" typeId="52616e676523232344415441232323">72&quot;</characteristic>
+        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">10</characteristic>
+        <characteristic name="AP" typeId="415023232344415441232323">1</characteristic>
+        <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 1, Exoshock</characteristic>
       </characteristics>
     </profile>
-    <profile id="e58e-67e0-e173-1f8b" name="Arachnus Heavy Blaze Cannon (Burst Fire)" book="HH7" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
+    <profile id="e58e-67e0-e173-1f8b" name="Arachnus Heavy Blaze Cannon (Burst Fire)" publicationId="a30a-7522-pubN95872" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
-        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="48&quot;"/>
-        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="8"/>
-        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="3"/>
-        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 4"/>
+        <characteristic name="Range" typeId="52616e676523232344415441232323">48&quot;</characteristic>
+        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">8</characteristic>
+        <characteristic name="AP" typeId="415023232344415441232323">3</characteristic>
+        <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 4</characteristic>
       </characteristics>
     </profile>
-    <profile id="a234-e343-fb57-423f" name="Psyk-Out Grenade (Thrown)" book="HH7" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
+    <profile id="a234-e343-fb57-423f" name="Psyk-Out Grenade (Thrown)" publicationId="a30a-7522-pubN95872" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
-        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="8"/>
-        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="2"/>
-        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="-"/>
-        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Assault 1, Blast, Psi-Shock"/>
+        <characteristic name="Range" typeId="52616e676523232344415441232323">8</characteristic>
+        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">2</characteristic>
+        <characteristic name="AP" typeId="415023232344415441232323">-</characteristic>
+        <characteristic name="Type" typeId="5479706523232344415441232323">Assault 1, Blast, Psi-Shock</characteristic>
       </characteristics>
     </profile>
-    <profile id="a5ee-4cdc-5ced-c368" name="Stake-Crossbow" book="HH7" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
+    <profile id="a5ee-4cdc-5ced-c368" name="Stake-Crossbow" publicationId="a30a-7522-pubN95872" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
-        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="24"/>
-        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="5"/>
-        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="-"/>
-        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Rapid Fire, Psi-Shock"/>
+        <characteristic name="Range" typeId="52616e676523232344415441232323">24</characteristic>
+        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">5</characteristic>
+        <characteristic name="AP" typeId="415023232344415441232323">-</characteristic>
+        <characteristic name="Type" typeId="5479706523232344415441232323">Rapid Fire, Psi-Shock</characteristic>
       </characteristics>
     </profile>
-    <profile id="432e-7f24-6937-aa48" name="Psyk-Out Grenade (Launcher)" book="HH7" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
+    <profile id="432e-7f24-6937-aa48" name="Psyk-Out Grenade (Launcher)" publicationId="a30a-7522-pubN95872" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
-        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="24"/>
-        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="2"/>
-        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="-"/>
-        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Assault 1, Blast, Psi-Shock "/>
+        <characteristic name="Range" typeId="52616e676523232344415441232323">24</characteristic>
+        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">2</characteristic>
+        <characteristic name="AP" typeId="415023232344415441232323">-</characteristic>
+        <characteristic name="Type" typeId="5479706523232344415441232323">Assault 1, Blast, Psi-Shock </characteristic>
       </characteristics>
     </profile>
-    <profile id="fab0-4815-efaa-a613" name="Psyk-Out Missile" book="HH7" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
+    <profile id="fab0-4815-efaa-a613" name="Psyk-Out Missile" publicationId="a30a-7522-pubN95872" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
-        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="48"/>
-        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="2"/>
-        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="-"/>
-        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 1, Blast, Pinning, Psi-Shock"/>
+        <characteristic name="Range" typeId="52616e676523232344415441232323">48</characteristic>
+        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">2</characteristic>
+        <characteristic name="AP" typeId="415023232344415441232323">-</characteristic>
+        <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 1, Blast, Pinning, Psi-Shock</characteristic>
       </characteristics>
     </profile>
-    <profile id="2042-be09-f23c-fbb9" name="Proteus Neuro-Lash" book="HH7" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
+    <profile id="2042-be09-f23c-fbb9" name="Proteus Neuro-Lash" publicationId="a30a-7522-pubN95872" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
-        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="-"/>
-        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="+1"/>
-        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="-"/>
-        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Melee, Two-Handed, Electro-Arc, Sweeping Strikes"/>
+        <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
+        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">+1</characteristic>
+        <characteristic name="AP" typeId="415023232344415441232323">-</characteristic>
+        <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Two-Handed, Electro-Arc, Sweeping Strikes</characteristic>
       </characteristics>
     </profile>
-    <profile id="e8e8-bbc9-fb47-e91b" name="Execution Blade" book="HH7" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
+    <profile id="e8e8-bbc9-fb47-e91b" name="Execution Blade" publicationId="a30a-7522-pubN95872" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
-        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="-"/>
-        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="+1"/>
-        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="3"/>
-        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Melee, Two-Handed, Piercing Cut, Duellist&apos;s Edge"/>
+        <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
+        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">+1</characteristic>
+        <characteristic name="AP" typeId="415023232344415441232323">3</characteristic>
+        <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Two-Handed, Piercing Cut, Duellist&apos;s Edge</characteristic>
       </characteristics>
     </profile>
-    <profile id="2d80-e016-4c0b-9a22" name="Needle Pistol" book="HH7" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
+    <profile id="2d80-e016-4c0b-9a22" name="Needle Pistol" publicationId="a30a-7522-pubN95872" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
-        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="12"/>
-        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="2"/>
-        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="5"/>
-        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Pistol, Poisoned (4+), Rending"/>
+        <characteristic name="Range" typeId="52616e676523232344415441232323">12</characteristic>
+        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">2</characteristic>
+        <characteristic name="AP" typeId="415023232344415441232323">5</characteristic>
+        <characteristic name="Type" typeId="5479706523232344415441232323">Pistol, Poisoned (4+), Rending</characteristic>
       </characteristics>
     </profile>
-    <profile id="692f-190e-f395-a636" name="Assault Needler" book="HH7" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="18"/>
-        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="2"/>
-        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="5"/>
-        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Assault 2, Poisoned (4+), Rending"/>
-      </characteristics>
+    <profile id="692f-190e-f395-a636" name="Assault Needler" publicationId="a30a-7522-pubN95872" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="52616e676523232344415441232323">18</characteristic>
+        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">2</characteristic>
+        <characteristic name="AP" typeId="415023232344415441232323">5</characteristic>
+        <characteristic name="Type" typeId="5479706523232344415441232323">Assault 2, Poisoned (4+), Rending</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="a389-4914-28ac-3c24" name="Snare Gun" publicationId="a30a-7522-pubN95872" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="52616e676523232344415441232323">12</characteristic>
+        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">*</characteristic>
+        <characteristic name="AP" typeId="415023232344415441232323">-</characteristic>
+        <characteristic name="Type" typeId="5479706523232344415441232323">Assault 1, Snare, Pinning</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="943e-ce67-f8bb-fed8" name="Shield Captain" publicationId="a30a-7522-pubN95872" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+      <characteristics>
+        <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry (Character)</characteristic>
+        <characteristic name="WS" typeId="575323232344415441232323">6</characteristic>
+        <characteristic name="BS" typeId="425323232344415441232323">5</characteristic>
+        <characteristic name="S" typeId="5323232344415441232323">5</characteristic>
+        <characteristic name="T" typeId="5423232344415441232323">5</characteristic>
+        <characteristic name="W" typeId="5723232344415441232323">4</characteristic>
+        <characteristic name="I" typeId="4923232344415441232323">6</characteristic>
+        <characteristic name="A" typeId="4123232344415441232323">5</characteristic>
+        <characteristic name="LD" typeId="4c4423232344415441232323">10</characteristic>
+        <characteristic name="Save" typeId="5361766523232344415441232323">2+</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="896c-9540-49b4-1d08" name="Charnabal Sabre" publicationId="a30a-7522-pubN105003" page="86" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+      <characteristics>
+        <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
+        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">User</characteristic>
+        <characteristic name="AP" typeId="415023232344415441232323">-</characteristic>
+        <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Rending, Deullist&apos;s Edge</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="d7f5-8d27-73ca-2c52" name="Vratine Armour" publicationId="a30a-7522-pubN95872" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
+      <characteristics>
+        <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">3+</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="69d5-d069-6768-2b5e" name="The Sword of Oblivion" publicationId="a30a-7522-pubN95872" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
+        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">+2</characteristic>
+        <characteristic name="AP" typeId="415023232344415441232323">2</characteristic>
+        <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Two-Handed, Murderous Strike, Duellist&apos;s Edge</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="3f68-d37b-6be9-3cd4" name="Oblivion Knight-Centura" publicationId="a30a-7522-pubN95872" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+      <characteristics>
+        <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry (Character)</characteristic>
+        <characteristic name="WS" typeId="575323232344415441232323">5</characteristic>
+        <characteristic name="BS" typeId="425323232344415441232323">4</characteristic>
+        <characteristic name="S" typeId="5323232344415441232323">3</characteristic>
+        <characteristic name="T" typeId="5423232344415441232323">3</characteristic>
+        <characteristic name="W" typeId="5723232344415441232323">3</characteristic>
+        <characteristic name="I" typeId="4923232344415441232323">5</characteristic>
+        <characteristic name="A" typeId="4123232344415441232323">3</characteristic>
+        <characteristic name="LD" typeId="4c4423232344415441232323">9</characteristic>
+        <characteristic name="Save" typeId="5361766523232344415441232323">2+</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="c39c-b1bf-bf79-1452" name="Questora" publicationId="a30a-7522-pubN95872" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+      <characteristics>
+        <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry</characteristic>
+        <characteristic name="WS" typeId="575323232344415441232323">4</characteristic>
+        <characteristic name="BS" typeId="425323232344415441232323">4</characteristic>
+        <characteristic name="S" typeId="5323232344415441232323">3</characteristic>
+        <characteristic name="T" typeId="5423232344415441232323">3</characteristic>
+        <characteristic name="W" typeId="5723232344415441232323">1</characteristic>
+        <characteristic name="I" typeId="4923232344415441232323">4</characteristic>
+        <characteristic name="A" typeId="4123232344415441232323">2</characteristic>
+        <characteristic name="LD" typeId="4c4423232344415441232323">9</characteristic>
+        <characteristic name="Save" typeId="5361766523232344415441232323">3+</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="58f8-6083-45f3-44e6" name="Silent Judge" publicationId="a30a-7522-pubN95872" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+      <characteristics>
+        <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry (Character)</characteristic>
+        <characteristic name="WS" typeId="575323232344415441232323">4</characteristic>
+        <characteristic name="BS" typeId="425323232344415441232323">4</characteristic>
+        <characteristic name="S" typeId="5323232344415441232323">3</characteristic>
+        <characteristic name="T" typeId="5423232344415441232323">3</characteristic>
+        <characteristic name="W" typeId="5723232344415441232323">2</characteristic>
+        <characteristic name="I" typeId="4923232344415441232323">4</characteristic>
+        <characteristic name="A" typeId="4123232344415441232323">2</characteristic>
+        <characteristic name="LD" typeId="4c4423232344415441232323">9</characteristic>
+        <characteristic name="Save" typeId="5361766523232344415441232323">3+</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="cdc5-87f0-cf6d-b250" name="Constantin Valdor" publicationId="a30a-7522-pubN77499" page="" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+      <characteristics>
+        <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry (Character)</characteristic>
+        <characteristic name="WS" typeId="575323232344415441232323">7</characteristic>
+        <characteristic name="BS" typeId="425323232344415441232323">5</characteristic>
+        <characteristic name="S" typeId="5323232344415441232323">5</characteristic>
+        <characteristic name="T" typeId="5423232344415441232323">5</characteristic>
+        <characteristic name="W" typeId="5723232344415441232323">5</characteristic>
+        <characteristic name="I" typeId="4923232344415441232323">6</characteristic>
+        <characteristic name="A" typeId="4123232344415441232323">5*</characteristic>
+        <characteristic name="LD" typeId="4c4423232344415441232323">10</characteristic>
+        <characteristic name="Save" typeId="5361766523232344415441232323">2+</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="11c2-8160-f8a0-fa51" name="Jenetia Krole" publicationId="a30a-7522-pubN95872" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+      <characteristics>
+        <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry (Character)</characteristic>
+        <characteristic name="WS" typeId="575323232344415441232323">6</characteristic>
+        <characteristic name="BS" typeId="425323232344415441232323">4</characteristic>
+        <characteristic name="S" typeId="5323232344415441232323">3</characteristic>
+        <characteristic name="T" typeId="5423232344415441232323">3</characteristic>
+        <characteristic name="W" typeId="5723232344415441232323">3</characteristic>
+        <characteristic name="I" typeId="4923232344415441232323">5</characteristic>
+        <characteristic name="A" typeId="4123232344415441232323">4</characteristic>
+        <characteristic name="LD" typeId="4c4423232344415441232323">10</characteristic>
+        <characteristic name="Save" typeId="5361766523232344415441232323">2+</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="99fd-6a57-9e37-571e" name="Custodian Guard" publicationId="a30a-7522-pubN95872" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+      <characteristics>
+        <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry (Character)</characteristic>
+        <characteristic name="WS" typeId="575323232344415441232323">5</characteristic>
+        <characteristic name="BS" typeId="425323232344415441232323">5</characteristic>
+        <characteristic name="S" typeId="5323232344415441232323">5</characteristic>
+        <characteristic name="T" typeId="5423232344415441232323">5</characteristic>
+        <characteristic name="W" typeId="5723232344415441232323">2</characteristic>
+        <characteristic name="I" typeId="4923232344415441232323">5</characteristic>
+        <characteristic name="A" typeId="4123232344415441232323">2</characteristic>
+        <characteristic name="LD" typeId="4c4423232344415441232323">9</characteristic>
+        <characteristic name="Save" typeId="5361766523232344415441232323">2+</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="c75a-ed2c-71e8-996e" name="Oblivion Knight" publicationId="a30a-7522-pubN95872" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+      <characteristics>
+        <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry</characteristic>
+        <characteristic name="WS" typeId="575323232344415441232323">4</characteristic>
+        <characteristic name="BS" typeId="425323232344415441232323">4</characteristic>
+        <characteristic name="S" typeId="5323232344415441232323">3</characteristic>
+        <characteristic name="T" typeId="5423232344415441232323">3</characteristic>
+        <characteristic name="W" typeId="5723232344415441232323">1</characteristic>
+        <characteristic name="I" typeId="4923232344415441232323">4</characteristic>
+        <characteristic name="A" typeId="4123232344415441232323">2</characteristic>
+        <characteristic name="LD" typeId="4c4423232344415441232323">8</characteristic>
+        <characteristic name="Save" typeId="5361766523232344415441232323">3+</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="619b-fd43-fe72-e4dd" name="Oblivion Knight Mistress" publicationId="a30a-7522-pubN95872" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+      <characteristics>
+        <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry (Character)</characteristic>
+        <characteristic name="WS" typeId="575323232344415441232323">4</characteristic>
+        <characteristic name="BS" typeId="425323232344415441232323">4</characteristic>
+        <characteristic name="S" typeId="5323232344415441232323">3</characteristic>
+        <characteristic name="T" typeId="5423232344415441232323">3</characteristic>
+        <characteristic name="W" typeId="5723232344415441232323">2</characteristic>
+        <characteristic name="I" typeId="4923232344415441232323">4</characteristic>
+        <characteristic name="A" typeId="4123232344415441232323">2</characteristic>
+        <characteristic name="LD" typeId="4c4423232344415441232323">9</characteristic>
+        <characteristic name="Save" typeId="5361766523232344415441232323">3+</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="c131-8798-6ce6-2bcb" name="Sentinel Guard" publicationId="a30a-7522-pubN95872" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+      <characteristics>
+        <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry (Character)</characteristic>
+        <characteristic name="WS" typeId="575323232344415441232323">5</characteristic>
+        <characteristic name="BS" typeId="425323232344415441232323">5</characteristic>
+        <characteristic name="S" typeId="5323232344415441232323">5</characteristic>
+        <characteristic name="T" typeId="5423232344415441232323">5</characteristic>
+        <characteristic name="W" typeId="5723232344415441232323">2</characteristic>
+        <characteristic name="I" typeId="4923232344415441232323">5</characteristic>
+        <characteristic name="A" typeId="4123232344415441232323">2</characteristic>
+        <characteristic name="LD" typeId="4c4423232344415441232323">9</characteristic>
+        <characteristic name="Save" typeId="5361766523232344415441232323">2+</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="074e-25bb-c644-f4bc" name="Hetaeron Guard" publicationId="a30a-7522-pubN95872" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+      <characteristics>
+        <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry (Character)</characteristic>
+        <characteristic name="WS" typeId="575323232344415441232323">5</characteristic>
+        <characteristic name="BS" typeId="425323232344415441232323">5</characteristic>
+        <characteristic name="S" typeId="5323232344415441232323">5</characteristic>
+        <characteristic name="T" typeId="5423232344415441232323">5</characteristic>
+        <characteristic name="W" typeId="5723232344415441232323">3</characteristic>
+        <characteristic name="I" typeId="4923232344415441232323">5</characteristic>
+        <characteristic name="A" typeId="4123232344415441232323">3</characteristic>
+        <characteristic name="LD" typeId="4c4423232344415441232323">10</characteristic>
+        <characteristic name="Save" typeId="5361766523232344415441232323">2+</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="6329-c318-322f-3690" name="Contemptor-Achillus Dreadnought" publicationId="a30a-7522-pubN95872" hidden="false" typeId="57616c6b657223232344415441232323" typeName="Walker">
+      <characteristics>
+        <characteristic name="WS" typeId="575323232344415441232323">6</characteristic>
+        <characteristic name="BS" typeId="425323232344415441232323">5</characteristic>
+        <characteristic name="S" typeId="5323232344415441232323">8</characteristic>
+        <characteristic name="Front" typeId="46726f6e7423232344415441232323">13</characteristic>
+        <characteristic name="Side" typeId="5369646523232344415441232323">13</characteristic>
+        <characteristic name="Rear" typeId="5265617223232344415441232323">11</characteristic>
+        <characteristic name="I" typeId="4923232344415441232323">5</characteristic>
+        <characteristic name="A" typeId="4123232344415441232323">4</characteristic>
+        <characteristic name="HP" typeId="485023232344415441232323">3</characteristic>
+        <characteristic name="Type" typeId="5479706523232344415441232323">Vehicle (Walker)</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="d87d-0686-d02f-ed9c" name="Achillus Dreadspear" publicationId="a30a-7522-pubN95872" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
+        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">10*</characteristic>
+        <characteristic name="AP" typeId="415023232344415441232323">2</characteristic>
+        <characteristic name="Type" typeId="5479706523232344415441232323">Melee, *Impaling, Master-Crafted</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="fb44-2178-c180-a450" name="Coronus Grav-Carrier" publicationId="a30a-7522-pubN95872" hidden="false" typeId="307d-047f-ca13-706b" typeName="Transport">
+      <characteristics>
+        <characteristic name="Capacity" typeId="8285-4205-b6cd-8473">12</characteristic>
+        <characteristic name="Fire Points" typeId="b270-a7f9-22b2-3702">0</characteristic>
+        <characteristic name="Access Points" typeId="d17b-0342-b1dc-b8e7">1 at the Rear</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="e63f-762a-dde4-4c66" name="Coronus Grav-Carrier" publicationId="a30a-7522-pubN95872" hidden="false" typeId="56656869636c6523232344415441232323" typeName="Vehicle">
+      <characteristics>
+        <characteristic name="BS" typeId="425323232344415441232323">5</characteristic>
+        <characteristic name="Front" typeId="46726f6e7423232344415441232323">13</characteristic>
+        <characteristic name="Side" typeId="5369646523232344415441232323">12</characteristic>
+        <characteristic name="Rear" typeId="5265617223232344415441232323">11</characteristic>
+        <characteristic name="HP" typeId="485023232344415441232323">4</characteristic>
+        <characteristic name="Type" typeId="5479706523232344415441232323">Fast Skimmer</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="78ef-cbfb-dbf3-a6ae" name="Kharon Pattern Acquisitor" publicationId="a30a-7522-pubN95872" hidden="false" typeId="307d-047f-ca13-706b" typeName="Transport">
+      <characteristics>
+        <characteristic name="Capacity" typeId="8285-4205-b6cd-8473">12</characteristic>
+        <characteristic name="Fire Points" typeId="b270-a7f9-22b2-3702">0</characteristic>
+        <characteristic name="Access Points" typeId="d17b-0342-b1dc-b8e7">1 front hatch</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="a514-a6f2-c616-52d2" name="Kharon Pattern Acquisitor" publicationId="a30a-7522-pubN95872" hidden="false" typeId="56656869636c6523232344415441232323" typeName="Vehicle">
+      <characteristics>
+        <characteristic name="BS" typeId="425323232344415441232323">4</characteristic>
+        <characteristic name="Front" typeId="46726f6e7423232344415441232323">12</characteristic>
+        <characteristic name="Side" typeId="5369646523232344415441232323">11</characteristic>
+        <characteristic name="Rear" typeId="5265617223232344415441232323">10</characteristic>
+        <characteristic name="HP" typeId="485023232344415441232323">4</characteristic>
+        <characteristic name="Type" typeId="5479706523232344415441232323">Fast Skimmer Tank</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="b2b1-a620-b8da-15a0" name="Aquilon Terminator" publicationId="a30a-7522-pubN95872" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+      <characteristics>
+        <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry (Character)</characteristic>
+        <characteristic name="WS" typeId="575323232344415441232323">5</characteristic>
+        <characteristic name="BS" typeId="425323232344415441232323">5</characteristic>
+        <characteristic name="S" typeId="5323232344415441232323">5</characteristic>
+        <characteristic name="T" typeId="5423232344415441232323">5</characteristic>
+        <characteristic name="W" typeId="5723232344415441232323">3</characteristic>
+        <characteristic name="I" typeId="4923232344415441232323">5</characteristic>
+        <characteristic name="A" typeId="4123232344415441232323">3</characteristic>
+        <characteristic name="LD" typeId="4c4423232344415441232323">9</characteristic>
+        <characteristic name="Save" typeId="5361766523232344415441232323">2+</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="0478-968b-221a-4d91" name="Prosecutor" publicationId="a30a-7522-pubN95872" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+      <characteristics>
+        <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry</characteristic>
+        <characteristic name="WS" typeId="575323232344415441232323">4</characteristic>
+        <characteristic name="BS" typeId="425323232344415441232323">4</characteristic>
+        <characteristic name="S" typeId="5323232344415441232323">3</characteristic>
+        <characteristic name="T" typeId="5423232344415441232323">3</characteristic>
+        <characteristic name="W" typeId="5723232344415441232323">1</characteristic>
+        <characteristic name="I" typeId="4923232344415441232323">4</characteristic>
+        <characteristic name="A" typeId="4123232344415441232323">1</characteristic>
+        <characteristic name="LD" typeId="4c4423232344415441232323">8</characteristic>
+        <characteristic name="Save" typeId="5361766523232344415441232323">3+</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="4c13-7e48-ffef-d350" name="Prosecutor Mistress" publicationId="a30a-7522-pubN95872" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+      <characteristics>
+        <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry (Character)</characteristic>
+        <characteristic name="WS" typeId="575323232344415441232323">4</characteristic>
+        <characteristic name="BS" typeId="425323232344415441232323">4</characteristic>
+        <characteristic name="S" typeId="5323232344415441232323">3</characteristic>
+        <characteristic name="T" typeId="5423232344415441232323">3</characteristic>
+        <characteristic name="W" typeId="5723232344415441232323">1</characteristic>
+        <characteristic name="I" typeId="4923232344415441232323">4</characteristic>
+        <characteristic name="A" typeId="4123232344415441232323">2</characteristic>
+        <characteristic name="LD" typeId="4c4423232344415441232323">9</characteristic>
+        <characteristic name="Save" typeId="5361766523232344415441232323">3+</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="84d2-df3c-0971-52b2" name="Vigilator" publicationId="a30a-7522-pubN95872" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+      <characteristics>
+        <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry</characteristic>
+        <characteristic name="WS" typeId="575323232344415441232323">4</characteristic>
+        <characteristic name="BS" typeId="425323232344415441232323">4</characteristic>
+        <characteristic name="S" typeId="5323232344415441232323">3</characteristic>
+        <characteristic name="T" typeId="5423232344415441232323">3</characteristic>
+        <characteristic name="W" typeId="5723232344415441232323">1</characteristic>
+        <characteristic name="I" typeId="4923232344415441232323">4</characteristic>
+        <characteristic name="A" typeId="4123232344415441232323">1</characteristic>
+        <characteristic name="LD" typeId="4c4423232344415441232323">8</characteristic>
+        <characteristic name="Save" typeId="5361766523232344415441232323">3+</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="516a-af98-8713-2632" name="Vigilator Mistress" publicationId="a30a-7522-pubN95872" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+      <characteristics>
+        <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry (Character)</characteristic>
+        <characteristic name="WS" typeId="575323232344415441232323">4</characteristic>
+        <characteristic name="BS" typeId="425323232344415441232323">4</characteristic>
+        <characteristic name="S" typeId="5323232344415441232323">3</characteristic>
+        <characteristic name="T" typeId="5423232344415441232323">3</characteristic>
+        <characteristic name="W" typeId="5723232344415441232323">1</characteristic>
+        <characteristic name="I" typeId="4923232344415441232323">4</characteristic>
+        <characteristic name="A" typeId="4123232344415441232323">2</characteristic>
+        <characteristic name="LD" typeId="4c4423232344415441232323">9</characteristic>
+        <characteristic name="Save" typeId="5361766523232344415441232323">3+</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="a538-26b1-51ac-5277" name="Hellion" publicationId="a30a-7522-pubN95872" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="52616e676523232344415441232323">24&quot;</characteristic>
+        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">7</characteristic>
+        <characteristic name="AP" typeId="415023232344415441232323">4</characteristic>
+        <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 4, Twin-Linked, Pinning</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="7afd-4f57-4ff4-6545" name="Pursuer" publicationId="a30a-7522-pubN95872" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+      <characteristics>
+        <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry</characteristic>
+        <characteristic name="WS" typeId="575323232344415441232323">4</characteristic>
+        <characteristic name="BS" typeId="425323232344415441232323">4</characteristic>
+        <characteristic name="S" typeId="5323232344415441232323">3</characteristic>
+        <characteristic name="T" typeId="5423232344415441232323">3</characteristic>
+        <characteristic name="W" typeId="5723232344415441232323">1</characteristic>
+        <characteristic name="I" typeId="4923232344415441232323">4</characteristic>
+        <characteristic name="A" typeId="4123232344415441232323">1</characteristic>
+        <characteristic name="LD" typeId="4c4423232344415441232323">8</characteristic>
+        <characteristic name="Save" typeId="5361766523232344415441232323">3+</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="4c14-8e91-08e2-b6c8" name="Pursuer Mistress" publicationId="a30a-7522-pubN95872" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+      <characteristics>
+        <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry (Character)</characteristic>
+        <characteristic name="WS" typeId="575323232344415441232323">4</characteristic>
+        <characteristic name="BS" typeId="425323232344415441232323">4</characteristic>
+        <characteristic name="S" typeId="5323232344415441232323">3</characteristic>
+        <characteristic name="T" typeId="5423232344415441232323">3</characteristic>
+        <characteristic name="W" typeId="5723232344415441232323">1</characteristic>
+        <characteristic name="I" typeId="4923232344415441232323">4</characteristic>
+        <characteristic name="A" typeId="4123232344415441232323">2</characteristic>
+        <characteristic name="LD" typeId="4c4423232344415441232323">9</characteristic>
+        <characteristic name="Save" typeId="5361766523232344415441232323">3+</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="0f2e-5714-931f-e35c" name="Cyber-Jackal" publicationId="a30a-7522-pubN95872" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+      <characteristics>
+        <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry</characteristic>
+        <characteristic name="WS" typeId="575323232344415441232323">4</characteristic>
+        <characteristic name="BS" typeId="425323232344415441232323">2</characteristic>
+        <characteristic name="S" typeId="5323232344415441232323">4</characteristic>
+        <characteristic name="T" typeId="5423232344415441232323">4</characteristic>
+        <characteristic name="W" typeId="5723232344415441232323">2</characteristic>
+        <characteristic name="I" typeId="4923232344415441232323">4</characteristic>
+        <characteristic name="A" typeId="4123232344415441232323">2</characteristic>
+        <characteristic name="LD" typeId="4c4423232344415441232323">5</characteristic>
+        <characteristic name="Save" typeId="5361766523232344415441232323">5+</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="b355-edee-f44f-11f3" name="Steeltalon Wing" publicationId="a30a-7522-pubN95872" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+      <characteristics>
+        <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry</characteristic>
+        <characteristic name="WS" typeId="575323232344415441232323">3</characteristic>
+        <characteristic name="BS" typeId="425323232344415441232323">0</characteristic>
+        <characteristic name="S" typeId="5323232344415441232323">3</characteristic>
+        <characteristic name="T" typeId="5423232344415441232323">2</characteristic>
+        <characteristic name="W" typeId="5723232344415441232323">3</characteristic>
+        <characteristic name="I" typeId="4923232344415441232323">5</characteristic>
+        <characteristic name="A" typeId="4123232344415441232323">3</characteristic>
+        <characteristic name="LD" typeId="4c4423232344415441232323">5</characteristic>
+        <characteristic name="Save" typeId="5361766523232344415441232323">-</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="634b-5e08-5355-c8d1" name="Gyrfalcon Jetbike" publicationId="a30a-7522-pubN95872" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
+      <characteristics>
+        <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Failed Charge distances may be re-rolled when using the jetbike.</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="dcf0-ff9a-7712-e3e1" name="Custodian Agamatus" publicationId="a30a-7522-pubN95872" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+      <characteristics>
+        <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Jetbike (Character)</characteristic>
+        <characteristic name="WS" typeId="575323232344415441232323">5</characteristic>
+        <characteristic name="BS" typeId="425323232344415441232323">5</characteristic>
+        <characteristic name="S" typeId="5323232344415441232323">5</characteristic>
+        <characteristic name="T" typeId="5423232344415441232323">6</characteristic>
+        <characteristic name="W" typeId="5723232344415441232323">2</characteristic>
+        <characteristic name="I" typeId="4923232344415441232323">5</characteristic>
+        <characteristic name="A" typeId="4123232344415441232323">2</characteristic>
+        <characteristic name="LD" typeId="4c4423232344415441232323">9</characteristic>
+        <characteristic name="Save" typeId="5361766523232344415441232323">2+</characteristic>
+      </characteristics>
     </profile>
-    <profile id="a389-4914-28ac-3c24" name="Snare Gun" book="HH7" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="12"/>
-        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="*"/>
-        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="-"/>
-        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Assault 1, Snare, Pinning"/>
-      </characteristics>
-    </profile>
-    <profile id="943e-ce67-f8bb-fed8" name="Shield Captain" book="HH7" hidden="false" profileTypeId="556e697423232344415441232323" profileTypeName="Unit">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Unit Type" characteristicTypeId="556e6974205479706523232344415441232323" value="Infantry (Character)"/>
-        <characteristic name="WS" characteristicTypeId="575323232344415441232323" value="6"/>
-        <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="5"/>
-        <characteristic name="S" characteristicTypeId="5323232344415441232323" value="5"/>
-        <characteristic name="T" characteristicTypeId="5423232344415441232323" value="5"/>
-        <characteristic name="W" characteristicTypeId="5723232344415441232323" value="4"/>
-        <characteristic name="I" characteristicTypeId="4923232344415441232323" value="6"/>
-        <characteristic name="A" characteristicTypeId="4123232344415441232323" value="5"/>
-        <characteristic name="LD" characteristicTypeId="4c4423232344415441232323" value="10"/>
-        <characteristic name="Save" characteristicTypeId="5361766523232344415441232323" value="2+"/>
-      </characteristics>
-    </profile>
-    <profile id="896c-9540-49b4-1d08" name="Charnabal Sabre" book="HH:LACAL" page="86" hidden="false" profileTypeId="576561706f6e23232344415441232323">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="-"/>
-        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="User"/>
-        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="-"/>
-        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Melee, Rending, Deullist&apos;s Edge"/>
-      </characteristics>
-    </profile>
-    <profile id="d7f5-8d27-73ca-2c52" name="Vratine Armour" book="HH7" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323" profileTypeName="Wargear Item">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Description" characteristicTypeId="4465736372697074696f6e23232344415441232323" value="3+"/>
-      </characteristics>
-    </profile>
-    <profile id="69d5-d069-6768-2b5e" name="The Sword of Oblivion" book="HH7" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="-"/>
-        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="+2"/>
-        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="2"/>
-        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Melee, Two-Handed, Murderous Strike, Duellist&apos;s Edge"/>
-      </characteristics>
-    </profile>
-    <profile id="3f68-d37b-6be9-3cd4" name="Oblivion Knight-Centura" book="HH7" hidden="false" profileTypeId="556e697423232344415441232323" profileTypeName="Unit">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Unit Type" characteristicTypeId="556e6974205479706523232344415441232323" value="Infantry (Character)"/>
-        <characteristic name="WS" characteristicTypeId="575323232344415441232323" value="5"/>
-        <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="4"/>
-        <characteristic name="S" characteristicTypeId="5323232344415441232323" value="3"/>
-        <characteristic name="T" characteristicTypeId="5423232344415441232323" value="3"/>
-        <characteristic name="W" characteristicTypeId="5723232344415441232323" value="3"/>
-        <characteristic name="I" characteristicTypeId="4923232344415441232323" value="5"/>
-        <characteristic name="A" characteristicTypeId="4123232344415441232323" value="3"/>
-        <characteristic name="LD" characteristicTypeId="4c4423232344415441232323" value="9"/>
-        <characteristic name="Save" characteristicTypeId="5361766523232344415441232323" value="2+"/>
-      </characteristics>
-    </profile>
-    <profile id="c39c-b1bf-bf79-1452" name="Questora" book="HH7" hidden="false" profileTypeId="556e697423232344415441232323" profileTypeName="Unit">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Unit Type" characteristicTypeId="556e6974205479706523232344415441232323" value="Infantry"/>
-        <characteristic name="WS" characteristicTypeId="575323232344415441232323" value="4"/>
-        <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="4"/>
-        <characteristic name="S" characteristicTypeId="5323232344415441232323" value="3"/>
-        <characteristic name="T" characteristicTypeId="5423232344415441232323" value="3"/>
-        <characteristic name="W" characteristicTypeId="5723232344415441232323" value="1"/>
-        <characteristic name="I" characteristicTypeId="4923232344415441232323" value="4"/>
-        <characteristic name="A" characteristicTypeId="4123232344415441232323" value="2"/>
-        <characteristic name="LD" characteristicTypeId="4c4423232344415441232323" value="9"/>
-        <characteristic name="Save" characteristicTypeId="5361766523232344415441232323" value="3+"/>
-      </characteristics>
-    </profile>
-    <profile id="58f8-6083-45f3-44e6" name="Silent Judge" book="HH7" hidden="false" profileTypeId="556e697423232344415441232323" profileTypeName="Unit">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Unit Type" characteristicTypeId="556e6974205479706523232344415441232323" value="Infantry (Character)"/>
-        <characteristic name="WS" characteristicTypeId="575323232344415441232323" value="4"/>
-        <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="4"/>
-        <characteristic name="S" characteristicTypeId="5323232344415441232323" value="3"/>
-        <characteristic name="T" characteristicTypeId="5423232344415441232323" value="3"/>
-        <characteristic name="W" characteristicTypeId="5723232344415441232323" value="2"/>
-        <characteristic name="I" characteristicTypeId="4923232344415441232323" value="4"/>
-        <characteristic name="A" characteristicTypeId="4123232344415441232323" value="2"/>
-        <characteristic name="LD" characteristicTypeId="4c4423232344415441232323" value="9"/>
-        <characteristic name="Save" characteristicTypeId="5361766523232344415441232323" value="3+"/>
-      </characteristics>
-    </profile>
-    <profile id="cdc5-87f0-cf6d-b250" name="Constantin Valdor" book="HH8: Malevolence" page="" hidden="false" profileTypeId="556e697423232344415441232323" profileTypeName="Unit">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Unit Type" characteristicTypeId="556e6974205479706523232344415441232323" value="Infantry (Character)"/>
-        <characteristic name="WS" characteristicTypeId="575323232344415441232323" value="7"/>
-        <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="5"/>
-        <characteristic name="S" characteristicTypeId="5323232344415441232323" value="5"/>
-        <characteristic name="T" characteristicTypeId="5423232344415441232323" value="5"/>
-        <characteristic name="W" characteristicTypeId="5723232344415441232323" value="5"/>
-        <characteristic name="I" characteristicTypeId="4923232344415441232323" value="6"/>
-        <characteristic name="A" characteristicTypeId="4123232344415441232323" value="5*"/>
-        <characteristic name="LD" characteristicTypeId="4c4423232344415441232323" value="10"/>
-        <characteristic name="Save" characteristicTypeId="5361766523232344415441232323" value="2+"/>
-      </characteristics>
-    </profile>
-    <profile id="11c2-8160-f8a0-fa51" name="Jenetia Krole" book="HH7" hidden="false" profileTypeId="556e697423232344415441232323" profileTypeName="Unit">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Unit Type" characteristicTypeId="556e6974205479706523232344415441232323" value="Infantry (Character)"/>
-        <characteristic name="WS" characteristicTypeId="575323232344415441232323" value="6"/>
-        <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="4"/>
-        <characteristic name="S" characteristicTypeId="5323232344415441232323" value="3"/>
-        <characteristic name="T" characteristicTypeId="5423232344415441232323" value="3"/>
-        <characteristic name="W" characteristicTypeId="5723232344415441232323" value="3"/>
-        <characteristic name="I" characteristicTypeId="4923232344415441232323" value="5"/>
-        <characteristic name="A" characteristicTypeId="4123232344415441232323" value="4"/>
-        <characteristic name="LD" characteristicTypeId="4c4423232344415441232323" value="10"/>
-        <characteristic name="Save" characteristicTypeId="5361766523232344415441232323" value="2+"/>
-      </characteristics>
-    </profile>
-    <profile id="99fd-6a57-9e37-571e" name="Custodian Guard" book="HH7" hidden="false" profileTypeId="556e697423232344415441232323" profileTypeName="Unit">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Unit Type" characteristicTypeId="556e6974205479706523232344415441232323" value="Infantry (Character)"/>
-        <characteristic name="WS" characteristicTypeId="575323232344415441232323" value="5"/>
-        <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="5"/>
-        <characteristic name="S" characteristicTypeId="5323232344415441232323" value="5"/>
-        <characteristic name="T" characteristicTypeId="5423232344415441232323" value="5"/>
-        <characteristic name="W" characteristicTypeId="5723232344415441232323" value="2"/>
-        <characteristic name="I" characteristicTypeId="4923232344415441232323" value="5"/>
-        <characteristic name="A" characteristicTypeId="4123232344415441232323" value="2"/>
-        <characteristic name="LD" characteristicTypeId="4c4423232344415441232323" value="9"/>
-        <characteristic name="Save" characteristicTypeId="5361766523232344415441232323" value="2+"/>
-      </characteristics>
-    </profile>
-    <profile id="c75a-ed2c-71e8-996e" name="Oblivion Knight" book="HH7" hidden="false" profileTypeId="556e697423232344415441232323" profileTypeName="Unit">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Unit Type" characteristicTypeId="556e6974205479706523232344415441232323" value="Infantry"/>
-        <characteristic name="WS" characteristicTypeId="575323232344415441232323" value="4"/>
-        <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="4"/>
-        <characteristic name="S" characteristicTypeId="5323232344415441232323" value="3"/>
-        <characteristic name="T" characteristicTypeId="5423232344415441232323" value="3"/>
-        <characteristic name="W" characteristicTypeId="5723232344415441232323" value="1"/>
-        <characteristic name="I" characteristicTypeId="4923232344415441232323" value="4"/>
-        <characteristic name="A" characteristicTypeId="4123232344415441232323" value="2"/>
-        <characteristic name="LD" characteristicTypeId="4c4423232344415441232323" value="8"/>
-        <characteristic name="Save" characteristicTypeId="5361766523232344415441232323" value="3+"/>
-      </characteristics>
-    </profile>
-    <profile id="619b-fd43-fe72-e4dd" name="Oblivion Knight Mistress" book="HH7" hidden="false" profileTypeId="556e697423232344415441232323" profileTypeName="Unit">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Unit Type" characteristicTypeId="556e6974205479706523232344415441232323" value="Infantry (Character)"/>
-        <characteristic name="WS" characteristicTypeId="575323232344415441232323" value="4"/>
-        <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="4"/>
-        <characteristic name="S" characteristicTypeId="5323232344415441232323" value="3"/>
-        <characteristic name="T" characteristicTypeId="5423232344415441232323" value="3"/>
-        <characteristic name="W" characteristicTypeId="5723232344415441232323" value="2"/>
-        <characteristic name="I" characteristicTypeId="4923232344415441232323" value="4"/>
-        <characteristic name="A" characteristicTypeId="4123232344415441232323" value="2"/>
-        <characteristic name="LD" characteristicTypeId="4c4423232344415441232323" value="9"/>
-        <characteristic name="Save" characteristicTypeId="5361766523232344415441232323" value="3+"/>
-      </characteristics>
-    </profile>
-    <profile id="c131-8798-6ce6-2bcb" name="Sentinel Guard" book="HH7" hidden="false" profileTypeId="556e697423232344415441232323" profileTypeName="Unit">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Unit Type" characteristicTypeId="556e6974205479706523232344415441232323" value="Infantry (Character)"/>
-        <characteristic name="WS" characteristicTypeId="575323232344415441232323" value="5"/>
-        <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="5"/>
-        <characteristic name="S" characteristicTypeId="5323232344415441232323" value="5"/>
-        <characteristic name="T" characteristicTypeId="5423232344415441232323" value="5"/>
-        <characteristic name="W" characteristicTypeId="5723232344415441232323" value="2"/>
-        <characteristic name="I" characteristicTypeId="4923232344415441232323" value="5"/>
-        <characteristic name="A" characteristicTypeId="4123232344415441232323" value="2"/>
-        <characteristic name="LD" characteristicTypeId="4c4423232344415441232323" value="9"/>
-        <characteristic name="Save" characteristicTypeId="5361766523232344415441232323" value="2+"/>
-      </characteristics>
-    </profile>
-    <profile id="074e-25bb-c644-f4bc" name="Hetaeron Guard" book="HH7" hidden="false" profileTypeId="556e697423232344415441232323" profileTypeName="Unit">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Unit Type" characteristicTypeId="556e6974205479706523232344415441232323" value="Infantry (Character)"/>
-        <characteristic name="WS" characteristicTypeId="575323232344415441232323" value="5"/>
-        <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="5"/>
-        <characteristic name="S" characteristicTypeId="5323232344415441232323" value="5"/>
-        <characteristic name="T" characteristicTypeId="5423232344415441232323" value="5"/>
-        <characteristic name="W" characteristicTypeId="5723232344415441232323" value="3"/>
-        <characteristic name="I" characteristicTypeId="4923232344415441232323" value="5"/>
-        <characteristic name="A" characteristicTypeId="4123232344415441232323" value="3"/>
-        <characteristic name="LD" characteristicTypeId="4c4423232344415441232323" value="10"/>
-        <characteristic name="Save" characteristicTypeId="5361766523232344415441232323" value="2+"/>
-      </characteristics>
-    </profile>
-    <profile id="6329-c318-322f-3690" name="Contemptor-Achillus Dreadnought" book="HH7" hidden="false" profileTypeId="57616c6b657223232344415441232323" profileTypeName="Walker">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="WS" characteristicTypeId="575323232344415441232323" value="6"/>
-        <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="5"/>
-        <characteristic name="S" characteristicTypeId="5323232344415441232323" value="8"/>
-        <characteristic name="Front" characteristicTypeId="46726f6e7423232344415441232323" value="13"/>
-        <characteristic name="Side" characteristicTypeId="5369646523232344415441232323" value="13"/>
-        <characteristic name="Rear" characteristicTypeId="5265617223232344415441232323" value="11"/>
-        <characteristic name="I" characteristicTypeId="4923232344415441232323" value="5"/>
-        <characteristic name="A" characteristicTypeId="4123232344415441232323" value="4"/>
-        <characteristic name="HP" characteristicTypeId="485023232344415441232323" value="3"/>
-        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Vehicle (Walker)"/>
-      </characteristics>
-    </profile>
-    <profile id="d87d-0686-d02f-ed9c" name="Achillus Dreadspear" book="HH7" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="-"/>
-        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="10*"/>
-        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="2"/>
-        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Melee, *Impaling, Master-Crafted"/>
-      </characteristics>
-    </profile>
-    <profile id="fb44-2178-c180-a450" name="Coronus Grav-Carrier" book="HH7" hidden="false" profileTypeId="307d-047f-ca13-706b" profileTypeName="Transport">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Capacity" characteristicTypeId="8285-4205-b6cd-8473" value="12"/>
-        <characteristic name="Fire Points" characteristicTypeId="b270-a7f9-22b2-3702" value="0"/>
-        <characteristic name="Access Points" characteristicTypeId="d17b-0342-b1dc-b8e7" value="1 at the Rear"/>
-      </characteristics>
-    </profile>
-    <profile id="e63f-762a-dde4-4c66" name="Coronus Grav-Carrier" book="HH7" hidden="false" profileTypeId="56656869636c6523232344415441232323" profileTypeName="Vehicle">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="5"/>
-        <characteristic name="Front" characteristicTypeId="46726f6e7423232344415441232323" value="13"/>
-        <characteristic name="Side" characteristicTypeId="5369646523232344415441232323" value="12"/>
-        <characteristic name="Rear" characteristicTypeId="5265617223232344415441232323" value="11"/>
-        <characteristic name="HP" characteristicTypeId="485023232344415441232323" value="4"/>
-        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Fast Skimmer"/>
-      </characteristics>
-    </profile>
-    <profile id="78ef-cbfb-dbf3-a6ae" name="Kharon Pattern Acquisitor" book="HH7" hidden="false" profileTypeId="307d-047f-ca13-706b" profileTypeName="Transport">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Capacity" characteristicTypeId="8285-4205-b6cd-8473" value="12"/>
-        <characteristic name="Fire Points" characteristicTypeId="b270-a7f9-22b2-3702" value="0"/>
-        <characteristic name="Access Points" characteristicTypeId="d17b-0342-b1dc-b8e7" value="1 front hatch"/>
-      </characteristics>
-    </profile>
-    <profile id="a514-a6f2-c616-52d2" name="Kharon Pattern Acquisitor" book="HH7" hidden="false" profileTypeId="56656869636c6523232344415441232323" profileTypeName="Vehicle">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="4"/>
-        <characteristic name="Front" characteristicTypeId="46726f6e7423232344415441232323" value="12"/>
-        <characteristic name="Side" characteristicTypeId="5369646523232344415441232323" value="11"/>
-        <characteristic name="Rear" characteristicTypeId="5265617223232344415441232323" value="10"/>
-        <characteristic name="HP" characteristicTypeId="485023232344415441232323" value="4"/>
-        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Fast Skimmer Tank"/>
-      </characteristics>
-    </profile>
-    <profile id="b2b1-a620-b8da-15a0" name="Aquilon Terminator" book="HH7" hidden="false" profileTypeId="556e697423232344415441232323" profileTypeName="Unit">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Unit Type" characteristicTypeId="556e6974205479706523232344415441232323" value="Infantry (Character)"/>
-        <characteristic name="WS" characteristicTypeId="575323232344415441232323" value="5"/>
-        <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="5"/>
-        <characteristic name="S" characteristicTypeId="5323232344415441232323" value="5"/>
-        <characteristic name="T" characteristicTypeId="5423232344415441232323" value="5"/>
-        <characteristic name="W" characteristicTypeId="5723232344415441232323" value="3"/>
-        <characteristic name="I" characteristicTypeId="4923232344415441232323" value="5"/>
-        <characteristic name="A" characteristicTypeId="4123232344415441232323" value="3"/>
-        <characteristic name="LD" characteristicTypeId="4c4423232344415441232323" value="9"/>
-        <characteristic name="Save" characteristicTypeId="5361766523232344415441232323" value="2+"/>
-      </characteristics>
-    </profile>
-    <profile id="0478-968b-221a-4d91" name="Prosecutor" book="HH7" hidden="false" profileTypeId="556e697423232344415441232323" profileTypeName="Unit">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Unit Type" characteristicTypeId="556e6974205479706523232344415441232323" value="Infantry"/>
-        <characteristic name="WS" characteristicTypeId="575323232344415441232323" value="4"/>
-        <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="4"/>
-        <characteristic name="S" characteristicTypeId="5323232344415441232323" value="3"/>
-        <characteristic name="T" characteristicTypeId="5423232344415441232323" value="3"/>
-        <characteristic name="W" characteristicTypeId="5723232344415441232323" value="1"/>
-        <characteristic name="I" characteristicTypeId="4923232344415441232323" value="4"/>
-        <characteristic name="A" characteristicTypeId="4123232344415441232323" value="1"/>
-        <characteristic name="LD" characteristicTypeId="4c4423232344415441232323" value="8"/>
-        <characteristic name="Save" characteristicTypeId="5361766523232344415441232323" value="3+"/>
-      </characteristics>
-    </profile>
-    <profile id="4c13-7e48-ffef-d350" name="Prosecutor Mistress" book="HH7" hidden="false" profileTypeId="556e697423232344415441232323" profileTypeName="Unit">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Unit Type" characteristicTypeId="556e6974205479706523232344415441232323" value="Infantry (Character)"/>
-        <characteristic name="WS" characteristicTypeId="575323232344415441232323" value="4"/>
-        <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="4"/>
-        <characteristic name="S" characteristicTypeId="5323232344415441232323" value="3"/>
-        <characteristic name="T" characteristicTypeId="5423232344415441232323" value="3"/>
-        <characteristic name="W" characteristicTypeId="5723232344415441232323" value="1"/>
-        <characteristic name="I" characteristicTypeId="4923232344415441232323" value="4"/>
-        <characteristic name="A" characteristicTypeId="4123232344415441232323" value="2"/>
-        <characteristic name="LD" characteristicTypeId="4c4423232344415441232323" value="9"/>
-        <characteristic name="Save" characteristicTypeId="5361766523232344415441232323" value="3+"/>
-      </characteristics>
-    </profile>
-    <profile id="84d2-df3c-0971-52b2" name="Vigilator" book="HH7" hidden="false" profileTypeId="556e697423232344415441232323" profileTypeName="Unit">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Unit Type" characteristicTypeId="556e6974205479706523232344415441232323" value="Infantry"/>
-        <characteristic name="WS" characteristicTypeId="575323232344415441232323" value="4"/>
-        <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="4"/>
-        <characteristic name="S" characteristicTypeId="5323232344415441232323" value="3"/>
-        <characteristic name="T" characteristicTypeId="5423232344415441232323" value="3"/>
-        <characteristic name="W" characteristicTypeId="5723232344415441232323" value="1"/>
-        <characteristic name="I" characteristicTypeId="4923232344415441232323" value="4"/>
-        <characteristic name="A" characteristicTypeId="4123232344415441232323" value="1"/>
-        <characteristic name="LD" characteristicTypeId="4c4423232344415441232323" value="8"/>
-        <characteristic name="Save" characteristicTypeId="5361766523232344415441232323" value="3+"/>
-      </characteristics>
-    </profile>
-    <profile id="516a-af98-8713-2632" name="Vigilator Mistress" book="HH7" hidden="false" profileTypeId="556e697423232344415441232323" profileTypeName="Unit">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Unit Type" characteristicTypeId="556e6974205479706523232344415441232323" value="Infantry (Character)"/>
-        <characteristic name="WS" characteristicTypeId="575323232344415441232323" value="4"/>
-        <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="4"/>
-        <characteristic name="S" characteristicTypeId="5323232344415441232323" value="3"/>
-        <characteristic name="T" characteristicTypeId="5423232344415441232323" value="3"/>
-        <characteristic name="W" characteristicTypeId="5723232344415441232323" value="1"/>
-        <characteristic name="I" characteristicTypeId="4923232344415441232323" value="4"/>
-        <characteristic name="A" characteristicTypeId="4123232344415441232323" value="2"/>
-        <characteristic name="LD" characteristicTypeId="4c4423232344415441232323" value="9"/>
-        <characteristic name="Save" characteristicTypeId="5361766523232344415441232323" value="3+"/>
-      </characteristics>
-    </profile>
-    <profile id="a538-26b1-51ac-5277" name="Hellion" book="HH7" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="24&quot;"/>
-        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="7"/>
-        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="4"/>
-        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 4, Twin-Linked, Pinning"/>
-      </characteristics>
-    </profile>
-    <profile id="7afd-4f57-4ff4-6545" name="Pursuer" book="HH7" hidden="false" profileTypeId="556e697423232344415441232323" profileTypeName="Unit">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Unit Type" characteristicTypeId="556e6974205479706523232344415441232323" value="Infantry"/>
-        <characteristic name="WS" characteristicTypeId="575323232344415441232323" value="4"/>
-        <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="4"/>
-        <characteristic name="S" characteristicTypeId="5323232344415441232323" value="3"/>
-        <characteristic name="T" characteristicTypeId="5423232344415441232323" value="3"/>
-        <characteristic name="W" characteristicTypeId="5723232344415441232323" value="1"/>
-        <characteristic name="I" characteristicTypeId="4923232344415441232323" value="4"/>
-        <characteristic name="A" characteristicTypeId="4123232344415441232323" value="1"/>
-        <characteristic name="LD" characteristicTypeId="4c4423232344415441232323" value="8"/>
-        <characteristic name="Save" characteristicTypeId="5361766523232344415441232323" value="3+"/>
-      </characteristics>
-    </profile>
-    <profile id="4c14-8e91-08e2-b6c8" name="Pursuer Mistress" book="HH7" hidden="false" profileTypeId="556e697423232344415441232323" profileTypeName="Unit">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Unit Type" characteristicTypeId="556e6974205479706523232344415441232323" value="Infantry (Character)"/>
-        <characteristic name="WS" characteristicTypeId="575323232344415441232323" value="4"/>
-        <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="4"/>
-        <characteristic name="S" characteristicTypeId="5323232344415441232323" value="3"/>
-        <characteristic name="T" characteristicTypeId="5423232344415441232323" value="3"/>
-        <characteristic name="W" characteristicTypeId="5723232344415441232323" value="1"/>
-        <characteristic name="I" characteristicTypeId="4923232344415441232323" value="4"/>
-        <characteristic name="A" characteristicTypeId="4123232344415441232323" value="2"/>
-        <characteristic name="LD" characteristicTypeId="4c4423232344415441232323" value="9"/>
-        <characteristic name="Save" characteristicTypeId="5361766523232344415441232323" value="3+"/>
-      </characteristics>
-    </profile>
-    <profile id="0f2e-5714-931f-e35c" name="Cyber-Jackal" book="HH7" hidden="false" profileTypeId="556e697423232344415441232323" profileTypeName="Unit">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Unit Type" characteristicTypeId="556e6974205479706523232344415441232323" value="Infantry"/>
-        <characteristic name="WS" characteristicTypeId="575323232344415441232323" value="4"/>
-        <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="2"/>
-        <characteristic name="S" characteristicTypeId="5323232344415441232323" value="4"/>
-        <characteristic name="T" characteristicTypeId="5423232344415441232323" value="4"/>
-        <characteristic name="W" characteristicTypeId="5723232344415441232323" value="2"/>
-        <characteristic name="I" characteristicTypeId="4923232344415441232323" value="4"/>
-        <characteristic name="A" characteristicTypeId="4123232344415441232323" value="2"/>
-        <characteristic name="LD" characteristicTypeId="4c4423232344415441232323" value="5"/>
-        <characteristic name="Save" characteristicTypeId="5361766523232344415441232323" value="5+"/>
-      </characteristics>
-    </profile>
-    <profile id="b355-edee-f44f-11f3" name="Steeltalon Wing" book="HH7" hidden="false" profileTypeId="556e697423232344415441232323" profileTypeName="Unit">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Unit Type" characteristicTypeId="556e6974205479706523232344415441232323" value="Infantry"/>
-        <characteristic name="WS" characteristicTypeId="575323232344415441232323" value="3"/>
-        <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="0"/>
-        <characteristic name="S" characteristicTypeId="5323232344415441232323" value="3"/>
-        <characteristic name="T" characteristicTypeId="5423232344415441232323" value="2"/>
-        <characteristic name="W" characteristicTypeId="5723232344415441232323" value="3"/>
-        <characteristic name="I" characteristicTypeId="4923232344415441232323" value="5"/>
-        <characteristic name="A" characteristicTypeId="4123232344415441232323" value="3"/>
-        <characteristic name="LD" characteristicTypeId="4c4423232344415441232323" value="5"/>
-        <characteristic name="Save" characteristicTypeId="5361766523232344415441232323" value="-"/>
-      </characteristics>
-    </profile>
-    <profile id="634b-5e08-5355-c8d1" name="Gyrfalcon Jetbike" book="HH7" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323" profileTypeName="Wargear Item">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Description" characteristicTypeId="4465736372697074696f6e23232344415441232323" value="Failed Charge distances may be re-rolled when using the jetbike."/>
-      </characteristics>
-    </profile>
-    <profile id="dcf0-ff9a-7712-e3e1" name="Custodian Agamatus" book="HH7" hidden="false" profileTypeId="556e697423232344415441232323" profileTypeName="Unit">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Unit Type" characteristicTypeId="556e6974205479706523232344415441232323" value="Jetbike (Character)"/>
-        <characteristic name="WS" characteristicTypeId="575323232344415441232323" value="5"/>
-        <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="5"/>
-        <characteristic name="S" characteristicTypeId="5323232344415441232323" value="5"/>
-        <characteristic name="T" characteristicTypeId="5423232344415441232323" value="6"/>
-        <characteristic name="W" characteristicTypeId="5723232344415441232323" value="2"/>
-        <characteristic name="I" characteristicTypeId="4923232344415441232323" value="5"/>
-        <characteristic name="A" characteristicTypeId="4123232344415441232323" value="2"/>
-        <characteristic name="LD" characteristicTypeId="4c4423232344415441232323" value="9"/>
-        <characteristic name="Save" characteristicTypeId="5361766523232344415441232323" value="2+"/>
-      </characteristics>
-    </profile>
-    <profile id="a222-27fb-496a-dc5e" name="Pallas Grav-Attack" book="HH7" hidden="false" profileTypeId="56656869636c6523232344415441232323" profileTypeName="Vehicle">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="5"/>
-        <characteristic name="Front" characteristicTypeId="46726f6e7423232344415441232323" value="12"/>
-        <characteristic name="Side" characteristicTypeId="5369646523232344415441232323" value="11"/>
-        <characteristic name="Rear" characteristicTypeId="5265617223232344415441232323" value="11"/>
-        <characteristic name="HP" characteristicTypeId="485023232344415441232323" value="2"/>
-        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Fast, Skimmer"/>
-      </characteristics>
-    </profile>
-    <profile id="0ee6-f79c-ff88-7773" name="Seeker" book="HH7" hidden="false" profileTypeId="556e697423232344415441232323" profileTypeName="Unit">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Unit Type" characteristicTypeId="556e6974205479706523232344415441232323" value="Infantry"/>
-        <characteristic name="WS" characteristicTypeId="575323232344415441232323" value="4"/>
-        <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="4"/>
-        <characteristic name="S" characteristicTypeId="5323232344415441232323" value="3"/>
-        <characteristic name="T" characteristicTypeId="5423232344415441232323" value="3"/>
-        <characteristic name="W" characteristicTypeId="5723232344415441232323" value="1"/>
-        <characteristic name="I" characteristicTypeId="4923232344415441232323" value="4"/>
-        <characteristic name="A" characteristicTypeId="4123232344415441232323" value="1"/>
-        <characteristic name="LD" characteristicTypeId="4c4423232344415441232323" value="8"/>
-        <characteristic name="Save" characteristicTypeId="5361766523232344415441232323" value="3+"/>
-      </characteristics>
-    </profile>
-    <profile id="d18b-f29b-a2b1-d194" name="Seeker Mistress" book="HH7" hidden="false" profileTypeId="556e697423232344415441232323" profileTypeName="Unit">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Unit Type" characteristicTypeId="556e6974205479706523232344415441232323" value="Infantry (Character)"/>
-        <characteristic name="WS" characteristicTypeId="575323232344415441232323" value="4"/>
-        <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="4"/>
-        <characteristic name="S" characteristicTypeId="5323232344415441232323" value="3"/>
-        <characteristic name="T" characteristicTypeId="5423232344415441232323" value="3"/>
-        <characteristic name="W" characteristicTypeId="5723232344415441232323" value="1"/>
-        <characteristic name="I" characteristicTypeId="4923232344415441232323" value="4"/>
-        <characteristic name="A" characteristicTypeId="4123232344415441232323" value="2"/>
-        <characteristic name="LD" characteristicTypeId="4c4423232344415441232323" value="9"/>
-        <characteristic name="Save" characteristicTypeId="5361766523232344415441232323" value="3+"/>
-      </characteristics>
-    </profile>
-    <profile id="5a99-1a1a-7c69-3613" name="Galatus Warblade" book="HH7" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="Melee"/>
-        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="x2"/>
-        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="2"/>
-        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Melee, Shred, Rampage"/>
-      </characteristics>
-    </profile>
-    <profile id="0b06-b727-909f-9126" name="Contemptor-Galatus Dreadnought" book="HH7" page="" hidden="false" profileTypeId="57616c6b657223232344415441232323" profileTypeName="Walker">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="WS" characteristicTypeId="575323232344415441232323" value="6"/>
-        <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="5"/>
-        <characteristic name="S" characteristicTypeId="5323232344415441232323" value="8"/>
-        <characteristic name="Front" characteristicTypeId="46726f6e7423232344415441232323" value="13"/>
-        <characteristic name="Side" characteristicTypeId="5369646523232344415441232323" value="13"/>
-        <characteristic name="Rear" characteristicTypeId="5265617223232344415441232323" value="11"/>
-        <characteristic name="I" characteristicTypeId="4923232344415441232323" value="5"/>
-        <characteristic name="A" characteristicTypeId="4123232344415441232323" value="4"/>
-        <characteristic name="HP" characteristicTypeId="485023232344415441232323" value="3"/>
-        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Walker"/>
-      </characteristics>
-    </profile>
-    <profile id="767b-d879-1e5f-bc94" name="Dreadnought Praesidium Shield" book="HH8" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323" profileTypeName="Wargear Item">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Description" characteristicTypeId="4465736372697074696f6e23232344415441232323" value="When subject to attacks originating in its Front Arc, or in assault, the model&apos;s invulnerable save is increased to 4+. In addition, attacks made in assault against it, other than by Gargantuan units and Super-Heavy Walkers, suffer a -1 penalty to hit (to a maximum of 6+) - note that this penalty has no effect on attacks which hit automatically."/>
-      </characteristics>
-    </profile>
-    <profile id="3a85-e9c8-548f-9c71" name="Paragon Power Blade" book="HH7" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="Melee"/>
-        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="+1/+2*"/>
-        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="2"/>
-        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Melee, Lightning Blows, Murderous Strike, Specialist Weapon"/>
-      </characteristics>
-    </profile>
-    <profile id="7001-00aa-5d65-dbd8" name="The Apollonian Spear Power Blade" book="HH7" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="Melee"/>
-        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="+1/+2*"/>
-        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="2"/>
-        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Melee, Lightning Blows, Murderous Strike, Molecular Severance, Specialist Weapon"/>
-      </characteristics>
-    </profile>
-    <profile id="3912-42bf-2de6-6611" name="Hyper-Velocity Bolter" book="HH7" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="18&quot;"/>
-        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="5"/>
-        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="2"/>
-        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Assault 2, Concussive"/>
-      </characteristics>
-    </profile>
-    <profile id="bd4f-4ba1-a337-9b50" name="Illastus Accelerator Culverin" book="HH7" hidden="false" profileTypeId="576561706f6e23232344415441232323" profileTypeName="Weapon">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Range" characteristicTypeId="52616e676523232344415441232323" value="36&quot;"/>
-        <characteristic name="Strength" characteristicTypeId="537472656e67746823232344415441232323" value="7"/>
-        <characteristic name="AP" characteristicTypeId="415023232344415441232323" value="2"/>
-        <characteristic name="Type" characteristicTypeId="5479706523232344415441232323" value="Heavy 5, Rending, Heliothermic Detonation"/>
-      </characteristics>
-    </profile>
-    <profile id="783e-c8f7-4312-98c7" name="Custodian Jump Harness" book="" hidden="false" profileTypeId="57617267656172204974656d23232344415441232323" profileTypeName="Wargear Item">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Description" characteristicTypeId="4465736372697074696f6e23232344415441232323" value="Custodian jump harness provides a 3+ armour save and the Auramite Pinions special rule."/>
-      </characteristics>
-    </profile>
-    <profile id="11d9-f1a7-f2de-8ffa" name="Custodian Venatari" book="" hidden="false" profileTypeId="556e697423232344415441232323" profileTypeName="Unit">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Unit Type" characteristicTypeId="556e6974205479706523232344415441232323" value="Jump Infantry (Character)"/>
-        <characteristic name="WS" characteristicTypeId="575323232344415441232323" value="5"/>
-        <characteristic name="BS" characteristicTypeId="425323232344415441232323" value="5"/>
-        <characteristic name="S" characteristicTypeId="5323232344415441232323" value="5"/>
-        <characteristic name="T" characteristicTypeId="5423232344415441232323" value="5"/>
-        <characteristic name="W" characteristicTypeId="5723232344415441232323" value="2"/>
-        <characteristic name="I" characteristicTypeId="4923232344415441232323" value="5"/>
-        <characteristic name="A" characteristicTypeId="4123232344415441232323" value="2"/>
-        <characteristic name="LD" characteristicTypeId="4c4423232344415441232323" value="9"/>
-        <characteristic name="Save" characteristicTypeId="5361766523232344415441232323" value="3+"/>
+    <profile id="a222-27fb-496a-dc5e" name="Pallas Grav-Attack" publicationId="a30a-7522-pubN95872" hidden="false" typeId="56656869636c6523232344415441232323" typeName="Vehicle">
+      <characteristics>
+        <characteristic name="BS" typeId="425323232344415441232323">5</characteristic>
+        <characteristic name="Front" typeId="46726f6e7423232344415441232323">12</characteristic>
+        <characteristic name="Side" typeId="5369646523232344415441232323">11</characteristic>
+        <characteristic name="Rear" typeId="5265617223232344415441232323">11</characteristic>
+        <characteristic name="HP" typeId="485023232344415441232323">2</characteristic>
+        <characteristic name="Type" typeId="5479706523232344415441232323">Fast, Skimmer</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="0ee6-f79c-ff88-7773" name="Seeker" publicationId="a30a-7522-pubN95872" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+      <characteristics>
+        <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry</characteristic>
+        <characteristic name="WS" typeId="575323232344415441232323">4</characteristic>
+        <characteristic name="BS" typeId="425323232344415441232323">4</characteristic>
+        <characteristic name="S" typeId="5323232344415441232323">3</characteristic>
+        <characteristic name="T" typeId="5423232344415441232323">3</characteristic>
+        <characteristic name="W" typeId="5723232344415441232323">1</characteristic>
+        <characteristic name="I" typeId="4923232344415441232323">4</characteristic>
+        <characteristic name="A" typeId="4123232344415441232323">1</characteristic>
+        <characteristic name="LD" typeId="4c4423232344415441232323">8</characteristic>
+        <characteristic name="Save" typeId="5361766523232344415441232323">3+</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="d18b-f29b-a2b1-d194" name="Seeker Mistress" publicationId="a30a-7522-pubN95872" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+      <characteristics>
+        <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry (Character)</characteristic>
+        <characteristic name="WS" typeId="575323232344415441232323">4</characteristic>
+        <characteristic name="BS" typeId="425323232344415441232323">4</characteristic>
+        <characteristic name="S" typeId="5323232344415441232323">3</characteristic>
+        <characteristic name="T" typeId="5423232344415441232323">3</characteristic>
+        <characteristic name="W" typeId="5723232344415441232323">1</characteristic>
+        <characteristic name="I" typeId="4923232344415441232323">4</characteristic>
+        <characteristic name="A" typeId="4123232344415441232323">2</characteristic>
+        <characteristic name="LD" typeId="4c4423232344415441232323">9</characteristic>
+        <characteristic name="Save" typeId="5361766523232344415441232323">3+</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="5a99-1a1a-7c69-3613" name="Galatus Warblade" publicationId="a30a-7522-pubN95872" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="52616e676523232344415441232323">Melee</characteristic>
+        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">x2</characteristic>
+        <characteristic name="AP" typeId="415023232344415441232323">2</characteristic>
+        <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Shred, Rampage</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="0b06-b727-909f-9126" name="Contemptor-Galatus Dreadnought" publicationId="a30a-7522-pubN95872" page="" hidden="false" typeId="57616c6b657223232344415441232323" typeName="Walker">
+      <characteristics>
+        <characteristic name="WS" typeId="575323232344415441232323">6</characteristic>
+        <characteristic name="BS" typeId="425323232344415441232323">5</characteristic>
+        <characteristic name="S" typeId="5323232344415441232323">8</characteristic>
+        <characteristic name="Front" typeId="46726f6e7423232344415441232323">13</characteristic>
+        <characteristic name="Side" typeId="5369646523232344415441232323">13</characteristic>
+        <characteristic name="Rear" typeId="5265617223232344415441232323">11</characteristic>
+        <characteristic name="I" typeId="4923232344415441232323">5</characteristic>
+        <characteristic name="A" typeId="4123232344415441232323">4</characteristic>
+        <characteristic name="HP" typeId="485023232344415441232323">3</characteristic>
+        <characteristic name="Type" typeId="5479706523232344415441232323">Walker</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="767b-d879-1e5f-bc94" name="Dreadnought Praesidium Shield" publicationId="a30a-7522-pubN94931" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
+      <characteristics>
+        <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">When subject to attacks originating in its Front Arc, or in assault, the model&apos;s invulnerable save is increased to 4+. In addition, attacks made in assault against it, other than by Gargantuan units and Super-Heavy Walkers, suffer a -1 penalty to hit (to a maximum of 6+) - note that this penalty has no effect on attacks which hit automatically.</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="3a85-e9c8-548f-9c71" name="Paragon Power Blade" publicationId="a30a-7522-pubN95872" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="52616e676523232344415441232323">Melee</characteristic>
+        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">+1/+2*</characteristic>
+        <characteristic name="AP" typeId="415023232344415441232323">2</characteristic>
+        <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Lightning Blows, Murderous Strike, Specialist Weapon</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="7001-00aa-5d65-dbd8" name="The Apollonian Spear Power Blade" publicationId="a30a-7522-pubN95872" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="52616e676523232344415441232323">Melee</characteristic>
+        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">+1/+2*</characteristic>
+        <characteristic name="AP" typeId="415023232344415441232323">2</characteristic>
+        <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Lightning Blows, Murderous Strike, Molecular Severance, Specialist Weapon</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="3912-42bf-2de6-6611" name="Hyper-Velocity Bolter" publicationId="a30a-7522-pubN95872" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="52616e676523232344415441232323">18&quot;</characteristic>
+        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">5</characteristic>
+        <characteristic name="AP" typeId="415023232344415441232323">2</characteristic>
+        <characteristic name="Type" typeId="5479706523232344415441232323">Assault 2, Concussive</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="bd4f-4ba1-a337-9b50" name="Illastus Accelerator Culverin" publicationId="a30a-7522-pubN95872" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="52616e676523232344415441232323">36&quot;</characteristic>
+        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">7</characteristic>
+        <characteristic name="AP" typeId="415023232344415441232323">2</characteristic>
+        <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 5, Rending, Heliothermic Detonation</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="783e-c8f7-4312-98c7" name="Custodian Jump Harness" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
+      <characteristics>
+        <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Custodian jump harness provides a 3+ armour save and the Auramite Pinions special rule.</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="11d9-f1a7-f2de-8ffa" name="Custodian Venatari" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+      <characteristics>
+        <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Jump Infantry (Character)</characteristic>
+        <characteristic name="WS" typeId="575323232344415441232323">5</characteristic>
+        <characteristic name="BS" typeId="425323232344415441232323">5</characteristic>
+        <characteristic name="S" typeId="5323232344415441232323">5</characteristic>
+        <characteristic name="T" typeId="5423232344415441232323">5</characteristic>
+        <characteristic name="W" typeId="5723232344415441232323">2</characteristic>
+        <characteristic name="I" typeId="4923232344415441232323">5</characteristic>
+        <characteristic name="A" typeId="4123232344415441232323">2</characteristic>
+        <characteristic name="LD" typeId="4c4423232344415441232323">9</characteristic>
+        <characteristic name="Save" typeId="5361766523232344415441232323">3+</characteristic>
       </characteristics>
     </profile>
   </sharedProfiles>


### PR DESCRIPTION
1) I still get the "minimum 1 compulsory HQ" when Magistus Amon is selected, he is not a support HQ so this shouldn't happen.
FIX - Amon was missing the compulsory HQ tick.

2) When I give Azek Ahriman a command squad, I should be able to give them mastery level 2 as an option but it is missing.
FIX - Termy command squad was missing brotherhood of sorcerers,

FIX - Also fixed another error that was flagging up that Magnus, Ahriman and Amon were all not counting as the armies min requirement of Psyker lv 1.