### PR TITLE
Various Fixes, including RoW, Moirax and Thrall units

### DIFF
--- a/(HH) Mechanicum - Questoris Knight.cat
+++ b/(HH) Mechanicum - Questoris Knight.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="32d1ddc6-3187-cf6f-3bf8-9891e527a002" name="Questoris Knight Crusade Army" revision="46" battleScribeVersion="2.02" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="85" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="32d1ddc6-3187-cf6f-3bf8-9891e527a002" name="Questoris Knight Crusade Army" revision="47" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="85" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="32d1ddc6--pubN65537" name="Age of Darkness Crusade Army List"/>
     <publication id="32d1ddc6--pubN66650" name="HH4: Conquest"/>
@@ -136,7 +136,7 @@
     </forceEntry>
   </forceEntries>
   <selectionEntries>
-    <selectionEntry id="48ee846f-5f68-d83d-4f9a-e1a797dc1cd1" name="Aucteller" publicationId="32d1ddc6--pubN66650" page="296" hidden="false" collective="false" type="unit">
+    <selectionEntry id="48ee846f-5f68-d83d-4f9a-e1a797dc1cd1" name="Aucteller" publicationId="32d1ddc6--pubN66650" page="296" hidden="false" collective="false" import="true" type="unit">
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxInForce" type="max"/>
       </constraints>
@@ -154,13 +154,13 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
         <categoryLink id="48ee846f-5f68-d83d-4f9a-e1a797dc1cd1-456c6974657323232344415441232323" hidden="false" targetId="456c6974657323232344415441232323" primary="true"/>
       </categoryLinks>
       <entryLinks>
-        <entryLink id="c1e90647-960a-2d15-b131-b355ea288de1" hidden="false" collective="false" targetId="3fc4-9d7f-969b-35bb" type="selectionEntryGroup"/>
+        <entryLink id="c1e90647-960a-2d15-b131-b355ea288de1" hidden="false" collective="false" import="true" targetId="3fc4-9d7f-969b-35bb" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="35.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="c9c2bc37-7048-4ed5-80c0-fb13d224f96a" name="Lord Scion" publicationId="32d1ddc6--pubN66650" page="295" hidden="false" collective="false" type="unit">
+    <selectionEntry id="c9c2bc37-7048-4ed5-80c0-fb13d224f96a" name="Lord Scion" publicationId="32d1ddc6--pubN66650" page="295" hidden="false" collective="false" import="true" type="unit">
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
       </constraints>
@@ -173,13 +173,13 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
         <categoryLink id="c9c2bc37-7048-4ed5-80c0-fb13d224f96a-485123232344415441232323" hidden="false" targetId="485123232344415441232323" primary="true"/>
       </categoryLinks>
       <entryLinks>
-        <entryLink id="0d826049-6db2-6635-065c-6b6c34faf886" name="Knight Armour" hidden="false" collective="false" targetId="3fc4-9d7f-969b-35bb" type="selectionEntryGroup"/>
+        <entryLink id="0d826049-6db2-6635-065c-6b6c34faf886" name="Knight Armour" hidden="false" collective="false" import="true" targetId="3fc4-9d7f-969b-35bb" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="25.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="5137fc47-e383-8e21-a01a-cdf4cbb73094" name="Preceptor" publicationId="32d1ddc6--pubN66650" page="296" hidden="false" collective="false" type="unit">
+    <selectionEntry id="5137fc47-e383-8e21-a01a-cdf4cbb73094" name="Preceptor" publicationId="32d1ddc6--pubN66650" page="296" hidden="false" collective="false" import="true" type="unit">
       <rules>
         <rule id="c95171e5-7f98-b827-ef57-0b6e15cc6719" name="Oracle of Battle" publicationId="32d1ddc6--pubN66650" page="296" hidden="false">
           <description>While at least one Preceptor is on the table, Knights from the same detachment may add +1 to their Reserves rolls. In addition, the Preceptor and any Knight models that are part of the same detachment and within 6&quot; have the Interceptor special rule and may fire Overwatch with any eligible weapons until their next player turn. Note that this is an exception to the normal special rule for Super-heavy Walkters, and in the case of Hellfire template weapons, D6 hits are scored rather than D3.</description>
@@ -189,13 +189,13 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
         <categoryLink id="5137fc47-e383-8e21-a01a-cdf4cbb73094-456c6974657323232344415441232323" hidden="false" targetId="456c6974657323232344415441232323" primary="true"/>
       </categoryLinks>
       <entryLinks>
-        <entryLink id="4ab3a26f-0903-b2fd-0147-9134a6dfbe49" hidden="false" collective="false" targetId="3fc4-9d7f-969b-35bb" type="selectionEntryGroup"/>
+        <entryLink id="4ab3a26f-0903-b2fd-0147-9134a6dfbe49" hidden="false" collective="false" import="true" targetId="3fc4-9d7f-969b-35bb" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="25.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="0374f5e8-736f-e990-acd5-75cb44d303a1" name="Scion Arbalester" publicationId="32d1ddc6--pubN66650" page="298" hidden="false" collective="false" type="unit">
+    <selectionEntry id="0374f5e8-736f-e990-acd5-75cb44d303a1" name="Scion Arbalester" publicationId="32d1ddc6--pubN66650" page="298" hidden="false" collective="false" import="true" type="unit">
       <rules>
         <rule id="b6d3b822-a604-fbc5-8dbf-4dcdb913ad6b" name="Weapon Calibration" publicationId="32d1ddc6--pubN66650" page="298" hidden="false">
           <description>The weapons-mounts and targeting systems of a Knight Arbalester have been finely attuned by their pilot and are extremely responsive to their skills. The Knight has the Tank Hunters special rule and, in addition, so long as it has not moved in the preceding Movement phase, it may, if its controlling player wishes, count all its weapons as having the Skyfire special rule in the Shooting phase.</description>
@@ -208,13 +208,13 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
         <categoryLink id="0374f5e8-736f-e990-acd5-75cb44d303a1-486561767920537570706f727423232344415441232323" hidden="false" targetId="486561767920537570706f727423232344415441232323" primary="true"/>
       </categoryLinks>
       <entryLinks>
-        <entryLink id="3da0370c-c75e-cac8-444f-8825d1e13c4e" hidden="false" collective="false" targetId="3fc4-9d7f-969b-35bb" type="selectionEntryGroup"/>
+        <entryLink id="3da0370c-c75e-cac8-444f-8825d1e13c4e" hidden="false" collective="false" import="true" targetId="3fc4-9d7f-969b-35bb" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="25.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="2f44-17e9-3707-22f2" name="Scion Aspirant" publicationId="32d1ddc6--pubN66650" page="297" hidden="false" collective="false" type="unit">
+    <selectionEntry id="2f44-17e9-3707-22f2" name="Scion Aspirant" publicationId="32d1ddc6--pubN66650" page="297" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="increment" field="maxInForce" value="1">
           <repeats>
@@ -281,13 +281,13 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
         <categoryLink id="4a8e-4fc8-a57b-75aa" name="New CategoryLink" hidden="false" targetId="219d-aefa-dfa5-44db" primary="false"/>
       </categoryLinks>
       <entryLinks>
-        <entryLink id="2b9a8404-7f63-e329-43d7-4ea33400a5a5" hidden="false" collective="false" targetId="3fc4-9d7f-969b-35bb" type="selectionEntryGroup"/>
+        <entryLink id="2b9a8404-7f63-e329-43d7-4ea33400a5a5" hidden="false" collective="false" import="true" targetId="3fc4-9d7f-969b-35bb" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="-35.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="97fcca37-2121-18e9-f084-4f254332c535" name="Scion Dolorous" publicationId="32d1ddc6--pubN66650" page="297" hidden="false" collective="false" type="unit">
+    <selectionEntry id="97fcca37-2121-18e9-f084-4f254332c535" name="Scion Dolorous" publicationId="32d1ddc6--pubN66650" page="297" hidden="false" collective="false" import="true" type="unit">
       <rules>
         <rule id="1ad8fa30-bf2e-1ade-84b2-f035101f3d86" name="Dolorous Charge" publicationId="32d1ddc6--pubN66650" page="297" hidden="false">
           <description>A Knight with this special rule must re-roll failed charges and, in addition, must re-roll failed Sweeping Advances.</description>
@@ -300,13 +300,13 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
         <categoryLink id="97fcca37-2121-18e9-f084-4f254332c535-466173742041747461636b23232344415441232323" hidden="false" targetId="466173742041747461636b23232344415441232323" primary="true"/>
       </categoryLinks>
       <entryLinks>
-        <entryLink id="fb020419-12a2-a1fe-70c9-e021de9617ba" hidden="false" collective="false" targetId="3fc4-9d7f-969b-35bb" type="selectionEntryGroup"/>
+        <entryLink id="fb020419-12a2-a1fe-70c9-e021de9617ba" hidden="false" collective="false" import="true" targetId="3fc4-9d7f-969b-35bb" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="25.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="a9b3942b-357b-159d-698d-73661a1f3bff" name="Scion Implacable" publicationId="32d1ddc6--pubN66650" page="298" hidden="false" collective="false" type="unit">
+    <selectionEntry id="a9b3942b-357b-159d-698d-73661a1f3bff" name="Scion Implacable" publicationId="32d1ddc6--pubN66650" page="298" hidden="false" collective="false" import="true" type="unit">
       <rules>
         <rule id="f6ca3bc6-aa39-58f0-dd9e-2ba8d2c83fbf" name="Wall Breaker" publicationId="32d1ddc6--pubN66650" page="298" hidden="false">
           <description>A Knight with this special rule adds +1 to any results rolled on the Building Damage table as a result of any of its attacks (this is cumulative to any bonus for a weapon&apos;s AP).</description>
@@ -319,13 +319,13 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
         <categoryLink id="a9b3942b-357b-159d-698d-73661a1f3bff-486561767920537570706f727423232344415441232323" hidden="false" targetId="486561767920537570706f727423232344415441232323" primary="true"/>
       </categoryLinks>
       <entryLinks>
-        <entryLink id="b385b77e-808b-7f52-6b74-0cef057b32cd" hidden="false" collective="false" targetId="3fc4-9d7f-969b-35bb" type="selectionEntryGroup"/>
+        <entryLink id="b385b77e-808b-7f52-6b74-0cef057b32cd" hidden="false" collective="false" import="true" targetId="3fc4-9d7f-969b-35bb" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="35.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="5053f8a2-cc7f-f635-1044-b149aed1513e" name="Scion Martial" publicationId="32d1ddc6--pubN66650" page="297" hidden="false" collective="false" type="unit">
+    <selectionEntry id="5053f8a2-cc7f-f635-1044-b149aed1513e" name="Scion Martial" publicationId="32d1ddc6--pubN66650" page="297" hidden="false" collective="false" import="true" type="unit">
       <infoLinks>
         <infoLink id="f46d7af6-d9cf-a52c-39b3-d6569197ff0f" hidden="false" targetId="4764-48d9-da41-afaa" type="rule"/>
       </infoLinks>
@@ -334,13 +334,13 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
         <categoryLink id="4d6a-d089-7507-6e98" name="New CategoryLink" hidden="false" targetId="219d-aefa-dfa5-44db" primary="false"/>
       </categoryLinks>
       <entryLinks>
-        <entryLink id="2a152931-5e29-c5d6-1962-69b34128de76" hidden="false" collective="false" targetId="3fc4-9d7f-969b-35bb" type="selectionEntryGroup"/>
+        <entryLink id="2a152931-5e29-c5d6-1962-69b34128de76" hidden="false" collective="false" import="true" targetId="3fc4-9d7f-969b-35bb" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="ff61-cf0e-681b-82bb" name="Scion Uhlan" publicationId="32d1ddc6--pubN66650" page="297" hidden="false" collective="false" type="unit">
+    <selectionEntry id="ff61-cf0e-681b-82bb" name="Scion Uhlan" publicationId="32d1ddc6--pubN66650" page="297" hidden="false" collective="false" import="true" type="unit">
       <rules>
         <rule id="955c6a6d-62db-3190-a6fb-ad53119398ca" name="Impetuous Advance" publicationId="32d1ddc6--pubN66650" page="297" hidden="false">
           <description>Scions Uhlan have the Scout ad Hit abd Run special rules, however in order to achieve these abilities, they have the Sacristans strip down the armour of their Knights in order to lighten them for speed. In all cases, the Scions Uhlan reduce the Armour value of their Front Armour by -1.</description>
@@ -357,13 +357,13 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
         <categoryLink id="ff61-cf0e-681b-82bb-466173742041747461636b23232344415441232323" hidden="false" targetId="466173742041747461636b23232344415441232323" primary="true"/>
       </categoryLinks>
       <entryLinks>
-        <entryLink id="0ac5a9c1-154c-391d-e63c-ea95e7710d0c" hidden="false" collective="false" targetId="3fc4-9d7f-969b-35bb" type="selectionEntryGroup"/>
+        <entryLink id="0ac5a9c1-154c-391d-e63c-ea95e7710d0c" hidden="false" collective="false" import="true" targetId="3fc4-9d7f-969b-35bb" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="33d55e37-58db-535e-ffb4-0c9136c15e25" name="Seneschal" publicationId="32d1ddc6--pubN66650" page="295" hidden="false" collective="false" type="unit">
+    <selectionEntry id="33d55e37-58db-535e-ffb4-0c9136c15e25" name="Seneschal" publicationId="32d1ddc6--pubN66650" page="295" hidden="false" collective="false" import="true" type="unit">
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
       </constraints>
@@ -379,13 +379,13 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
         <categoryLink id="33d55e37-58db-535e-ffb4-0c9136c15e25-485123232344415441232323" hidden="false" targetId="485123232344415441232323" primary="true"/>
       </categoryLinks>
       <entryLinks>
-        <entryLink id="d68922c4-1f12-ba8f-c17f-65225738046d" hidden="false" collective="false" targetId="3fc4-9d7f-969b-35bb" type="selectionEntryGroup"/>
+        <entryLink id="d68922c4-1f12-ba8f-c17f-65225738046d" hidden="false" collective="false" import="true" targetId="3fc4-9d7f-969b-35bb" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="50.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="dbcc-f750-c3cb-2dcf" name="Scion Auxilia" publicationId="32d1ddc6--pubN66650" page="297" hidden="false" collective="false" type="unit">
+    <selectionEntry id="dbcc-f750-c3cb-2dcf" name="Scion Auxilia" publicationId="32d1ddc6--pubN66650" page="297" hidden="false" collective="false" import="true" type="unit">
       <infoLinks>
         <infoLink id="9f59-5499-23fb-9144" name="Objective Secured" hidden="false" targetId="4764-48d9-da41-afaa" type="rule"/>
       </infoLinks>
@@ -393,18 +393,18 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
         <categoryLink id="dc12-2675-4bfb-2b03" hidden="false" targetId="54726f6f707323232344415441232323" primary="true"/>
       </categoryLinks>
       <entryLinks>
-        <entryLink id="6592-ed1e-78ca-c6eb" name="Questoris Knight Armiger Talon" hidden="false" collective="false" targetId="1072-d634-f6c6-b41e" type="selectionEntry"/>
+        <entryLink id="6592-ed1e-78ca-c6eb" name="Questoris Knight Armiger Talon" hidden="false" collective="false" import="true" targetId="1072-d634-f6c6-b41e" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="25.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="7d67-3c94-ab8b-58da" name="Scion Amuntar" publicationId="3545-f6f0-40fe-a51e" page="" hidden="false" collective="false" type="unit">
+    <selectionEntry id="7d67-3c94-ab8b-58da" name="Scion Amuntar" publicationId="3545-f6f0-40fe-a51e" page="" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
         <categoryLink id="bbfe-f633-a486-1d67" hidden="false" targetId="54726f6f707323232344415441232323" primary="true"/>
       </categoryLinks>
       <entryLinks>
-        <entryLink id="c8bc-7aca-f383-ca94" name="Mechanicum Knight Moirax Talon" hidden="false" collective="false" targetId="e00d-ca82-e2ce-b437" type="selectionEntry"/>
+        <entryLink id="c8bc-7aca-f383-ca94" name="Mechanicum Knight Moirax Talon" hidden="false" collective="false" import="true" targetId="e00d-ca82-e2ce-b437" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="30.0"/>
@@ -412,7 +412,7 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
     </selectionEntry>
   </selectionEntries>
   <entryLinks>
-    <entryLink id="849c-0f60-509d-16d1" name="Archmagos Draykavac" hidden="false" collective="false" targetId="27575b75-5e1e-26ab-1074-fa91b73e2216" type="selectionEntry">
+    <entryLink id="849c-0f60-509d-16d1" name="Archmagos Draykavac" hidden="false" collective="false" import="true" targetId="27575b75-5e1e-26ab-1074-fa91b73e2216" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -424,7 +424,7 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
         <categoryLink id="849c-0f60-509d-16d1-485123232344415441232323" hidden="false" targetId="485123232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="3135-573f-145d-9803" name="Castellax Class Battle-Automata Maniple" hidden="false" collective="false" targetId="48db-84ca-2bad-520f" type="selectionEntry">
+    <entryLink id="3135-573f-145d-9803" name="Castellax Class Battle-Automata Maniple" hidden="false" collective="false" import="true" targetId="48db-84ca-2bad-520f" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -436,7 +436,7 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
         <categoryLink id="3135-573f-145d-9803-54726f6f707323232344415441232323" hidden="false" targetId="54726f6f707323232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="e7c5-6f1f-f20c-385e" name="Vorax Class Battle-automata Maniple" hidden="false" collective="false" targetId="deb3-68a3-5d36-eb3d" type="selectionEntry">
+    <entryLink id="e7c5-6f1f-f20c-385e" name="Vorax Class Battle-automata Maniple" hidden="false" collective="false" import="true" targetId="deb3-68a3-5d36-eb3d" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -448,22 +448,22 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
         <categoryLink id="e7c5-6f1f-f20c-385e-466173742041747461636b23232344415441232323" hidden="false" targetId="466173742041747461636b23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="02c6-f507-ac2e-504c" name="Allegiance" hidden="false" collective="false" targetId="7719-aa4f-3366-84f2" type="selectionEntry">
+    <entryLink id="02c6-f507-ac2e-504c" name="Allegiance" hidden="false" collective="false" import="true" targetId="7719-aa4f-3366-84f2" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="02c6-f507-ac2e-504c-5297-7e0f-fa0b-3537" hidden="false" targetId="5297-7e0f-fa0b-3537" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="9112-60df-c178-6f7b" name="New EntryLink" hidden="false" collective="false" targetId="1fa3-1f86-94a6-bf48" type="selectionEntry">
+    <entryLink id="9112-60df-c178-6f7b" name="New EntryLink" hidden="false" collective="false" import="true" targetId="1fa3-1f86-94a6-bf48" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="9112-60df-c178-6f7b-1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="26f2-8478-6580-218f" name="New EntryLink" hidden="false" collective="false" targetId="16d6-25c4-af92-4329" type="selectionEntry">
+    <entryLink id="26f2-8478-6580-218f" name="New EntryLink" hidden="false" collective="false" import="true" targetId="16d6-25c4-af92-4329" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="26f2-8478-6580-218f-1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="4e49-8766-3548-9870" name="New EntryLink" hidden="false" collective="false" targetId="fb92-d215-2011-f911" type="selectionEntry">
+    <entryLink id="4e49-8766-3548-9870" name="New EntryLink" hidden="false" collective="false" import="true" targetId="fb92-d215-2011-f911" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -475,87 +475,87 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
         <categoryLink id="4e49-8766-3548-9870-1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="4179-a726-fc3c-addf" name="New EntryLink" hidden="false" collective="false" targetId="b894-adfc-6d3d-fde4" type="selectionEntry">
+    <entryLink id="4179-a726-fc3c-addf" name="New EntryLink" hidden="false" collective="false" import="true" targetId="b894-adfc-6d3d-fde4" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="4179-a726-fc3c-addf-1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="53b7-53cc-3df0-a8a1" name="New EntryLink" hidden="false" collective="false" targetId="ab80-0fef-3e93-8e64" type="selectionEntry">
+    <entryLink id="53b7-53cc-3df0-a8a1" name="New EntryLink" hidden="false" collective="false" import="true" targetId="ab80-0fef-3e93-8e64" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="53b7-53cc-3df0-a8a1-1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="1415-df03-ac69-b34a" name="New EntryLink" hidden="false" collective="false" targetId="df05-8179-624e-f8b2" type="selectionEntry">
+    <entryLink id="1415-df03-ac69-b34a" name="New EntryLink" hidden="false" collective="false" import="true" targetId="df05-8179-624e-f8b2" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="1415-df03-ac69-b34a-1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="85c5-15e1-0aca-7ed4" name="New EntryLink" hidden="false" collective="false" targetId="04bf-6c22-19fb-4e46" type="selectionEntry">
+    <entryLink id="85c5-15e1-0aca-7ed4" name="New EntryLink" hidden="false" collective="false" import="true" targetId="04bf-6c22-19fb-4e46" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="85c5-15e1-0aca-7ed4-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="3f06-44f6-7e22-ed9a" name="Aegis Defense Line" hidden="false" collective="false" targetId="a505-05af-bd44-56b6" type="selectionEntry">
+    <entryLink id="3f06-44f6-7e22-ed9a" name="Aegis Defense Line" hidden="false" collective="false" import="true" targetId="a505-05af-bd44-56b6" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="3f06-44f6-7e22-ed9a-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="8e68-7554-29f8-0870" name="New EntryLink" hidden="false" collective="false" targetId="0f73-97f2-b832-f6d0" type="selectionEntry">
+    <entryLink id="8e68-7554-29f8-0870" name="New EntryLink" hidden="false" collective="false" import="true" targetId="0f73-97f2-b832-f6d0" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="8e68-7554-29f8-0870-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="90ab-6253-d941-da40" name="New EntryLink" hidden="false" collective="false" targetId="0116-c81b-1c0f-251c" type="selectionEntry">
+    <entryLink id="90ab-6253-d941-da40" name="New EntryLink" hidden="false" collective="false" import="true" targetId="0116-c81b-1c0f-251c" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="90ab-6253-d941-da40-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="b053-e05a-0caa-89fc" name="New EntryLink" hidden="false" collective="false" targetId="a172-78de-aaa6-2201" type="selectionEntry">
+    <entryLink id="b053-e05a-0caa-89fc" name="New EntryLink" hidden="false" collective="false" import="true" targetId="a172-78de-aaa6-2201" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="b053-e05a-0caa-89fc-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="25b9-2bfa-a936-84c4" name="New EntryLink" hidden="false" collective="false" targetId="595a-908e-96a1-f121" type="selectionEntry">
+    <entryLink id="25b9-2bfa-a936-84c4" name="New EntryLink" hidden="false" collective="false" import="true" targetId="595a-908e-96a1-f121" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="25b9-2bfa-a936-84c4-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="2639-13a0-1091-5189" name="New EntryLink" hidden="false" collective="false" targetId="e0b3-77ca-af76-bd8b" type="selectionEntry">
+    <entryLink id="2639-13a0-1091-5189" name="New EntryLink" hidden="false" collective="false" import="true" targetId="e0b3-77ca-af76-bd8b" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="2639-13a0-1091-5189-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="5d90-f197-8cfd-1b42" name="New EntryLink" hidden="false" collective="false" targetId="3015-0b77-e848-c0f5" type="selectionEntry">
+    <entryLink id="5d90-f197-8cfd-1b42" name="New EntryLink" hidden="false" collective="false" import="true" targetId="3015-0b77-e848-c0f5" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="5d90-f197-8cfd-1b42-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="8d58-d4ea-b375-c1c2" name="New EntryLink" hidden="false" collective="false" targetId="c05d-2231-2481-4037" type="selectionEntry">
+    <entryLink id="8d58-d4ea-b375-c1c2" name="New EntryLink" hidden="false" collective="false" import="true" targetId="c05d-2231-2481-4037" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="8d58-d4ea-b375-c1c2-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="5d47-f621-ee0e-2544" name="New EntryLink" hidden="false" collective="false" targetId="6140-dc64-5896-957f" type="selectionEntry">
+    <entryLink id="5d47-f621-ee0e-2544" name="New EntryLink" hidden="false" collective="false" import="true" targetId="6140-dc64-5896-957f" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="5d47-f621-ee0e-2544-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="cad9-127d-bb6f-0243" name="New EntryLink" hidden="false" collective="false" targetId="55c6-268b-357f-d070" type="selectionEntry">
+    <entryLink id="cad9-127d-bb6f-0243" name="New EntryLink" hidden="false" collective="false" import="true" targetId="55c6-268b-357f-d070" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="cad9-127d-bb6f-0243-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="9d3b-652a-8f38-ba48" name="New EntryLink" hidden="false" collective="false" targetId="e40b-468f-f1d7-d05d" type="selectionEntry">
+    <entryLink id="9d3b-652a-8f38-ba48" name="New EntryLink" hidden="false" collective="false" import="true" targetId="e40b-468f-f1d7-d05d" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="9d3b-652a-8f38-ba48-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="fa5a-7dbb-c0ea-2f53" name="New EntryLink" hidden="false" collective="false" targetId="e10f-7b90-ecd3-80a5" type="selectionEntry">
+    <entryLink id="fa5a-7dbb-c0ea-2f53" name="New EntryLink" hidden="false" collective="false" import="true" targetId="e10f-7b90-ecd3-80a5" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="fa5a-7dbb-c0ea-2f53-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="8b9e-027f-f676-d4e0" name="Legio Titanicus Warbringer Nemesis Titan" hidden="false" collective="false" targetId="ecb3-83b9-4ba7-47a9" type="selectionEntry">
+    <entryLink id="8b9e-027f-f676-d4e0" name="Legio Titanicus Warbringer Nemesis Titan" hidden="false" collective="false" import="true" targetId="ecb3-83b9-4ba7-47a9" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="641f-b7f4-977d-9020" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
         <categoryLink id="4ad3-cc77-6e21-b20b" name="New CategoryLink" hidden="false" targetId="264d-166e-36c0-77b7" primary="false"/>
@@ -564,20 +564,20 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
     </entryLink>
   </entryLinks>
   <sharedSelectionEntries>
-    <selectionEntry id="deb3-68a3-5d36-eb3d" name="Vorax Class Battle-automata Maniple" page="" hidden="false" collective="false" type="unit">
+    <selectionEntry id="deb3-68a3-5d36-eb3d" name="Vorax Class Battle-automata Maniple" page="" hidden="false" collective="false" import="true" type="unit">
       <infoLinks>
         <infoLink id="a080-e2a8-dc43-1112" name="New InfoLink" hidden="false" targetId="69e5-fc02-1f9d-63c2" type="rule"/>
         <infoLink id="57a5-1a50-7092-3d9c" name="New InfoLink" hidden="false" targetId="9b30-1da3-eb8d-ce7a" type="rule"/>
         <infoLink id="b4e3-29d6-986a-2b25" name="New InfoLink" hidden="false" targetId="a8c1-185a-cdd9-b5ce" type="profile"/>
       </infoLinks>
       <selectionEntries>
-        <selectionEntry id="efb2-67e0-c8a5-9d43" name="Vorax Class Battle-automata" page="0" hidden="false" collective="false" type="model">
+        <selectionEntry id="efb2-67e0-c8a5-9d43" name="Vorax Class Battle-automata" page="0" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f557-1a16-8c37-f307" type="min"/>
             <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="867d-a720-a911-50dc" type="max"/>
           </constraints>
           <profiles>
-            <profile id="712d-49a5-7c53-fbc4" name="Vorax" publicationId="32d1ddc6--pubN69303" page="46" hidden="false" typeId="556e697423232344415441232323" typeName="">
+            <profile id="712d-49a5-7c53-fbc4" name="Vorax" publicationId="32d1ddc6--pubN69303" page="46" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Monstrous Creature</characteristic>
                 <characteristic name="WS" typeId="575323232344415441232323">4</characteristic>
@@ -593,7 +593,7 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
             </profile>
           </profiles>
           <selectionEntries>
-            <selectionEntry id="1b52-8c7c-83a4-64a9" name="Two Rotor Cannons" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="1b52-8c7c-83a4-64a9" name="Two Rotor Cannons" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="78a2-15ad-9505-6d4f" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d184-3263-bd4e-5f9b" type="min"/>
@@ -622,7 +622,7 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="d354-81fd-0caa-5f51" name="Power Blades" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="d354-81fd-0caa-5f51" name="Power Blades" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="140d-0980-edb7-af3f" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b7b9-1b6f-217a-af03" type="min"/>
@@ -639,13 +639,13 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
             </selectionEntry>
           </selectionEntries>
           <selectionEntryGroups>
-            <selectionEntryGroup id="fa3c-7f3b-88e8-ae06" name="May exchange Lightning Gun for:" hidden="false" collective="false">
+            <selectionEntryGroup id="fa3c-7f3b-88e8-ae06" name="May exchange Lightning Gun for:" hidden="false" collective="false" import="true">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a565-730f-b042-5f27" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="344b-2ce3-cd66-cd7c" type="min"/>
               </constraints>
               <selectionEntries>
-                <selectionEntry id="4aae-cbed-3fbf-8d18" name="Irad-cleanser" page="0" hidden="false" collective="false" type="upgrade">
+                <selectionEntry id="4aae-cbed-3fbf-8d18" name="Irad-cleanser" page="0" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
                     <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8c27-a396-9ad7-84b8" type="max"/>
                   </constraints>
@@ -658,7 +658,7 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
                     <cost name="pts" typeId="points" value="10.0"/>
                   </costs>
                 </selectionEntry>
-                <selectionEntry id="27ab-2725-5de6-7e71" name="Lightning Gun" hidden="false" collective="false" type="upgrade">
+                <selectionEntry id="27ab-2725-5de6-7e71" name="Lightning Gun" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
                     <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b106-e238-5f3d-1195" type="max"/>
                   </constraints>
@@ -678,7 +678,7 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
             <cost name="pts" typeId="points" value="65.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="5857-e4d4-6c02-014c" name="Infravisors" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="5857-e4d4-6c02-014c" name="Infravisors" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="34ee-b342-1b97-aa4f" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="92ab-f743-a8d0-44ef" type="min"/>
@@ -692,9 +692,9 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="721b-07af-5d09-abc5" name="Maniple may take any of the following upgrades:" hidden="false" collective="false">
+        <selectionEntryGroup id="721b-07af-5d09-abc5" name="Maniple may take any of the following upgrades:" hidden="false" collective="false" import="true">
           <selectionEntries>
-            <selectionEntry id="62e7-2ed4-0f7a-d02b" name="Searchlights" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="62e7-2ed4-0f7a-d02b" name="Searchlights" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="increment" field="points" value="1.0">
                   <repeats>
@@ -712,7 +712,7 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="5e54-e7c7-616b-099e" name="Frag Grenades" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="5e54-e7c7-616b-099e" name="Frag Grenades" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="increment" field="points" value="5.0">
                   <repeats>
@@ -731,7 +731,7 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="4917-9705-c924-9779" name="Enhanced Targeting Arrays" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="4917-9705-c924-9779" name="Enhanced Targeting Arrays" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="increment" field="points" value="15">
                   <repeats>
@@ -751,9 +751,9 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="6ea4-be19-165b-5df5" name="Entire Maniple may equip Rotor Cannons with:" hidden="false" collective="false">
+        <selectionEntryGroup id="6ea4-be19-165b-5df5" name="Entire Maniple may equip Rotor Cannons with:" hidden="false" collective="false" import="true">
           <selectionEntries>
-            <selectionEntry id="3c66-f02d-af81-ecfe" name="Bio-corrosive ammunition" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="3c66-f02d-af81-ecfe" name="Bio-corrosive ammunition" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="increment" field="points" value="10.0">
                   <repeats>
@@ -772,7 +772,7 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="c7ae-23c6-9acc-b89f" name="New EntryLink" hidden="false" collective="false" targetId="dff8-d7b6-960a-aa5b" type="selectionEntryGroup">
+        <entryLink id="c7ae-23c6-9acc-b89f" name="New EntryLink" hidden="false" collective="false" import="true" targetId="dff8-d7b6-960a-aa5b" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
@@ -781,25 +781,25 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="d0b8-a41e-6b2b-baa7" name="New EntryLink" hidden="false" collective="false" targetId="0c9d-9eaa-d513-caa3" type="selectionEntry"/>
+        <entryLink id="d0b8-a41e-6b2b-baa7" name="New EntryLink" hidden="false" collective="false" import="true" targetId="0c9d-9eaa-d513-caa3" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="48db-84ca-2bad-520f" name="Castellax Class Battle-Automata Maniple" page="" hidden="false" collective="false" type="unit">
+    <selectionEntry id="48db-84ca-2bad-520f" name="Castellax Class Battle-Automata Maniple" page="" hidden="false" collective="false" import="true" type="unit">
       <infoLinks>
         <infoLink id="7678-ae60-16f2-e948" name="" hidden="false" targetId="988c-d4d0-9418-1165" type="rule"/>
         <infoLink id="a7f0-6bc1-ed4a-34dc" name="New InfoLink" hidden="false" targetId="d5cf-bd98-2854-13cf" type="rule"/>
       </infoLinks>
       <selectionEntries>
-        <selectionEntry id="09ad-ef83-4a62-46fe" name="Castellax class Battle-automata" page="" hidden="false" collective="false" type="model">
+        <selectionEntry id="09ad-ef83-4a62-46fe" name="Castellax class Battle-automata" page="" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2514-b4ae-39f4-093e" type="min"/>
             <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="38db-7bf2-0694-b3f4" type="max"/>
           </constraints>
           <profiles>
-            <profile id="659d-11d2-faad-4259" name="Castellax" publicationId="32d1ddc6--pubN69303" page="41" hidden="false" typeId="556e697423232344415441232323" typeName="">
+            <profile id="659d-11d2-faad-4259" name="Castellax" publicationId="32d1ddc6--pubN69303" page="41" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Monstrous Creature</characteristic>
                 <characteristic name="WS" typeId="575323232344415441232323">3</characteristic>
@@ -815,13 +815,13 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
             </profile>
           </profiles>
           <selectionEntryGroups>
-            <selectionEntryGroup id="6564-7afd-3cef-078a" name="May exchange its Mauler bolt cannon for:" hidden="false" collective="false" defaultSelectionEntryId="4ed8-630f-8684-ebe1">
+            <selectionEntryGroup id="6564-7afd-3cef-078a" name="May exchange its Mauler bolt cannon for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="4ed8-630f-8684-ebe1">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="84b2-b418-e7d8-4052" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9947-1981-7c77-5638" type="min"/>
               </constraints>
               <selectionEntries>
-                <selectionEntry id="9ecb-8606-a575-1ff1" name="Darkfire Cannon" page="0" hidden="false" collective="false" type="upgrade">
+                <selectionEntry id="9ecb-8606-a575-1ff1" name="Darkfire Cannon" page="0" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f3ce-e636-1d57-9a53" type="max"/>
                   </constraints>
@@ -835,7 +835,7 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
                     <cost name="pts" typeId="points" value="20.0"/>
                   </costs>
                 </selectionEntry>
-                <selectionEntry id="886f-0bee-a174-f694" name="Multi-melta" page="0" hidden="false" collective="false" type="upgrade">
+                <selectionEntry id="886f-0bee-a174-f694" name="Multi-melta" page="0" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7305-9e27-a1aa-b216" type="max"/>
                   </constraints>
@@ -847,7 +847,7 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
                     <cost name="pts" typeId="points" value="0.0"/>
                   </costs>
                 </selectionEntry>
-                <selectionEntry id="4ed8-630f-8684-ebe1" name="Mauler Bolt Cannon" hidden="false" collective="false" type="upgrade">
+                <selectionEntry id="4ed8-630f-8684-ebe1" name="Mauler Bolt Cannon" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="af97-7a77-a66b-da26" type="max"/>
                   </constraints>
@@ -861,7 +861,7 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
                 </selectionEntry>
               </selectionEntries>
             </selectionEntryGroup>
-            <selectionEntryGroup id="c204-c9c9-9110-ca90" name="May Exchange one or both bolters for:" hidden="false" collective="false" defaultSelectionEntryId="9f45-90b4-1220-dd2b">
+            <selectionEntryGroup id="c204-c9c9-9110-ca90" name="May Exchange one or both bolters for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="9f45-90b4-1220-dd2b">
               <modifiers>
                 <modifier type="set" field="5d2a-e961-7953-6b83" value="1">
                   <conditions>
@@ -879,7 +879,7 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5d2a-e961-7953-6b83" type="min"/>
               </constraints>
               <selectionEntries>
-                <selectionEntry id="48d3-a65a-239b-289c" name="Flamer" page="0" hidden="false" collective="false" type="upgrade">
+                <selectionEntry id="48d3-a65a-239b-289c" name="Flamer" page="0" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
                     <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c06b-9c84-5a9a-743a" type="max"/>
                   </constraints>
@@ -887,7 +887,7 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
                     <cost name="pts" typeId="points" value="5.0"/>
                   </costs>
                 </selectionEntry>
-                <selectionEntry id="9f45-90b4-1220-dd2b" name="Bolter" hidden="false" collective="false" type="upgrade">
+                <selectionEntry id="9f45-90b4-1220-dd2b" name="Bolter" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
                     <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f241-287b-5881-e9d6" type="max"/>
                   </constraints>
@@ -900,13 +900,13 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
                 </selectionEntry>
               </selectionEntries>
             </selectionEntryGroup>
-            <selectionEntryGroup id="c022-8531-3529-fe49" name="May Exchange Shock Chargers for:" hidden="false" collective="false" defaultSelectionEntryId="4894-9e9e-82e5-b213">
+            <selectionEntryGroup id="c022-8531-3529-fe49" name="May Exchange Shock Chargers for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="4894-9e9e-82e5-b213">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="314f-0125-9b5d-03fb" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="321e-e0ed-e440-d5e5" type="min"/>
               </constraints>
               <selectionEntries>
-                <selectionEntry id="e927-193b-8cf1-70fd" name="Two Power Blades" page="0" hidden="false" collective="false" type="upgrade">
+                <selectionEntry id="e927-193b-8cf1-70fd" name="Two Power Blades" page="0" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c5d0-644c-e051-03f1" type="max"/>
                   </constraints>
@@ -920,7 +920,7 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
                     <cost name="pts" typeId="points" value="10.0"/>
                   </costs>
                 </selectionEntry>
-                <selectionEntry id="f11e-3352-b97f-3693" name="Siege Wrecker" page="0" hidden="false" collective="false" type="upgrade">
+                <selectionEntry id="f11e-3352-b97f-3693" name="Siege Wrecker" page="0" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="56a0-fb06-e473-31a1" type="max"/>
                   </constraints>
@@ -934,7 +934,7 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
                     <cost name="pts" typeId="points" value="20.0"/>
                   </costs>
                 </selectionEntry>
-                <selectionEntry id="4894-9e9e-82e5-b213" name="Shock Chargers" hidden="false" collective="false" type="upgrade">
+                <selectionEntry id="4894-9e9e-82e5-b213" name="Shock Chargers" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b895-e509-7063-3f17" type="max"/>
                   </constraints>
@@ -954,9 +954,9 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="5a40-8fd5-37b7-8ec4" name="Maniple may take any of the following upgrades:" hidden="false" collective="false">
+        <selectionEntryGroup id="5a40-8fd5-37b7-8ec4" name="Maniple may take any of the following upgrades:" hidden="false" collective="false" import="true">
           <selectionEntries>
-            <selectionEntry id="6801-cbdd-fb6a-761c" name="Searchlights" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="6801-cbdd-fb6a-761c" name="Searchlights" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="increment" field="points" value="1">
                   <repeats>
@@ -974,7 +974,7 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="25c4-ab1a-3773-5ced" name="Infravisors" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="25c4-ab1a-3773-5ced" name="Infravisors" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="increment" field="points" value="5">
                   <repeats>
@@ -993,7 +993,7 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="2388-67a0-fbab-56d9" name="Frag Grenades" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="2388-67a0-fbab-56d9" name="Frag Grenades" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="increment" field="points" value="5.0">
                   <repeats>
@@ -1012,7 +1012,7 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="eafb-4aa0-594d-5dbc" name="Enhanced Targeting Arrays" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="eafb-4aa0-594d-5dbc" name="Enhanced Targeting Arrays" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="increment" field="points" value="15">
                   <repeats>
@@ -1034,7 +1034,7 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="9e93-5e2f-d21c-63bf" name="A single Maniple may be upgraded with:" hidden="false" collective="false" targetId="dff8-d7b6-960a-aa5b" type="selectionEntryGroup">
+        <entryLink id="9e93-5e2f-d21c-63bf" name="A single Maniple may be upgraded with:" hidden="false" collective="false" import="true" targetId="dff8-d7b6-960a-aa5b" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
@@ -1043,25 +1043,25 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="b6c3-b1be-9ce6-cb2f" name="New EntryLink" hidden="false" collective="false" targetId="0c9d-9eaa-d513-caa3" type="selectionEntry"/>
+        <entryLink id="b6c3-b1be-9ce6-cb2f" name="New EntryLink" hidden="false" collective="false" import="true" targetId="0c9d-9eaa-d513-caa3" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="7719-aa4f-3366-84f2" name="Allegiance" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="7719-aa4f-3366-84f2" name="Allegiance" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="ae6f-3de0-9682-079d" type="min"/>
       </constraints>
       <selectionEntryGroups>
-        <selectionEntryGroup id="860a-fa24-8724-0a29" name="Allegiance" hidden="false" collective="false">
+        <selectionEntryGroup id="860a-fa24-8724-0a29" name="Allegiance" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6568-7e81-94f8-7946" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="afb3-8086-6edb-3f3a" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6951-01f7-7675-d69b" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="44a9-d907-13fa-4fc4" name="Traitor" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="44a9-d907-13fa-4fc4" name="Traitor" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="set" field="18ef-3206-400c-0b5a" value="1">
                   <conditions>
@@ -1076,7 +1076,7 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="513f-ab95-ad10-b2ec" name="Loyalist" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="513f-ab95-ad10-b2ec" name="Loyalist" hidden="false" collective="false" import="true" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
@@ -1088,7 +1088,7 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="3902-a5e5-c69e-7a01" name="Questoris Knight Dominus" publicationId="32d1ddc6--pubN72251" page="" hidden="false" collective="false" type="model">
+    <selectionEntry id="3902-a5e5-c69e-7a01" name="Questoris Knight Dominus" publicationId="32d1ddc6--pubN72251" page="" hidden="false" collective="false" import="true" type="model">
       <profiles>
         <profile id="ecb2-e57a-adb8-0ab8" name="Questoris Knight Dominus" publicationId="32d1ddc6--pubN72251" page="" hidden="false" typeId="0694-6ddb-9e1d-40bd" typeName="Super-heavy Walker">
           <characteristics>
@@ -1109,7 +1109,7 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
         <infoLink id="337d-4388-852d-759f" name="Ion Shield" hidden="false" targetId="342d5e83-9f9b-42c0-cecb-e6c9c197ab9d" type="profile"/>
       </infoLinks>
       <selectionEntries>
-        <selectionEntry id="164f-e083-7cc9-0038" name="Twin-Linked Meltaguns" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="164f-e083-7cc9-0038" name="Twin-Linked Meltaguns" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4759-48d1-f5d5-9bfb" type="max"/>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7054-cd48-fae5-9e66" type="min"/>
@@ -1123,18 +1123,18 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="40d2-b432-3a8e-f14b" name="May be upgraded with:" hidden="false" collective="false">
+        <selectionEntryGroup id="40d2-b432-3a8e-f14b" name="May be upgraded with:" hidden="false" collective="false" import="true">
           <entryLinks>
-            <entryLink id="a3e5-e508-71d5-268b" name="Occular Augmetics" hidden="false" collective="false" targetId="348b-40f4-c774-1f9a" type="selectionEntry"/>
+            <entryLink id="a3e5-e508-71d5-268b" name="Occular Augmetics" hidden="false" collective="false" import="true" targetId="348b-40f4-c774-1f9a" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="4754-e94e-cb94-7ed8" name="May take Three of the following carapace weapons:" hidden="false" collective="false" defaultSelectionEntryId="4ce9-ebbc-bc9e-4059">
+        <selectionEntryGroup id="4754-e94e-cb94-7ed8" name="May take Three of the following carapace weapons:" hidden="false" collective="false" import="true" defaultSelectionEntryId="4ce9-ebbc-bc9e-4059">
           <constraints>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0869-9c49-3855-d2d9" type="max"/>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3084-6034-6dd7-4295" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="4ce9-ebbc-bc9e-4059" name="Twin-Linked Siegebreaker Cannon" publicationId="32d1ddc6--pubN72251" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="4ce9-ebbc-bc9e-4059" name="Twin-Linked Siegebreaker Cannon" publicationId="32d1ddc6--pubN72251" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a6d0-8256-eb24-dc7e" type="max"/>
               </constraints>
@@ -1152,7 +1152,7 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="de42-1578-e085-e2af" name="Two Shieldbreaker Missiles" publicationId="32d1ddc6--pubN72251" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="de42-1578-e085-e2af" name="Two Shieldbreaker Missiles" publicationId="32d1ddc6--pubN72251" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ee86-0ceb-0df8-b3d6" type="max"/>
               </constraints>
@@ -1177,18 +1177,18 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="b586-4020-ddad-4473" name="May take 2 weapons for the following" hidden="false" collective="false" defaultSelectionEntryId="a3a5-cfa9-4075-19c9">
+        <selectionEntryGroup id="b586-4020-ddad-4473" name="May take 2 weapons for the following" hidden="false" collective="false" import="true" defaultSelectionEntryId="a3a5-cfa9-4075-19c9">
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4c5c-068e-e051-df61" type="max"/>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bd11-c71e-cbe4-c027" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="a3a5-cfa9-4075-19c9" name="Canflagration Cannon" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="a3a5-cfa9-4075-19c9" name="Canflagration Cannon" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="294a-a7e8-0879-4d87" type="max"/>
               </constraints>
               <profiles>
-                <profile id="7d01-170d-5ad8-1b5d" name="Conflagration Cannon" publicationId="32d1ddc6--pubN72251" page="" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+                <profile id="7d01-170d-5ad8-1b5d" name="Conflagration Cannon" publicationId="32d1ddc6--pubN72251" page="" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
                   <characteristics>
                     <characteristic name="Range" typeId="52616e676523232344415441232323">Hellstorm</characteristic>
                     <characteristic name="Strength" typeId="537472656e67746823232344415441232323">7</characteristic>
@@ -1201,12 +1201,12 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
                 <cost name="pts" typeId="points" value="30.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="2960-54a3-7350-6b2c" name="Plasma Decimator" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="2960-54a3-7350-6b2c" name="Plasma Decimator" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7dbe-a6b6-85a0-d624" type="max"/>
               </constraints>
               <profiles>
-                <profile id="9595-6887-dfe5-2411" name="Plasma Decimator" publicationId="32d1ddc6--pubN72251" page="" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+                <profile id="9595-6887-dfe5-2411" name="Plasma Decimator" publicationId="32d1ddc6--pubN72251" page="" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
                   <characteristics>
                     <characteristic name="Range" typeId="52616e676523232344415441232323">48&quot;</characteristic>
                     <characteristic name="Strength" typeId="537472656e67746823232344415441232323">8</characteristic>
@@ -1219,12 +1219,12 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
                 <cost name="pts" typeId="points" value="55.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="c8a8-c30e-1557-3f15" name="Thundercoil Harpoon" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="c8a8-c30e-1557-3f15" name="Thundercoil Harpoon" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f7ea-2317-0da3-745d" type="max"/>
               </constraints>
               <profiles>
-                <profile id="7f72-40cb-8212-8ca0" name="Thundercoil Harpoon" publicationId="32d1ddc6--pubN72251" page="" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+                <profile id="7f72-40cb-8212-8ca0" name="Thundercoil Harpoon" publicationId="32d1ddc6--pubN72251" page="" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
                   <characteristics>
                     <characteristic name="Range" typeId="52616e676523232344415441232323">12&quot;</characteristic>
                     <characteristic name="Strength" typeId="537472656e67746823232344415441232323">10</characteristic>
@@ -1242,12 +1242,12 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
                 <cost name="pts" typeId="points" value="50.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="8cd2-6b1d-d537-1c8e" name="Volcano Lance" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="8cd2-6b1d-d537-1c8e" name="Volcano Lance" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ff8a-5756-26a1-09ec" type="max"/>
               </constraints>
               <profiles>
-                <profile id="8b6e-01c6-02d5-7425" name="Volcano Lance" publicationId="32d1ddc6--pubN72251" page="" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+                <profile id="8b6e-01c6-02d5-7425" name="Volcano Lance" publicationId="32d1ddc6--pubN72251" page="" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
                   <characteristics>
                     <characteristic name="Range" typeId="52616e676523232344415441232323">80&quot;</characteristic>
                     <characteristic name="Strength" typeId="537472656e67746823232344415441232323">9</characteristic>
@@ -1264,14 +1264,14 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="e2bc-e4ca-f7b9-bec8" name="Household Rank" hidden="false" collective="false" targetId="2f28-c5f0-6110-c614" type="selectionEntry"/>
-        <entryLink id="7c89-7095-26d0-a6a3" name="Blessed Autosimulacra" hidden="false" collective="false" targetId="b09a-5d32-464b-4b2d" type="selectionEntry"/>
+        <entryLink id="e2bc-e4ca-f7b9-bec8" name="Household Rank" hidden="false" collective="false" import="true" targetId="2f28-c5f0-6110-c614" type="selectionEntry"/>
+        <entryLink id="7c89-7095-26d0-a6a3" name="Blessed Autosimulacra" hidden="false" collective="false" import="true" targetId="b09a-5d32-464b-4b2d" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="360.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="1072-d634-f6c6-b41e" name="Questoris Knight Armiger Talon" publicationId="32d1ddc6--pubN73210" page="" hidden="false" collective="false" type="model">
+    <selectionEntry id="1072-d634-f6c6-b41e" name="Questoris Knight Armiger Talon" publicationId="32d1ddc6--pubN73210" page="" hidden="false" collective="false" import="true" type="model">
       <constraints>
         <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bfcf-dc21-205d-ba14" type="max"/>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="23f7-3615-4d95-bd73" type="min"/>
@@ -1312,13 +1312,13 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
         <infoLink id="d093-3802-81a6-8852" name="Implacable Advance" hidden="false" targetId="5ecb-551d-0f68-3a79" type="rule"/>
       </infoLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="fcad-4f0f-99fc-0eea" name="May take One weapon for the following" hidden="false" collective="false">
+        <selectionEntryGroup id="fcad-4f0f-99fc-0eea" name="May take One weapon for the following" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="be8b-e52b-e3d7-b121" type="max"/>
             <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="451b-cd15-bd45-1bfa" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="1339-4875-1437-b228" name="Heavy Stubber" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="1339-4875-1437-b228" name="Heavy Stubber" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5d53-b2b2-425f-c8ee" type="max"/>
               </constraints>
@@ -1336,7 +1336,7 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
                 <cost name="pts" typeId="points" value="5.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="c749-a58d-b86e-1a51" name="Meltagun" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="c749-a58d-b86e-1a51" name="Meltagun" hidden="false" collective="false" import="true" type="upgrade">
               <profiles>
                 <profile id="031b-80c8-50ef-1146" name="Meltagun" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
                   <characteristics>
@@ -1353,18 +1353,18 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="95d6-6eb0-2d77-36b7" name="Must take Two weapons for the following" hidden="false" collective="false" defaultSelectionEntryId="918d-2398-9da1-5cf6">
+        <selectionEntryGroup id="95d6-6eb0-2d77-36b7" name="Must take Two weapons for the following" hidden="false" collective="false" import="true" defaultSelectionEntryId="918d-2398-9da1-5cf6">
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0017-ed45-eb5d-3139" type="max"/>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e86-96fc-61b0-dce4" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="918d-2398-9da1-5cf6" name="Dreadnaught Close Combat Weapon" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="918d-2398-9da1-5cf6" name="Dreadnaught Close Combat Weapon" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0ca9-9daa-d247-33c8" type="max"/>
               </constraints>
               <profiles>
-                <profile id="83b6-e34b-605e-7080" name="Dreadnaught Close Combat Weapon" page="" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+                <profile id="83b6-e34b-605e-7080" name="Dreadnaught Close Combat Weapon" page="" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
                   <characteristics>
                     <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
                     <characteristic name="Strength" typeId="537472656e67746823232344415441232323">10</characteristic>
@@ -1377,12 +1377,12 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="0320-28f4-46f7-ca89" name="Armiger Autocannon" publicationId="32d1ddc6--pubN73210" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="0320-28f4-46f7-ca89" name="Armiger Autocannon" publicationId="32d1ddc6--pubN73210" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a381-df56-7aed-04d4" type="max"/>
               </constraints>
               <profiles>
-                <profile id="8303-fed8-7388-ff02" name="Armiger Autocannon (Armour Piercing Rounds)" publicationId="32d1ddc6--pubN72251" page="" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+                <profile id="8303-fed8-7388-ff02" name="Armiger Autocannon (Armour Piercing Rounds)" publicationId="32d1ddc6--pubN72251" page="" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
                   <characteristics>
                     <characteristic name="Range" typeId="52616e676523232344415441232323">64&quot;</characteristic>
                     <characteristic name="Strength" typeId="537472656e67746823232344415441232323">7</characteristic>
@@ -1390,7 +1390,7 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
                     <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 2, Sunder</characteristic>
                   </characteristics>
                 </profile>
-                <profile id="59d2-d3ed-7f5c-740d" name="Armiger Autocannon (Incediary Rounds)" publicationId="32d1ddc6--pubN72251" page="" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+                <profile id="59d2-d3ed-7f5c-740d" name="Armiger Autocannon (Incediary Rounds)" publicationId="32d1ddc6--pubN72251" page="" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
                   <characteristics>
                     <characteristic name="Range" typeId="52616e676523232344415441232323">64&quot;</characteristic>
                     <characteristic name="Strength" typeId="537472656e67746823232344415441232323">7</characteristic>
@@ -1403,12 +1403,12 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
                 <cost name="pts" typeId="points" value="15.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="2ab8-f653-fb91-e6ae" name="Armiger Thermal Spear" publicationId="32d1ddc6--pubN73210" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="2ab8-f653-fb91-e6ae" name="Armiger Thermal Spear" publicationId="32d1ddc6--pubN73210" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1ca8-4645-2a47-9988" type="max"/>
               </constraints>
               <profiles>
-                <profile id="0d5a-6abd-ea6e-9fd9" name="Armiger Thermal Spear" publicationId="32d1ddc6--pubN72251" page="" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+                <profile id="0d5a-6abd-ea6e-9fd9" name="Armiger Thermal Spear" publicationId="32d1ddc6--pubN72251" page="" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
                   <characteristics>
                     <characteristic name="Range" typeId="52616e676523232344415441232323">36&quot;</characteristic>
                     <characteristic name="Strength" typeId="537472656e67746823232344415441232323">8</characteristic>
@@ -1423,7 +1423,7 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="67ff-11a1-7990-c20e" name="May Take Bio-Corrosive Rounds for Heavy Stubber" hidden="false" collective="false">
+        <selectionEntryGroup id="67ff-11a1-7990-c20e" name="May Take Bio-Corrosive Rounds for Heavy Stubber" hidden="false" collective="false" import="true">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
@@ -1435,7 +1435,7 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="78cd-164a-0769-53df" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="802b-988c-eb01-a502" name="Bio-Corrosive Rounds" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="802b-988c-eb01-a502" name="Bio-Corrosive Rounds" hidden="false" collective="false" import="true" type="upgrade">
               <profiles>
                 <profile id="cfb6-0425-9090-20c2" name="Bio-Corrosive Rounds" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
                   <characteristics>
@@ -1457,7 +1457,7 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
         <cost name="pts" typeId="points" value="150.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="e00d-ca82-e2ce-b437" name="Mechanicum Knight Moirax Talon" publicationId="3545-f6f0-40fe-a51e" page="" hidden="false" collective="false" type="model">
+    <selectionEntry id="e00d-ca82-e2ce-b437" name="Mechanicum Knight Moirax Talon" publicationId="3545-f6f0-40fe-a51e" page="" hidden="false" collective="false" import="true" type="model">
       <constraints>
         <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fc92-4e43-49fa-da11" type="max"/>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1bb4-41a4-13af-4316" type="min"/>
@@ -1510,18 +1510,18 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <infoLink id="ff18-ee1b-02b4-8d09" name="Move Through Cover" hidden="false" targetId="6d06-5ea0-9a17-ca97" type="rule"/>
       </infoLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="d152-3a4b-26fc-648f" name="Must take Two weapons for the following" hidden="false" collective="false" defaultSelectionEntryId="157b-faf2-9d0f-2529">
+        <selectionEntryGroup id="d152-3a4b-26fc-648f" name="Must take Two weapons for the following" hidden="false" collective="false" import="true" defaultSelectionEntryId="157b-faf2-9d0f-2529">
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="587f-25ba-efb4-487f" type="max"/>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a974-fbf7-a684-2695" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="e0e8-f876-d161-f6b0" name="Gyges Siege Claw with in-built Rad Cleanser" publicationId="3545-f6f0-40fe-a51e" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="e0e8-f876-d161-f6b0" name="Gyges Siege Claw with in-built Rad Cleanser" publicationId="3545-f6f0-40fe-a51e" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4437-9a03-b06f-8398" type="max"/>
               </constraints>
               <profiles>
-                <profile id="e291-f37a-a996-4528" name="Gyges Siege Claw" publicationId="3545-f6f0-40fe-a51e" page="" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+                <profile id="e291-f37a-a996-4528" name="Gyges Siege Claw" publicationId="3545-f6f0-40fe-a51e" page="" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
                   <characteristics>
                     <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
                     <characteristic name="Strength" typeId="537472656e67746823232344415441232323">X2</characteristic>
@@ -1537,12 +1537,12 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="157b-faf2-9d0f-2529" name="Volkite Veuglaire" publicationId="3545-f6f0-40fe-a51e" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="157b-faf2-9d0f-2529" name="Volkite Veuglaire" publicationId="3545-f6f0-40fe-a51e" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="778f-2963-6d96-c0fb" type="max"/>
               </constraints>
               <profiles>
-                <profile id="af87-e01b-d06a-c7c3" name="Volkite Veuglaire" publicationId="3545-f6f0-40fe-a51e" page="" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+                <profile id="af87-e01b-d06a-c7c3" name="Volkite Veuglaire" publicationId="3545-f6f0-40fe-a51e" page="" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
                   <characteristics>
                     <characteristic name="Range" typeId="52616e676523232344415441232323">36&quot;</characteristic>
                     <characteristic name="Strength" typeId="537472656e67746823232344415441232323">6</characteristic>
@@ -1554,13 +1554,16 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
               <infoLinks>
                 <infoLink id="ccf8-b373-a79f-73f9" name="Deflagrate" hidden="false" targetId="cbcf-5f25-f8ea-7cfd" type="rule"/>
               </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
             </selectionEntry>
-            <selectionEntry id="925d-07af-b9ff-5731" name="Lightning Lock" publicationId="3545-f6f0-40fe-a51e" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="925d-07af-b9ff-5731" name="Lightning Lock" publicationId="3545-f6f0-40fe-a51e" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d352-9984-cc66-3ab3" type="max"/>
               </constraints>
               <profiles>
-                <profile id="5041-b875-0de3-b795" name="Lightning Lock" publicationId="3545-f6f0-40fe-a51e" page="" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+                <profile id="5041-b875-0de3-b795" name="Lightning Lock" publicationId="3545-f6f0-40fe-a51e" page="" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
                   <characteristics>
                     <characteristic name="Range" typeId="52616e676523232344415441232323">36&quot;</characteristic>
                     <characteristic name="Strength" typeId="537472656e67746823232344415441232323">6</characteristic>
@@ -1577,6 +1580,66 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
                 <cost name="pts" typeId="points" value="5.0"/>
               </costs>
             </selectionEntry>
+            <selectionEntry id="1b51-dd6d-eb30-694a" name="Graviton pulsar" publicationId="3545-f6f0-40fe-a51e" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f35-0a42-fd0c-ee4f" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="5fbd-3852-5b01-65be" name="Graviton pulsar" publicationId="3545-f6f0-40fe-a51e" page="" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="52616e676523232344415441232323">24&quot;</characteristic>
+                    <characteristic name="Strength" typeId="537472656e67746823232344415441232323">-</characteristic>
+                    <characteristic name="AP" typeId="415023232344415441232323">4</characteristic>
+                    <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 2, Blast (3&quot;), Concussive, Graviton Pulse, Haywire</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink id="3366-0c5b-3981-4352" name="Graviton Pulse" hidden="false" targetId="2d57-8425-0ec0-a9cf" type="rule"/>
+                <infoLink id="88d1-960a-84f5-295f" name="Haywire" hidden="false" targetId="6970-1bf3-b33e-5dce" type="rule"/>
+                <infoLink id="98ec-07a7-cd5b-be0e" name="Concussive" hidden="false" targetId="9d85-46f7-f5e6-a5f7" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="da69-e790-e3b9-e465" name="Armiger Conversion Beam Cannon" publicationId="3545-f6f0-40fe-a51e" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5267-d192-bce5-76fe" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="ea60-e5da-c246-54bc" name="Armiger Conversion Beam Cannon (3)" publicationId="3545-f6f0-40fe-a51e" page="" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="52616e676523232344415441232323">42&quot; – 72&quot;</characteristic>
+                    <characteristic name="Strength" typeId="537472656e67746823232344415441232323">10</characteristic>
+                    <characteristic name="AP" typeId="415023232344415441232323">1</characteristic>
+                    <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 1, Blast (3&quot;)
+</characteristic>
+                  </characteristics>
+                </profile>
+                <profile id="09e8-cd3a-36c0-5206" name="Armiger Conversion Beam Cannon (2)" publicationId="3545-f6f0-40fe-a51e" page="" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="52616e676523232344415441232323">18&quot; – 42&quot;</characteristic>
+                    <characteristic name="Strength" typeId="537472656e67746823232344415441232323">8</characteristic>
+                    <characteristic name="AP" typeId="415023232344415441232323">4</characteristic>
+                    <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 1, Blast (3&quot;)
+)</characteristic>
+                  </characteristics>
+                </profile>
+                <profile id="670b-5351-74bc-e838" name="Armiger Conversion Beam Cannon (1)" publicationId="3545-f6f0-40fe-a51e" page="" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="52616e676523232344415441232323">Up to 18&quot;</characteristic>
+                    <characteristic name="Strength" typeId="537472656e67746823232344415441232323">6</characteristic>
+                    <characteristic name="AP" typeId="415023232344415441232323">-</characteristic>
+                    <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 1, Blast (3&quot;)
+</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
@@ -1586,24 +1649,24 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
-    <selectionEntryGroup id="3fc4-9d7f-969b-35bb" name="Knight Armour" hidden="false" collective="false">
+    <selectionEntryGroup id="3fc4-9d7f-969b-35bb" name="Knight Armour" hidden="false" collective="false" import="true">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7891-efe8-70eb-d282" type="min"/>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9250-2094-a907-dc6b" type="max"/>
       </constraints>
       <entryLinks>
-        <entryLink id="e8e1-c9e9-394d-5fbf" name="Cerastus Knight-Acheron" hidden="false" collective="false" targetId="b4ddbe68-7095-397e-dec4-162170dbdbcd" type="selectionEntry"/>
-        <entryLink id="e499-4dc2-bbfd-53dd" name="Cerastus Knight-Atrapos" hidden="false" collective="false" targetId="baad-77d0-04c2-e05f" type="selectionEntry"/>
-        <entryLink id="2aff-c26b-26b6-fd14" name="Cerastus Knight-Castigator" hidden="false" collective="false" targetId="b1cf8528-c9d0-2c2a-3f19-522e5532f273" type="selectionEntry"/>
-        <entryLink id="e1ee-e1ad-873f-a9cb" name="Lancer" hidden="false" collective="false" targetId="ca45ca55-eae1-1a81-8afc-1330611055a6" type="selectionEntry"/>
-        <entryLink id="eae7-2fc9-40d1-3977" name="Questoris Knight Crusader" hidden="false" collective="false" targetId="09ee-4370-1462-2cb5" type="selectionEntry"/>
-        <entryLink id="0ea8-43d3-a3c2-0554" name="Errant" hidden="false" collective="false" targetId="4b70feb1-a2e7-2f93-8320-1d6775bf5a59" type="selectionEntry"/>
-        <entryLink id="a918-71fe-b21c-cbf8" name="Questoris Knight Gallant" hidden="false" collective="false" targetId="74b8-f485-4b58-0071" type="selectionEntry"/>
-        <entryLink id="f50a-385a-d690-f0dd" name="Magaera" hidden="false" collective="false" targetId="fb7cd031-7573-eb28-4446-d709eb5acdbc" type="selectionEntry"/>
-        <entryLink id="f4cf-f09c-20a4-b376" name="Questoris Knight Paladin" hidden="false" collective="false" targetId="02eb28bb-1883-8603-0af7-b8bf2b7b69c8" type="selectionEntry"/>
-        <entryLink id="9a04-fad2-e544-64e5" name="Questoris Knight Styrix" hidden="false" collective="false" targetId="a5b350ff-895e-4557-70a6-d24a936919c2" type="selectionEntry"/>
-        <entryLink id="1b11-f6ea-15eb-3c0f" name="Questoris Knight Warden" hidden="false" collective="false" targetId="f4f1-dad6-0596-ca5a" type="selectionEntry"/>
-        <entryLink id="d945-aaa8-2751-4c23" name="Acastus Knight Porphyrion" hidden="false" collective="false" targetId="4ded-9de3-f964-33a7" type="selectionEntry">
+        <entryLink id="e8e1-c9e9-394d-5fbf" name="Cerastus Knight-Acheron" hidden="false" collective="false" import="true" targetId="b4ddbe68-7095-397e-dec4-162170dbdbcd" type="selectionEntry"/>
+        <entryLink id="e499-4dc2-bbfd-53dd" name="Cerastus Knight-Atrapos" hidden="false" collective="false" import="true" targetId="baad-77d0-04c2-e05f" type="selectionEntry"/>
+        <entryLink id="2aff-c26b-26b6-fd14" name="Cerastus Knight-Castigator" hidden="false" collective="false" import="true" targetId="b1cf8528-c9d0-2c2a-3f19-522e5532f273" type="selectionEntry"/>
+        <entryLink id="e1ee-e1ad-873f-a9cb" name="Lancer" hidden="false" collective="false" import="true" targetId="ca45ca55-eae1-1a81-8afc-1330611055a6" type="selectionEntry"/>
+        <entryLink id="eae7-2fc9-40d1-3977" name="Questoris Knight Crusader" hidden="false" collective="false" import="true" targetId="09ee-4370-1462-2cb5" type="selectionEntry"/>
+        <entryLink id="0ea8-43d3-a3c2-0554" name="Errant" hidden="false" collective="false" import="true" targetId="4b70feb1-a2e7-2f93-8320-1d6775bf5a59" type="selectionEntry"/>
+        <entryLink id="a918-71fe-b21c-cbf8" name="Questoris Knight Gallant" hidden="false" collective="false" import="true" targetId="74b8-f485-4b58-0071" type="selectionEntry"/>
+        <entryLink id="f50a-385a-d690-f0dd" name="Magaera" hidden="false" collective="false" import="true" targetId="fb7cd031-7573-eb28-4446-d709eb5acdbc" type="selectionEntry"/>
+        <entryLink id="f4cf-f09c-20a4-b376" name="Questoris Knight Paladin" hidden="false" collective="false" import="true" targetId="02eb28bb-1883-8603-0af7-b8bf2b7b69c8" type="selectionEntry"/>
+        <entryLink id="9a04-fad2-e544-64e5" name="Questoris Knight Styrix" hidden="false" collective="false" import="true" targetId="a5b350ff-895e-4557-70a6-d24a936919c2" type="selectionEntry"/>
+        <entryLink id="1b11-f6ea-15eb-3c0f" name="Questoris Knight Warden" hidden="false" collective="false" import="true" targetId="f4f1-dad6-0596-ca5a" type="selectionEntry"/>
+        <entryLink id="d945-aaa8-2751-4c23" name="Acastus Knight Porphyrion" hidden="false" collective="false" import="true" targetId="4ded-9de3-f964-33a7" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditionGroups>
@@ -1617,16 +1680,16 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="38ae-7cc3-463a-a8de" name="Questoris Knight Dominus" hidden="false" collective="false" targetId="3902-a5e5-c69e-7a01" type="selectionEntry"/>
+        <entryLink id="38ae-7cc3-463a-a8de" name="Questoris Knight Dominus" hidden="false" collective="false" import="true" targetId="3902-a5e5-c69e-7a01" type="selectionEntry"/>
       </entryLinks>
     </selectionEntryGroup>
-    <selectionEntryGroup id="365d-5bf0-6a3b-6253" name="Allegiance" hidden="false" collective="false">
+    <selectionEntryGroup id="365d-5bf0-6a3b-6253" name="Allegiance" hidden="false" collective="false" import="true">
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fd70-c2ca-dd70-af09" type="max"/>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="15f0-d927-76df-091f" type="min"/>
       </constraints>
       <selectionEntries>
-        <selectionEntry id="2f4f-fd79-5fb1-b6d0" name="Traitor" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="2f4f-fd79-5fb1-b6d0" name="Traitor" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="bf76-4f0a-5544-8892" type="max"/>
           </constraints>
@@ -1634,7 +1697,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
             <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="cde0-afa1-b2ff-7a07" name="Loyalist" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="cde0-afa1-b2ff-7a07" name="Loyalist" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6c5a-fff2-05d9-60b4" type="max"/>
           </constraints>
@@ -1644,9 +1707,9 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         </selectionEntry>
       </selectionEntries>
     </selectionEntryGroup>
-    <selectionEntryGroup id="5527-f4ef-035b-11c2" name="Wargear" hidden="false" collective="false">
+    <selectionEntryGroup id="5527-f4ef-035b-11c2" name="Wargear" hidden="false" collective="false" import="true">
       <selectionEntries>
-        <selectionEntry id="b4ea-a586-86a9-02eb" name="Nuncio-vox" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="b4ea-a586-86a9-02eb" name="Nuncio-vox" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8ccf-07cb-9064-9762" type="max"/>
           </constraints>
@@ -1657,7 +1720,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
             <cost name="pts" typeId="points" value="10.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="91c7-90a8-a1ae-cde0" name="Legion Vexilla" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="91c7-90a8-a1ae-cde0" name="Legion Vexilla" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a592-1d66-c299-b987" type="max"/>
           </constraints>
@@ -1668,7 +1731,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
             <cost name="pts" typeId="points" value="10.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="dd74-ccdb-9bc6-7069" name="Artificer Armour" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="dd74-ccdb-9bc6-7069" name="Artificer Armour" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="535d-a0a7-ce4e-6ab5" type="max"/>
           </constraints>
@@ -1683,7 +1746,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
             <cost name="pts" typeId="points" value="10.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="ab39-d41c-7f2d-a92b" name="Combat Shield" publicationId="32d1ddc6--pubN74776" page="131" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="ab39-d41c-7f2d-a92b" name="Combat Shield" publicationId="32d1ddc6--pubN74776" page="131" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8e0d-f89e-8c8d-2d29" type="max"/>
           </constraints>
@@ -1698,7 +1761,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
             <cost name="pts" typeId="points" value="5.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="1c30-47c5-950a-e3df" name="Boarding Shield" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="1c30-47c5-950a-e3df" name="Boarding Shield" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4f5f-b5eb-eb91-d212" type="max"/>
           </constraints>
@@ -1709,7 +1772,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
             <cost name="pts" typeId="points" value="10.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="131a-f920-a4da-1196" name="Jump Pack" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="131a-f920-a4da-1196" name="Jump Pack" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="bb9a-1adf-8c3d-0560" type="max"/>
             <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c90e-f674-9793-926a" type="min"/>
@@ -1724,7 +1787,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
             <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="5b17-8f37-be37-1146" name="Space Marine Bike" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="5b17-8f37-be37-1146" name="Space Marine Bike" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d441-c235-b1b9-eb8f" type="max"/>
             <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8c45-d376-3ee9-a6f7" type="min"/>
@@ -1745,7 +1808,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <sharedProfiles>
-    <profile id="e8a4-795e-882b-6109" name="Rad Furnace" publicationId="3545-f6f0-40fe-a51e" page="223" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="">
+    <profile id="e8a4-795e-882b-6109" name="Rad Furnace" publicationId="3545-f6f0-40fe-a51e" page="223" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
       <characteristics>
         <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">All models locked in combat with this unit suffer -1 to their Toughness for the duration of the combat. Models equiped with Rad Furnace are immune to this effect as well as to Rad Grenades. Any weapon with Poison or Rad-phage only woulds a model with a Rad Furnace on a 6.  </characteristic>
       </characteristics>

--- a/(HH) Mechanicum - Taghmata Army List.cat
+++ b/(HH) Mechanicum - Taghmata Army List.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="cf03-f607-41dc-7545" name="Mechanicum: Taghmata Army List" revision="86" battleScribeVersion="2.02" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="85" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="cf03-f607-41dc-7545" name="Mechanicum: Taghmata Army List" revision="87" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="85" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="cf03-f607-pubN65537" name="Horus Heresy: Taghmata Army List"/>
     <publication id="cf03-f607-pubN65563" name="AoDRB"/>
@@ -831,7 +831,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
     </forceEntry>
   </forceEntries>
   <selectionEntries>
-    <selectionEntry id="2da6-98c4-2a24-507d" name="Questoris Knight Armiger Talon" publicationId="cf03-f607-pubN70802" page="" hidden="false" collective="false" type="model">
+    <selectionEntry id="2da6-98c4-2a24-507d" name="Questoris Knight Armiger Talon" publicationId="cf03-f607-pubN70802" page="" hidden="false" collective="false" import="true" type="model">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3f17-d1bb-2a1a-b1ca" type="max"/>
       </constraints>
@@ -844,13 +844,13 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <categoryLink id="0f11-7749-1067-0d45" name="Heavy Support" hidden="false" targetId="486561767920537570706f727423232344415441232323" primary="true"/>
       </categoryLinks>
       <entryLinks>
-        <entryLink id="043a-5dce-26f0-e395" name="Questoris Knight Armiger Talon" hidden="false" collective="false" targetId="678d-0533-f5f7-2e43" type="selectionEntry"/>
+        <entryLink id="043a-5dce-26f0-e395" name="Questoris Knight Armiger Talon" hidden="false" collective="false" import="true" targetId="678d-0533-f5f7-2e43" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="25.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="bb4f-7771-ee2c-ff1a" name="Mechanicum Knight Moirax Talon" publicationId="ece2-a265-6237-7efa" page="" hidden="false" collective="false" type="model">
+    <selectionEntry id="bb4f-7771-ee2c-ff1a" name="Mechanicum Knight Moirax Talon" publicationId="ece2-a265-6237-7efa" page="" hidden="false" collective="false" import="true" type="model">
       <rules>
         <rule id="d0c5-283a-57ac-5532" name="Moirax Talon" hidden="false">
           <description>When first deployed on the battlefield (either at the start of the game or when arriving via Reserves later on), the Knights in a Talon must be placed within 6&quot; of each other. Afterwards, they are not treated as a Vehicle squadron but operate independently as individual units for the purposes of taking any actions, as well as for determining Victory points in missions which make use of Victory points for destroying units.</description>
@@ -860,7 +860,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <categoryLink id="c209-50a7-28b7-3f59" name="Heavy Support" hidden="false" targetId="486561767920537570706f727423232344415441232323" primary="true"/>
       </categoryLinks>
       <entryLinks>
-        <entryLink id="479d-b201-cb6e-0084" name="Mechanicum Knight Moirax Talon" hidden="false" collective="false" targetId="6ad8-fbf2-07a8-237c" type="selectionEntry"/>
+        <entryLink id="479d-b201-cb6e-0084" name="Mechanicum Knight Moirax Talon" hidden="false" collective="false" import="true" targetId="6ad8-fbf2-07a8-237c" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="30.0"/>
@@ -868,18 +868,18 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
     </selectionEntry>
   </selectionEntries>
   <entryLinks>
-    <entryLink id="6a75-6b49-08b0-c64e" name="Macrocarid Explorator" hidden="false" collective="false" targetId="0de5-5b51-907d-e5e2" type="selectionEntry">
+    <entryLink id="6a75-6b49-08b0-c64e" name="Macrocarid Explorator" hidden="false" collective="false" import="true" targetId="0de5-5b51-907d-e5e2" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="6a75-6b49-08b0-c64e-486561767920537570706f727423232344415441232323" hidden="false" targetId="486561767920537570706f727423232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="7d01-dee0-622d-20c6" name="Tech-Priest Auxillia" hidden="false" collective="false" targetId="bcad-45c9-3b27-a7ca" type="selectionEntry">
+    <entryLink id="7d01-dee0-622d-20c6" name="Tech-Priest Auxillia" hidden="false" collective="false" import="true" targetId="bcad-45c9-3b27-a7ca" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="7d01-dee0-622d-20c6-456c6974657323232344415441232323" hidden="false" targetId="456c6974657323232344415441232323" primary="true"/>
         <categoryLink id="47bf-54d5-bca7-d8cf" name="New CategoryLink" hidden="false" targetId="f74d-4679-75a6-1252" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="7dac-f007-ce18-6142" name="Tech-Priest Auxillia" hidden="false" collective="false" targetId="bcad-45c9-3b27-a7ca" type="selectionEntry">
+    <entryLink id="7dac-f007-ce18-6142" name="Tech-Priest Auxillia" hidden="false" collective="false" import="true" targetId="bcad-45c9-3b27-a7ca" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -892,7 +892,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <categoryLink id="2685-3e18-c6f1-89b1" name="New CategoryLink" hidden="false" targetId="f74d-4679-75a6-1252" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="c7ac-9d02-c011-f222" name="Scyllax Guardian-Automata Covenant" hidden="false" collective="false" targetId="314b-bec3-5501-a0aa" type="selectionEntry">
+    <entryLink id="c7ac-9d02-c011-f222" name="Scyllax Guardian-Automata Covenant" hidden="false" collective="false" import="true" targetId="314b-bec3-5501-a0aa" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -906,13 +906,13 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <categoryLink id="3981-00cb-75e5-2790" name="New CategoryLink" hidden="false" targetId="219d-aefa-dfa5-44db" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="9a0a-e41a-013b-c48f" name="Vorax Class Battle-automata Maniple" hidden="false" collective="false" targetId="deb3-68a3-5d36-eb3d" type="selectionEntry">
+    <entryLink id="9a0a-e41a-013b-c48f" name="Vorax Class Battle-automata Maniple" hidden="false" collective="false" import="true" targetId="deb3-68a3-5d36-eb3d" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="9a0a-e41a-013b-c48f-466173742041747461636b23232344415441232323" hidden="false" targetId="466173742041747461636b23232344415441232323" primary="true"/>
         <categoryLink id="8bdc-6e5e-3cd8-3676" name="New CategoryLink" hidden="false" targetId="7fdd-2a97-d0e9-6524" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="ec8a-2676-2661-296e" name="Castellax Class Battle-Automata Maniple" hidden="false" collective="false" targetId="48db-84ca-2bad-520f" type="selectionEntry">
+    <entryLink id="ec8a-2676-2661-296e" name="Castellax Class Battle-Automata Maniple" hidden="false" collective="false" import="true" targetId="48db-84ca-2bad-520f" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -932,7 +932,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <categoryLink id="ec8a-2676-2661-296e-54726f6f707323232344415441232323" hidden="false" targetId="54726f6f707323232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="a6da-fabe-6b98-c46e" name="Secutarii Peltast Phalanx" hidden="false" collective="false" targetId="8190-e779-2c49-c564" type="selectionEntry">
+    <entryLink id="a6da-fabe-6b98-c46e" name="Secutarii Peltast Phalanx" hidden="false" collective="false" import="true" targetId="8190-e779-2c49-c564" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -954,7 +954,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <categoryLink id="a6da-fabe-6b98-c46e-54726f6f707323232344415441232323" hidden="false" targetId="54726f6f707323232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="4fe0-ed8d-a28a-d78d" name="Secutarii Hoplite Phalanx" hidden="false" collective="false" targetId="4ff6-b526-4208-0d33" type="selectionEntry">
+    <entryLink id="4fe0-ed8d-a28a-d78d" name="Secutarii Hoplite Phalanx" hidden="false" collective="false" import="true" targetId="4ff6-b526-4208-0d33" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -976,66 +976,66 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <categoryLink id="4fe0-ed8d-a28a-d78d-54726f6f707323232344415441232323" hidden="false" targetId="54726f6f707323232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="3447-78a1-19ec-64d4" name="Karacnos Assault Tank" hidden="false" collective="false" targetId="ec0b-3124-e0e4-6336" type="selectionEntry">
+    <entryLink id="3447-78a1-19ec-64d4" name="Karacnos Assault Tank" hidden="false" collective="false" import="true" targetId="ec0b-3124-e0e4-6336" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="3447-78a1-19ec-64d4-486561767920537570706f727423232344415441232323" hidden="false" targetId="486561767920537570706f727423232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="c6d8-d4b0-8ca6-1de7" name="Ordinatus Minoris Macro Engine" hidden="false" collective="false" targetId="7cdb-8db0-bfd6-ce3c" type="selectionEntry">
+    <entryLink id="c6d8-d4b0-8ca6-1de7" name="Ordinatus Minoris Macro Engine" hidden="false" collective="false" import="true" targetId="7cdb-8db0-bfd6-ce3c" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="c6d8-d4b0-8ca6-1de7-1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="4816-7548-8274-c75c" name="Vultarax Stratos-automata Maniple" hidden="false" collective="false" targetId="972c-91a0-764b-3fe0" type="selectionEntry">
+    <entryLink id="4816-7548-8274-c75c" name="Vultarax Stratos-automata Maniple" hidden="false" collective="false" import="true" targetId="972c-91a0-764b-3fe0" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="4816-7548-8274-c75c-466173742041747461636b23232344415441232323" hidden="false" targetId="466173742041747461636b23232344415441232323" primary="true"/>
         <categoryLink id="a3e7-960f-d552-c0b5" name="New CategoryLink" hidden="false" targetId="7fdd-2a97-d0e9-6524" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="b637-4c88-f152-dd34" name="Acastus Knight Porphyrion" hidden="false" collective="false" targetId="4ded-9de3-f964-33a7" type="selectionEntry">
+    <entryLink id="b637-4c88-f152-dd34" name="Acastus Knight Porphyrion" hidden="false" collective="false" import="true" targetId="4ded-9de3-f964-33a7" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="b637-4c88-f152-dd34-1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="a8be-c5b3-71f2-beee" name="Crusade Fleet Arvus Lighter Orbital Shuttle" hidden="false" collective="false" targetId="7b0f-7bfb-ca1f-e761" type="selectionEntry">
+    <entryLink id="a8be-c5b3-71f2-beee" name="Crusade Fleet Arvus Lighter Orbital Shuttle" hidden="false" collective="false" import="true" targetId="7b0f-7bfb-ca1f-e761" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="a8be-c5b3-71f2-beee-466173742041747461636b23232344415441232323" hidden="false" targetId="466173742041747461636b23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="eb49-9c86-cc4d-9897" name="Crusade Fleet Avenger Strike Fighter" hidden="false" collective="false" targetId="11c8-2e78-8328-31e4" type="selectionEntry">
+    <entryLink id="eb49-9c86-cc4d-9897" name="Crusade Fleet Avenger Strike Fighter" hidden="false" collective="false" import="true" targetId="11c8-2e78-8328-31e4" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="eb49-9c86-cc4d-9897-466173742041747461636b23232344415441232323" hidden="false" targetId="466173742041747461636b23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="6168-b447-65bb-476a" name="Crusade Fleet Primaris-Lightning Strike Fighter" hidden="false" collective="false" targetId="5d68-1fb8-1f66-af3a" type="selectionEntry">
+    <entryLink id="6168-b447-65bb-476a" name="Crusade Fleet Primaris-Lightning Strike Fighter" hidden="false" collective="false" import="true" targetId="5d68-1fb8-1f66-af3a" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="6168-b447-65bb-476a-466173742041747461636b23232344415441232323" hidden="false" targetId="466173742041747461636b23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="b89f-6149-6ea0-4a3e" name="Legio Titanicus Reaver Battle Titan" hidden="false" collective="false" targetId="1fa3-1f86-94a6-bf48" type="selectionEntry">
+    <entryLink id="b89f-6149-6ea0-4a3e" name="Legio Titanicus Reaver Battle Titan" hidden="false" collective="false" import="true" targetId="1fa3-1f86-94a6-bf48" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="b89f-6149-6ea0-4a3e-1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
         <categoryLink id="474c-e22d-885e-0442" name="New CategoryLink" hidden="false" targetId="5f7c-939a-f2de-413a" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="04b9-f36b-de77-b975" name="Legio Titanicus Warhound Scout Titan" hidden="false" collective="false" targetId="b894-adfc-6d3d-fde4" type="selectionEntry">
+    <entryLink id="04b9-f36b-de77-b975" name="Legio Titanicus Warhound Scout Titan" hidden="false" collective="false" import="true" targetId="b894-adfc-6d3d-fde4" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="04b9-f36b-de77-b975-1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
         <categoryLink id="a00f-22e4-274d-916b" name="New CategoryLink" hidden="false" targetId="5f7c-939a-f2de-413a" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="a143-d91f-0fd8-4ac5" name="Legio Titanicus Warlord Battle Titan" hidden="false" collective="false" targetId="ab80-0fef-3e93-8e64" type="selectionEntry">
+    <entryLink id="a143-d91f-0fd8-4ac5" name="Legio Titanicus Warlord Battle Titan" hidden="false" collective="false" import="true" targetId="ab80-0fef-3e93-8e64" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="a143-d91f-0fd8-4ac5-1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
         <categoryLink id="770b-534b-8b1e-2361" name="New CategoryLink" hidden="false" targetId="5f7c-939a-f2de-413a" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="8017-56b9-70cc-39f7" name="Cerastus Knight-Atrapos" hidden="false" collective="false" targetId="baad-77d0-04c2-e05f" type="selectionEntry">
+    <entryLink id="8017-56b9-70cc-39f7" name="Cerastus Knight-Atrapos" hidden="false" collective="false" import="true" targetId="baad-77d0-04c2-e05f" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="8017-56b9-70cc-39f7-1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="62b4-53bc-36ca-57d2" name="Secutarii Axiarch" hidden="false" collective="false" targetId="bd94-0269-4234-4a81" type="selectionEntry">
+    <entryLink id="62b4-53bc-36ca-57d2" name="Secutarii Axiarch" hidden="false" collective="false" import="true" targetId="bd94-0269-4234-4a81" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="f855-004d-6a48-f343" value="-1">
           <conditions>
@@ -1052,92 +1052,92 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <categoryLink id="62b4-53bc-36ca-57d2-485123232344415441232323" hidden="false" targetId="485123232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="d488-e09b-cfa5-35ca" name="Aquila Strongpoint" hidden="false" collective="false" targetId="16d6-25c4-af92-4329" type="selectionEntry">
+    <entryLink id="d488-e09b-cfa5-35ca" name="Aquila Strongpoint" hidden="false" collective="false" import="true" targetId="16d6-25c4-af92-4329" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="d488-e09b-cfa5-35ca-1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="f163-b853-4f1b-2414" name="Warlord-Sinister Patter Battle Psi-Titan" hidden="false" collective="false" targetId="fb92-d215-2011-f911" type="selectionEntry">
+    <entryLink id="f163-b853-4f1b-2414" name="Warlord-Sinister Patter Battle Psi-Titan" hidden="false" collective="false" import="true" targetId="fb92-d215-2011-f911" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="f163-b853-4f1b-2414-1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="2629-f745-a484-3119" name="Allegiance" hidden="false" collective="false" targetId="4f6b-4baa-d1e2-9b03" type="selectionEntry">
+    <entryLink id="2629-f745-a484-3119" name="Allegiance" hidden="false" collective="false" import="true" targetId="4f6b-4baa-d1e2-9b03" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="2629-f745-a484-3119-5297-7e0f-fa0b-3537" hidden="false" targetId="5297-7e0f-fa0b-3537" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="07f3-29dc-731d-f882" name="Wall of Martyrs Vengeance Weapon Battery" hidden="false" collective="false" targetId="04bf-6c22-19fb-4e46" type="selectionEntry">
+    <entryLink id="07f3-29dc-731d-f882" name="Wall of Martyrs Vengeance Weapon Battery" hidden="false" collective="false" import="true" targetId="04bf-6c22-19fb-4e46" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="07f3-29dc-731d-f882-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="6853-c72e-77f7-7fe9" name="Aegis Defense Line" hidden="false" collective="false" targetId="a505-05af-bd44-56b6" type="selectionEntry">
+    <entryLink id="6853-c72e-77f7-7fe9" name="Aegis Defense Line" hidden="false" collective="false" import="true" targetId="a505-05af-bd44-56b6" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="6853-c72e-77f7-7fe9-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="8d54-7e21-d690-5e63" name="Wall of Martyrs Imperial Defence Line" hidden="false" collective="false" targetId="0f73-97f2-b832-f6d0" type="selectionEntry">
+    <entryLink id="8d54-7e21-d690-5e63" name="Wall of Martyrs Imperial Defence Line" hidden="false" collective="false" import="true" targetId="0f73-97f2-b832-f6d0" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="8d54-7e21-d690-5e63-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="9dca-943b-368a-09bc" name="Wall of Martyrs Imperial Defence Emplacement" hidden="false" collective="false" targetId="df05-8179-624e-f8b2" type="selectionEntry">
+    <entryLink id="9dca-943b-368a-09bc" name="Wall of Martyrs Imperial Defence Emplacement" hidden="false" collective="false" import="true" targetId="df05-8179-624e-f8b2" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="9dca-943b-368a-09bc-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="7238-cd37-70ee-d126" name="Wall of Martyrs Imperial Bunker" hidden="false" collective="false" targetId="0116-c81b-1c0f-251c" type="selectionEntry">
+    <entryLink id="7238-cd37-70ee-d126" name="Wall of Martyrs Imperial Bunker" hidden="false" collective="false" import="true" targetId="0116-c81b-1c0f-251c" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="7238-cd37-70ee-d126-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="45cf-6fb5-847a-fe7f" name="Wall of Martyrs Firestorm Redoubt" hidden="false" collective="false" targetId="a172-78de-aaa6-2201" type="selectionEntry">
+    <entryLink id="45cf-6fb5-847a-fe7f" name="Wall of Martyrs Firestorm Redoubt" hidden="false" collective="false" import="true" targetId="a172-78de-aaa6-2201" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="45cf-6fb5-847a-fe7f-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="4d39-e78e-aa8c-3526" name="Shrine of the Aquila" hidden="false" collective="false" targetId="595a-908e-96a1-f121" type="selectionEntry">
+    <entryLink id="4d39-e78e-aa8c-3526" name="Shrine of the Aquila" hidden="false" collective="false" import="true" targetId="595a-908e-96a1-f121" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="4d39-e78e-aa8c-3526-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="ff78-4e11-e0f3-9503" name="Sanctum Imperialis" hidden="false" collective="false" targetId="e0b3-77ca-af76-bd8b" type="selectionEntry">
+    <entryLink id="ff78-4e11-e0f3-9503" name="Sanctum Imperialis" hidden="false" collective="false" import="true" targetId="e0b3-77ca-af76-bd8b" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="ff78-4e11-e0f3-9503-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="425f-a363-f672-7867" name="Plasma Obliterator" hidden="false" collective="false" targetId="3015-0b77-e848-c0f5" type="selectionEntry">
+    <entryLink id="425f-a363-f672-7867" name="Plasma Obliterator" hidden="false" collective="false" import="true" targetId="3015-0b77-e848-c0f5" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="425f-a363-f672-7867-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="31e2-35e7-32ad-acb8" name="Manufactorum" hidden="false" collective="false" targetId="6140-dc64-5896-957f" type="selectionEntry">
+    <entryLink id="31e2-35e7-32ad-acb8" name="Manufactorum" hidden="false" collective="false" import="true" targetId="6140-dc64-5896-957f" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="31e2-35e7-32ad-acb8-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="2be9-5af0-6412-78d9" name="Imperial Primus Redoubt" hidden="false" collective="false" targetId="c05d-2231-2481-4037" type="selectionEntry">
+    <entryLink id="2be9-5af0-6412-78d9" name="Imperial Primus Redoubt" hidden="false" collective="false" import="true" targetId="c05d-2231-2481-4037" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="2be9-5af0-6412-78d9-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="808e-b852-a76b-939f" name="Imperial Castelum Stronghold" hidden="false" collective="false" targetId="e40b-468f-f1d7-d05d" type="selectionEntry">
+    <entryLink id="808e-b852-a76b-939f" name="Imperial Castelum Stronghold" hidden="false" collective="false" import="true" targetId="e40b-468f-f1d7-d05d" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="808e-b852-a76b-939f-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="ca7d-57c9-2a37-be01" name="Imperial Bastion" hidden="false" collective="false" targetId="55c6-268b-357f-d070" type="selectionEntry">
+    <entryLink id="ca7d-57c9-2a37-be01" name="Imperial Bastion" hidden="false" collective="false" import="true" targetId="55c6-268b-357f-d070" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="ca7d-57c9-2a37-be01-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="54f6-9b6b-c64c-753a" name="Basilica Administratum" hidden="false" collective="false" targetId="e10f-7b90-ecd3-80a5" type="selectionEntry">
+    <entryLink id="54f6-9b6b-c64c-753a" name="Basilica Administratum" hidden="false" collective="false" import="true" targetId="e10f-7b90-ecd3-80a5" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="54f6-9b6b-c64c-753a-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="7f94-d779-b55e-3e78" name="Thallax Cohort" hidden="false" collective="false" targetId="b39b-9817-025c-62da" type="selectionEntry">
+    <entryLink id="7f94-d779-b55e-3e78" name="Thallax Cohort" hidden="false" collective="false" import="true" targetId="b39b-9817-025c-62da" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -1152,7 +1152,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <categoryLink id="1e4f-1949-0021-72ef" name="New CategoryLink" hidden="false" targetId="37f2-7398-84ee-6fdf" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="ea1f-fb78-d2de-4a0c" name="Castellax Class Battle-Automata Maniple" hidden="true" collective="false" targetId="48db-84ca-2bad-520f" type="selectionEntry">
+    <entryLink id="ea1f-fb78-d2de-4a0c" name="Castellax Class Battle-Automata Maniple" hidden="true" collective="false" import="true" targetId="48db-84ca-2bad-520f" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
@@ -1173,7 +1173,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <categoryLink id="97c9-d370-5bb8-b00b" name="New CategoryLink" hidden="false" targetId="54726f6f707323232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="bcdc-d06d-a499-5b39" name="Thallax Cohort" hidden="true" collective="false" targetId="b39b-9817-025c-62da" type="selectionEntry">
+    <entryLink id="bcdc-d06d-a499-5b39" name="Thallax Cohort" hidden="true" collective="false" import="true" targetId="b39b-9817-025c-62da" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
@@ -1187,7 +1187,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <categoryLink id="9d75-6e8e-d457-0cbe" name="New CategoryLink" hidden="false" targetId="54726f6f707323232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="c113-055f-0a53-5b42" name="Adsecularis Covenant" hidden="true" collective="false" targetId="7e54-a6b2-1982-0706" type="selectionEntry">
+    <entryLink id="c113-055f-0a53-5b42" name="Adsecularis Covenant" hidden="true" collective="false" import="true" targetId="7e54-a6b2-1982-0706" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
@@ -1205,7 +1205,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <categoryLink id="3447-df86-ebd9-0702" name="New CategoryLink" hidden="false" targetId="54726f6f707323232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="b4f3-3ee3-c867-b2c0" name="Adsecularis Covenant" hidden="true" collective="false" targetId="7e54-a6b2-1982-0706" type="selectionEntry">
+    <entryLink id="b4f3-3ee3-c867-b2c0" name="Adsecularis Covenant" hidden="true" collective="false" import="true" targetId="7e54-a6b2-1982-0706" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
@@ -1222,7 +1222,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <categoryLink id="7c09-c1a3-0a5a-ca8d" name="New CategoryLink" hidden="false" targetId="54726f6f707323232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="cfd6-6c7a-c47e-6d65" name="Scyllax Guardian-Automata Covenant" hidden="true" collective="false" targetId="314b-bec3-5501-a0aa" type="selectionEntry">
+    <entryLink id="cfd6-6c7a-c47e-6d65" name="Scyllax Guardian-Automata Covenant" hidden="true" collective="false" import="true" targetId="314b-bec3-5501-a0aa" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
@@ -1235,13 +1235,13 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <categoryLink id="ef5f-e29a-274c-1854" name="New CategoryLink" hidden="false" targetId="f74d-4679-75a6-1252" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="b36e-b70d-53a0-2b7c" name="Anacharis Scoria" hidden="false" collective="false" targetId="83ef-4568-5093-61d5" type="selectionEntry">
+    <entryLink id="b36e-b70d-53a0-2b7c" name="Anacharis Scoria" hidden="false" collective="false" import="true" targetId="83ef-4568-5093-61d5" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="a7f7-962f-f6e5-a717" name="New CategoryLink" hidden="false" targetId="becd-7a6d-e80f-878e" primary="false"/>
         <categoryLink id="b6c9-d9c2-b84d-182b" name="New CategoryLink" hidden="false" targetId="485123232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="e755-bf80-490e-2022" name="Navigator" hidden="true" collective="false" targetId="00f3-1eed-88ff-5c46" type="selectionEntry">
+    <entryLink id="e755-bf80-490e-2022" name="Navigator" hidden="true" collective="false" import="true" targetId="00f3-1eed-88ff-5c46" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
@@ -1254,28 +1254,28 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <categoryLink id="96fa-dc46-db85-502a" name="New CategoryLink" hidden="false" targetId="f74d-4679-75a6-1252" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="b165-8077-1bcf-4df7" name="Ursarax Cohort" hidden="false" collective="false" targetId="2f28-034a-ca2c-5b9e" type="selectionEntry">
+    <entryLink id="b165-8077-1bcf-4df7" name="Ursarax Cohort" hidden="false" collective="false" import="true" targetId="2f28-034a-ca2c-5b9e" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="d1cf-e15a-ea51-45ed" name="New CategoryLink" hidden="false" targetId="466173742041747461636b23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="4107-f38f-37a0-131e" name="Legio" hidden="false" collective="false" targetId="8352-9d62-82af-9642" type="selectionEntry"/>
-    <entryLink id="cd17-1f96-4a9e-cf90" name="Krios Battle Tank Squadron" hidden="false" collective="false" targetId="4934-5161-12f7-f0f8" type="selectionEntry">
+    <entryLink id="4107-f38f-37a0-131e" name="Legio" hidden="false" collective="false" import="true" targetId="8352-9d62-82af-9642" type="selectionEntry"/>
+    <entryLink id="cd17-1f96-4a9e-cf90" name="Krios Battle Tank Squadron" hidden="false" collective="false" import="true" targetId="4934-5161-12f7-f0f8" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="8e79-4980-f228-dac3" name="New CategoryLink" hidden="false" targetId="486561767920537570706f727423232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="a83c-8b05-dad4-4493" name="Arlatax Class Battle-automata Maniple" hidden="false" collective="false" targetId="eaf8-70d7-0806-b22e" type="selectionEntry">
+    <entryLink id="a83c-8b05-dad4-4493" name="Arlatax Class Battle-automata Maniple" hidden="false" collective="false" import="true" targetId="eaf8-70d7-0806-b22e" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="bf75-a7b5-f983-ed04" name="New CategoryLink" hidden="false" targetId="466173742041747461636b23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="6858-0dfc-94e4-1487" name="Domitar Class Battle-automata Maniple" hidden="false" collective="false" targetId="911d-55a5-94c4-41ac" type="selectionEntry">
+    <entryLink id="6858-0dfc-94e4-1487" name="Domitar Class Battle-automata Maniple" hidden="false" collective="false" import="true" targetId="911d-55a5-94c4-41ac" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="9f19-46a1-d01f-bfa1" name="New CategoryLink" hidden="false" targetId="456c6974657323232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="c65b-f4b0-4045-3c5a" name="Ordo Reductor Minotaur Battery" hidden="false" collective="false" targetId="e35c-8e84-62ed-7814" type="selectionEntry">
+    <entryLink id="c65b-f4b0-4045-3c5a" name="Ordo Reductor Minotaur Battery" hidden="false" collective="false" import="true" targetId="e35c-8e84-62ed-7814" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -1287,17 +1287,17 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <categoryLink id="8f6b-70ab-cffc-18db" name="New CategoryLink" hidden="false" targetId="486561767920537570706f727423232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="7eaf-3b89-0b7e-2858" name="Ordo Reductor Artillery Tank Battery" hidden="false" collective="false" targetId="de9f-f10c-c0a9-789b" type="selectionEntry">
+    <entryLink id="7eaf-3b89-0b7e-2858" name="Ordo Reductor Artillery Tank Battery" hidden="false" collective="false" import="true" targetId="de9f-f10c-c0a9-789b" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="0e0a-7503-6af7-ad7b" name="New CategoryLink" hidden="false" targetId="486561767920537570706f727423232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="d374-6127-ba36-07d0" name="Tarantula Sentry Gun Battery" hidden="false" collective="false" targetId="29c7-a5ff-4521-f4f3" type="selectionEntry">
+    <entryLink id="d374-6127-ba36-07d0" name="Tarantula Sentry Gun Battery" hidden="false" collective="false" import="true" targetId="29c7-a5ff-4521-f4f3" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="ae00-cf96-3371-ac5f" name="New CategoryLink" hidden="false" targetId="466173742041747461636b23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="7bc3-4c9b-a14c-d3c2" name="Archmagos Dominus" hidden="true" collective="false" targetId="e35b-b300-7fb2-e063" type="selectionEntry">
+    <entryLink id="7bc3-4c9b-a14c-d3c2" name="Archmagos Dominus" hidden="true" collective="false" import="true" targetId="e35b-b300-7fb2-e063" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
@@ -1310,25 +1310,25 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <categoryLink id="01e4-e7fd-1cf5-bacd" name="New CategoryLink" hidden="false" targetId="485123232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="697b-52bf-d5bd-46e8" name="Thanatar-Calix Class Siege-Automata" hidden="false" collective="false" targetId="93b9-6dc9-3d02-db32" type="selectionEntry">
+    <entryLink id="697b-52bf-d5bd-46e8" name="Thanatar-Calix Class Siege-Automata" hidden="false" collective="false" import="true" targetId="93b9-6dc9-3d02-db32" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="77ef-09b9-4d9c-cdaa" name="New CategoryLink" hidden="false" targetId="486561767920537570706f727423232344415441232323" primary="true"/>
         <categoryLink id="7c15-e346-2975-b338" name="New CategoryLink" hidden="false" targetId="7fdd-2a97-d0e9-6524" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="7a4e-c7f8-46c1-5c58" name="Thanatar-Cynis Class Siege-Automata Maniple" page="" hidden="false" collective="false" targetId="c888-532b-f933-ce1d" type="selectionEntry">
+    <entryLink id="7a4e-c7f8-46c1-5c58" name="Thanatar-Cynis Class Siege-Automata Maniple" page="" hidden="false" collective="false" import="true" targetId="c888-532b-f933-ce1d" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="e84c-7335-429c-a9f2" name="New CategoryLink" hidden="false" targetId="7fdd-2a97-d0e9-6524" primary="false"/>
         <categoryLink id="1a6f-fb20-4bb5-1cac" name="New CategoryLink" hidden="false" targetId="486561767920537570706f727423232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="38f8-832c-1638-0623" name="The Homonculex" hidden="false" collective="false" targetId="96be-db78-16ac-5163" type="selectionEntry">
+    <entryLink id="38f8-832c-1638-0623" name="The Homonculex" hidden="false" collective="false" import="true" targetId="96be-db78-16ac-5163" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="aad4-e130-3cbb-ec89" name="New CategoryLink" hidden="false" targetId="7fdd-2a97-d0e9-6524" primary="false"/>
         <categoryLink id="59c5-f66f-50c2-3565" name="New CategoryLink" hidden="false" targetId="466173742041747461636b23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="fc87-1477-dc2f-53bf" name="Archmagos Draykavac" hidden="true" collective="false" targetId="2ff2-0526-3cea-acb2" type="selectionEntry">
+    <entryLink id="fc87-1477-dc2f-53bf" name="Archmagos Draykavac" hidden="true" collective="false" import="true" targetId="2ff2-0526-3cea-acb2" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
@@ -1341,7 +1341,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <categoryLink id="0fe2-7424-1932-b54f" name="New CategoryLink" hidden="false" targetId="485123232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="be7d-5e7a-26a6-e9c6" name="Archmagos Inar Satarael" hidden="false" collective="false" targetId="7095-280b-9ccc-b7bc" type="selectionEntry">
+    <entryLink id="be7d-5e7a-26a6-e9c6" name="Archmagos Inar Satarael" hidden="false" collective="false" import="true" targetId="7095-280b-9ccc-b7bc" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -1354,7 +1354,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <categoryLink id="fe90-cb89-8899-bc3e" name="New CategoryLink" hidden="false" targetId="485123232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="26e6-4e76-0f8e-29c2" name="Magos Dominus" hidden="true" collective="false" targetId="f891-cee8-321e-f159" type="selectionEntry">
+    <entryLink id="26e6-4e76-0f8e-29c2" name="Magos Dominus" hidden="true" collective="false" import="true" targetId="f891-cee8-321e-f159" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
@@ -1366,7 +1366,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <categoryLink id="ceef-3182-c221-51ab" name="New CategoryLink" hidden="false" targetId="485123232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="f2b2-170e-52e7-073d" name="Magos Prime" hidden="true" collective="false" targetId="aa74-77f4-7266-36b6" type="selectionEntry">
+    <entryLink id="f2b2-170e-52e7-073d" name="Magos Prime" hidden="true" collective="false" import="true" targetId="aa74-77f4-7266-36b6" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
@@ -1378,7 +1378,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <categoryLink id="baab-8987-7c5b-e9b4" name="New CategoryLink" hidden="false" targetId="485123232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="53a1-ee52-c81e-d15c" name="Magos Reductor" hidden="true" collective="false" targetId="04e8-11de-2eb4-67e0" type="selectionEntry">
+    <entryLink id="53a1-ee52-c81e-d15c" name="Magos Reductor" hidden="true" collective="false" import="true" targetId="04e8-11de-2eb4-67e0" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
@@ -1391,35 +1391,35 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <categoryLink id="9352-766f-47ed-95bb" name="New CategoryLink" hidden="false" targetId="485123232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="2e8651d2-f46c-04ae-9a4a-c9de33605496" name="Magos Reductor Calleb Decima" hidden="true" collective="false" targetId="a087-30ae-b858-1c8e" type="selectionEntry">
+    <entryLink id="2e8651d2-f46c-04ae-9a4a-c9de33605496" name="Magos Reductor Calleb Decima" hidden="true" collective="false" import="true" targetId="a087-30ae-b858-1c8e" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="e1d9-3be5-8a8f-59e8" name="New CategoryLink" hidden="false" targetId="485123232344415441232323" primary="true"/>
         <categoryLink id="f4bf-2a55-8ac2-2d78" name="New CategoryLink" hidden="false" targetId="becd-7a6d-e80f-878e" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="a223-073a-2444-a5b4" name="Myrmidon Destructors" hidden="false" collective="false" targetId="c89b-889f-bb97-a271" type="selectionEntry">
+    <entryLink id="a223-073a-2444-a5b4" name="Myrmidon Destructors" hidden="false" collective="false" import="true" targetId="c89b-889f-bb97-a271" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="e26a-3497-22a7-b8b4" name="New CategoryLink" hidden="false" targetId="486561767920537570706f727423232344415441232323" primary="true"/>
         <categoryLink id="afe0-cdfa-5521-a909" name="New CategoryLink" hidden="false" targetId="f74d-4679-75a6-1252" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="004c-e012-5637-e09e" name="Myrmidon Secutors" hidden="false" collective="false" targetId="75ff-b7a9-dfbf-502e" type="selectionEntry">
+    <entryLink id="004c-e012-5637-e09e" name="Myrmidon Secutors" hidden="false" collective="false" import="true" targetId="75ff-b7a9-dfbf-502e" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="a949-c757-e85e-1822" name="New CategoryLink" hidden="false" targetId="456c6974657323232344415441232323" primary="true"/>
         <categoryLink id="f316-c408-d1c1-6dec" name="New CategoryLink" hidden="false" targetId="f74d-4679-75a6-1252" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="bd2a-ba2a-a086-a8b2" name="War Machine Detachment" hidden="false" collective="false" targetId="4798-67b6-5f51-b275" type="selectionEntry">
+    <entryLink id="bd2a-ba2a-a086-a8b2" name="War Machine Detachment" hidden="false" collective="false" import="true" targetId="4798-67b6-5f51-b275" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="5f48-7dcb-c1cc-402a" name="New CategoryLink" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="5b71-fda2-1726-b263" name="Engines of Destruction" hidden="false" collective="false" targetId="91f0-3f18-50b7-ed4e" type="selectionEntry">
+    <entryLink id="5b71-fda2-1726-b263" name="Engines of Destruction" hidden="false" collective="false" import="true" targetId="91f0-3f18-50b7-ed4e" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="3bab-4c28-ca34-3ff3" name="New CategoryLink" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="92bf-c517-a343-1e64" name="Secutarii Hoplite Phalanx" hidden="true" collective="false" targetId="4ff6-b526-4208-0d33" type="selectionEntry">
+    <entryLink id="92bf-c517-a343-1e64" name="Secutarii Hoplite Phalanx" hidden="true" collective="false" import="true" targetId="4ff6-b526-4208-0d33" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
@@ -1442,7 +1442,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <categoryLink id="e63a-d105-14dd-62bb" name="New CategoryLink" hidden="false" targetId="219d-aefa-dfa5-44db" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="4c62-b68e-e8fe-ac62" name="Secutarii Peltast Phalanx" hidden="true" collective="false" targetId="8190-e779-2c49-c564" type="selectionEntry">
+    <entryLink id="4c62-b68e-e8fe-ac62" name="Secutarii Peltast Phalanx" hidden="true" collective="false" import="true" targetId="8190-e779-2c49-c564" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="8ca6-c4ee-0f61-effa" value="-1">
           <conditions>
@@ -1465,7 +1465,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <categoryLink id="5087-f9dc-01ba-5039" name="New CategoryLink" hidden="false" targetId="219d-aefa-dfa5-44db" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="a4c3-b327-2fbf-5621" name="Secutarii Axiarch" hidden="true" collective="false" targetId="bd94-0269-4234-4a81" type="selectionEntry">
+    <entryLink id="a4c3-b327-2fbf-5621" name="Secutarii Axiarch" hidden="true" collective="false" import="true" targetId="bd94-0269-4234-4a81" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
@@ -1483,17 +1483,17 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <categoryLink id="3ab7-7380-3aa8-309a" name="New CategoryLink" hidden="false" targetId="becd-7a6d-e80f-878e" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="41aa-d9dd-4085-db6d" name="Thanatar Class Siege-automata Maniple" hidden="false" collective="false" targetId="d7c6-3866-37eb-af76" type="selectionEntry">
+    <entryLink id="41aa-d9dd-4085-db6d" name="Thanatar Class Siege-automata Maniple" hidden="false" collective="false" import="true" targetId="d7c6-3866-37eb-af76" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="5939-d1f2-d54d-b51a" name="New CategoryLink" hidden="false" targetId="486561767920537570706f727423232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="2bee-1d3a-40ca-398c" name="Terrax Pattern Termite Assault Drill" hidden="false" collective="false" targetId="d3d9-21fc-ec42-270a" type="selectionEntry">
+    <entryLink id="2bee-1d3a-40ca-398c" name="Terrax Pattern Termite Assault Drill" hidden="false" collective="false" import="true" targetId="d3d9-21fc-ec42-270a" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="6a5e-d23e-bb66-24f2" name="New CategoryLink" hidden="false" targetId="466173742041747461636b23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="2446-35f3-3f1b-e153" name="Magos Prime" hidden="false" collective="false" targetId="aa74-77f4-7266-36b6" type="selectionEntry">
+    <entryLink id="2446-35f3-3f1b-e153" name="Magos Prime" hidden="false" collective="false" import="true" targetId="aa74-77f4-7266-36b6" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -1506,7 +1506,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <categoryLink id="ab45-c8e7-7795-0be2" name="New CategoryLink" hidden="false" targetId="485123232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="5bce-cf03-cea4-be28" name="Magos Dominus" hidden="false" collective="false" targetId="f891-cee8-321e-f159" type="selectionEntry">
+    <entryLink id="5bce-cf03-cea4-be28" name="Magos Dominus" hidden="false" collective="false" import="true" targetId="f891-cee8-321e-f159" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -1519,7 +1519,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <categoryLink id="7fc0-849e-db4a-d096" name="New CategoryLink" hidden="false" targetId="485123232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="5ab4-bb0f-b718-ca9d" name="Archmagos Inar Satarael" hidden="false" collective="false" targetId="7095-280b-9ccc-b7bc" type="selectionEntry">
+    <entryLink id="5ab4-bb0f-b718-ca9d" name="Archmagos Inar Satarael" hidden="false" collective="false" import="true" targetId="7095-280b-9ccc-b7bc" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -1531,14 +1531,14 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <categoryLink id="f6a5-749e-217f-10f1" name="New CategoryLink" hidden="false" targetId="485123232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="5c3a-0189-ddc2-0eb2" name="Thallax Cohort (Icarian)" hidden="false" collective="false" targetId="d893-4871-06f4-d2a9" type="selectionEntry">
+    <entryLink id="5c3a-0189-ddc2-0eb2" name="Thallax Cohort (Icarian)" hidden="false" collective="false" import="true" targetId="d893-4871-06f4-d2a9" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="17e3-b3a8-5e10-db91" name="New CategoryLink" hidden="false" targetId="afa3-c43a-c8c1-d8b6" primary="false"/>
         <categoryLink id="066d-3b13-644d-c8ba" name="New CategoryLink" hidden="false" targetId="37f2-7398-84ee-6fdf" primary="false"/>
         <categoryLink id="9646-7e4e-c0b4-2f2b" name="Heavy Support" hidden="false" targetId="486561767920537570706f727423232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="ac59-7e35-bd64-75ed" name="Legio Titanicus Warbringer Nemesis Titan" hidden="false" collective="false" targetId="ecb3-83b9-4ba7-47a9" type="selectionEntry">
+    <entryLink id="ac59-7e35-bd64-75ed" name="Legio Titanicus Warbringer Nemesis Titan" hidden="false" collective="false" import="true" targetId="ecb3-83b9-4ba7-47a9" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="ee41-10b8-a6ab-8885" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
         <categoryLink id="2a66-e748-20bb-08b1" name="New CategoryLink" hidden="false" targetId="264d-166e-36c0-77b7" primary="false"/>
@@ -1547,7 +1547,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
     </entryLink>
   </entryLinks>
   <sharedSelectionEntries>
-    <selectionEntry id="36c5-d6db-7224-1e47" name="Support Unit" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="36c5-d6db-7224-1e47" name="Support Unit" hidden="false" collective="false" import="true" type="upgrade">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -1583,7 +1583,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="04c4-8239-657a-ced2" name="Support Squad" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="04c4-8239-657a-ced2" name="Support Squad" hidden="false" collective="false" import="true" type="upgrade">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -1612,7 +1612,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="fc8c-3f13-02b6-034e" name="Support Officer" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="fc8c-3f13-02b6-034e" name="Support Officer" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="67db-8cbd-ae76-b897" type="max"/>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="13c3-1f2b-4540-5421" type="min"/>
@@ -1626,7 +1626,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="d7c6-3866-37eb-af76" name="Thanatar Class Siege-automata Maniple" hidden="false" collective="false" type="unit">
+    <selectionEntry id="d7c6-3866-37eb-af76" name="Thanatar Class Siege-automata Maniple" hidden="false" collective="false" import="true" type="unit">
       <infoLinks>
         <infoLink id="67d4-e1ef-588a-47e9" name="Cybernetica Cortex" hidden="false" targetId="f6c9-cdb7-c695-5b6b" type="rule"/>
         <infoLink id="cba2-88ce-8788-ec9b" hidden="false" targetId="d5cf-bd98-2854-13cf" type="rule"/>
@@ -1637,13 +1637,13 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <categoryLink id="7454-62e5-efbc-355d" name="New CategoryLink" hidden="false" targetId="7fdd-2a97-d0e9-6524" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="7f94-9230-ab0a-259e" name="Thanatar Class Siege-automata" publicationId="cf03-f607-pubN76780" page="0" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="7f94-9230-ab0a-259e" name="Thanatar Class Siege-automata" publicationId="cf03-f607-pubN76780" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <profiles>
-            <profile id="1d9f-74bd-40b6-8d34" name="Thanatar Class Siege-automata" publicationId="cf03-f607-pubN76270" page="51" hidden="false" typeId="556e697423232344415441232323" typeName="">
+            <profile id="1d9f-74bd-40b6-8d34" name="Thanatar Class Siege-automata" publicationId="cf03-f607-pubN76270" page="51" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Monstrous Creature</characteristic>
                 <characteristic name="WS" typeId="575323232344415441232323">3</characteristic>
@@ -1659,7 +1659,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
             </profile>
           </profiles>
           <selectionEntries>
-            <selectionEntry id="98c4-5b80-0e20-b196" name="Automantic Shielding" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="98c4-5b80-0e20-b196" name="Automantic Shielding" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1c45-9a4a-b8de-a86a" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f4c4-c740-465d-b739" type="max"/>
@@ -1671,13 +1671,13 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="cd77-4bdd-4506-6f2a" name="Hellex plasma mortar" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="cd77-4bdd-4506-6f2a" name="Hellex plasma mortar" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="01ae-a480-b10a-dbbf" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e533-1ddc-f9a5-c50c" type="max"/>
               </constraints>
               <profiles>
-                <profile id="c198-6c5b-f862-32c7" name="Hellex Plasma Mortar (Stationary)" publicationId="cf03-f607-pubN76979" page="227" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+                <profile id="c198-6c5b-f862-32c7" name="Hellex Plasma Mortar (Stationary)" publicationId="cf03-f607-pubN76979" page="227" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
                   <characteristics>
                     <characteristic name="Range" typeId="52616e676523232344415441232323">12&quot; - 48&quot;</characteristic>
                     <characteristic name="Strength" typeId="537472656e67746823232344415441232323">8</characteristic>
@@ -1692,7 +1692,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
                 </rule>
               </rules>
               <selectionEntries>
-                <selectionEntry id="1b03-f965-d303-67a6" name="Hellex plasma mortar" hidden="false" collective="false" type="upgrade">
+                <selectionEntry id="1b03-f965-d303-67a6" name="Hellex plasma mortar" hidden="false" collective="false" import="true" type="upgrade">
                   <costs>
                     <cost name="pts" typeId="points" value="0.0"/>
                   </costs>
@@ -1702,7 +1702,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="7905-b7da-aabc-8d36" name="Mauler pattern bolt cannon" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="7905-b7da-aabc-8d36" name="Mauler pattern bolt cannon" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="93e6-664c-b37d-6365" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b728-1ace-b8d0-29f7" type="min"/>
@@ -1714,7 +1714,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="c76b-1c02-0fd6-0689" name="Infravisor" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="c76b-1c02-0fd6-0689" name="Infravisor" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b7da-27bc-4b85-fad0" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9faf-ac97-9232-e8b1" type="max"/>
@@ -1733,9 +1733,9 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="04a3-6a3d-6142-b711" name="Maniple may take any of the following upgrades:" hidden="false" collective="false">
+        <selectionEntryGroup id="04a3-6a3d-6142-b711" name="Maniple may take any of the following upgrades:" hidden="false" collective="false" import="true">
           <selectionEntries>
-            <selectionEntry id="f92b-b8c8-bb4d-67c7" name="Searchlight" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="f92b-b8c8-bb4d-67c7" name="Searchlight" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="increment" field="points" value="1.0">
                   <repeats>
@@ -1750,7 +1750,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="a5b1-984f-c501-268d" name="Enhanced Targeting Array" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="a5b1-984f-c501-268d" name="Enhanced Targeting Array" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="increment" field="points" value="15.0">
                   <repeats>
@@ -1770,9 +1770,9 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="58ad-1581-7b3d-1800" name="A single Maniple may take:" hidden="false" collective="false">
+        <selectionEntryGroup id="58ad-1581-7b3d-1800" name="A single Maniple may take:" hidden="false" collective="false" import="true">
           <entryLinks>
-            <entryLink id="33e4-200d-8a0c-eeca" hidden="false" collective="false" targetId="34924deb-f4e5-7739-5606-87600d1740bb" type="selectionEntry"/>
+            <entryLink id="33e4-200d-8a0c-eeca" hidden="false" collective="false" import="true" targetId="34924deb-f4e5-7739-5606-87600d1740bb" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
@@ -1780,7 +1780,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="48db-84ca-2bad-520f" name="Castellax Class Battle-Automata Maniple" page="" hidden="false" collective="false" type="unit">
+    <selectionEntry id="48db-84ca-2bad-520f" name="Castellax Class Battle-Automata Maniple" page="" hidden="false" collective="false" import="true" type="unit">
       <infoLinks>
         <infoLink id="7678-ae60-16f2-e948" name="" hidden="false" targetId="988c-d4d0-9418-1165" type="rule"/>
         <infoLink id="a7f0-6bc1-ed4a-34dc" name="New InfoLink" hidden="false" targetId="d5cf-bd98-2854-13cf" type="rule"/>
@@ -1791,13 +1791,13 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <categoryLink id="2372-4a90-f4b4-78c2" name="New CategoryLink" hidden="false" targetId="78ea-eea8-0ac5-b7de" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="09ad-ef83-4a62-46fe" name="Castellax class Battle-automata" page="" hidden="false" collective="false" type="model">
+        <selectionEntry id="09ad-ef83-4a62-46fe" name="Castellax class Battle-automata" page="" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2514-b4ae-39f4-093e" type="min"/>
             <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="38db-7bf2-0694-b3f4" type="max"/>
           </constraints>
           <profiles>
-            <profile id="659d-11d2-faad-4259" name="Castellax" publicationId="cf03-f607-pubN76270" page="41" hidden="false" typeId="556e697423232344415441232323" typeName="">
+            <profile id="659d-11d2-faad-4259" name="Castellax" publicationId="cf03-f607-pubN76270" page="41" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
               <modifiers>
                 <modifier type="increment" field="4923232344415441232323" value="1">
                   <conditions>
@@ -1820,13 +1820,13 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
             </profile>
           </profiles>
           <selectionEntryGroups>
-            <selectionEntryGroup id="6564-7afd-3cef-078a" name="May exchange its Mauler bolt cannon for:" hidden="false" collective="false" defaultSelectionEntryId="11ea-37df-c659-bc84">
+            <selectionEntryGroup id="6564-7afd-3cef-078a" name="May exchange its Mauler bolt cannon for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="11ea-37df-c659-bc84">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="84b2-b418-e7d8-4052" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9947-1981-7c77-5638" type="min"/>
               </constraints>
               <selectionEntries>
-                <selectionEntry id="9ecb-8606-a575-1ff1" name="Darkfire Cannon" page="0" hidden="false" collective="false" type="upgrade">
+                <selectionEntry id="9ecb-8606-a575-1ff1" name="Darkfire Cannon" page="0" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f3ce-e636-1d57-9a53" type="max"/>
                   </constraints>
@@ -1842,11 +1842,11 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
                 </selectionEntry>
               </selectionEntries>
               <entryLinks>
-                <entryLink id="11ea-37df-c659-bc84" name="Mauler Bolt Cannon" hidden="false" collective="false" targetId="5f67-828c-a452-e97e" type="selectionEntry"/>
-                <entryLink id="77d7-40c8-a18b-8ff2" name="Multi-melta" hidden="false" collective="false" targetId="d1c0-746f-2b39-5f17" type="selectionEntry"/>
+                <entryLink id="11ea-37df-c659-bc84" name="Mauler Bolt Cannon" hidden="false" collective="false" import="true" targetId="5f67-828c-a452-e97e" type="selectionEntry"/>
+                <entryLink id="77d7-40c8-a18b-8ff2" name="Multi-melta" hidden="false" collective="false" import="true" targetId="d1c0-746f-2b39-5f17" type="selectionEntry"/>
               </entryLinks>
             </selectionEntryGroup>
-            <selectionEntryGroup id="c204-c9c9-9110-ca90" name="May Exchange one or both bolters for:" hidden="false" collective="false" defaultSelectionEntryId="9f45-90b4-1220-dd2b">
+            <selectionEntryGroup id="c204-c9c9-9110-ca90" name="May Exchange one or both bolters for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="9f45-90b4-1220-dd2b">
               <modifiers>
                 <modifier type="set" field="5d2a-e961-7953-6b83" value="1">
                   <conditions>
@@ -1864,7 +1864,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5d2a-e961-7953-6b83" type="min"/>
               </constraints>
               <selectionEntries>
-                <selectionEntry id="48d3-a65a-239b-289c" name="Flamer" page="0" hidden="false" collective="false" type="upgrade">
+                <selectionEntry id="48d3-a65a-239b-289c" name="Flamer" page="0" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
                     <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c06b-9c84-5a9a-743a" type="max"/>
                   </constraints>
@@ -1872,7 +1872,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
                     <cost name="pts" typeId="points" value="5.0"/>
                   </costs>
                 </selectionEntry>
-                <selectionEntry id="9f45-90b4-1220-dd2b" name="Bolter" hidden="false" collective="false" type="upgrade">
+                <selectionEntry id="9f45-90b4-1220-dd2b" name="Bolter" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
                     <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f241-287b-5881-e9d6" type="max"/>
                   </constraints>
@@ -1885,13 +1885,13 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
                 </selectionEntry>
               </selectionEntries>
             </selectionEntryGroup>
-            <selectionEntryGroup id="c022-8531-3529-fe49" name="May Exchange Shock Chargers for:" hidden="false" collective="false" defaultSelectionEntryId="4894-9e9e-82e5-b213">
+            <selectionEntryGroup id="c022-8531-3529-fe49" name="May Exchange Shock Chargers for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="4894-9e9e-82e5-b213">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="314f-0125-9b5d-03fb" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="321e-e0ed-e440-d5e5" type="min"/>
               </constraints>
               <selectionEntries>
-                <selectionEntry id="e927-193b-8cf1-70fd" name="Two Power Blades" page="0" hidden="false" collective="false" type="upgrade">
+                <selectionEntry id="e927-193b-8cf1-70fd" name="Two Power Blades" page="0" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c5d0-644c-e051-03f1" type="max"/>
                   </constraints>
@@ -1905,7 +1905,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
                     <cost name="pts" typeId="points" value="10.0"/>
                   </costs>
                 </selectionEntry>
-                <selectionEntry id="f11e-3352-b97f-3693" name="Siege Wrecker" page="0" hidden="false" collective="false" type="upgrade">
+                <selectionEntry id="f11e-3352-b97f-3693" name="Siege Wrecker" page="0" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="56a0-fb06-e473-31a1" type="max"/>
                   </constraints>
@@ -1919,7 +1919,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
                     <cost name="pts" typeId="points" value="20.0"/>
                   </costs>
                 </selectionEntry>
-                <selectionEntry id="4894-9e9e-82e5-b213" name="Shock Chargers" hidden="false" collective="false" type="upgrade">
+                <selectionEntry id="4894-9e9e-82e5-b213" name="Shock Chargers" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b895-e509-7063-3f17" type="max"/>
                   </constraints>
@@ -1939,9 +1939,9 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="5a40-8fd5-37b7-8ec4" name="Maniple may take any of the following upgrades:" hidden="false" collective="false">
+        <selectionEntryGroup id="5a40-8fd5-37b7-8ec4" name="Maniple may take any of the following upgrades:" hidden="false" collective="false" import="true">
           <selectionEntries>
-            <selectionEntry id="6801-cbdd-fb6a-761c" name="Searchlights" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="6801-cbdd-fb6a-761c" name="Searchlights" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="increment" field="points" value="1">
                   <repeats>
@@ -1959,7 +1959,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="25c4-ab1a-3773-5ced" name="Infravisors" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="25c4-ab1a-3773-5ced" name="Infravisors" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="increment" field="points" value="5">
                   <repeats>
@@ -1978,7 +1978,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="2388-67a0-fbab-56d9" name="Frag Grenades" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="2388-67a0-fbab-56d9" name="Frag Grenades" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="increment" field="points" value="5.0">
                   <repeats>
@@ -1997,7 +1997,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="eafb-4aa0-594d-5dbc" name="Enhanced Targeting Arrays" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="eafb-4aa0-594d-5dbc" name="Enhanced Targeting Arrays" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="increment" field="points" value="15">
                   <repeats>
@@ -2019,8 +2019,8 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="1351-345f-cd72-e42d" name="Support Unit" hidden="false" collective="false" targetId="36c5-d6db-7224-1e47" type="selectionEntry"/>
-        <entryLink id="9e93-5e2f-d21c-63bf" name="New EntryLink" hidden="false" collective="false" targetId="dff8-d7b6-960a-aa5b" type="selectionEntryGroup">
+        <entryLink id="1351-345f-cd72-e42d" name="Support Unit" hidden="false" collective="false" import="true" targetId="36c5-d6db-7224-1e47" type="selectionEntry"/>
+        <entryLink id="9e93-5e2f-d21c-63bf" name="New EntryLink" hidden="false" collective="false" import="true" targetId="dff8-d7b6-960a-aa5b" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
@@ -2029,13 +2029,13 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="b6c3-b1be-9ce6-cb2f" name="New EntryLink" hidden="false" collective="false" targetId="0c9d-9eaa-d513-caa3" type="selectionEntry"/>
+        <entryLink id="b6c3-b1be-9ce6-cb2f" name="New EntryLink" hidden="false" collective="false" import="true" targetId="0c9d-9eaa-d513-caa3" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="deb3-68a3-5d36-eb3d" name="Vorax Class Battle-automata Maniple" page="" hidden="false" collective="false" type="unit">
+    <selectionEntry id="deb3-68a3-5d36-eb3d" name="Vorax Class Battle-automata Maniple" page="" hidden="false" collective="false" import="true" type="unit">
       <infoLinks>
         <infoLink id="a080-e2a8-dc43-1112" name="New InfoLink" hidden="false" targetId="69e5-fc02-1f9d-63c2" type="rule"/>
         <infoLink id="57a5-1a50-7092-3d9c" name="New InfoLink" hidden="false" targetId="9b30-1da3-eb8d-ce7a" type="rule"/>
@@ -2045,13 +2045,13 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <categoryLink id="5c9b-acfa-588b-9aeb" name="New CategoryLink" hidden="false" targetId="7fdd-2a97-d0e9-6524" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="efb2-67e0-c8a5-9d43" name="Vorax Class Battle-automata" page="0" hidden="false" collective="false" type="model">
+        <selectionEntry id="efb2-67e0-c8a5-9d43" name="Vorax Class Battle-automata" page="0" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f557-1a16-8c37-f307" type="min"/>
             <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="867d-a720-a911-50dc" type="max"/>
           </constraints>
           <profiles>
-            <profile id="712d-49a5-7c53-fbc4" name="Vorax" publicationId="cf03-f607-pubN76270" page="46" hidden="false" typeId="556e697423232344415441232323" typeName="">
+            <profile id="712d-49a5-7c53-fbc4" name="Vorax" publicationId="cf03-f607-pubN76270" page="46" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Monstrous Creature</characteristic>
                 <characteristic name="WS" typeId="575323232344415441232323">4</characteristic>
@@ -2067,7 +2067,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
             </profile>
           </profiles>
           <selectionEntries>
-            <selectionEntry id="1b52-8c7c-83a4-64a9" name="Two Rotor Cannons" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="1b52-8c7c-83a4-64a9" name="Two Rotor Cannons" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="78a2-15ad-9505-6d4f" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d184-3263-bd4e-5f9b" type="min"/>
@@ -2096,7 +2096,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="d354-81fd-0caa-5f51" name="Power Blades" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="d354-81fd-0caa-5f51" name="Power Blades" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="140d-0980-edb7-af3f" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b7b9-1b6f-217a-af03" type="min"/>
@@ -2113,13 +2113,13 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
             </selectionEntry>
           </selectionEntries>
           <selectionEntryGroups>
-            <selectionEntryGroup id="fa3c-7f3b-88e8-ae06" name="May exchange Lightning Gun for:" hidden="false" collective="false" defaultSelectionEntryId="27ab-2725-5de6-7e71">
+            <selectionEntryGroup id="fa3c-7f3b-88e8-ae06" name="May exchange Lightning Gun for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="27ab-2725-5de6-7e71">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a565-730f-b042-5f27" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="344b-2ce3-cd66-cd7c" type="min"/>
               </constraints>
               <selectionEntries>
-                <selectionEntry id="4aae-cbed-3fbf-8d18" name="Irad-cleanser" page="0" hidden="false" collective="false" type="upgrade">
+                <selectionEntry id="4aae-cbed-3fbf-8d18" name="Irad-cleanser" page="0" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
                     <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8c27-a396-9ad7-84b8" type="max"/>
                   </constraints>
@@ -2132,7 +2132,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
                     <cost name="pts" typeId="points" value="10.0"/>
                   </costs>
                 </selectionEntry>
-                <selectionEntry id="27ab-2725-5de6-7e71" name="Lightning Gun" hidden="false" collective="false" type="upgrade">
+                <selectionEntry id="27ab-2725-5de6-7e71" name="Lightning Gun" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
                     <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b106-e238-5f3d-1195" type="max"/>
                   </constraints>
@@ -2152,7 +2152,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
             <cost name="pts" typeId="points" value="65.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="5857-e4d4-6c02-014c" name="Infravisors" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="5857-e4d4-6c02-014c" name="Infravisors" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="34ee-b342-1b97-aa4f" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="92ab-f743-a8d0-44ef" type="min"/>
@@ -2166,9 +2166,9 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="721b-07af-5d09-abc5" name="Maniple may take any of the following upgrades:" hidden="false" collective="false">
+        <selectionEntryGroup id="721b-07af-5d09-abc5" name="Maniple may take any of the following upgrades:" hidden="false" collective="false" import="true">
           <selectionEntries>
-            <selectionEntry id="62e7-2ed4-0f7a-d02b" name="Searchlights" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="62e7-2ed4-0f7a-d02b" name="Searchlights" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="increment" field="points" value="1.0">
                   <repeats>
@@ -2186,7 +2186,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="5e54-e7c7-616b-099e" name="Frag Grenades" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="5e54-e7c7-616b-099e" name="Frag Grenades" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="increment" field="points" value="5.0">
                   <repeats>
@@ -2205,7 +2205,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="4917-9705-c924-9779" name="Enhanced Targeting Arrays" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="4917-9705-c924-9779" name="Enhanced Targeting Arrays" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="increment" field="points" value="15">
                   <repeats>
@@ -2225,9 +2225,9 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="6ea4-be19-165b-5df5" name="Entire Maniple may equip Rotor Cannons with:" hidden="false" collective="false">
+        <selectionEntryGroup id="6ea4-be19-165b-5df5" name="Entire Maniple may equip Rotor Cannons with:" hidden="false" collective="false" import="true">
           <selectionEntries>
-            <selectionEntry id="3c66-f02d-af81-ecfe" name="Bio-corrosive ammunition" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="3c66-f02d-af81-ecfe" name="Bio-corrosive ammunition" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="increment" field="points" value="10.0">
                   <repeats>
@@ -2246,7 +2246,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="c7ae-23c6-9acc-b89f" name="New EntryLink" hidden="false" collective="false" targetId="dff8-d7b6-960a-aa5b" type="selectionEntryGroup">
+        <entryLink id="c7ae-23c6-9acc-b89f" name="New EntryLink" hidden="false" collective="false" import="true" targetId="dff8-d7b6-960a-aa5b" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
@@ -2255,13 +2255,13 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="d0b8-a41e-6b2b-baa7" name="New EntryLink" hidden="false" collective="false" targetId="0c9d-9eaa-d513-caa3" type="selectionEntry"/>
+        <entryLink id="d0b8-a41e-6b2b-baa7" name="New EntryLink" hidden="false" collective="false" import="true" targetId="0c9d-9eaa-d513-caa3" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="00cf-20ab-1b17-aad1" name="Archmagos" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="00cf-20ab-1b17-aad1" name="Archmagos" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
@@ -2279,13 +2279,13 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="3f6b-6c3a-5855-a5ae" name="Arlatax" hidden="false" collective="false" type="model">
+    <selectionEntry id="3f6b-6c3a-5855-a5ae" name="Arlatax" hidden="false" collective="false" import="true" type="model">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
         <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
       </constraints>
       <profiles>
-        <profile id="6541-820d-ace7-de64" name="Arlatax" publicationId="cf03-f607-pubN80487" page="274" hidden="false" typeId="556e697423232344415441232323" typeName="">
+        <profile id="6541-820d-ace7-de64" name="Arlatax" publicationId="cf03-f607-pubN80487" page="274" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
           <modifiers>
             <modifier type="increment" field="4923232344415441232323" value="1">
               <conditions>
@@ -2306,7 +2306,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
             <characteristic name="Save" typeId="5361766523232344415441232323">3+</characteristic>
           </characteristics>
         </profile>
-        <profile id="fee7-003f-11f8-d56a" name="Arlatax Power Claw" publicationId="cf03-f607-pubN80487" page="274" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+        <profile id="fee7-003f-11f8-d56a" name="Arlatax Power Claw" publicationId="cf03-f607-pubN80487" page="274" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
           <characteristics>
             <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
             <characteristic name="Strength" typeId="537472656e67746823232344415441232323">+2</characteristic>
@@ -2314,7 +2314,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
             <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Shred</characteristic>
           </characteristics>
         </profile>
-        <profile id="b63e-172e-2f5c-7fc2" name="Arlatax Power Claw Inbuilt Cannon" publicationId="cf03-f607-pubN80487" page="274" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+        <profile id="b63e-172e-2f5c-7fc2" name="Arlatax Power Claw Inbuilt Cannon" publicationId="cf03-f607-pubN80487" page="274" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
           <characteristics>
             <characteristic name="Range" typeId="52616e676523232344415441232323">24&quot;</characteristic>
             <characteristic name="Strength" typeId="537472656e67746823232344415441232323">6</characteristic>
@@ -2336,9 +2336,9 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <categoryLink id="d115-15ed-f2d3-34bc" name="New CategoryLink" hidden="false" targetId="78ea-eea8-0ac5-b7de" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="0e70-6b1b-6528-5cb7" name="May replace one of its Power Claws with:" hidden="false" collective="false">
+        <selectionEntryGroup id="0e70-6b1b-6528-5cb7" name="May replace one of its Power Claws with:" hidden="false" collective="false" import="true">
           <entryLinks>
-            <entryLink id="7606-fd5e-dc3f-998f" name="New EntryLink" hidden="false" collective="false" targetId="07c9-6c73-c97f-cb10" type="selectionEntry"/>
+            <entryLink id="7606-fd5e-dc3f-998f" name="New EntryLink" hidden="false" collective="false" import="true" targetId="07c9-6c73-c97f-cb10" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
@@ -2346,7 +2346,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <cost name="pts" typeId="points" value="175.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="d9b1f29e-b530-49be-4b13-919e81a45b69" name="Battle Servitor Control" publicationId="cf03-f607-pubN80892" page="43" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="d9b1f29e-b530-49be-4b13-919e81a45b69" name="Battle Servitor Control" publicationId="cf03-f607-pubN80892" page="43" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
       </constraints>
@@ -2357,12 +2357,12 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <cost name="pts" typeId="points" value="15.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="1bc5-f4e3-a97e-1da4" name="Belicosa Pattern Volcano Cannon" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="1bc5-f4e3-a97e-1da4" name="Belicosa Pattern Volcano Cannon" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
       </constraints>
       <profiles>
-        <profile id="bfe4-e2fb-5231-ac7c" name="Belicosa Pattern Volcano Cannon" publicationId="cf03-f607-pubN80965" page="264" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+        <profile id="bfe4-e2fb-5231-ac7c" name="Belicosa Pattern Volcano Cannon" publicationId="cf03-f607-pubN80965" page="264" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
           <characteristics>
             <characteristic name="Range" typeId="52616e676523232344415441232323">180&quot;</characteristic>
             <characteristic name="Strength" typeId="537472656e67746823232344415441232323">D</characteristic>
@@ -2381,7 +2381,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="fb66-11c0-3cb4-aac3" name="Blessed Autosimulacra" publicationId="cf03-f607-pubN76780" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="fb66-11c0-3cb4-aac3" name="Blessed Autosimulacra" publicationId="cf03-f607-pubN76780" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
       </constraints>
@@ -2392,7 +2392,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <cost name="pts" typeId="points" value="10.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="49db7652-fb76-bf7d-1d4e-7bd6e33d8c6e" name="Breacher Charge" publicationId="cf03-f607-pubN80892" page="0" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="49db7652-fb76-bf7d-1d4e-7bd6e33d8c6e" name="Breacher Charge" publicationId="cf03-f607-pubN80892" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="e571333a-2234-23ad-b872-ac4730518453" hidden="false" targetId="99a47c75-0410-1c54-8124-3adcbd64aa7e" type="profile"/>
         <infoLink id="32fb2543-4434-95c0-0834-cecbec922aa8" hidden="false" targetId="3b2f58a3-f819-22a4-7b62-fcd43773f7fa" type="rule"/>
@@ -2401,7 +2401,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="10e739aa-3153-9348-3458-738dd5938617" name="Chainsword or Combat Blade" page="0" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="10e739aa-3153-9348-3458-738dd5938617" name="Chainsword or Combat Blade" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
@@ -2410,7 +2410,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="3f38d321-12f2-5f34-726f-08b9e03eb50a" name="Charnabal Sabre" page="0" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="3f38d321-12f2-5f34-726f-08b9e03eb50a" name="Charnabal Sabre" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="669d83c8-2445-a5fe-6c36-ee1008d7bb2e" hidden="false" targetId="50707f97-ecd0-785e-cccc-8f866cac5ecb" type="profile"/>
         <infoLink id="678d24dd-4517-f2b3-6c6a-f9749310904b" hidden="false" targetId="ecfa2ca1-a0dc-98c5-cf90-3d110382112f" type="rule"/>
@@ -2419,7 +2419,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="e4b12fd7-ca72-5279-a63c-36223abdd186" name="Combat Shield" page="0" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="e4b12fd7-ca72-5279-a63c-36223abdd186" name="Combat Shield" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
       </constraints>
@@ -2430,7 +2430,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <cost name="pts" typeId="points" value="5.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="56fc88c5-200c-7d1b-dc29-64471bbf63bf" name="Conversion Beamer" publicationId="cf03-f607-pubN80892" page="0" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="56fc88c5-200c-7d1b-dc29-64471bbf63bf" name="Conversion Beamer" publicationId="cf03-f607-pubN80892" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
       </constraints>
@@ -2443,7 +2443,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="dd09a633-0c59-7ea7-d62e-e978aefb3cff" name="Cyber-familiar" publicationId="cf03-f607-pubN80892" page="0" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="dd09a633-0c59-7ea7-d62e-e978aefb3cff" name="Cyber-familiar" publicationId="cf03-f607-pubN80892" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
       </constraints>
@@ -2454,7 +2454,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <cost name="pts" typeId="points" value="15.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="6794e011-2261-296b-6b1d-94fa15089b4c" name="Cyber-occularis" page="0" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="6794e011-2261-296b-6b1d-94fa15089b4c" name="Cyber-occularis" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <rules>
         <rule id="61d8a463-c841-31b0-a214-f3fd25e6ba71" name="Fearless" page="0" hidden="false"/>
         <rule id="47c96dd3-1da5-0b7b-ad65-bde4db706844" name="Stealth" page="0" hidden="false"/>
@@ -2468,7 +2468,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <cost name="pts" typeId="points" value="15.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="b447aa23-84e4-1ec8-6d38-32ad9f377774" name="Digital Lasers" page="0" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="b447aa23-84e4-1ec8-6d38-32ad9f377774" name="Digital Lasers" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
       </constraints>
@@ -2479,7 +2479,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <cost name="pts" typeId="points" value="15.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="c92a3180-03bc-a10e-e3ef-0583fb1b7ae1" name="Frag and Krak Grenades" page="0" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="c92a3180-03bc-a10e-e3ef-0583fb1b7ae1" name="Frag and Krak Grenades" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
@@ -2488,7 +2488,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="14a7fda8-1896-921f-f636-722dbe5f39dd" name="Frag, Krak, and Rad Grenades" page="0" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="14a7fda8-1896-921f-f636-722dbe5f39dd" name="Frag, Krak, and Rad Grenades" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
@@ -2500,7 +2500,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="4e6055a9-83c9-d85b-e657-0cb85f3f1fcc" name="Graviton Gun" page="0" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="4e6055a9-83c9-d85b-e657-0cb85f3f1fcc" name="Graviton Gun" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
       </constraints>
@@ -2512,7 +2512,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="7f49-c1b9-6ea9-2624" name="Graviton Imploder" page="0" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="7f49-c1b9-6ea9-2624" name="Graviton Imploder" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
       </constraints>
@@ -2525,7 +2525,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <cost name="pts" typeId="points" value="35.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="d054f965-5059-139b-029b-61b60c1af93d" name="Grenade Harness" page="0" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="d054f965-5059-139b-029b-61b60c1af93d" name="Grenade Harness" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
       </constraints>
@@ -2537,7 +2537,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="1501761c-e675-edf5-e2c5-6e51f554e377" name="Ground-tracking Auguries" publicationId="cf03-f607-pubN80892" page="43" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="1501761c-e675-edf5-e2c5-6e51f554e377" name="Ground-tracking Auguries" publicationId="cf03-f607-pubN80892" page="43" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
       </constraints>
@@ -2548,7 +2548,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <cost name="pts" typeId="points" value="10.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="512b-a9be-50a4-c909" name="Heavy Bolter" publicationId="cf03-f607-pubN76780" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="512b-a9be-50a4-c909" name="Heavy Bolter" publicationId="cf03-f607-pubN76780" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="d1e2-a781-69e7-922d" name="New InfoLink" hidden="false" targetId="271e-6286-86cc-06dd" type="profile"/>
       </infoLinks>
@@ -2556,7 +2556,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="3763d263-605b-61d9-4dc5-5a4ebfc66d5f" name="Heavy Conversion Beamer" publicationId="cf03-f607-pubN80892" page="0" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="3763d263-605b-61d9-4dc5-5a4ebfc66d5f" name="Heavy Conversion Beamer" publicationId="cf03-f607-pubN80892" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
       </constraints>
@@ -2570,7 +2570,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="fc12-daad-3988-3994" name="Heavy Flamer" page="0" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="fc12-daad-3988-3994" name="Heavy Flamer" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
       </constraints>
@@ -2581,7 +2581,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="0bf8f2fc-9b86-ba49-39bc-e0cc87f334aa" name="Iron Halo" page="0" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="0bf8f2fc-9b86-ba49-39bc-e0cc87f334aa" name="Iron Halo" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
       </constraints>
@@ -2592,7 +2592,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <cost name="pts" typeId="points" value="25.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="7c878373-5ea8-3773-4cd6-17492e2f6a97" name="Lascutter" page="0" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="7c878373-5ea8-3773-4cd6-17492e2f6a97" name="Lascutter" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
       </constraints>
@@ -2604,7 +2604,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="9d9f-63d3-f635-7fd5" name="Machinator Array" page="0" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="9d9f-63d3-f635-7fd5" name="Machinator Array" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e6f9-4ab3-377c-aa30" type="max"/>
       </constraints>
@@ -2628,7 +2628,7 @@ A model equipped with a machinator array may make two additional attacks per tur
         <cost name="pts" typeId="points" value="25.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="6f8e-c7a5-c784-384d" name="Machine Spirit" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="6f8e-c7a5-c784-384d" name="Machine Spirit" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
       </constraints>
@@ -2639,12 +2639,12 @@ A model equipped with a machinator array may make two additional attacks per tur
         <cost name="pts" typeId="points" value="10.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="0de5-5b51-907d-e5e2" name="Macrocarid Explorator" hidden="false" collective="false" type="model">
+    <selectionEntry id="0de5-5b51-907d-e5e2" name="Macrocarid Explorator" hidden="false" collective="false" import="true" type="model">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
       </constraints>
       <profiles>
-        <profile id="1208-f8bb-cf2b-5f30" name="Macrocarid Explorator" publicationId="cf03-f607-pubN76270" page="55" hidden="false" typeId="56656869636c6523232344415441232323" typeName="">
+        <profile id="1208-f8bb-cf2b-5f30" name="Macrocarid Explorator" publicationId="cf03-f607-pubN76270" page="55" hidden="false" typeId="56656869636c6523232344415441232323" typeName="Vehicle">
           <characteristics>
             <characteristic name="BS" typeId="425323232344415441232323">4</characteristic>
             <characteristic name="Front" typeId="46726f6e7423232344415441232323">14</characteristic>
@@ -2683,9 +2683,9 @@ A model equipped with a machinator array may make two additional attacks per tur
         <categoryLink id="6da2-a031-1275-c287" name="New CategoryLink" hidden="false" targetId="e59c-462e-9d9c-66dd" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="63c3-25e2-df81-fced" name="May take any of the following:" hidden="false" collective="false">
+        <selectionEntryGroup id="63c3-25e2-df81-fced" name="May take any of the following:" hidden="false" collective="false" import="true">
           <selectionEntries>
-            <selectionEntry id="bb31-3968-59a1-0fbe" name="Dozer Blade" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="bb31-3968-59a1-0fbe" name="Dozer Blade" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
@@ -2696,7 +2696,7 @@ A model equipped with a machinator array may make two additional attacks per tur
                 <cost name="pts" typeId="points" value="5.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="878a-7475-a6eb-be99" name="Armoured Ceramite" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="878a-7475-a6eb-be99" name="Armoured Ceramite" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
@@ -2707,7 +2707,7 @@ A model equipped with a machinator array may make two additional attacks per tur
                 <cost name="pts" typeId="points" value="20.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="2662-0251-c4f3-c89b" name="Explorator Augury Web" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="2662-0251-c4f3-c89b" name="Explorator Augury Web" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
@@ -2726,12 +2726,12 @@ Reduces transport capacity to 8.</description>
                 <cost name="pts" typeId="points" value="50.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="a0d7-2c93-19ee-e6a3" name="Servo-rig" publicationId="cf03-f607-pubN76780" page="55" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="a0d7-2c93-19ee-e6a3" name="Servo-rig" publicationId="cf03-f607-pubN76780" page="55" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <profiles>
-                <profile id="17a1-52b3-4af7-5f20" name="Servo-rig" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+                <profile id="17a1-52b3-4af7-5f20" name="Servo-rig" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
                   <characteristics>
                     <characteristic name="Range" typeId="52616e676523232344415441232323">3</characteristic>
                     <characteristic name="Strength" typeId="537472656e67746823232344415441232323">8</characteristic>
@@ -2749,7 +2749,7 @@ Reduces transport capacity to 8.</description>
                 <cost name="pts" typeId="points" value="20.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="1ca9-3335-4169-fa9f" name="Flare Shield" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="1ca9-3335-4169-fa9f" name="Flare Shield" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
@@ -2760,7 +2760,7 @@ Reduces transport capacity to 8.</description>
                 <cost name="pts" typeId="points" value="25.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="d5b9-1a52-08d0-94f1" name="Auxiliary Drive" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="d5b9-1a52-08d0-94f1" name="Auxiliary Drive" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
@@ -2773,20 +2773,20 @@ Reduces transport capacity to 8.</description>
             </selectionEntry>
           </selectionEntries>
           <entryLinks>
-            <entryLink id="d3c7-961b-1659-eee3" name="Anbaric Claw" hidden="false" collective="false" targetId="deed-3c25-b77e-a0e8" type="selectionEntry">
+            <entryLink id="d3c7-961b-1659-eee3" name="Anbaric Claw" hidden="false" collective="false" import="true" targetId="deed-3c25-b77e-a0e8" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="points" value="10"/>
               </modifiers>
             </entryLink>
-            <entryLink id="80dd-50c4-2c9a-83b4" name="Hunter-killer Missile" hidden="false" collective="false" targetId="287b-b205-0926-5822" type="selectionEntry"/>
+            <entryLink id="80dd-50c4-2c9a-83b4" name="Hunter-killer Missile" hidden="false" collective="false" import="true" targetId="287b-b205-0926-5822" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="0a83-cb55-702b-a71e" name="Sponson-mounted:" hidden="false" collective="false" defaultSelectionEntryId="7694-41a5-0a3d-8864">
+        <selectionEntryGroup id="0a83-cb55-702b-a71e" name="Sponson-mounted:" hidden="false" collective="false" import="true" defaultSelectionEntryId="7694-41a5-0a3d-8864">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="5981-ed97-d256-99ec" name="Two Twin-linked mauler bolt cannon" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="5981-ed97-d256-99ec" name="Two Twin-linked mauler bolt cannon" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <infoLinks>
                 <infoLink id="925e-e912-bdd1-ed12" name="Mauler Bolt Cannon" hidden="false" targetId="0225-fc80-29f1-09db" type="profile"/>
               </infoLinks>
@@ -2794,7 +2794,7 @@ Reduces transport capacity to 8.</description>
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="067b-1e05-f64b-dc52" name="Two irradiation engines" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="067b-1e05-f64b-dc52" name="Two irradiation engines" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <infoLinks>
                 <infoLink id="7ed7-11b7-65a0-6811" name="Irradiation Engine" hidden="false" targetId="926a370f-f4c1-b644-34f2-c348a5ce36c0" type="profile"/>
                 <infoLink id="9c2e-9cbd-9335-5806" name="Fleshbane" hidden="false" targetId="4575-0a0a-caaf-e4bf" type="rule"/>
@@ -2805,7 +2805,7 @@ Reduces transport capacity to 8.</description>
                 <cost name="pts" typeId="points" value="40.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="7694-41a5-0a3d-8864" name="Two Twin-linked Lascannons" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="7694-41a5-0a3d-8864" name="Two Twin-linked Lascannons" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <infoLinks>
                 <infoLink id="e64e-4d14-41cd-d559" name="Lascannon" hidden="false" targetId="1cce-972c-022a-2590" type="profile"/>
               </infoLinks>
@@ -2815,13 +2815,13 @@ Reduces transport capacity to 8.</description>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="e019-37e7-d2f2-7728" name="Hull-mounted:" hidden="false" collective="false" defaultSelectionEntryId="73c1-481e-ec7c-4898">
+        <selectionEntryGroup id="e019-37e7-d2f2-7728" name="Hull-mounted:" hidden="false" collective="false" import="true" defaultSelectionEntryId="73c1-481e-ec7c-4898">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxSelections" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="58a7-689d-2614-78e2" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="39cf-7ffa-ab92-0dfb" name="Twin-linked Phased-Plasma Fusil" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="39cf-7ffa-ab92-0dfb" name="Twin-linked Phased-Plasma Fusil" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
@@ -2832,7 +2832,7 @@ Reduces transport capacity to 8.</description>
                 <cost name="pts" typeId="points" value="10.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="7fb7-ce10-a67f-1fd1" name="Twin-linked Rad Cleanser" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="7fb7-ce10-a67f-1fd1" name="Twin-linked Rad Cleanser" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
@@ -2845,33 +2845,33 @@ Reduces transport capacity to 8.</description>
             </selectionEntry>
           </selectionEntries>
           <entryLinks>
-            <entryLink id="cb44-7e32-e94a-1557" name="Machine Spirit" hidden="false" collective="false" targetId="6f8e-c7a5-c784-384d" type="selectionEntry"/>
-            <entryLink id="73c1-481e-ec7c-4898" name="Mauler Bolt Cannon" hidden="false" collective="false" targetId="5f67-828c-a452-e97e" type="selectionEntry"/>
-            <entryLink id="fd4e-bb81-dfed-6ec8" name="Volkite Culverin" hidden="false" collective="false" targetId="edadef72-c786-ab75-6888-15d0cc090857" type="selectionEntry"/>
-            <entryLink id="a425-7267-f9a7-b7ec" name="Multi-melta" hidden="false" collective="false" targetId="d1c0-746f-2b39-5f17" type="selectionEntry"/>
-            <entryLink id="1e3a-c68a-ec9a-84fc" name="Lascannon" hidden="false" collective="false" targetId="8036-b730-d533-e31f" type="selectionEntry">
+            <entryLink id="cb44-7e32-e94a-1557" name="Machine Spirit" hidden="false" collective="false" import="true" targetId="6f8e-c7a5-c784-384d" type="selectionEntry"/>
+            <entryLink id="73c1-481e-ec7c-4898" name="Mauler Bolt Cannon" hidden="false" collective="false" import="true" targetId="5f67-828c-a452-e97e" type="selectionEntry"/>
+            <entryLink id="fd4e-bb81-dfed-6ec8" name="Volkite Culverin" hidden="false" collective="false" import="true" targetId="edadef72-c786-ab75-6888-15d0cc090857" type="selectionEntry"/>
+            <entryLink id="a425-7267-f9a7-b7ec" name="Multi-melta" hidden="false" collective="false" import="true" targetId="d1c0-746f-2b39-5f17" type="selectionEntry"/>
+            <entryLink id="1e3a-c68a-ec9a-84fc" name="Lascannon" hidden="false" collective="false" import="true" targetId="8036-b730-d533-e31f" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="points" value="5"/>
               </modifiers>
             </entryLink>
-            <entryLink id="9a4b-1467-b7ca-bd2b" name="Conversion Beamer" hidden="false" collective="false" targetId="56fc88c5-200c-7d1b-dc29-64471bbf63bf" type="selectionEntry">
+            <entryLink id="9a4b-1467-b7ca-bd2b" name="Conversion Beamer" hidden="false" collective="false" import="true" targetId="56fc88c5-200c-7d1b-dc29-64471bbf63bf" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="points" value="0.0"/>
               </modifiers>
             </entryLink>
-            <entryLink id="7c24-a0fd-a672-9b50" name="Graviton Imploder" hidden="false" collective="false" targetId="231a-26e7-f47f-6f5a" type="selectionEntry">
+            <entryLink id="7c24-a0fd-a672-9b50" name="Graviton Imploder" hidden="false" collective="false" import="true" targetId="231a-26e7-f47f-6f5a" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="points" value="15"/>
               </modifiers>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="e035-4a83-c90f-5c41" name="Psyarkana" hidden="false" collective="false">
+        <selectionEntryGroup id="e035-4a83-c90f-5c41" name="Psyarkana" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c888-753a-f27c-80ff" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="a42e-1752-2a65-d06b" name="Armatus Necrotechnica" hidden="false" collective="false" targetId="e78c-d1a1-c20f-dae8" type="selectionEntry">
+            <entryLink id="a42e-1752-2a65-d06b" name="Armatus Necrotechnica" hidden="false" collective="false" import="true" targetId="e78c-d1a1-c20f-dae8" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="hidden" value="false"/>
               </modifiers>
@@ -2883,7 +2883,7 @@ Reduces transport capacity to 8.</description>
         <cost name="pts" typeId="points" value="195.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="34924deb-f4e5-7739-5606-87600d1740bb" name="Paragon of Metal" page="0" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="34924deb-f4e5-7739-5606-87600d1740bb" name="Paragon of Metal" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
@@ -2895,7 +2895,7 @@ Reduces transport capacity to 8.</description>
         <cost name="pts" typeId="points" value="35.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="1de1f2d9-0857-67bf-d191-297d0f9f60bc" name="Phosphex Bomb" page="0" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="1de1f2d9-0857-67bf-d191-297d0f9f60bc" name="Phosphex Bomb" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
       </constraints>
@@ -2908,7 +2908,7 @@ Reduces transport capacity to 8.</description>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="40e37f6e-a984-4232-4dc4-807ed9028f62" name="Refractor Field" page="0" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="40e37f6e-a984-4232-4dc4-807ed9028f62" name="Refractor Field" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
       </constraints>
@@ -2919,7 +2919,7 @@ Reduces transport capacity to 8.</description>
         <cost name="pts" typeId="points" value="10.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="0e7b97c8-732a-74fa-6bf2-de2e1f747483" name="Rotor Cannon" page="0" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="0e7b97c8-732a-74fa-6bf2-de2e1f747483" name="Rotor Cannon" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
       </constraints>
@@ -2930,7 +2930,7 @@ Reduces transport capacity to 8.</description>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="314b-bec3-5501-a0aa" name="Scyllax Guardian-Automata Covenant" publicationId="cf03-f607-pubN76780" page="40" hidden="false" collective="false" type="unit">
+    <selectionEntry id="314b-bec3-5501-a0aa" name="Scyllax Guardian-Automata Covenant" publicationId="cf03-f607-pubN76780" page="40" hidden="false" collective="false" import="true" type="unit">
       <constraints>
         <constraint field="selections" scope="parent" value="-1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
       </constraints>
@@ -2948,13 +2948,13 @@ Reduces transport capacity to 8.</description>
         <infoLink id="8b48-9aca-ce6d-8f96" name="New InfoLink" hidden="false" targetId="a225-e39b-3699-c8f8" type="rule"/>
       </infoLinks>
       <selectionEntries>
-        <selectionEntry id="92f0-d2fd-187f-9640" name="Scyllax Guardian-Automata" hidden="false" collective="false" type="model">
+        <selectionEntry id="92f0-d2fd-187f-9640" name="Scyllax Guardian-Automata" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
             <constraint field="selections" scope="parent" value="16.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <profiles>
-            <profile id="6214-d259-f981-fb17" name="Scyllax Guardian-Automata" publicationId="cf03-f607-pubN80965" page="223" hidden="false" typeId="556e697423232344415441232323" typeName="">
+            <profile id="6214-d259-f981-fb17" name="Scyllax Guardian-Automata" publicationId="cf03-f607-pubN80965" page="223" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry</characteristic>
                 <characteristic name="WS" typeId="575323232344415441232323">3</characteristic>
@@ -2973,13 +2973,13 @@ Reduces transport capacity to 8.</description>
             <cost name="pts" typeId="points" value="35.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="a222-c64c-b38f-310e" name="Scyllax Bolter" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="a222-c64c-b38f-310e" name="Scyllax Bolter" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c3c0-853c-6471-1688" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ca45-7c3a-394f-1758" type="max"/>
           </constraints>
           <profiles>
-            <profile id="9fa0-5132-53a8-99e0" name="Scyllax Bolter" publicationId="cf03-f607-pubN80965" page="223" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+            <profile id="9fa0-5132-53a8-99e0" name="Scyllax Bolter" publicationId="cf03-f607-pubN80965" page="223" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
               <characteristics>
                 <characteristic name="Range" typeId="52616e676523232344415441232323">30&quot;</characteristic>
                 <characteristic name="Strength" typeId="537472656e67746823232344415441232323">4</characteristic>
@@ -2992,13 +2992,13 @@ Reduces transport capacity to 8.</description>
             <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="95c0-8ae0-bd68-debf" name="Mechadendrite combat array" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="95c0-8ae0-bd68-debf" name="Mechadendrite combat array" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e4f3-923c-7653-0e3a" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5087-8c66-3145-c69b" type="max"/>
           </constraints>
           <profiles>
-            <profile id="928a-341d-d005-f8c1" name="Mechadendrite Combat Array" publicationId="cf03-f607-pubN80965" page="223" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+            <profile id="928a-341d-d005-f8c1" name="Mechadendrite Combat Array" publicationId="cf03-f607-pubN80965" page="223" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
               <characteristics>
                 <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
                 <characteristic name="Strength" typeId="537472656e67746823232344415441232323">User</characteristic>
@@ -3006,7 +3006,7 @@ Reduces transport capacity to 8.</description>
                 <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Maelstrom, Dismemberment</characteristic>
               </characteristics>
             </profile>
-            <profile id="0ff0-c43d-f17d-945d" name="Mechadendrite Combat Array (Dismemberment)" publicationId="cf03-f607-pubN80965" page="223" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+            <profile id="0ff0-c43d-f17d-945d" name="Mechadendrite Combat Array (Dismemberment)" publicationId="cf03-f607-pubN80965" page="223" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
               <characteristics>
                 <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
                 <characteristic name="Strength" typeId="537472656e67746823232344415441232323">+3</characteristic>
@@ -3029,7 +3029,7 @@ Reduces transport capacity to 8.</description>
             <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="9bbd-ba35-33ca-a607" name="Rad Furnace" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="9bbd-ba35-33ca-a607" name="Rad Furnace" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="eeca-e42a-7955-bd26" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3bd3-82b5-18f3-8085" type="max"/>
@@ -3043,7 +3043,7 @@ Reduces transport capacity to 8.</description>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="a02e-68f0-8bd9-882f" name="One in four may replace their Scyllax boltgun with:" hidden="false" collective="false">
+        <selectionEntryGroup id="a02e-68f0-8bd9-882f" name="One in four may replace their Scyllax boltgun with:" hidden="false" collective="false" import="true">
           <modifiers>
             <modifier type="increment" field="maxSelections" value="1.0">
               <repeats>
@@ -3055,7 +3055,7 @@ Reduces transport capacity to 8.</description>
             <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="d32c-8a3c-44ca-cff2" name="Meltagun" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="d32c-8a3c-44ca-cff2" name="Meltagun" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
@@ -3063,7 +3063,7 @@ Reduces transport capacity to 8.</description>
                 <cost name="pts" typeId="points" value="15.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="7a75-b48e-553a-193f" name="Graviton Gun" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="7a75-b48e-553a-193f" name="Graviton Gun" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
@@ -3075,7 +3075,7 @@ Reduces transport capacity to 8.</description>
                 <cost name="pts" typeId="points" value="15.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="432b-e1ee-1265-4d38" name="Rad-cleanser" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="432b-e1ee-1265-4d38" name="Rad-cleanser" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
@@ -3086,7 +3086,7 @@ Reduces transport capacity to 8.</description>
                 <cost name="pts" typeId="points" value="20.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="7aca-bdc8-a8f8-ca3a" name="Plasma gun" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="7aca-bdc8-a8f8-ca3a" name="Plasma gun" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
@@ -3096,7 +3096,7 @@ Reduces transport capacity to 8.</description>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="d271-880e-5c73-9be9" name="Any Scyllax may replace their Scyllax boltgun for:" hidden="false" collective="false">
+        <selectionEntryGroup id="d271-880e-5c73-9be9" name="Any Scyllax may replace their Scyllax boltgun for:" hidden="false" collective="false" import="true">
           <modifiers>
             <modifier type="increment" field="maxSelections" value="1.0">
               <repeats>
@@ -3113,7 +3113,7 @@ Reduces transport capacity to 8.</description>
             <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="83b9-0cc1-a8d6-f06e" name="Rotor Cannon" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="83b9-0cc1-a8d6-f06e" name="Rotor Cannon" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="16.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
@@ -3124,7 +3124,7 @@ Reduces transport capacity to 8.</description>
                 <cost name="pts" typeId="points" value="5.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="5638-fed6-2c5d-7d43" name="Flamer" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="5638-fed6-2c5d-7d43" name="Flamer" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="16.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
@@ -3132,7 +3132,7 @@ Reduces transport capacity to 8.</description>
                 <cost name="pts" typeId="points" value="10.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="9bd5-eb9f-c506-c260" name="Volkite Charger" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="9bd5-eb9f-c506-c260" name="Volkite Charger" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="16.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
@@ -3143,12 +3143,12 @@ Reduces transport capacity to 8.</description>
                 <cost name="pts" typeId="points" value="10.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="3340-0140-85c9-4601" name="Enhanced Array" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="3340-0140-85c9-4601" name="Enhanced Array" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="16.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <profiles>
-                <profile id="8567-6208-c3c1-d251" name="Enhanced Array" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="">
+                <profile id="8567-6208-c3c1-d251" name="Enhanced Array" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
                   <characteristics>
                     <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Gains +1 Attack</characteristic>
                   </characteristics>
@@ -3160,9 +3160,9 @@ Reduces transport capacity to 8.</description>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="d752-8e75-e5cb-fbe1" name="Entire squad may take:" hidden="false" collective="false">
+        <selectionEntryGroup id="d752-8e75-e5cb-fbe1" name="Entire squad may take:" hidden="false" collective="false" import="true">
           <selectionEntries>
-            <selectionEntry id="416b-0a32-f138-ab27" name="Frag Grenades" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="416b-0a32-f138-ab27" name="Frag Grenades" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
@@ -3174,13 +3174,13 @@ Reduces transport capacity to 8.</description>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="5e3f-f812-312a-644e" hidden="false" collective="false" targetId="bb6538b0-0f23-8a43-9752-dd356ba76e46" type="selectionEntry"/>
+        <entryLink id="5e3f-f812-312a-644e" hidden="false" collective="false" import="true" targetId="bb6538b0-0f23-8a43-9752-dd356ba76e46" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="15.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="1e27e511-cf75-d55a-6807-b67be6f7474f" name="Searchlight" page="0" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="1e27e511-cf75-d55a-6807-b67be6f7474f" name="Searchlight" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
@@ -3189,7 +3189,7 @@ Reduces transport capacity to 8.</description>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="614f1c53-8660-ed9a-a4af-e1dddd482e51" name="Siege Wrecker" page="0" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="614f1c53-8660-ed9a-a4af-e1dddd482e51" name="Siege Wrecker" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
       </constraints>
@@ -3201,7 +3201,7 @@ Reduces transport capacity to 8.</description>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="ae84-b0ea-6c1b-d2c8" name="Smoke Launcher" page="0" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="ae84-b0ea-6c1b-d2c8" name="Smoke Launcher" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
@@ -3213,18 +3213,18 @@ Reduces transport capacity to 8.</description>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="bcad-45c9-3b27-a7ca" name="Tech-Priest Auxillia" publicationId="cf03-f607-pubN76780" page="34" hidden="false" collective="false" type="unit">
+    <selectionEntry id="bcad-45c9-3b27-a7ca" name="Tech-Priest Auxillia" publicationId="cf03-f607-pubN76780" page="34" hidden="false" collective="false" import="true" type="unit">
       <constraints>
         <constraint field="selections" scope="parent" value="-1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
       </constraints>
       <selectionEntries>
-        <selectionEntry id="bfe7-f070-15b7-6b31" name="Adept" publicationId="cf03-f607-pubN76780" page="34" hidden="false" collective="false" type="model">
+        <selectionEntry id="bfe7-f070-15b7-6b31" name="Adept" publicationId="cf03-f607-pubN76780" page="34" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <profiles>
-            <profile id="4aa6-f812-03da-ac4f" name="Adept" publicationId="cf03-f607-pubN86172" page="271" hidden="false" typeId="556e697423232344415441232323" typeName="">
+            <profile id="4aa6-f812-03da-ac4f" name="Adept" publicationId="cf03-f607-pubN86172" page="271" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
@@ -3250,9 +3250,9 @@ Reduces transport capacity to 8.</description>
             <infoLink id="aa6a-93d2-b608-181f" hidden="false" targetId="5aad03df-0fd0-5920-0aec-2aefbe5bcf5b" type="rule"/>
           </infoLinks>
           <selectionEntryGroups>
-            <selectionEntryGroup id="1d6e-ba51-5c75-718f" name="Any Adept may take:" hidden="false" collective="false">
+            <selectionEntryGroup id="1d6e-ba51-5c75-718f" name="Any Adept may take:" hidden="false" collective="false" import="true">
               <selectionEntries>
-                <selectionEntry id="c858-fdeb-4b22-02a2" name="Nuncio-vox" page="0" hidden="false" collective="false" type="upgrade">
+                <selectionEntry id="c858-fdeb-4b22-02a2" name="Nuncio-vox" page="0" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
                   </constraints>
@@ -3263,7 +3263,7 @@ Reduces transport capacity to 8.</description>
                     <cost name="pts" typeId="points" value="10.0"/>
                   </costs>
                 </selectionEntry>
-                <selectionEntry id="4fd4-3e1a-4d63-e57b" name="Volkite Charger" page="0" hidden="false" collective="false" type="upgrade">
+                <selectionEntry id="4fd4-3e1a-4d63-e57b" name="Volkite Charger" page="0" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
                   </constraints>
@@ -3275,7 +3275,7 @@ Reduces transport capacity to 8.</description>
                     <cost name="pts" typeId="points" value="10.0"/>
                   </costs>
                 </selectionEntry>
-                <selectionEntry id="b8aa-00a7-f26c-b181" name="Cortex Controller" page="0" hidden="false" collective="false" type="upgrade">
+                <selectionEntry id="b8aa-00a7-f26c-b181" name="Cortex Controller" page="0" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
                   </constraints>
@@ -3294,7 +3294,7 @@ Reduces transport capacity to 8.</description>
                     <cost name="pts" typeId="points" value="15.0"/>
                   </costs>
                 </selectionEntry>
-                <selectionEntry id="8eb0-9749-91c0-7c9e" name="Graviton Gun" page="0" hidden="false" collective="false" type="upgrade">
+                <selectionEntry id="8eb0-9749-91c0-7c9e" name="Graviton Gun" page="0" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
                   </constraints>
@@ -3306,7 +3306,7 @@ Reduces transport capacity to 8.</description>
                     <cost name="pts" typeId="points" value="15.0"/>
                   </costs>
                 </selectionEntry>
-                <selectionEntry id="ff90-d2f1-d3ef-8eda" name="Cyber-familiar" page="0" hidden="false" collective="false" type="upgrade">
+                <selectionEntry id="ff90-d2f1-d3ef-8eda" name="Cyber-familiar" page="0" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
                   </constraints>
@@ -3319,17 +3319,17 @@ Reduces transport capacity to 8.</description>
                 </selectionEntry>
               </selectionEntries>
               <entryLinks>
-                <entryLink id="8692-e3c3-e8e4-9e57" name="New EntryLink" hidden="false" collective="false" targetId="2645-2048-de94-299c" type="selectionEntry"/>
-                <entryLink id="ca7e-939a-3b3e-9f46" name="New EntryLink" hidden="false" collective="false" targetId="acf4-096f-2127-80a3" type="selectionEntry"/>
+                <entryLink id="8692-e3c3-e8e4-9e57" name="New EntryLink" hidden="false" collective="false" import="true" targetId="2645-2048-de94-299c" type="selectionEntry"/>
+                <entryLink id="ca7e-939a-3b3e-9f46" name="New EntryLink" hidden="false" collective="false" import="true" targetId="acf4-096f-2127-80a3" type="selectionEntry"/>
               </entryLinks>
             </selectionEntryGroup>
-            <selectionEntryGroup id="357d-b90a-64c5-172f" name="Techno-Arcana" hidden="false" collective="false">
+            <selectionEntryGroup id="357d-b90a-64c5-172f" name="Techno-Arcana" hidden="false" collective="false" import="true">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <selectionEntries>
-                <selectionEntry id="431d-f992-653c-cb3e" name="Enginseer" page="0" hidden="false" collective="false" type="upgrade">
+                <selectionEntry id="431d-f992-653c-cb3e" name="Enginseer" page="0" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
                   </constraints>
@@ -3343,7 +3343,7 @@ Reduces transport capacity to 8.</description>
                     <cost name="pts" typeId="points" value="0.0"/>
                   </costs>
                 </selectionEntry>
-                <selectionEntry id="e16a-40db-b722-dc10" name="Lacyraemarta" page="0" hidden="false" collective="false" type="upgrade">
+                <selectionEntry id="e16a-40db-b722-dc10" name="Lacyraemarta" page="0" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
                   </constraints>
@@ -3359,7 +3359,7 @@ Reduces transport capacity to 8.</description>
                     <cost name="pts" typeId="points" value="0.0"/>
                   </costs>
                 </selectionEntry>
-                <selectionEntry id="4032-4e2d-46e5-660e" name="Reductor" page="0" hidden="false" collective="false" type="upgrade">
+                <selectionEntry id="4032-4e2d-46e5-660e" name="Reductor" page="0" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
                   </constraints>
@@ -3375,7 +3375,7 @@ Reduces transport capacity to 8.</description>
                 </selectionEntry>
               </selectionEntries>
             </selectionEntryGroup>
-            <selectionEntryGroup id="b215-824e-13f9-ef25" name="Exchange Servo-arm for:" hidden="false" collective="false">
+            <selectionEntryGroup id="b215-824e-13f9-ef25" name="Exchange Servo-arm for:" hidden="false" collective="false" import="true">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
@@ -3388,7 +3388,7 @@ Reduces transport capacity to 8.</description>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <selectionEntries>
-                <selectionEntry id="12bc-e6e1-f46a-7fc1" name="Graviton Imploder" page="0" hidden="false" collective="false" type="upgrade">
+                <selectionEntry id="12bc-e6e1-f46a-7fc1" name="Graviton Imploder" page="0" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
                   </constraints>
@@ -3400,7 +3400,7 @@ Reduces transport capacity to 8.</description>
                     <cost name="pts" typeId="points" value="25.0"/>
                   </costs>
                 </selectionEntry>
-                <selectionEntry id="549e-d730-a418-47fc" name="Conversion Beamer" publicationId="cf03-f607-pubN80892" page="0" hidden="false" collective="false" type="upgrade">
+                <selectionEntry id="549e-d730-a418-47fc" name="Conversion Beamer" publicationId="cf03-f607-pubN80892" page="0" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
                   </constraints>
@@ -3415,14 +3415,14 @@ Reduces transport capacity to 8.</description>
                 </selectionEntry>
               </selectionEntries>
             </selectionEntryGroup>
-            <selectionEntryGroup id="6245-e160-fff0-87c4" name="A single Adept may be upgraded to:" hidden="false" collective="false">
+            <selectionEntryGroup id="6245-e160-fff0-87c4" name="A single Adept may be upgraded to:" hidden="false" collective="false" import="true">
               <selectionEntries>
-                <selectionEntry id="8277-a13b-8e6e-092b" name="Magos Auxilia" hidden="false" collective="false" type="upgrade">
+                <selectionEntry id="8277-a13b-8e6e-092b" name="Magos Auxilia" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
                   </constraints>
                   <profiles>
-                    <profile id="933d-ca0e-934f-a560" name="Magos Auxilia" publicationId="cf03-f607-pubN76270" page="34" hidden="false" typeId="556e697423232344415441232323" typeName="">
+                    <profile id="933d-ca0e-934f-a560" name="Magos Auxilia" publicationId="cf03-f607-pubN76270" page="34" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
                       <characteristics>
                         <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry (Character)</characteristic>
                         <characteristic name="WS" typeId="575323232344415441232323">3</characteristic>
@@ -3451,7 +3451,7 @@ Reduces transport capacity to 8.</description>
             <cost name="pts" typeId="points" value="20.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="818b-b1ff-1e4a-7767" name="Servo-automata" publicationId="cf03-f607-pubN76780" page="34" hidden="false" collective="false" type="model">
+        <selectionEntry id="818b-b1ff-1e4a-7767" name="Servo-automata" publicationId="cf03-f607-pubN76780" page="34" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
             <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
@@ -3467,7 +3467,7 @@ Reduces transport capacity to 8.</description>
             <infoLink id="ac2d-1d31-91cd-bb12" hidden="false" targetId="9458b91c-55d7-ac17-21a3-4235e153b328" type="profile"/>
           </infoLinks>
           <selectionEntries>
-            <selectionEntry id="1c54-cb6a-de58-e42a" name="Close combat weapon" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="1c54-cb6a-de58-e42a" name="Close combat weapon" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a4c6-cba4-75f2-1734" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="07c7-aba5-527a-a34e" type="max"/>
@@ -3481,7 +3481,7 @@ Reduces transport capacity to 8.</description>
             <cost name="pts" typeId="points" value="5.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="f9f3-037e-22d7-00b8" name="Laspistol" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="f9f3-037e-22d7-00b8" name="Laspistol" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="fe06-9935-7baa-270f" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5720-5267-5468-8917" type="max"/>
@@ -3493,7 +3493,7 @@ Reduces transport capacity to 8.</description>
             <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="a2f5-4f23-c9f8-87b7" name="Power axe" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="a2f5-4f23-c9f8-87b7" name="Power axe" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3d51-57cc-db7a-0bd7" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="213c-6e4b-da64-19fe" type="max"/>
@@ -3507,7 +3507,7 @@ Reduces transport capacity to 8.</description>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="ebc5-6fcb-6c04-fd1b" name="Any Servo-automata may take:" hidden="false" collective="false">
+        <selectionEntryGroup id="ebc5-6fcb-6c04-fd1b" name="Any Servo-automata may take:" hidden="false" collective="false" import="true">
           <modifiers>
             <modifier type="increment" field="maxSelections" value="1.0">
               <repeats>
@@ -3519,7 +3519,7 @@ Reduces transport capacity to 8.</description>
             <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="4195-c9c9-ffef-d830" name="Las-lock" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="4195-c9c9-ffef-d830" name="Las-lock" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
@@ -3530,7 +3530,7 @@ Reduces transport capacity to 8.</description>
                 <cost name="pts" typeId="points" value="1.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="9796-284e-b27b-f444" name="Servo-arm" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="9796-284e-b27b-f444" name="Servo-arm" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
@@ -3541,7 +3541,7 @@ Reduces transport capacity to 8.</description>
                 <cost name="pts" typeId="points" value="5.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="5e86-2913-5fc9-7dcb" name="Flamer" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="5e86-2913-5fc9-7dcb" name="Flamer" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
@@ -3552,7 +3552,7 @@ Reduces transport capacity to 8.</description>
                 <cost name="pts" typeId="points" value="5.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="1185-a6fb-5bae-102c" name="Rotor Cannon" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="1185-a6fb-5bae-102c" name="Rotor Cannon" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
@@ -3563,7 +3563,7 @@ Reduces transport capacity to 8.</description>
                 <cost name="pts" typeId="points" value="10.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="abd5-1079-4b36-356a" name="Heavy Bolter" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="abd5-1079-4b36-356a" name="Heavy Bolter" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
@@ -3574,7 +3574,7 @@ Reduces transport capacity to 8.</description>
                 <cost name="pts" typeId="points" value="15.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="bfd2-ae59-e713-7ee2" name="Multi-melta" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="bfd2-ae59-e713-7ee2" name="Multi-melta" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
@@ -3582,7 +3582,7 @@ Reduces transport capacity to 8.</description>
                 <cost name="pts" typeId="points" value="15.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="3ba6-918a-6e4d-43f9" name="Maxima Bolter" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="3ba6-918a-6e4d-43f9" name="Maxima Bolter" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
@@ -3597,13 +3597,13 @@ Reduces transport capacity to 8.</description>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="454d-a8b6-71ee-716f" hidden="false" collective="false" targetId="bb6538b0-0f23-8a43-9752-dd356ba76e46" type="selectionEntry"/>
+        <entryLink id="454d-a8b6-71ee-716f" hidden="false" collective="false" import="true" targetId="bb6538b0-0f23-8a43-9752-dd356ba76e46" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="25.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="bb6538b0-0f23-8a43-9752-dd356ba76e46" name="Triaros Armoured Conveyor" publicationId="cf03-f607-pubN76979" page="224" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="bb6538b0-0f23-8a43-9752-dd356ba76e46" name="Triaros Armoured Conveyor" publicationId="cf03-f607-pubN76979" page="224" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
       </constraints>
@@ -3613,12 +3613,12 @@ Reduces transport capacity to 8.</description>
         <infoLink id="a1e7-c5e5-c102-f1d7" name="New InfoLink" hidden="false" targetId="c584-ada8-935d-9ed7" type="profile"/>
       </infoLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="6aa5-2f0e-f94f-d297" name="Psyarkana" hidden="false" collective="false">
+        <selectionEntryGroup id="6aa5-2f0e-f94f-d297" name="Psyarkana" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="721e-e7eb-9bd4-be6a" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="63e7-773d-871c-40c5" name="Armatus Necrotechnica" hidden="false" collective="false" targetId="e78c-d1a1-c20f-dae8" type="selectionEntry">
+            <entryLink id="63e7-773d-871c-40c5" name="Armatus Necrotechnica" hidden="false" collective="false" import="true" targetId="e78c-d1a1-c20f-dae8" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="hidden" value="false"/>
               </modifiers>
@@ -3627,21 +3627,21 @@ Reduces transport capacity to 8.</description>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="fbeb-5ea1-c9da-c323" name="Flare Shield" hidden="false" collective="false" targetId="776e-2ea5-2be8-fee3" type="selectionEntry"/>
-        <entryLink id="267e-df38-e055-f06c" name="Triaros/Karacnos optionals:" hidden="false" collective="false" targetId="4e41-e567-a14d-8e3a" type="selectionEntryGroup">
+        <entryLink id="fbeb-5ea1-c9da-c323" name="Flare Shield" hidden="false" collective="false" import="true" targetId="776e-2ea5-2be8-fee3" type="selectionEntry"/>
+        <entryLink id="267e-df38-e055-f06c" name="Triaros/Karacnos optionals:" hidden="false" collective="false" import="true" targetId="4e41-e567-a14d-8e3a" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="name" value="May take any of the following:"/>
           </modifiers>
         </entryLink>
-        <entryLink id="a381-97d9-7a14-e63b" name="New EntryLink" hidden="false" collective="false" targetId="0a18-686c-1dfb-4b71" type="selectionEntry"/>
-        <entryLink id="8b10-c322-064d-314d" name="New EntryLink" hidden="false" collective="false" targetId="48e5-e3dc-433e-d5a6" type="selectionEntry"/>
-        <entryLink id="ea9b-623f-5a9a-c1cb" name="New EntryLink" hidden="false" collective="false" targetId="f2a5-f499-58e1-21e8" type="selectionEntry"/>
+        <entryLink id="a381-97d9-7a14-e63b" name="New EntryLink" hidden="false" collective="false" import="true" targetId="0a18-686c-1dfb-4b71" type="selectionEntry"/>
+        <entryLink id="8b10-c322-064d-314d" name="New EntryLink" hidden="false" collective="false" import="true" targetId="48e5-e3dc-433e-d5a6" type="selectionEntry"/>
+        <entryLink id="ea9b-623f-5a9a-c1cb" name="New EntryLink" hidden="false" collective="false" import="true" targetId="f2a5-f499-58e1-21e8" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="135.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="30c2c848-c1d3-e61f-6632-a91bcee1fdc4" name="Twin-Linked Bolter" page="0" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="30c2c848-c1d3-e61f-6632-a91bcee1fdc4" name="Twin-Linked Bolter" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
@@ -3653,7 +3653,7 @@ Reduces transport capacity to 8.</description>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="7677dd1e-d159-6a47-ab20-ed0d7e70a0e7" name="Volkite Caliver" page="0" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="7677dd1e-d159-6a47-ab20-ed0d7e70a0e7" name="Volkite Caliver" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
       </constraints>
@@ -3665,7 +3665,7 @@ Reduces transport capacity to 8.</description>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="2075c6c6-b54d-2d3e-fce9-0543efa392f8" name="Volkite Charger" page="0" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="2075c6c6-b54d-2d3e-fce9-0543efa392f8" name="Volkite Charger" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
       </constraints>
@@ -3677,7 +3677,7 @@ Reduces transport capacity to 8.</description>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="edadef72-c786-ab75-6888-15d0cc090857" name="Volkite Culverin" page="0" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="edadef72-c786-ab75-6888-15d0cc090857" name="Volkite Culverin" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
       </constraints>
@@ -3689,7 +3689,7 @@ Reduces transport capacity to 8.</description>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="a7ac402a-2804-0342-d16a-23c3098a57ef" name="Volkite Serpentia" page="0" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="a7ac402a-2804-0342-d16a-23c3098a57ef" name="Volkite Serpentia" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
       </constraints>
@@ -3701,7 +3701,7 @@ Reduces transport capacity to 8.</description>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="ae94-81c7-edf1-b10d" name="Secutarii war plate" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="ae94-81c7-edf1-b10d" name="Secutarii war plate" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ade6-4de9-8b67-e70b" type="min"/>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6849-0171-0759-ce49" type="max"/>
@@ -3710,7 +3710,7 @@ Reduces transport capacity to 8.</description>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="c472-6345-24b3-f952" name="Secutarii" hidden="false" collective="false" type="model">
+    <selectionEntry id="c472-6345-24b3-f952" name="Secutarii" hidden="false" collective="false" import="true" type="model">
       <constraints>
         <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c608-7245-f009-8fef" type="min"/>
         <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="159d-4f16-5905-7fb4" type="max"/>
@@ -3726,7 +3726,7 @@ Reduces transport capacity to 8.</description>
         <cost name="pts" typeId="points" value="11.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="c968-115e-0e8b-7836" name="Arc Lance" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="c968-115e-0e8b-7836" name="Arc Lance" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d277-2b19-d18e-9bba" type="max"/>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="94d6-e5de-8c9b-b58c" type="min"/>
@@ -3739,7 +3739,7 @@ Reduces transport capacity to 8.</description>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="7811-c16f-d263-419c" name="Mag-inverter Shield" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="7811-c16f-d263-419c" name="Mag-inverter Shield" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="56a3-a7c6-f7bd-fb7e" type="max"/>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f05-1c3d-239a-da5e" type="min"/>
@@ -3751,7 +3751,7 @@ Reduces transport capacity to 8.</description>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="8190-e779-2c49-c564" name="Secutarii Peltast Phalanx" publicationId="cf03-f607-pubN89244" hidden="false" collective="false" type="unit">
+    <selectionEntry id="8190-e779-2c49-c564" name="Secutarii Peltast Phalanx" publicationId="cf03-f607-pubN89244" hidden="false" collective="false" import="true" type="unit">
       <constraints>
         <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8ca6-c4ee-0f61-effa" type="max"/>
       </constraints>
@@ -3766,7 +3766,7 @@ Reduces transport capacity to 8.</description>
         <categoryLink id="c63e-9be3-05b4-db86" name="New CategoryLink" hidden="false" targetId="f74d-4679-75a6-1252" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="84ce-92fd-3a06-de23" name="Secutarii Alpha" hidden="false" collective="false" type="model">
+        <selectionEntry id="84ce-92fd-3a06-de23" name="Secutarii Alpha" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3842-23ca-dd0a-f270" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e78c-2dc7-340c-6b8f" type="max"/>
@@ -3775,43 +3775,43 @@ Reduces transport capacity to 8.</description>
             <infoLink id="1968-46fb-4d98-b55b" hidden="false" targetId="f3a4-dac5-1296-0daf" type="profile"/>
           </infoLinks>
           <selectionEntryGroups>
-            <selectionEntryGroup id="fc26-3324-44b0-9ad9" name="Secutarii Alpha Additonal Weapons" hidden="false" collective="false">
+            <selectionEntryGroup id="fc26-3324-44b0-9ad9" name="Secutarii Alpha Additonal Weapons" hidden="false" collective="false" import="true">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0624-1bcc-542a-9c3c" type="max"/>
               </constraints>
               <entryLinks>
-                <entryLink id="b22d-eefa-8068-d56d" hidden="false" collective="false" targetId="fc08-3275-0e79-6421" type="selectionEntry"/>
-                <entryLink id="1340-5e95-dc11-9cdc" name="New EntryLink" hidden="false" collective="false" targetId="2089-a4b7-cbfd-e448" type="selectionEntry"/>
-                <entryLink id="5c09-15e3-eaf5-73e7" name="New EntryLink" hidden="false" collective="false" targetId="a7ac402a-2804-0342-d16a-23c3098a57ef" type="selectionEntry">
+                <entryLink id="b22d-eefa-8068-d56d" hidden="false" collective="false" import="true" targetId="fc08-3275-0e79-6421" type="selectionEntry"/>
+                <entryLink id="1340-5e95-dc11-9cdc" name="New EntryLink" hidden="false" collective="false" import="true" targetId="2089-a4b7-cbfd-e448" type="selectionEntry"/>
+                <entryLink id="5c09-15e3-eaf5-73e7" name="New EntryLink" hidden="false" collective="false" import="true" targetId="a7ac402a-2804-0342-d16a-23c3098a57ef" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="points" value="5"/>
                   </modifiers>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
-            <selectionEntryGroup id="d11e-dee9-d278-13e3" name="Exchange Galvanic Caster for:" hidden="false" collective="false" defaultSelectionEntryId="6625-e14c-6627-af17">
+            <selectionEntryGroup id="d11e-dee9-d278-13e3" name="Exchange Galvanic Caster for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="6625-e14c-6627-af17">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c7ff-b044-f314-fee3" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4678-6022-a950-3b13" type="min"/>
               </constraints>
               <entryLinks>
-                <entryLink id="cc32-9951-2840-bbcf" hidden="false" collective="false" targetId="5123-2580-422c-33f8" type="selectionEntry"/>
-                <entryLink id="5295-9090-357a-0512" name="Arc Maul" hidden="false" collective="false" targetId="6951-c813-b83f-d5a4" type="selectionEntry">
+                <entryLink id="cc32-9951-2840-bbcf" hidden="false" collective="false" import="true" targetId="5123-2580-422c-33f8" type="selectionEntry"/>
+                <entryLink id="5295-9090-357a-0512" name="Arc Maul" hidden="false" collective="false" import="true" targetId="6951-c813-b83f-d5a4" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="points" value="0.0"/>
                   </modifiers>
                 </entryLink>
-                <entryLink id="061f-2b44-b165-363c" name="Arc Rifle" hidden="false" collective="false" targetId="9663-feec-8ebc-b809" type="selectionEntry"/>
-                <entryLink id="6625-e14c-6627-af17" hidden="false" collective="false" targetId="7b6e-1246-67b8-f13b" type="selectionEntry"/>
-                <entryLink id="b688-9bea-1e85-ef6c" name="Radium Carbine" hidden="false" collective="false" targetId="8f89-db02-97ce-aa1f" type="selectionEntry"/>
+                <entryLink id="061f-2b44-b165-363c" name="Arc Rifle" hidden="false" collective="false" import="true" targetId="9663-feec-8ebc-b809" type="selectionEntry"/>
+                <entryLink id="6625-e14c-6627-af17" hidden="false" collective="false" import="true" targetId="7b6e-1246-67b8-f13b" type="selectionEntry"/>
+                <entryLink id="b688-9bea-1e85-ef6c" name="Radium Carbine" hidden="false" collective="false" import="true" targetId="8f89-db02-97ce-aa1f" type="selectionEntry"/>
               </entryLinks>
             </selectionEntryGroup>
-            <selectionEntryGroup id="a4c4-ba5e-66b9-5f81" name="Additional Wargear" hidden="false" collective="false">
+            <selectionEntryGroup id="a4c4-ba5e-66b9-5f81" name="Additional Wargear" hidden="false" collective="false" import="true">
               <entryLinks>
-                <entryLink id="7714-b83a-1d9e-dd9b" name="New EntryLink" hidden="false" collective="false" targetId="40e37f6e-a984-4232-4dc4-807ed9028f62" type="selectionEntry"/>
-                <entryLink id="3d62-aa81-031d-11b5" name="New EntryLink" hidden="false" collective="false" targetId="73c4-584c-c927-3cbd" type="selectionEntry"/>
-                <entryLink id="12dd-731d-3c89-8164" name="New EntryLink" hidden="false" collective="false" targetId="2645-2048-de94-299c" type="selectionEntry"/>
-                <entryLink id="0be8-d373-44b8-857f" name="New EntryLink" hidden="false" collective="false" targetId="e672-6b87-a1d3-24db" type="selectionEntry">
+                <entryLink id="7714-b83a-1d9e-dd9b" name="New EntryLink" hidden="false" collective="false" import="true" targetId="40e37f6e-a984-4232-4dc4-807ed9028f62" type="selectionEntry"/>
+                <entryLink id="3d62-aa81-031d-11b5" name="New EntryLink" hidden="false" collective="false" import="true" targetId="73c4-584c-c927-3cbd" type="selectionEntry"/>
+                <entryLink id="12dd-731d-3c89-8164" name="New EntryLink" hidden="false" collective="false" import="true" targetId="2645-2048-de94-299c" type="selectionEntry"/>
+                <entryLink id="0be8-d373-44b8-857f" name="New EntryLink" hidden="false" collective="false" import="true" targetId="e672-6b87-a1d3-24db" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="points" value="5"/>
                   </modifiers>
@@ -3820,7 +3820,7 @@ Reduces transport capacity to 8.</description>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks>
-            <entryLink id="a80a-deff-47f8-685e" hidden="false" collective="false" targetId="ae94-81c7-edf1-b10d" type="selectionEntry"/>
+            <entryLink id="a80a-deff-47f8-685e" hidden="false" collective="false" import="true" targetId="ae94-81c7-edf1-b10d" type="selectionEntry"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="21.0"/>
@@ -3828,7 +3828,7 @@ Reduces transport capacity to 8.</description>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="496d-981c-5fb0-144d" name="May Exchange Galvanic-caster for:" hidden="false" collective="false">
+        <selectionEntryGroup id="496d-981c-5fb0-144d" name="May Exchange Galvanic-caster for:" hidden="false" collective="false" import="true">
           <modifiers>
             <modifier type="increment" field="bce1-3b4f-11b3-8c06" value="1">
               <repeats>
@@ -3840,16 +3840,16 @@ Reduces transport capacity to 8.</description>
             <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bce1-3b4f-11b3-8c06" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="743e-8d5c-d92b-72d8" name="New EntryLink" hidden="false" collective="false" targetId="9663-feec-8ebc-b809" type="selectionEntry"/>
-            <entryLink id="ce79-9c75-71ad-e572" name="New EntryLink" hidden="false" collective="false" targetId="8f89-db02-97ce-aa1f" type="selectionEntry"/>
+            <entryLink id="743e-8d5c-d92b-72d8" name="New EntryLink" hidden="false" collective="false" import="true" targetId="9663-feec-8ebc-b809" type="selectionEntry"/>
+            <entryLink id="ce79-9c75-71ad-e572" name="New EntryLink" hidden="false" collective="false" import="true" targetId="8f89-db02-97ce-aa1f" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="7e77-cd37-bc06-6a1c" name="Equip all Galvanic-casters with" hidden="false" collective="false">
+        <selectionEntryGroup id="7e77-cd37-bc06-6a1c" name="Equip all Galvanic-casters with" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="00af-85c8-6e8a-cd2a" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="d922-1b78-1bec-f718" name="Kinetic Hammershot rounds" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="d922-1b78-1bec-f718" name="Kinetic Hammershot rounds" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="increment" field="points" value="3">
                   <repeats>
@@ -3880,17 +3880,17 @@ Reduces transport capacity to 8.</description>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="9cb4-df13-2a96-b366" name="" hidden="false" collective="false" targetId="5cd6-814b-5784-13f5" type="selectionEntry"/>
-        <entryLink id="3b53-d120-06ae-a40c" hidden="false" collective="false" targetId="c472-6345-24b3-f952" type="selectionEntry"/>
-        <entryLink id="9933-fe28-89b7-4b5b" hidden="false" collective="false" targetId="ae94-81c7-edf1-b10d" type="selectionEntry"/>
-        <entryLink id="d5c3-1c21-5714-e009" hidden="false" collective="false" targetId="7b6e-1246-67b8-f13b" type="selectionEntry"/>
-        <entryLink id="0c3c-5921-cc0e-1ab3" hidden="false" collective="false" targetId="04fc-9823-28ea-591d" type="selectionEntryGroup"/>
+        <entryLink id="9cb4-df13-2a96-b366" name="" hidden="false" collective="false" import="true" targetId="5cd6-814b-5784-13f5" type="selectionEntry"/>
+        <entryLink id="3b53-d120-06ae-a40c" hidden="false" collective="false" import="true" targetId="c472-6345-24b3-f952" type="selectionEntry"/>
+        <entryLink id="9933-fe28-89b7-4b5b" hidden="false" collective="false" import="true" targetId="ae94-81c7-edf1-b10d" type="selectionEntry"/>
+        <entryLink id="d5c3-1c21-5714-e009" hidden="false" collective="false" import="true" targetId="7b6e-1246-67b8-f13b" type="selectionEntry"/>
+        <entryLink id="0c3c-5921-cc0e-1ab3" hidden="false" collective="false" import="true" targetId="04fc-9823-28ea-591d" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="5cd6-814b-5784-13f5" name="Kyropatris field generator" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="5cd6-814b-5784-13f5" name="Kyropatris field generator" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f414-b66b-c636-366d" type="min"/>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3ca2-3b1e-08f8-0c4b" type="max"/>
@@ -3902,7 +3902,7 @@ Reduces transport capacity to 8.</description>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="8f89-db02-97ce-aa1f" name="Radium Carbine" publicationId="cf03-f607-pubN90339" page="56" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="8f89-db02-97ce-aa1f" name="Radium Carbine" publicationId="cf03-f607-pubN90339" page="56" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="b83d-7f00-4b0a-dfba" hidden="false" targetId="0fd9-ce23-46af-2541" type="profile"/>
         <infoLink id="d087-ce14-c899-4487" hidden="false" targetId="a5ba-753a-58f6-81cc" type="rule"/>
@@ -3911,7 +3911,7 @@ Reduces transport capacity to 8.</description>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="73c4-584c-c927-3cbd" name="Omnispex" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="73c4-584c-c927-3cbd" name="Omnispex" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4543-6492-e692-44f6" type="max"/>
       </constraints>
@@ -3922,18 +3922,18 @@ Reduces transport capacity to 8.</description>
         <cost name="pts" typeId="points" value="10.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="5123-2580-422c-33f8" name="Power Weapon" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="5123-2580-422c-33f8" name="Power Weapon" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="514c-a9bb-a4eb-bbab" type="max"/>
       </constraints>
       <selectionEntryGroups>
-        <selectionEntryGroup id="96d0-6fbd-b88a-7da2" name="Power Weapon" hidden="false" collective="false">
+        <selectionEntryGroup id="96d0-6fbd-b88a-7da2" name="Power Weapon" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="28b7-8dc1-2529-c408" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="92b6-321c-b24c-912a" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="4862-ac84-bff2-a5f9" name="Power Sword" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="4862-ac84-bff2-a5f9" name="Power Sword" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="517a-d3e5-67c9-48a6" type="max"/>
               </constraints>
@@ -3944,7 +3944,7 @@ Reduces transport capacity to 8.</description>
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="6ce2-15fc-46d8-f687" name="Power Axe" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="6ce2-15fc-46d8-f687" name="Power Axe" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6f21-cab9-6475-6641" type="max"/>
               </constraints>
@@ -3956,7 +3956,7 @@ Reduces transport capacity to 8.</description>
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="46dc-8a59-eb29-426c" name="Power Maul" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="46dc-8a59-eb29-426c" name="Power Maul" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="51ea-0ba6-c092-3aa3" type="max"/>
               </constraints>
@@ -3968,7 +3968,7 @@ Reduces transport capacity to 8.</description>
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="68c0-d1b2-4572-7b18" name="Power Lance" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="68c0-d1b2-4572-7b18" name="Power Lance" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ff19-271b-48ae-e1b7" type="max"/>
               </constraints>
@@ -3986,7 +3986,7 @@ Reduces transport capacity to 8.</description>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="2645-2048-de94-299c" name="Augury Scanner" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="2645-2048-de94-299c" name="Augury Scanner" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="05f2-cec1-96ff-344e" type="max"/>
       </constraints>
@@ -3997,7 +3997,7 @@ Reduces transport capacity to 8.</description>
         <cost name="pts" typeId="points" value="5.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="e672-6b87-a1d3-24db" name="Shattersphere Grenades" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="e672-6b87-a1d3-24db" name="Shattersphere Grenades" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af32-ba27-1d9e-d0e3" type="max"/>
       </constraints>
@@ -4010,7 +4010,7 @@ Reduces transport capacity to 8.</description>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="6951-c813-b83f-d5a4" name="Arc Maul" publicationId="cf03-f607-pubN90339" page="56" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="6951-c813-b83f-d5a4" name="Arc Maul" publicationId="cf03-f607-pubN90339" page="56" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4be5-0d56-f060-58ae" type="max"/>
       </constraints>
@@ -4023,7 +4023,7 @@ Reduces transport capacity to 8.</description>
         <cost name="pts" typeId="points" value="20.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="fc08-3275-0e79-6421" name="Arc Pistol" publicationId="cf03-f607-pubN90339" page="56" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="fc08-3275-0e79-6421" name="Arc Pistol" publicationId="cf03-f607-pubN90339" page="56" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="191e-059d-a03f-cb1d" type="max"/>
       </constraints>
@@ -4035,7 +4035,7 @@ Reduces transport capacity to 8.</description>
         <cost name="pts" typeId="points" value="10.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="9663-feec-8ebc-b809" name="Arc Rifle" publicationId="cf03-f607-pubN90339" page="56" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="9663-feec-8ebc-b809" name="Arc Rifle" publicationId="cf03-f607-pubN90339" page="56" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="ba74-7204-9267-020f" name="Arc Rifle" hidden="false" targetId="33f9-5be4-027c-99b5" type="profile"/>
         <infoLink id="bed5-20bb-3e7c-bd84" hidden="false" targetId="6970-1bf3-b33e-5dce" type="rule"/>
@@ -4044,7 +4044,7 @@ Reduces transport capacity to 8.</description>
         <cost name="pts" typeId="points" value="10.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="7b6e-1246-67b8-f13b" name="Galvanic Caster" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="7b6e-1246-67b8-f13b" name="Galvanic Caster" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="12f5-8bea-0313-d676" hidden="false" targetId="ca63-9ad3-2ba0-e94f" type="profile"/>
         <infoLink id="684d-2511-d875-a698" name="" hidden="false" targetId="4aac-be8d-15b3-b158" type="profile"/>
@@ -4054,7 +4054,7 @@ Reduces transport capacity to 8.</description>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="4ff6-b526-4208-0d33" name="Secutarii Hoplite Phalanx" publicationId="cf03-f607-pubN89244" hidden="false" collective="false" type="unit">
+    <selectionEntry id="4ff6-b526-4208-0d33" name="Secutarii Hoplite Phalanx" publicationId="cf03-f607-pubN89244" hidden="false" collective="false" import="true" type="unit">
       <constraints>
         <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6fb1-d527-17a7-2ba0" type="max"/>
       </constraints>
@@ -4068,7 +4068,7 @@ Reduces transport capacity to 8.</description>
         <categoryLink id="d19b-30dc-4650-0c80" name="New CategoryLink" hidden="false" targetId="f74d-4679-75a6-1252" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="7370-256c-75aa-a484" name="Secutarii Alpha" hidden="false" collective="false" type="model">
+        <selectionEntry id="7370-256c-75aa-a484" name="Secutarii Alpha" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2836-e1a1-8027-8983" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c968-a097-75ce-20b5" type="max"/>
@@ -4077,44 +4077,44 @@ Reduces transport capacity to 8.</description>
             <infoLink id="719b-4be3-353a-3fd9" hidden="false" targetId="f3a4-dac5-1296-0daf" type="profile"/>
           </infoLinks>
           <selectionEntryGroups>
-            <selectionEntryGroup id="92ad-e502-42c0-638a" name="Secutarii Alpha Additonal Weapons" hidden="false" collective="false">
+            <selectionEntryGroup id="92ad-e502-42c0-638a" name="Secutarii Alpha Additonal Weapons" hidden="false" collective="false" import="true">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1171-1ad0-89c6-ad49" type="max"/>
               </constraints>
               <entryLinks>
-                <entryLink id="792a-fbba-e5ab-61bb" hidden="false" collective="false" targetId="2089-a4b7-cbfd-e448" type="selectionEntry"/>
-                <entryLink id="7622-0fb2-dec5-03ab" name="New EntryLink" hidden="false" collective="false" targetId="fc08-3275-0e79-6421" type="selectionEntry"/>
-                <entryLink id="e119-074c-7db4-d3ee" name="New EntryLink" hidden="false" collective="false" targetId="a7ac402a-2804-0342-d16a-23c3098a57ef" type="selectionEntry">
+                <entryLink id="792a-fbba-e5ab-61bb" hidden="false" collective="false" import="true" targetId="2089-a4b7-cbfd-e448" type="selectionEntry"/>
+                <entryLink id="7622-0fb2-dec5-03ab" name="New EntryLink" hidden="false" collective="false" import="true" targetId="fc08-3275-0e79-6421" type="selectionEntry"/>
+                <entryLink id="e119-074c-7db4-d3ee" name="New EntryLink" hidden="false" collective="false" import="true" targetId="a7ac402a-2804-0342-d16a-23c3098a57ef" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="name" value="5"/>
                   </modifiers>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
-            <selectionEntryGroup id="9294-16b4-26c7-55d1" name="Exchange Arc Lance for:" hidden="false" collective="false" defaultSelectionEntryId="a8c1-6fbf-2f08-93f0">
+            <selectionEntryGroup id="9294-16b4-26c7-55d1" name="Exchange Arc Lance for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="a8c1-6fbf-2f08-93f0">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9194-b775-e1d3-b7f8" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0e7c-b49d-d90c-8bf1" type="min"/>
               </constraints>
               <entryLinks>
-                <entryLink id="30c8-2f3f-18f4-94ba" hidden="false" collective="false" targetId="5123-2580-422c-33f8" type="selectionEntry"/>
-                <entryLink id="328f-35e5-53d9-5463" name="Arc Maul" hidden="false" collective="false" targetId="6951-c813-b83f-d5a4" type="selectionEntry">
+                <entryLink id="30c8-2f3f-18f4-94ba" hidden="false" collective="false" import="true" targetId="5123-2580-422c-33f8" type="selectionEntry"/>
+                <entryLink id="328f-35e5-53d9-5463" name="Arc Maul" hidden="false" collective="false" import="true" targetId="6951-c813-b83f-d5a4" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="points" value="0.0"/>
                   </modifiers>
                 </entryLink>
-                <entryLink id="a8c1-6fbf-2f08-93f0" name="Arc Lance" hidden="false" collective="false" targetId="c968-115e-0e8b-7836" type="selectionEntry">
+                <entryLink id="a8c1-6fbf-2f08-93f0" name="Arc Lance" hidden="false" collective="false" import="true" targetId="c968-115e-0e8b-7836" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="94d6-e5de-8c9b-b58c" value="0.0"/>
                   </modifiers>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
-            <selectionEntryGroup id="0f8f-592e-f6de-7dfe" name="Additional Wargear" hidden="false" collective="false">
+            <selectionEntryGroup id="0f8f-592e-f6de-7dfe" name="Additional Wargear" hidden="false" collective="false" import="true">
               <entryLinks>
-                <entryLink id="b97f-4262-3bd9-45d0" name="New EntryLink" hidden="false" collective="false" targetId="2645-2048-de94-299c" type="selectionEntry"/>
-                <entryLink id="6186-0ec6-fd3d-5833" name="New EntryLink" hidden="false" collective="false" targetId="73c4-584c-c927-3cbd" type="selectionEntry"/>
-                <entryLink id="bf63-04d7-893e-fbe5" name="New EntryLink" hidden="false" collective="false" targetId="e672-6b87-a1d3-24db" type="selectionEntry">
+                <entryLink id="b97f-4262-3bd9-45d0" name="New EntryLink" hidden="false" collective="false" import="true" targetId="2645-2048-de94-299c" type="selectionEntry"/>
+                <entryLink id="6186-0ec6-fd3d-5833" name="New EntryLink" hidden="false" collective="false" import="true" targetId="73c4-584c-c927-3cbd" type="selectionEntry"/>
+                <entryLink id="bf63-04d7-893e-fbe5" name="New EntryLink" hidden="false" collective="false" import="true" targetId="e672-6b87-a1d3-24db" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="points" value="5"/>
                   </modifiers>
@@ -4123,7 +4123,7 @@ Reduces transport capacity to 8.</description>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks>
-            <entryLink id="4de1-7e69-f589-3a72" hidden="false" collective="false" targetId="ae94-81c7-edf1-b10d" type="selectionEntry"/>
+            <entryLink id="4de1-7e69-f589-3a72" hidden="false" collective="false" import="true" targetId="ae94-81c7-edf1-b10d" type="selectionEntry"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="22.0"/>
@@ -4131,29 +4131,29 @@ Reduces transport capacity to 8.</description>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="be52-28e0-11a5-32c8" name="Standard Wargear" hidden="false" collective="false">
+        <selectionEntryGroup id="be52-28e0-11a5-32c8" name="Standard Wargear" hidden="false" collective="false" import="true">
           <entryLinks>
-            <entryLink id="7867-b8ae-753d-428e" name="New EntryLink" hidden="false" collective="false" targetId="ae94-81c7-edf1-b10d" type="selectionEntry"/>
-            <entryLink id="b332-72a8-030d-1496" name="Arc Lance" hidden="false" collective="false" targetId="c968-115e-0e8b-7836" type="selectionEntry"/>
-            <entryLink id="b047-f5d4-0c83-d02a" hidden="false" collective="false" targetId="5cd6-814b-5784-13f5" type="selectionEntry"/>
-            <entryLink id="0687-0066-8df3-b83d" name="New EntryLink" hidden="false" collective="false" targetId="7811-c16f-d263-419c" type="selectionEntry"/>
+            <entryLink id="7867-b8ae-753d-428e" name="New EntryLink" hidden="false" collective="false" import="true" targetId="ae94-81c7-edf1-b10d" type="selectionEntry"/>
+            <entryLink id="b332-72a8-030d-1496" name="Arc Lance" hidden="false" collective="false" import="true" targetId="c968-115e-0e8b-7836" type="selectionEntry"/>
+            <entryLink id="b047-f5d4-0c83-d02a" hidden="false" collective="false" import="true" targetId="5cd6-814b-5784-13f5" type="selectionEntry"/>
+            <entryLink id="0687-0066-8df3-b83d" name="New EntryLink" hidden="false" collective="false" import="true" targetId="7811-c16f-d263-419c" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="a3b5-07e3-8e3f-416b" name="" hidden="false" collective="false" targetId="c472-6345-24b3-f952" type="selectionEntry">
+        <entryLink id="a3b5-07e3-8e3f-416b" name="" hidden="false" collective="false" import="true" targetId="c472-6345-24b3-f952" type="selectionEntry">
           <modifiers>
             <modifier type="append" field="name" value="Hoplite"/>
             <modifier type="set" field="points" value="12"/>
           </modifiers>
         </entryLink>
-        <entryLink id="bc60-ee64-0ab8-641b" hidden="false" collective="false" targetId="04fc-9823-28ea-591d" type="selectionEntryGroup"/>
+        <entryLink id="bc60-ee64-0ab8-641b" hidden="false" collective="false" import="true" targetId="04fc-9823-28ea-591d" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="776e-2ea5-2be8-fee3" name="Flare Shield" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="776e-2ea5-2be8-fee3" name="Flare Shield" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="49f9-15de-cd0e-b980" type="min"/>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3333-7c65-5394-7d26" type="max"/>
@@ -4165,7 +4165,7 @@ Reduces transport capacity to 8.</description>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="0a18-686c-1dfb-4b71" name="Shock Ram" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="0a18-686c-1dfb-4b71" name="Shock Ram" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e36f-9ab0-be3d-15fd" type="min"/>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="93f5-6819-f527-39b5" type="max"/>
@@ -4177,7 +4177,7 @@ Reduces transport capacity to 8.</description>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="48e5-e3dc-433e-d5a6" name="Twin-Linked Mauler Bolt Cannon" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="48e5-e3dc-433e-d5a6" name="Twin-Linked Mauler Bolt Cannon" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="480b-8bad-7d34-baa3" type="min"/>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b431-1501-6b7e-9b71" type="max"/>
@@ -4190,20 +4190,20 @@ Reduces transport capacity to 8.</description>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="f2a5-f499-58e1-21e8" name="Volkite Sentinel" hidden="false" collective="true" type="upgrade">
+    <selectionEntry id="f2a5-f499-58e1-21e8" name="Volkite Sentinel" hidden="false" collective="true" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e2f1-877a-ee4c-ee34" type="min"/>
         <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c350-273e-e4b2-8b59" type="max"/>
       </constraints>
       <profiles>
-        <profile id="eadf-25c4-1717-6724" name="Volkite Sentinels" publicationId="cf03-f607-pubN76979" page="224" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="">
+        <profile id="eadf-25c4-1717-6724" name="Volkite Sentinels" publicationId="cf03-f607-pubN76979" page="224" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
           <characteristics>
             <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Each is a pintle-mounted Volkite Charger which can be fired in addition to any other weapons the vehicle is carrying without penalty and may target units separately from the vehicles main armament.  </characteristic>
           </characteristics>
         </profile>
       </profiles>
       <selectionEntries>
-        <selectionEntry id="6544-0741-204b-45f5" name="Volkite Charger" page="0" hidden="false" collective="true" type="upgrade">
+        <selectionEntry id="6544-0741-204b-45f5" name="Volkite Charger" page="0" hidden="false" collective="true" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3e64-c17c-e1fb-31c6" type="max"/>
           </constraints>
@@ -4217,13 +4217,13 @@ Reduces transport capacity to 8.</description>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink id="4837-d363-41ea-9338" name="New EntryLink" hidden="false" collective="false" targetId="2075c6c6-b54d-2d3e-fce9-0543efa392f8" type="selectionEntry"/>
+        <entryLink id="4837-d363-41ea-9338" name="New EntryLink" hidden="false" collective="false" import="true" targetId="2075c6c6-b54d-2d3e-fce9-0543efa392f8" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="ec0b-3124-e0e4-6336" name="Karacnos Assault Tank" publicationId="cf03-f607-pubN92488" page="" hidden="false" collective="false" type="unit">
+    <selectionEntry id="ec0b-3124-e0e4-6336" name="Karacnos Assault Tank" publicationId="cf03-f607-pubN92488" page="" hidden="false" collective="false" import="true" type="unit">
       <infoLinks>
         <infoLink id="52d0-f4db-e027-430a" name="Triaros Armoured Conveyor" hidden="false" targetId="fda8-891c-9dc6-8f59" type="profile">
           <modifiers>
@@ -4237,12 +4237,12 @@ Reduces transport capacity to 8.</description>
         <categoryLink id="f80c-90ae-5e28-65b0" name="New CategoryLink" hidden="false" targetId="e59c-462e-9d9c-66dd" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="34f4-7338-6bb9-6938" name="Psyarkana" hidden="false" collective="false">
+        <selectionEntryGroup id="34f4-7338-6bb9-6938" name="Psyarkana" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7f78-93c2-fba8-9f13" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="5905-fb60-5b44-cfa9" name="Armatus Necrotechnica" hidden="false" collective="false" targetId="e78c-d1a1-c20f-dae8" type="selectionEntry">
+            <entryLink id="5905-fb60-5b44-cfa9" name="Armatus Necrotechnica" hidden="false" collective="false" import="true" targetId="e78c-d1a1-c20f-dae8" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="hidden" value="false"/>
               </modifiers>
@@ -4251,21 +4251,21 @@ Reduces transport capacity to 8.</description>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="5e35-a71f-5e13-e6dc" name="New EntryLink" hidden="false" collective="false" targetId="776e-2ea5-2be8-fee3" type="selectionEntry"/>
-        <entryLink id="56d4-93c4-a502-cdd0" name="Triaros/Karacnos optionals:" hidden="false" collective="false" targetId="4e41-e567-a14d-8e3a" type="selectionEntryGroup">
+        <entryLink id="5e35-a71f-5e13-e6dc" name="New EntryLink" hidden="false" collective="false" import="true" targetId="776e-2ea5-2be8-fee3" type="selectionEntry"/>
+        <entryLink id="56d4-93c4-a502-cdd0" name="Triaros/Karacnos optionals:" hidden="false" collective="false" import="true" targetId="4e41-e567-a14d-8e3a" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="name" value="May take any of the following:"/>
           </modifiers>
         </entryLink>
-        <entryLink id="8f96-0dba-f6cb-ec83" name="New EntryLink" hidden="false" collective="false" targetId="0a18-686c-1dfb-4b71" type="selectionEntry"/>
-        <entryLink id="f45c-8e8d-bfe0-0dd7" name="New EntryLink" hidden="false" collective="false" targetId="c36a-4017-0eb5-c8d2" type="selectionEntry"/>
-        <entryLink id="9cd0-475b-7369-3013" name="Karacnos mortar battery" hidden="false" collective="false" targetId="81f0-cd7e-d2fe-e7a0" type="selectionEntry"/>
+        <entryLink id="8f96-0dba-f6cb-ec83" name="New EntryLink" hidden="false" collective="false" import="true" targetId="0a18-686c-1dfb-4b71" type="selectionEntry"/>
+        <entryLink id="f45c-8e8d-bfe0-0dd7" name="New EntryLink" hidden="false" collective="false" import="true" targetId="c36a-4017-0eb5-c8d2" type="selectionEntry"/>
+        <entryLink id="9cd0-475b-7369-3013" name="Karacnos mortar battery" hidden="false" collective="false" import="true" targetId="81f0-cd7e-d2fe-e7a0" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="225.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="c36a-4017-0eb5-c8d2" name="Lightning Blaster Sentinel" publicationId="cf03-f607-pubN92488" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="c36a-4017-0eb5-c8d2" name="Lightning Blaster Sentinel" publicationId="cf03-f607-pubN92488" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ff7b-0ca7-4a3f-2653" type="max"/>
         <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="673e-3c4d-f573-c25b" type="min"/>
@@ -4280,7 +4280,7 @@ Reduces transport capacity to 8.</description>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="81f0-cd7e-d2fe-e7a0" name="Karacnos mortar battery" publicationId="cf03-f607-pubN92488" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="81f0-cd7e-d2fe-e7a0" name="Karacnos mortar battery" publicationId="cf03-f607-pubN92488" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="46ef-e4f2-2515-490c" type="max"/>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="bcef-29aa-f05e-cc54" type="min"/>
@@ -4297,9 +4297,9 @@ Reduces transport capacity to 8.</description>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="7cdb-8db0-bfd6-ce3c" name="Ordinatus Minoris Macro Engine" publicationId="cf03-f607-pubN76270" page="62-63" hidden="false" collective="false" type="model">
+    <selectionEntry id="7cdb-8db0-bfd6-ce3c" name="Ordinatus Minoris Macro Engine" publicationId="cf03-f607-pubN76270" page="62-63" hidden="false" collective="false" import="true" type="model">
       <profiles>
-        <profile id="8d4c-eaec-780e-e619" name="Ordinatus Dispersion Shield" publicationId="cf03-f607-pubN76270" page="63" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="">
+        <profile id="8d4c-eaec-780e-e619" name="Ordinatus Dispersion Shield" publicationId="cf03-f607-pubN76270" page="63" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
           <characteristics>
             <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">An arcane and obscure hybrid of both void shield and flare shield technologies, the powerful dispersion shields mounted on Ordinatus class vehicles are designed to make them all but impervious to counter-battery fire. However, such is the strain the field creates on its generators that its protection degrades over time as its elements begin to burn out.  The protection provided by the dispersion shield affects only shooting attacks originating from its front and side arcs, and against barrage weapons from any arc. • On the first turn the ordinatus is in play, the strength of shooting attacks and the roll result on the Destroyer table made against it are at -3. • On the second turn the Ordinatus is in play, the strength of shooting attacks and the roll result on the Dectroyer table made against it are at -2. • On the third and subsequent turns the Ordinatus is in play, the strength of shooting attacks and the roll result on the Destroyer table made against it are at  -1. </characteristic>
           </characteristics>
@@ -4326,15 +4326,15 @@ D6 Result 1-2 Explosion
         <categoryLink id="c289-ed7e-c4ea-bfe0" name="New CategoryLink" hidden="false" targetId="8d56-b8fc-9b94-9cc9" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="d80b-d453-6859-07f5" name="Ordinatus" hidden="false" collective="false">
+        <selectionEntryGroup id="d80b-d453-6859-07f5" name="Ordinatus" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="acfe-83df-d113-1226" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="6909-3280-6bd6-a188" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="b688-c38b-6e1a-89ba" name="Ordinatus Sagittar" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="b688-c38b-6e1a-89ba" name="Ordinatus Sagittar" hidden="false" collective="false" import="true" type="upgrade">
               <profiles>
-                <profile id="c4f4-bd04-4632-fb58" name="Ordinatus Sagittar" publicationId="cf03-f607-pubN80487" page="276" hidden="false" typeId="56656869636c6523232344415441232323" typeName="">
+                <profile id="c4f4-bd04-4632-fb58" name="Ordinatus Sagittar" publicationId="cf03-f607-pubN80487" page="276" hidden="false" typeId="56656869636c6523232344415441232323" typeName="Vehicle">
                   <characteristics>
                     <characteristic name="BS" typeId="425323232344415441232323">4</characteristic>
                     <characteristic name="Front" typeId="46726f6e7423232344415441232323">14</characteristic>
@@ -4344,7 +4344,7 @@ D6 Result 1-2 Explosion
                     <characteristic name="Type" typeId="5479706523232344415441232323">Vehicle (Super-heavy)</characteristic>
                   </characteristics>
                 </profile>
-                <profile id="964b-3535-4895-7664" name="Belicosa Pattern Volcano Cannon" publicationId="cf03-f607-pubN80965" page="264" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+                <profile id="964b-3535-4895-7664" name="Belicosa Pattern Volcano Cannon" publicationId="cf03-f607-pubN80965" page="264" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
                   <characteristics>
                     <characteristic name="Range" typeId="52616e676523232344415441232323">180&quot;</characteristic>
                     <characteristic name="Strength" typeId="537472656e67746823232344415441232323">D</characteristic>
@@ -4362,9 +4362,9 @@ D6 Result 1-2 Explosion
                 <cost name="pts" typeId="points" value="700.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="6e5a-2023-9fc3-5d17" name="Ordinatus Ulator" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="6e5a-2023-9fc3-5d17" name="Ordinatus Ulator" hidden="false" collective="false" import="true" type="upgrade">
               <profiles>
-                <profile id="5ebd-86a1-7f3b-891a" name="Ordinatus Ulator" publicationId="cf03-f607-pubN80487" page="276" hidden="false" typeId="56656869636c6523232344415441232323" typeName="">
+                <profile id="5ebd-86a1-7f3b-891a" name="Ordinatus Ulator" publicationId="cf03-f607-pubN80487" page="276" hidden="false" typeId="56656869636c6523232344415441232323" typeName="Vehicle">
                   <characteristics>
                     <characteristic name="BS" typeId="425323232344415441232323">4</characteristic>
                     <characteristic name="Front" typeId="46726f6e7423232344415441232323">14</characteristic>
@@ -4374,7 +4374,7 @@ D6 Result 1-2 Explosion
                     <characteristic name="Type" typeId="5479706523232344415441232323">Vehicle (Super-heavy)</characteristic>
                   </characteristics>
                 </profile>
-                <profile id="8850-e81e-e27f-b9b8" name="Ulator class Sonic Destructor" publicationId="cf03-f607-pubN80487" page="277" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+                <profile id="8850-e81e-e27f-b9b8" name="Ulator class Sonic Destructor" publicationId="cf03-f607-pubN80487" page="277" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
                   <characteristics>
                     <characteristic name="Range" typeId="52616e676523232344415441232323">72&quot;</characteristic>
                     <characteristic name="Strength" typeId="537472656e67746823232344415441232323">X*</characteristic>
@@ -4413,7 +4413,7 @@ Buildings and Fortifications D</description>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="454b-59ec-debe-307d" name="New EntryLink" hidden="false" collective="false" targetId="edadef72-c786-ab75-6888-15d0cc090857" type="selectionEntry">
+        <entryLink id="454b-59ec-debe-307d" name="New EntryLink" hidden="false" collective="false" import="true" targetId="edadef72-c786-ab75-6888-15d0cc090857" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="maxSelections" value="3"/>
           </modifiers>
@@ -4426,7 +4426,7 @@ Buildings and Fortifications D</description>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="9355-440a-d46e-e47b" name="Cybernetica Cortex" publicationId="cf03-f607-pubN93687" page="110" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="9355-440a-d46e-e47b" name="Cybernetica Cortex" publicationId="cf03-f607-pubN93687" page="110" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="71a8-4cd1-574d-b9c4" type="max"/>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="29f3-70a0-6265-8a36" type="min"/>
@@ -4443,7 +4443,7 @@ Buildings and Fortifications D</description>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="972c-91a0-764b-3fe0" name="Vultarax Stratos-automata Maniple" hidden="false" collective="false" type="unit">
+    <selectionEntry id="972c-91a0-764b-3fe0" name="Vultarax Stratos-automata Maniple" hidden="false" collective="false" import="true" type="unit">
       <infoLinks>
         <infoLink id="d253-b242-911f-5b6f" name="New InfoLink" hidden="false" targetId="a225-e39b-3699-c8f8" type="rule"/>
         <infoLink id="002f-a0d8-35f3-9608" name="New InfoLink" hidden="false" targetId="d5cf-bd98-2854-13cf" type="rule"/>
@@ -4452,13 +4452,13 @@ Buildings and Fortifications D</description>
         <categoryLink id="2c87-df97-9d45-cdb9" name="New CategoryLink" hidden="false" targetId="7fdd-2a97-d0e9-6524" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="7d36-6762-8723-3ee2" name="Vultarax Stratos-automata" page="0" hidden="false" collective="false" type="model">
+        <selectionEntry id="7d36-6762-8723-3ee2" name="Vultarax Stratos-automata" page="0" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0351-f950-a3fc-9b97" type="min"/>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7d97-5815-e44b-ef59" type="max"/>
           </constraints>
           <profiles>
-            <profile id="dff2-ef91-c9fb-bcb3" name="Vultarax Stratos-automata" publicationId="cf03-f607-pubN76270" page="46" hidden="false" typeId="556e697423232344415441232323" typeName="">
+            <profile id="dff2-ef91-c9fb-bcb3" name="Vultarax Stratos-automata" publicationId="cf03-f607-pubN76270" page="46" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Flying Monstrous Creature</characteristic>
                 <characteristic name="WS" typeId="575323232344415441232323">3</characteristic>
@@ -4483,7 +4483,7 @@ Buildings and Fortifications D</description>
             </rule>
           </rules>
           <selectionEntries>
-            <selectionEntry id="6afd-13e0-1ef7-991d" name="Vultarax arc blaster " hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="6afd-13e0-1ef7-991d" name="Vultarax arc blaster " hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5318-55b9-f838-0841" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d00f-16c5-16d8-6a1f" type="max"/>
@@ -4502,7 +4502,7 @@ Buildings and Fortifications D</description>
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="adce-8f07-a4d7-a1cc" name="Setheno pattern havoc launcher" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="adce-8f07-a4d7-a1cc" name="Setheno pattern havoc launcher" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fbe6-2c29-70a5-880d" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="001a-2288-8a46-35a1" type="max"/>
@@ -4526,7 +4526,7 @@ Buildings and Fortifications D</description>
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="536b-8304-7ff2-b676" name="Battle-automata power blades" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="536b-8304-7ff2-b676" name="Battle-automata power blades" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="52f3-8802-73d8-d75d" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8345-b32c-1a30-38ef" type="max"/>
@@ -4548,7 +4548,7 @@ Buildings and Fortifications D</description>
                 <cost name="pts" typeId="points" value="15.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="84d2-2fda-192d-f58f" name="Enhanced targeting array" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="84d2-2fda-192d-f58f" name="Enhanced targeting array" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="35a8-6cbe-802f-cae8" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="edf8-7e4b-3788-2d07" type="max"/>
@@ -4560,7 +4560,7 @@ Buildings and Fortifications D</description>
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="2124-501f-b687-aa54" name="Searchlight" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="2124-501f-b687-aa54" name="Searchlight" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2171-a6aa-fa9b-cb25" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4a09-5a1f-301e-9cff" type="max"/>
@@ -4574,8 +4574,8 @@ Buildings and Fortifications D</description>
             </selectionEntry>
           </selectionEntries>
           <entryLinks>
-            <entryLink id="9596-c6fc-67e9-cdcc" name="New EntryLink" hidden="false" collective="false" targetId="776e-2ea5-2be8-fee3" type="selectionEntry"/>
-            <entryLink id="ee87-7cac-b7f5-48ee" name="New EntryLink" hidden="false" collective="false" targetId="9355-440a-d46e-e47b" type="selectionEntry"/>
+            <entryLink id="9596-c6fc-67e9-cdcc" name="New EntryLink" hidden="false" collective="false" import="true" targetId="776e-2ea5-2be8-fee3" type="selectionEntry"/>
+            <entryLink id="ee87-7cac-b7f5-48ee" name="New EntryLink" hidden="false" collective="false" import="true" targetId="9355-440a-d46e-e47b" type="selectionEntry"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="175.0"/>
@@ -4583,9 +4583,9 @@ Buildings and Fortifications D</description>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="44e2-e7d3-1d0d-2564" name="The Maniple may be upgraded to have: " hidden="false" collective="false">
+        <selectionEntryGroup id="44e2-e7d3-1d0d-2564" name="The Maniple may be upgraded to have: " hidden="false" collective="false" import="true">
           <selectionEntries>
-            <selectionEntry id="5e6e-deee-1a51-c9bd" name="Blessed Autosimulacra" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="5e6e-deee-1a51-c9bd" name="Blessed Autosimulacra" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="increment" field="points" value="10">
                   <repeats>
@@ -4610,7 +4610,7 @@ Buildings and Fortifications D</description>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="8d58-8392-abdd-c6f1" name="Smoke Launchers" page="0" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="8d58-8392-abdd-c6f1" name="Smoke Launchers" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f271-eea9-f518-2bf9" type="max"/>
       </constraints>
@@ -4621,7 +4621,7 @@ Buildings and Fortifications D</description>
         <cost name="pts" typeId="points" value="5.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="d00f-81d6-1749-9499" name="Extra Armour" page="0" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="d00f-81d6-1749-9499" name="Extra Armour" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c7a0-6cad-a4b2-ed76" type="max"/>
       </constraints>
@@ -4632,7 +4632,7 @@ Buildings and Fortifications D</description>
         <cost name="pts" typeId="points" value="5.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="287b-b205-0926-5822" name="Hunter-killer Missile" page="0" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="287b-b205-0926-5822" name="Hunter-killer Missile" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6ff9-d2e2-b7de-c7e3" type="max"/>
       </constraints>
@@ -4643,12 +4643,12 @@ Buildings and Fortifications D</description>
         <cost name="pts" typeId="points" value="5.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="07c9-6c73-c97f-cb10" name="Arc Scourge" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="07c9-6c73-c97f-cb10" name="Arc Scourge" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3057-8957-5f34-75c3" type="max"/>
       </constraints>
       <profiles>
-        <profile id="b1ce-d137-0618-4397" name="Arc Scourge" publicationId="cf03-f607-pubN80487" page="274" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+        <profile id="b1ce-d137-0618-4397" name="Arc Scourge" publicationId="cf03-f607-pubN80487" page="274" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
           <characteristics>
             <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
             <characteristic name="Strength" typeId="537472656e67746823232344415441232323">User</characteristic>
@@ -4666,7 +4666,7 @@ Buildings and Fortifications D</description>
         <cost name="pts" typeId="points" value="10.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="acf4-096f-2127-80a3" name="Melta Bombs" page="0" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="acf4-096f-2127-80a3" name="Melta Bombs" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8069-22b1-88de-45c8" type="max"/>
       </constraints>
@@ -4677,7 +4677,7 @@ Buildings and Fortifications D</description>
         <cost name="pts" typeId="points" value="5.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="bd94-0269-4234-4a81" name="Secutarii Axiarch" publicationId="cf03-f607-pubN92488" hidden="false" collective="false" type="unit">
+    <selectionEntry id="bd94-0269-4234-4a81" name="Secutarii Axiarch" publicationId="cf03-f607-pubN92488" hidden="false" collective="false" import="true" type="unit">
       <constraints>
         <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f855-004d-6a48-f343" type="max"/>
       </constraints>
@@ -4691,7 +4691,7 @@ Buildings and Fortifications D</description>
         <infoLink id="ef03-4124-3221-1bb3" name="New InfoLink" hidden="false" targetId="6595-834d-8a6d-5fc6" type="rule"/>
       </infoLinks>
       <selectionEntries>
-        <selectionEntry id="6461-6b48-a0ef-5384" name="May be equipped with any of the following" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="6461-6b48-a0ef-5384" name="May be equipped with any of the following" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b5e0-708e-c5ae-d9d1" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="edc3-a384-0190-b631" type="max"/>
@@ -4700,19 +4700,19 @@ Buildings and Fortifications D</description>
             <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="cd54-fdde-91fe-9b2e" name="Exchange Power Maul and Radium Pistol for:" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="cd54-fdde-91fe-9b2e" name="Exchange Power Maul and Radium Pistol for:" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fa44-2971-943b-ab5f" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a24e-896f-31ea-e73d" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="c09f-c802-eaa0-ba50" name="Arc lance and Mag-inverter shield" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="c09f-c802-eaa0-ba50" name="Arc lance and Mag-inverter shield" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b703-2aa7-ce87-5445" type="max"/>
               </constraints>
               <entryLinks>
-                <entryLink id="a2a6-4055-e6b8-4ec5" name="New EntryLink" hidden="false" collective="false" targetId="c968-115e-0e8b-7836" type="selectionEntry"/>
-                <entryLink id="d9de-c686-18b8-7f29" name="New EntryLink" hidden="false" collective="false" targetId="7811-c16f-d263-419c" type="selectionEntry"/>
+                <entryLink id="a2a6-4055-e6b8-4ec5" name="New EntryLink" hidden="false" collective="false" import="true" targetId="c968-115e-0e8b-7836" type="selectionEntry"/>
+                <entryLink id="d9de-c686-18b8-7f29" name="New EntryLink" hidden="false" collective="false" import="true" targetId="7811-c16f-d263-419c" type="selectionEntry"/>
               </entryLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
@@ -4725,8 +4725,8 @@ Buildings and Fortifications D</description>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="981b-7373-a54b-6a89" name="Standard Wargear" hidden="false" collective="false"/>
-        <selectionEntryGroup id="6ed4-0168-eeb1-5d28" name="May exchange Radium Pistol for:" hidden="false" collective="false" defaultSelectionEntryId="cdda-8303-d8fd-ee21">
+        <selectionEntryGroup id="981b-7373-a54b-6a89" name="Standard Wargear" hidden="false" collective="false" import="true"/>
+        <selectionEntryGroup id="6ed4-0168-eeb1-5d28" name="May exchange Radium Pistol for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="cdda-8303-d8fd-ee21">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
@@ -4738,22 +4738,22 @@ Buildings and Fortifications D</description>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b656-2164-2d04-acb6" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="cdda-8303-d8fd-ee21" name="New EntryLink" hidden="false" collective="false" targetId="2089-a4b7-cbfd-e448" type="selectionEntry">
+            <entryLink id="cdda-8303-d8fd-ee21" name="New EntryLink" hidden="false" collective="false" import="true" targetId="2089-a4b7-cbfd-e448" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="points" value="0.0"/>
               </modifiers>
             </entryLink>
-            <entryLink id="6154-ca99-8e23-4312" name="New EntryLink" hidden="false" collective="false" targetId="fc08-3275-0e79-6421" type="selectionEntry">
+            <entryLink id="6154-ca99-8e23-4312" name="New EntryLink" hidden="false" collective="false" import="true" targetId="fc08-3275-0e79-6421" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="points" value="5"/>
               </modifiers>
             </entryLink>
-            <entryLink id="1222-51b1-0367-cde3" name="New EntryLink" hidden="false" collective="false" targetId="a7ac402a-2804-0342-d16a-23c3098a57ef" type="selectionEntry"/>
-            <entryLink id="d963-c0d4-a190-407e" name="New EntryLink" hidden="false" collective="false" targetId="544a-70f1-4560-482b" type="selectionEntry"/>
-            <entryLink id="19fe-40c1-d067-3062" name="New EntryLink" hidden="false" collective="false" targetId="e884-dd64-6171-4c9a" type="selectionEntry"/>
+            <entryLink id="1222-51b1-0367-cde3" name="New EntryLink" hidden="false" collective="false" import="true" targetId="a7ac402a-2804-0342-d16a-23c3098a57ef" type="selectionEntry"/>
+            <entryLink id="d963-c0d4-a190-407e" name="New EntryLink" hidden="false" collective="false" import="true" targetId="544a-70f1-4560-482b" type="selectionEntry"/>
+            <entryLink id="19fe-40c1-d067-3062" name="New EntryLink" hidden="false" collective="false" import="true" targetId="e884-dd64-6171-4c9a" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="75b8-cb06-9283-833d" name="May exchange Arc Maul for:" hidden="false" collective="false" defaultSelectionEntryId="b959-741a-2340-5228">
+        <selectionEntryGroup id="75b8-cb06-9283-833d" name="May exchange Arc Maul for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="b959-741a-2340-5228">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
@@ -4765,25 +4765,25 @@ Buildings and Fortifications D</description>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="61a9-b6fa-0795-353a" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="b959-741a-2340-5228" name="Arc Maul" hidden="false" collective="false" targetId="6951-c813-b83f-d5a4" type="selectionEntry">
+            <entryLink id="b959-741a-2340-5228" name="Arc Maul" hidden="false" collective="false" import="true" targetId="6951-c813-b83f-d5a4" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="points" value="0.0"/>
               </modifiers>
             </entryLink>
-            <entryLink id="7939-0e9d-51b1-f383" name="New EntryLink" hidden="false" collective="false" targetId="5123-2580-422c-33f8" type="selectionEntry"/>
-            <entryLink id="1918-ac32-6f1e-db59" name="New EntryLink" hidden="false" collective="false" targetId="4327-a78f-a2cf-17f7" type="selectionEntry"/>
-            <entryLink id="41fb-c977-848b-df05" name="New EntryLink" hidden="false" collective="false" targetId="fcef-f5ac-16a3-9401" type="selectionEntry">
+            <entryLink id="7939-0e9d-51b1-f383" name="New EntryLink" hidden="false" collective="false" import="true" targetId="5123-2580-422c-33f8" type="selectionEntry"/>
+            <entryLink id="1918-ac32-6f1e-db59" name="New EntryLink" hidden="false" collective="false" import="true" targetId="4327-a78f-a2cf-17f7" type="selectionEntry"/>
+            <entryLink id="41fb-c977-848b-df05" name="New EntryLink" hidden="false" collective="false" import="true" targetId="fcef-f5ac-16a3-9401" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="points" value="5"/>
               </modifiers>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="c6f5-7057-4fd3-1567" name="May be equipped with any of the following" hidden="false" collective="false">
+        <selectionEntryGroup id="c6f5-7057-4fd3-1567" name="May be equipped with any of the following" hidden="false" collective="false" import="true">
           <entryLinks>
-            <entryLink id="eb6f-55cf-9696-1371" name="New EntryLink" hidden="false" collective="false" targetId="73c4-584c-c927-3cbd" type="selectionEntry"/>
-            <entryLink id="e7f2-db5c-093a-84c9" name="New EntryLink" hidden="false" collective="false" targetId="2645-2048-de94-299c" type="selectionEntry"/>
-            <entryLink id="3bcc-7921-cabb-d78e" name="New EntryLink" hidden="false" collective="false" targetId="e672-6b87-a1d3-24db" type="selectionEntry">
+            <entryLink id="eb6f-55cf-9696-1371" name="New EntryLink" hidden="false" collective="false" import="true" targetId="73c4-584c-c927-3cbd" type="selectionEntry"/>
+            <entryLink id="e7f2-db5c-093a-84c9" name="New EntryLink" hidden="false" collective="false" import="true" targetId="2645-2048-de94-299c" type="selectionEntry"/>
+            <entryLink id="3bcc-7921-cabb-d78e" name="New EntryLink" hidden="false" collective="false" import="true" targetId="e672-6b87-a1d3-24db" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="points" value="5"/>
               </modifiers>
@@ -4792,8 +4792,8 @@ Buildings and Fortifications D</description>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="c753-12f0-5089-61c6" name="" hidden="false" collective="false" targetId="5cd6-814b-5784-13f5" type="selectionEntry"/>
-        <entryLink id="7800-0915-0910-b934" name="New EntryLink" hidden="false" collective="false" targetId="40e37f6e-a984-4232-4dc4-807ed9028f62" type="selectionEntry">
+        <entryLink id="c753-12f0-5089-61c6" name="" hidden="false" collective="false" import="true" targetId="5cd6-814b-5784-13f5" type="selectionEntry"/>
+        <entryLink id="7800-0915-0910-b934" name="New EntryLink" hidden="false" collective="false" import="true" targetId="40e37f6e-a984-4232-4dc4-807ed9028f62" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="points" value="0.0"/>
           </modifiers>
@@ -4801,13 +4801,13 @@ Buildings and Fortifications D</description>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a257-6f30-7b83-2756" type="min"/>
           </constraints>
         </entryLink>
-        <entryLink id="faa6-e158-dba7-c69d" name="New EntryLink" hidden="false" collective="false" targetId="8833-9c4e-e34c-e9be" type="selectionEntry"/>
+        <entryLink id="faa6-e158-dba7-c69d" name="New EntryLink" hidden="false" collective="false" import="true" targetId="8833-9c4e-e34c-e9be" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="60.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="8833-9c4e-e34c-e9be" name="Titanshard Armour" publicationId="cf03-f607-pubN96051" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="8833-9c4e-e34c-e9be" name="Titanshard Armour" publicationId="cf03-f607-pubN96051" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="246e-a559-beed-e028" type="max"/>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="28b9-2580-aa9a-1cc6" type="min"/>
@@ -4820,9 +4820,9 @@ Buildings and Fortifications D</description>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="7b0f-7bfb-ca1f-e761" name="Crusade Fleet Arvus Lighter Orbital Shuttle" hidden="false" collective="false" type="unit">
+    <selectionEntry id="7b0f-7bfb-ca1f-e761" name="Crusade Fleet Arvus Lighter Orbital Shuttle" hidden="false" collective="false" import="true" type="unit">
       <profiles>
-        <profile id="44e0-2678-2bb6-c576" name="Arvus Lighter Orbital Shuttle" publicationId="cf03-f607-pubN76270" page="50" hidden="false" typeId="56656869636c6523232344415441232323" typeName="">
+        <profile id="44e0-2678-2bb6-c576" name="Arvus Lighter Orbital Shuttle" publicationId="cf03-f607-pubN76270" page="50" hidden="false" typeId="56656869636c6523232344415441232323" typeName="Vehicle">
           <characteristics>
             <characteristic name="BS" typeId="425323232344415441232323">3</characteristic>
             <characteristic name="Front" typeId="46726f6e7423232344415441232323">11</characteristic>
@@ -4850,12 +4850,12 @@ Buildings and Fortifications D</description>
         <categoryLink id="24ef-6fd9-6ed6-e5d1" name="New CategoryLink" hidden="false" targetId="53bd-99e7-aba0-e79f" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="6ad6-9dd7-4994-60f9" name="May take one of the following:" hidden="false" collective="false">
+        <selectionEntryGroup id="6ad6-9dd7-4994-60f9" name="May take one of the following:" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e42e-6e0a-e91c-9090" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="b706-2690-0d23-a459" name="Multi-laser" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="b706-2690-0d23-a459" name="Multi-laser" hidden="false" collective="false" import="true" type="upgrade">
               <infoLinks>
                 <infoLink id="4af4-18f5-946b-0625" name="Multi-laser" hidden="false" targetId="c812-a8fe-2b49-75a5" type="profile"/>
               </infoLinks>
@@ -4863,7 +4863,7 @@ Buildings and Fortifications D</description>
                 <cost name="pts" typeId="points" value="10.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="8a60-4b61-343b-2089" name="Autocannon" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="8a60-4b61-343b-2089" name="Autocannon" hidden="false" collective="false" import="true" type="upgrade">
               <infoLinks>
                 <infoLink id="83a5-9a5d-2de7-4270" name="Autocannon" hidden="false" targetId="d55f-eed0-800f-5789" type="profile"/>
               </infoLinks>
@@ -4871,7 +4871,7 @@ Buildings and Fortifications D</description>
                 <cost name="pts" typeId="points" value="10.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="f835-7925-5e93-fd6e" name="Twin-linked Multi-laser" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="f835-7925-5e93-fd6e" name="Twin-linked Multi-laser" hidden="false" collective="false" import="true" type="upgrade">
               <infoLinks>
                 <infoLink id="ca3a-db81-b97f-f9a4" name="Multi-laser" hidden="false" targetId="c812-a8fe-2b49-75a5" type="profile">
                   <modifiers>
@@ -4883,7 +4883,7 @@ Buildings and Fortifications D</description>
                 <cost name="pts" typeId="points" value="15.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="15fb-87cf-554f-0132" name="Twin-linked Lascannon" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="15fb-87cf-554f-0132" name="Twin-linked Lascannon" hidden="false" collective="false" import="true" type="upgrade">
               <infoLinks>
                 <infoLink id="dea8-7e67-50a2-bc63" name="Lascannon" hidden="false" targetId="1cce-972c-022a-2590" type="profile">
                   <modifiers>
@@ -4895,7 +4895,7 @@ Buildings and Fortifications D</description>
                 <cost name="pts" typeId="points" value="25.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="80ac-f243-b45a-0e9f" name="Twin-linked Autocannon" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="80ac-f243-b45a-0e9f" name="Twin-linked Autocannon" hidden="false" collective="false" import="true" type="upgrade">
               <infoLinks>
                 <infoLink id="4aa0-cfe6-ae9e-1faf" name="Autocannon" hidden="false" targetId="d55f-eed0-800f-5789" type="profile">
                   <modifiers>
@@ -4909,16 +4909,16 @@ Buildings and Fortifications D</description>
             </selectionEntry>
           </selectionEntries>
           <entryLinks>
-            <entryLink id="c650-3d4d-41ff-c62b" name="Lascannon" hidden="false" collective="false" targetId="8036-b730-d533-e31f" type="selectionEntry">
+            <entryLink id="c650-3d4d-41ff-c62b" name="Lascannon" hidden="false" collective="false" import="true" targetId="8036-b730-d533-e31f" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="points" value="20"/>
               </modifiers>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="fc2a-42d9-ddfd-9063" name="May take any of the following:" hidden="false" collective="false">
+        <selectionEntryGroup id="fc2a-42d9-ddfd-9063" name="May take any of the following:" hidden="false" collective="false" import="true">
           <selectionEntries>
-            <selectionEntry id="38cf-1d32-10ba-1a5b" name="Chaff launcher" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="38cf-1d32-10ba-1a5b" name="Chaff launcher" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="24f9-3f6e-7141-99c1" type="max"/>
               </constraints>
@@ -4929,7 +4929,7 @@ Buildings and Fortifications D</description>
                 <cost name="pts" typeId="points" value="10.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="e43f-c2d6-414e-89af" name="Armoured Cockpit" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="e43f-c2d6-414e-89af" name="Armoured Cockpit" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0ecd-6844-d82f-f5b4" type="max"/>
               </constraints>
@@ -4940,7 +4940,7 @@ Buildings and Fortifications D</description>
                 <cost name="pts" typeId="points" value="15.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="64a1-2f6d-910e-3d72" name="Illum Flares" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="64a1-2f6d-910e-3d72" name="Illum Flares" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7ccb-035a-d956-3ab0" type="max"/>
               </constraints>
@@ -4951,7 +4951,7 @@ Buildings and Fortifications D</description>
                 <cost name="pts" typeId="points" value="5.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="9935-df2f-ea28-a043" name="Searchlight" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="9935-df2f-ea28-a043" name="Searchlight" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9bcf-aed7-3a21-2262" type="max"/>
               </constraints>
@@ -4959,7 +4959,7 @@ Buildings and Fortifications D</description>
                 <cost name="pts" typeId="points" value="1.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="b049-75c7-9fda-441d" name="Flare Shield" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="b049-75c7-9fda-441d" name="Flare Shield" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c881-5b1e-a213-889b" type="max"/>
               </constraints>
@@ -4970,7 +4970,7 @@ Buildings and Fortifications D</description>
                 <cost name="pts" typeId="points" value="20.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="3ef4-a228-484c-453c" name="Modified to carry Battle-automata" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="3ef4-a228-484c-453c" name="Modified to carry Battle-automata" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e16c-3610-5cc4-24f6" type="max"/>
               </constraints>
@@ -4985,7 +4985,7 @@ Buildings and Fortifications D</description>
             </selectionEntry>
           </selectionEntries>
           <entryLinks>
-            <entryLink id="868a-9c49-7340-0d35" name="Extra Armour" hidden="false" collective="false" targetId="d00f-81d6-1749-9499" type="selectionEntry">
+            <entryLink id="868a-9c49-7340-0d35" name="Extra Armour" hidden="false" collective="false" import="true" targetId="d00f-81d6-1749-9499" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="points" value="10"/>
               </modifiers>
@@ -4997,9 +4997,9 @@ Buildings and Fortifications D</description>
         <cost name="pts" typeId="points" value="75.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="5d68-1fb8-1f66-af3a" name="Crusade Fleet Primaris-Lightning Strike Fighter" publicationId="cf03-f607-pubN76780" page="47" hidden="false" collective="false" type="unit">
+    <selectionEntry id="5d68-1fb8-1f66-af3a" name="Crusade Fleet Primaris-Lightning Strike Fighter" publicationId="cf03-f607-pubN76780" page="47" hidden="false" collective="false" import="true" type="unit">
       <profiles>
-        <profile id="5f6b-d6dd-568b-ebad" name="Crusade Fleet Primaris-Lightning Strike Fighter" publicationId="cf03-f607-pubN76270" page="48" hidden="false" typeId="56656869636c6523232344415441232323" typeName="">
+        <profile id="5f6b-d6dd-568b-ebad" name="Crusade Fleet Primaris-Lightning Strike Fighter" publicationId="cf03-f607-pubN76270" page="48" hidden="false" typeId="56656869636c6523232344415441232323" typeName="Vehicle">
           <characteristics>
             <characteristic name="BS" typeId="425323232344415441232323">4</characteristic>
             <characteristic name="Front" typeId="46726f6e7423232344415441232323">11</characteristic>
@@ -5009,7 +5009,7 @@ Buildings and Fortifications D</description>
             <characteristic name="Type" typeId="5479706523232344415441232323">Flyer</characteristic>
           </characteristics>
         </profile>
-        <profile id="c974-2a86-c1b9-a191" name="Chaff/Flare Launchers" publicationId="cf03-f607-pubN80892" page="90" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="">
+        <profile id="c974-2a86-c1b9-a191" name="Chaff/Flare Launchers" publicationId="cf03-f607-pubN80892" page="90" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
           <characteristics>
             <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Gains 4++ invulnerable against damage caused by missile weapons. </characteristic>
           </characteristics>
@@ -5031,14 +5031,14 @@ Buildings and Fortifications D</description>
         <categoryLink id="0744-a35e-1ec4-92cb" name="New CategoryLink" hidden="false" targetId="2d6f-e613-ab10-e55a" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="e744-5ed2-aa42-fdaa" name="May take any of the following:" hidden="false" collective="false">
+        <selectionEntryGroup id="e744-5ed2-aa42-fdaa" name="May take any of the following:" hidden="false" collective="false" import="true">
           <selectionEntries>
-            <selectionEntry id="ce59-f93f-70ae-31ba" name="Ramjet Diffraction Grid" publicationId="cf03-f607-pubN80892" page="43" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="ce59-f93f-70ae-31ba" name="Ramjet Diffraction Grid" publicationId="cf03-f607-pubN80892" page="43" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="aaa0-ce7e-5ebe-f07a" type="max"/>
               </constraints>
               <profiles>
-                <profile id="6264-e4a4-5d99-e9fb" name="Ramjet Diffraction Grid" publicationId="cf03-f607-pubN80892" page="42" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="">
+                <profile id="6264-e4a4-5d99-e9fb" name="Ramjet Diffraction Grid" publicationId="cf03-f607-pubN80892" page="42" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
                   <characteristics>
                     <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Reduces Strength value of incoming shooting attacks from side and rear armour by -1 but may never benefit from cover saves due to Night Fighting.  </characteristic>
                   </characteristics>
@@ -5048,7 +5048,7 @@ Buildings and Fortifications D</description>
                 <cost name="pts" typeId="points" value="20.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="3196-d362-cd3e-4cc5" name="Battle Servitor Control" publicationId="cf03-f607-pubN80892" page="43" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="3196-d362-cd3e-4cc5" name="Battle Servitor Control" publicationId="cf03-f607-pubN80892" page="43" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0111-958f-0306-f8c0" type="max"/>
               </constraints>
@@ -5059,7 +5059,7 @@ Buildings and Fortifications D</description>
                 <cost name="pts" typeId="points" value="15.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="664c-0439-607c-9563" name="Ground-tracking Auguries" publicationId="cf03-f607-pubN80892" page="43" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="664c-0439-607c-9563" name="Ground-tracking Auguries" publicationId="cf03-f607-pubN80892" page="43" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4e18-5278-67dc-d2f2" type="max"/>
               </constraints>
@@ -5072,12 +5072,12 @@ Buildings and Fortifications D</description>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="d22a-2025-30e2-c1d6" name="May equip three dual hardpoints:" hidden="false" collective="false">
+        <selectionEntryGroup id="d22a-2025-30e2-c1d6" name="May equip three dual hardpoints:" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6157-0b0f-9d25-96b6" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="f705-0db7-d791-4dc1" name="Twin-linked Autocannon" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="f705-0db7-d791-4dc1" name="Twin-linked Autocannon" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="49c2-519f-5c4c-7e30" type="max"/>
               </constraints>
@@ -5092,7 +5092,7 @@ Buildings and Fortifications D</description>
                 <cost name="pts" typeId="points" value="20.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="13f8-7378-f624-40e0" name="Twin-linked Multi-laser" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="13f8-7378-f624-40e0" name="Twin-linked Multi-laser" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a54c-2bd9-f1a5-8519" type="max"/>
               </constraints>
@@ -5107,7 +5107,7 @@ Buildings and Fortifications D</description>
                 <cost name="pts" typeId="points" value="20.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="29f8-3dd3-515d-3316" name="Twin-linked Missile Launcher" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="29f8-3dd3-515d-3316" name="Twin-linked Missile Launcher" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b729-f2a6-8e29-7154" type="max"/>
               </constraints>
@@ -5119,12 +5119,12 @@ Buildings and Fortifications D</description>
                 <cost name="pts" typeId="points" value="25.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="6c7b-e9b5-db9d-6ba5" name="Two Sunfury heavy missiles" publicationId="cf03-f607-pubN80892" page="43" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="6c7b-e9b5-db9d-6ba5" name="Two Sunfury heavy missiles" publicationId="cf03-f607-pubN80892" page="43" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6027-8c03-8225-3aaa" type="max"/>
               </constraints>
               <profiles>
-                <profile id="28fb-6fa9-9baa-6ca1" name="Sunfury heavy missile" publicationId="cf03-f607-pubN80892" page="43" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+                <profile id="28fb-6fa9-9baa-6ca1" name="Sunfury heavy missile" publicationId="cf03-f607-pubN80892" page="43" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
                   <characteristics>
                     <characteristic name="Range" typeId="52616e676523232344415441232323">36&quot;</characteristic>
                     <characteristic name="Strength" typeId="537472656e67746823232344415441232323">6</characteristic>
@@ -5141,12 +5141,12 @@ Buildings and Fortifications D</description>
                 <cost name="pts" typeId="points" value="15.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="5f35-3af3-40bc-f481" name="Two Kraken penetrator heavy missiles" publicationId="cf03-f607-pubN80892" page="43" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="5f35-3af3-40bc-f481" name="Two Kraken penetrator heavy missiles" publicationId="cf03-f607-pubN80892" page="43" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="81e7-ce06-4c69-2be7" type="max"/>
               </constraints>
               <profiles>
-                <profile id="c713-e734-928d-0dae" name="Kraken penetrator heavy missile" publicationId="cf03-f607-pubN80892" page="43" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+                <profile id="c713-e734-928d-0dae" name="Kraken penetrator heavy missile" publicationId="cf03-f607-pubN80892" page="43" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
                   <characteristics>
                     <characteristic name="Range" typeId="52616e676523232344415441232323">36&quot;</characteristic>
                     <characteristic name="Strength" typeId="537472656e67746823232344415441232323">8</characteristic>
@@ -5162,12 +5162,12 @@ Buildings and Fortifications D</description>
                 <cost name="pts" typeId="points" value="25.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="0dea-fbb6-1fa7-1b98" name="Phosphex bomb cluster" publicationId="cf03-f607-pubN80892" page="43" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="0dea-fbb6-1fa7-1b98" name="Phosphex bomb cluster" publicationId="cf03-f607-pubN80892" page="43" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a7b6-762a-aa3a-9415" type="max"/>
               </constraints>
               <profiles>
-                <profile id="8185-8a7e-f203-a5b2" name="Phosphex bomb cluster" publicationId="cf03-f607-pubN80892" page="43" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+                <profile id="8185-8a7e-f203-a5b2" name="Phosphex bomb cluster" publicationId="cf03-f607-pubN80892" page="43" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
                   <characteristics>
                     <characteristic name="Range" typeId="52616e676523232344415441232323">Bomb</characteristic>
                     <characteristic name="Strength" typeId="537472656e67746823232344415441232323">5</characteristic>
@@ -5190,12 +5190,12 @@ Buildings and Fortifications D</description>
                 <cost name="pts" typeId="points" value="25.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="03c6-fca2-76cd-2b06" name="Two Electromagnetic storm charges" publicationId="cf03-f607-pubN80892" page="43" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="03c6-fca2-76cd-2b06" name="Two Electromagnetic storm charges" publicationId="cf03-f607-pubN80892" page="43" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8db3-18f7-c901-1b85" type="max"/>
               </constraints>
               <profiles>
-                <profile id="c218-50fd-aa05-88aa" name="Electromagnetic storm charges" publicationId="cf03-f607-pubN80892" page="43" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+                <profile id="c218-50fd-aa05-88aa" name="Electromagnetic storm charges" publicationId="cf03-f607-pubN80892" page="43" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
                   <characteristics>
                     <characteristic name="Range" typeId="52616e676523232344415441232323">Bomb</characteristic>
                     <characteristic name="Strength" typeId="537472656e67746823232344415441232323">3</characteristic>
@@ -5219,19 +5219,19 @@ Buildings and Fortifications D</description>
         <cost name="pts" typeId="points" value="135.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="4f6b-4baa-d1e2-9b03" name="Allegiance" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="4f6b-4baa-d1e2-9b03" name="Allegiance" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="6390-14cb-52db-5483" type="min"/>
       </constraints>
       <selectionEntryGroups>
-        <selectionEntryGroup id="4a73-2d91-36c1-f36e" name="Allegiance" hidden="false" collective="false">
+        <selectionEntryGroup id="4a73-2d91-36c1-f36e" name="Allegiance" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6451-9271-a869-6da8" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="db78-fc42-7c77-3a0b" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b693-1a26-05b4-4bee" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="7441-34c0-5e21-eeaa" name="Traitor" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="7441-34c0-5e21-eeaa" name="Traitor" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="cfae-ad98-c5bf-8552" type="max"/>
               </constraints>
@@ -5239,7 +5239,7 @@ Buildings and Fortifications D</description>
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="a735-9091-b1d2-02d8" name="Loyalist" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="a735-9091-b1d2-02d8" name="Loyalist" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="091b-3436-2e5a-a9f0" type="max"/>
               </constraints>
@@ -5254,7 +5254,7 @@ Buildings and Fortifications D</description>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="544a-70f1-4560-482b" name="Photon Gauntlet" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="544a-70f1-4560-482b" name="Photon Gauntlet" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="0f75-938c-b004-fae2" name="Photon Gauntlet" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
           <characteristics>
@@ -5273,7 +5273,7 @@ Buildings and Fortifications D</description>
         <cost name="pts" typeId="points" value="5.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="e884-dd64-6171-4c9a" name="Archaeotech Pistol" page="0" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="e884-dd64-6171-4c9a" name="Archaeotech Pistol" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e8df-ff5d-e2e3-1a12" type="max"/>
       </constraints>
@@ -5285,7 +5285,7 @@ Buildings and Fortifications D</description>
         <cost name="pts" typeId="points" value="5.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="4327-a78f-a2cf-17f7" name="Corposant stave" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="4327-a78f-a2cf-17f7" name="Corposant stave" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="e66d-235b-8b70-5638" name="Corposant stave" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
           <characteristics>
@@ -5305,7 +5305,7 @@ Buildings and Fortifications D</description>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="2089-a4b7-cbfd-e448" name="Radium pistol" publicationId="cf03-f607-pubN90339" page="56" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="2089-a4b7-cbfd-e448" name="Radium pistol" publicationId="cf03-f607-pubN90339" page="56" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="bcbb-dfe5-a7c9-7525" name="" hidden="false" targetId="efa7-66c5-4b5f-a799" type="profile"/>
         <infoLink id="c25c-674a-5a07-bdd2" hidden="false" targetId="a5ba-753a-58f6-81cc" type="rule"/>
@@ -5314,7 +5314,7 @@ Buildings and Fortifications D</description>
         <cost name="pts" typeId="points" value="5.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="d266-0416-a5a6-881e" name="Legio Cybernetica" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="d266-0416-a5a6-881e" name="Legio Cybernetica" hidden="false" collective="false" import="true" type="upgrade">
       <rules>
         <rule id="63b4-5638-3ee9-3f50" name="Enhanced Cyber Control" publicationId="cf03-f607-pubN93687" page="74" hidden="false">
           <description>When chosen as a part of a Legio Cybernetica Battle Cohort detachment, all models with a Cybernetica Cortex gain +1 to their Initiative characteristic.</description>
@@ -5330,7 +5330,7 @@ Buildings and Fortifications D</description>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="0199-0faf-34c8-fbee" name="Ordo Reductor" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="0199-0faf-34c8-fbee" name="Ordo Reductor" hidden="false" collective="false" import="true" type="upgrade">
       <categoryLinks>
         <categoryLink id="29b4-9154-d288-9817" hidden="false" targetId="258478de-d031-8a7e-dcb0-7d56bee86952" primary="true"/>
       </categoryLinks>
@@ -5338,7 +5338,7 @@ Buildings and Fortifications D</description>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="d76d-0097-d56b-e6bf" name="Taghmata Omnissiah" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="d76d-0097-d56b-e6bf" name="Taghmata Omnissiah" hidden="false" collective="false" import="true" type="upgrade">
       <categoryLinks>
         <categoryLink id="cd3a-2490-70ca-9fda" hidden="false" targetId="258478de-d031-8a7e-dcb0-7d56bee86952" primary="true"/>
       </categoryLinks>
@@ -5346,7 +5346,7 @@ Buildings and Fortifications D</description>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="b39b-9817-025c-62da" name="Thallax Cohort" hidden="false" collective="false" type="unit">
+    <selectionEntry id="b39b-9817-025c-62da" name="Thallax Cohort" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="set" field="ddd9-4b79-18cf-650b" value="2">
           <conditions>
@@ -5358,13 +5358,13 @@ Buildings and Fortifications D</description>
         <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="ddd9-4b79-18cf-650b" type="min"/>
       </constraints>
       <selectionEntries>
-        <selectionEntry id="ff43-bada-c45f-3a9b" name="Thallax" hidden="false" collective="false" type="model">
+        <selectionEntry id="ff43-bada-c45f-3a9b" name="Thallax" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1f9c-6554-585a-6f62" type="min"/>
             <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b507-b0c9-f365-61fe" type="max"/>
           </constraints>
           <profiles>
-            <profile id="962c-1b0f-11ba-ab3b" name="Thallax" publicationId="cf03-f607-pubN99227" page="290" hidden="false" typeId="556e697423232344415441232323" typeName="">
+            <profile id="962c-1b0f-11ba-ab3b" name="Thallax" publicationId="cf03-f607-pubN99227" page="290" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Jet Pack Infantry</characteristic>
                 <characteristic name="WS" typeId="575323232344415441232323">3</characteristic>
@@ -5389,7 +5389,7 @@ Buildings and Fortifications D</description>
             <cost name="pts" typeId="points" value="40.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="c48f-5075-5087-8f48" name="Lightning gun" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="c48f-5075-5087-8f48" name="Lightning gun" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d573-df7a-fb3b-89a7" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7b60-432b-52b0-4727" type="max"/>
@@ -5405,9 +5405,9 @@ Buildings and Fortifications D</description>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="cd78-4960-ab7f-a3dd" name="Any Thallax may exchange their close combat weapon for:" hidden="false" collective="false">
+        <selectionEntryGroup id="cd78-4960-ab7f-a3dd" name="Any Thallax may exchange their close combat weapon for:" hidden="false" collective="false" import="true">
           <selectionEntries>
-            <selectionEntry id="a218-8432-7284-2b99" name="Heavy Chainblade" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="a218-8432-7284-2b99" name="Heavy Chainblade" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="increment" field="f25c-b1df-c7d3-6882" value="1">
                   <repeats>
@@ -5427,9 +5427,9 @@ Buildings and Fortifications D</description>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="9eca-32ce-1bbe-0079" name="Entire squad may take:" hidden="false" collective="false">
+        <selectionEntryGroup id="9eca-32ce-1bbe-0079" name="Entire squad may take:" hidden="false" collective="false" import="true">
           <selectionEntries>
-            <selectionEntry id="9c0c-00c8-476b-1d04" name="Melta bombs" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="9c0c-00c8-476b-1d04" name="Melta bombs" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="increment" field="points" value="5">
                   <repeats>
@@ -5449,7 +5449,7 @@ Buildings and Fortifications D</description>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="3bcb-13c2-48a2-0360" name="One in three may exchange their Lightning Gun for:" hidden="false" collective="false">
+        <selectionEntryGroup id="3bcb-13c2-48a2-0360" name="One in three may exchange their Lightning Gun for:" hidden="false" collective="false" import="true">
           <modifiers>
             <modifier type="increment" field="e3b5-78c9-ed61-165b" value="1">
               <repeats>
@@ -5461,7 +5461,7 @@ Buildings and Fortifications D</description>
             <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e3b5-78c9-ed61-165b" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="dbca-0f39-963e-756b" name="Multi-laser" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="dbca-0f39-963e-756b" name="Multi-laser" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="73f2-bae4-8f9e-bcb9" type="max"/>
               </constraints>
@@ -5472,7 +5472,7 @@ Buildings and Fortifications D</description>
                 <cost name="pts" typeId="points" value="5.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="d0db-82a3-d268-7568" name="Phase Plasma-fusil" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="d0db-82a3-d268-7568" name="Phase Plasma-fusil" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b6ea-d250-0de6-d80f" type="max"/>
               </constraints>
@@ -5483,7 +5483,7 @@ Buildings and Fortifications D</description>
                 <cost name="pts" typeId="points" value="10.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="4b8d-b2d4-7227-1293" name="Irad-cleanser" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="4b8d-b2d4-7227-1293" name="Irad-cleanser" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d362-85fe-89a4-7f42" type="max"/>
               </constraints>
@@ -5494,7 +5494,7 @@ Buildings and Fortifications D</description>
                 <cost name="pts" typeId="points" value="10.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="c2b2-d63f-77b4-3ed3" name="Multi-melta" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="c2b2-d63f-77b4-3ed3" name="Multi-melta" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1b28-1fe1-a209-2d80" type="max"/>
               </constraints>
@@ -5505,7 +5505,7 @@ Buildings and Fortifications D</description>
                 <cost name="pts" typeId="points" value="15.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="11e2-179b-e44b-79a7" name="Photon Thruster" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="11e2-179b-e44b-79a7" name="Photon Thruster" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2cca-4af4-3d2e-f379" type="max"/>
               </constraints>
@@ -5520,8 +5520,8 @@ Buildings and Fortifications D</description>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="4934-4c1a-b0c8-c4b0" name="Triaros Armoured Conveyor" hidden="false" collective="false" targetId="bb6538b0-0f23-8a43-9752-dd356ba76e46" type="selectionEntry"/>
-        <entryLink id="5c7f-660a-ddf0-5fcf" name="May be upgraded with one of the following augment upgrades:" hidden="false" collective="false" targetId="be81-6f96-f70e-ec07" type="selectionEntry">
+        <entryLink id="4934-4c1a-b0c8-c4b0" name="Triaros Armoured Conveyor" hidden="false" collective="false" import="true" targetId="bb6538b0-0f23-8a43-9752-dd356ba76e46" type="selectionEntry"/>
+        <entryLink id="5c7f-660a-ddf0-5fcf" name="May be upgraded with one of the following augment upgrades:" hidden="false" collective="false" import="true" targetId="be81-6f96-f70e-ec07" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="b39b-9817-025c-62da" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ea20-0077-988a-5fee" type="min"/>
           </constraints>
@@ -5531,15 +5531,15 @@ Buildings and Fortifications D</description>
         <cost name="pts" typeId="points" value="15.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="be81-6f96-f70e-ec07" name="May be upgraded with one of the following augment upgrades:" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="be81-6f96-f70e-ec07" name="May be upgraded with one of the following augment upgrades:" hidden="false" collective="false" import="true" type="upgrade">
       <entryLinks>
-        <entryLink id="f1af-9bc1-9fbd-10a3" name="May be upgraded with one of the following augment upgrades:" hidden="false" collective="false" targetId="34ef-5d4f-eacc-55f7" type="selectionEntryGroup"/>
+        <entryLink id="f1af-9bc1-9fbd-10a3" name="May be upgraded with one of the following augment upgrades:" hidden="false" collective="false" import="true" targetId="34ef-5d4f-eacc-55f7" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="7e54-a6b2-1982-0706" name="Adsecularis Covenant" publicationId="cf03-f607-pubN76780" page="37" hidden="false" collective="false" type="unit">
+    <selectionEntry id="7e54-a6b2-1982-0706" name="Adsecularis Covenant" publicationId="cf03-f607-pubN76780" page="37" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="set" field="86e5-0663-2fde-0bc1" value="1">
           <repeats>
@@ -5554,13 +5554,13 @@ Buildings and Fortifications D</description>
         <categoryLink id="8f1e-f00d-a6c1-7301" name="New CategoryLink" hidden="false" targetId="f74d-4679-75a6-1252" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="9e7e-232f-e016-6ce8" name="Tech-thrall" hidden="false" collective="false" type="model">
+        <selectionEntry id="9e7e-232f-e016-6ce8" name="Tech-thrall" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3f6c-82d1-e38d-14ba" type="min"/>
             <constraint field="selections" scope="parent" value="20.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0cc6-3756-885d-1bc4" type="max"/>
           </constraints>
           <profiles>
-            <profile id="2c45-82af-770e-2e12" name="Tech-thrall" publicationId="cf03-f607-pubN76270" page="37" hidden="false" typeId="556e697423232344415441232323" typeName="">
+            <profile id="2c45-82af-770e-2e12" name="Tech-thrall" publicationId="cf03-f607-pubN76270" page="37" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
               <modifiers>
                 <modifier type="set" field="5361766523232344415441232323" value="4+">
                   <conditions>
@@ -5582,30 +5582,39 @@ Buildings and Fortifications D</description>
               </characteristics>
             </profile>
           </profiles>
-          <rules>
-            <rule id="8c92-b98a-e0c9-939b" name="Feel no Pain (6+)" page="0" hidden="false">
+          <infoLinks>
+            <infoLink id="f01e-f54a-30cd-0dea" name="Feel No Pain (5+)" hidden="false" targetId="dbf6-2f12-bb4a-517c" type="rule">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="445a-8be0-c3ac-f45c" type="greaterThan"/>
+                    <condition field="selections" scope="7e54-a6b2-1982-0706" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="445a-8be0-c3ac-f45c" type="equalTo"/>
                   </conditions>
                 </modifier>
               </modifiers>
-            </rule>
-          </rules>
+            </infoLink>
+            <infoLink id="a5eb-d63a-0e04-5089" name="Feel No Pain (6+)" hidden="false" targetId="85da-2f19-3756-44de" type="rule">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="7e54-a6b2-1982-0706" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="445a-8be0-c3ac-f45c" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="3.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="e62f-bd12-5353-b752" name="Ranged weapon:" hidden="false" collective="false" defaultSelectionEntryId="bb67-e4be-c96a-0bb6">
+        <selectionEntryGroup id="e62f-bd12-5353-b752" name="Ranged weapon:" hidden="false" collective="false" import="true" defaultSelectionEntryId="bb67-e4be-c96a-0bb6">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7220-3f3d-cfb4-42d9" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4495-546a-04f6-c9f0" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="3c14-38da-f5c9-56ef" name="Mitralocks" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="3c14-38da-f5c9-56ef" name="Mitralocks" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b3d4-80f6-bd97-f9e3" type="max"/>
               </constraints>
@@ -5617,7 +5626,7 @@ Buildings and Fortifications D</description>
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="2eb4-fedb-984a-1a37" name="Heavy Chainblades" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="2eb4-fedb-984a-1a37" name="Heavy Chainblades" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="cf9a-913e-3804-894a" type="max"/>
               </constraints>
@@ -5628,7 +5637,7 @@ Buildings and Fortifications D</description>
                 <cost name="pts" typeId="points" value="20.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="bb67-e4be-c96a-0bb6" name="Las-lock" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="bb67-e4be-c96a-0bb6" name="Las-lock" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="05ef-d598-9407-2881" type="max"/>
               </constraints>
@@ -5641,9 +5650,9 @@ Buildings and Fortifications D</description>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="6401-0685-3898-3510" name="Entire squad may be given any upgrade:" hidden="false" collective="false">
+        <selectionEntryGroup id="6401-0685-3898-3510" name="Entire squad may be given any upgrade:" hidden="false" collective="false" import="true">
           <selectionEntries>
-            <selectionEntry id="7686-87dd-3035-0196" name="Frag Grenades" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="7686-87dd-3035-0196" name="Frag Grenades" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7476-9614-a377-f41d" type="max"/>
               </constraints>
@@ -5651,7 +5660,7 @@ Buildings and Fortifications D</description>
                 <cost name="pts" typeId="points" value="5.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="b0e6-e078-45c7-18b5" name="The Rite of Pure Thought" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="b0e6-e078-45c7-18b5" name="The Rite of Pure Thought" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="61a9-ae8a-6994-8bf3" type="max"/>
               </constraints>
@@ -5664,7 +5673,7 @@ Buildings and Fortifications D</description>
                 <cost name="pts" typeId="points" value="15.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="ca77-761d-d408-5321" name="Induction Chargers" publicationId="cf03-f607-pubN76780" page="37" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="ca77-761d-d408-5321" name="Induction Chargers" publicationId="cf03-f607-pubN76780" page="37" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="de9e-9d20-c51b-2c5b" type="max"/>
               </constraints>
@@ -5677,7 +5686,7 @@ Buildings and Fortifications D</description>
                 <cost name="pts" typeId="points" value="15.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="457c-cdd9-a458-baa9" name="Carapace Armour" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="457c-cdd9-a458-baa9" name="Carapace Armour" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3339-4489-fb37-ad9b" type="max"/>
               </constraints>
@@ -5685,12 +5694,14 @@ Buildings and Fortifications D</description>
                 <cost name="pts" typeId="points" value="20.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="445a-8be0-c3ac-f45c" name="Revenant Alchemistry" publicationId="cf03-f607-pubN76780" page="37" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="445a-8be0-c3ac-f45c" name="Revenant Alchemistry" publicationId="cf03-f607-pubN76780" page="37" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f634-31b6-0040-cc2f" type="max"/>
               </constraints>
               <rules>
-                <rule id="d8c7-d8a6-2c25-d955" name="Feel no Pain (5+)" page="0" hidden="true"/>
+                <rule id="3830-4679-fb46-9848" name="Revenant Alchemistry" hidden="false">
+                  <description>An Adsecularis Covenant with Revenant Alchemistry has the Hatred, Feel No Pain (5+) and Slow and Purposeful special rules</description>
+                </rule>
               </rules>
               <infoLinks>
                 <infoLink id="4fbd-24db-f44f-f988" name="Slow and Purposeful" hidden="false" targetId="f9ed-0927-e532-6d7f" type="rule"/>
@@ -5703,13 +5714,13 @@ Buildings and Fortifications D</description>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="7f0c-c408-8823-b2f6" name="Triaros Armoured Conveyor" hidden="false" collective="false" targetId="bb6538b0-0f23-8a43-9752-dd356ba76e46" type="selectionEntry"/>
+        <entryLink id="7f0c-c408-8823-b2f6" name="Triaros Armoured Conveyor" hidden="false" collective="false" import="true" targetId="bb6538b0-0f23-8a43-9752-dd356ba76e46" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="5.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="46a4-3ef5-bcaf-b561" name="Archimandrite" page="0" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="46a4-3ef5-bcaf-b561" name="Archimandrite" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -5732,7 +5743,7 @@ Buildings and Fortifications D</description>
         <cost name="pts" typeId="points" value="35.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="02dc-3228-2e92-c3a8" name="Lachrimallus" page="0" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="02dc-3228-2e92-c3a8" name="Lachrimallus" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="30d6-1782-dfc6-62a1" type="max"/>
       </constraints>
@@ -5751,7 +5762,7 @@ Buildings and Fortifications D</description>
         <cost name="pts" typeId="points" value="25.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="0330-6762-6797-0a42" name="Macrotek" page="0" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="0330-6762-6797-0a42" name="Macrotek" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="79bb-231f-493d-8d0e" type="max"/>
       </constraints>
@@ -5767,7 +5778,7 @@ Buildings and Fortifications D</description>
         <cost name="pts" typeId="points" value="20.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="c615-024f-f3f7-78e6" name="Malagra" publicationId="cf03-f607-pubN76979" page="215" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="c615-024f-f3f7-78e6" name="Malagra" publicationId="cf03-f607-pubN76979" page="215" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="134b-027b-3f51-b869" type="max"/>
       </constraints>
@@ -5784,7 +5795,7 @@ Buildings and Fortifications D</description>
         <cost name="pts" typeId="points" value="30.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="1b7f-df93-0cbf-cf8c" name="Myrmidax" page="0" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="1b7f-df93-0cbf-cf8c" name="Myrmidax" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f5ac-2cb8-cee7-1c0a" type="max"/>
       </constraints>
@@ -5803,12 +5814,12 @@ Buildings and Fortifications D</description>
         <cost name="pts" typeId="points" value="25.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="0065-6fab-1d05-84eb" name="Ordinator" page="0" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="0065-6fab-1d05-84eb" name="Ordinator" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b037-d043-b869-5a1e" type="max"/>
       </constraints>
       <profiles>
-        <profile id="fbb5-204d-7ade-9f91" name="Bombardment" page="0" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+        <profile id="fbb5-204d-7ade-9f91" name="Bombardment" page="0" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
           <characteristics>
             <characteristic name="Range" typeId="52616e676523232344415441232323">Unlimited</characteristic>
             <characteristic name="Strength" typeId="537472656e67746823232344415441232323">8</characteristic>
@@ -5830,7 +5841,7 @@ Buildings and Fortifications D</description>
         <cost name="pts" typeId="points" value="35.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="83ef-4568-5093-61d5" name="Anacharis Scoria" hidden="false" collective="false" type="unit">
+    <selectionEntry id="83ef-4568-5093-61d5" name="Anacharis Scoria" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -5844,7 +5855,7 @@ Buildings and Fortifications D</description>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="2771-37b9-f1c4-793c" type="max"/>
       </constraints>
       <profiles>
-        <profile id="0a16-d44e-d1c5-294f" name="Anacharis Scoria" publicationId="cf03-f607-pubN80487" page="272" hidden="false" typeId="556e697423232344415441232323" typeName="">
+        <profile id="0a16-d44e-d1c5-294f" name="Anacharis Scoria" publicationId="cf03-f607-pubN80487" page="272" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
           <modifiers>
             <modifier type="set" field="5723232344415441232323" value="5">
               <conditions>
@@ -5870,7 +5881,7 @@ Buildings and Fortifications D</description>
             <characteristic name="Save" typeId="5361766523232344415441232323">2+</characteristic>
           </characteristics>
         </profile>
-        <profile id="c7a7-8105-a8fb-d09f" name="The Vodian Sceptre" publicationId="cf03-f607-pubN80487" page="272" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+        <profile id="c7a7-8105-a8fb-d09f" name="The Vodian Sceptre" publicationId="cf03-f607-pubN80487" page="272" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
           <characteristics>
             <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
             <characteristic name="Strength" typeId="537472656e67746823232344415441232323">+2</characteristic>
@@ -5927,14 +5938,14 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
         <categoryLink id="25c3-3e90-03e6-1fb5" name="New CategoryLink" hidden="false" targetId="f74d-4679-75a6-1252" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="e95e-c67e-94f4-87be" name="May be mounted on:" hidden="false" collective="false">
+        <selectionEntryGroup id="e95e-c67e-94f4-87be" name="May be mounted on:" hidden="false" collective="false" import="true">
           <selectionEntries>
-            <selectionEntry id="7036-e2e2-8907-a43e" name="Xanathite Abeyant" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="7036-e2e2-8907-a43e" name="Xanathite Abeyant" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3b05-5f19-5869-dab2" type="max"/>
               </constraints>
               <profiles>
-                <profile id="b4c8-e5ff-4fe8-1de3" name="Xanathite Abeyant" publicationId="cf03-f607-pubN80487" page="273" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="">
+                <profile id="b4c8-e5ff-4fe8-1de3" name="Xanathite Abeyant" publicationId="cf03-f607-pubN80487" page="273" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
                   <characteristics>
                     <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Confers +1 Wound, +1 Attack, Move Through Cover, Very Bulky, Hardened Armour, It Will Not Die, and a Photon Thruster which can be fired in addition to his usual shooting attacks.  </characteristic>
                   </characteristics>
@@ -5958,9 +5969,9 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
         <cost name="pts" typeId="points" value="275.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="00f3-1eed-88ff-5c46" name="Navigator" publicationId="cf03-f607-pubN102601" hidden="false" collective="false" type="unit">
+    <selectionEntry id="00f3-1eed-88ff-5c46" name="Navigator" publicationId="cf03-f607-pubN102601" hidden="false" collective="false" import="true" type="unit">
       <profiles>
-        <profile id="fa77-894f-2c36-3d29" name="Navigator" publicationId="cf03-f607-pubN102601" hidden="false" typeId="556e697423232344415441232323" typeName="">
+        <profile id="fa77-894f-2c36-3d29" name="Navigator" publicationId="cf03-f607-pubN102601" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
           <characteristics>
             <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry (Character)</characteristic>
             <characteristic name="WS" typeId="575323232344415441232323">2</characteristic>
@@ -5974,7 +5985,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
             <characteristic name="Save" typeId="5361766523232344415441232323">6+</characteristic>
           </characteristics>
         </profile>
-        <profile id="5ec8-4529-62be-8430" name="Ætherlabe Staff" publicationId="cf03-f607-pubN102601" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="">
+        <profile id="5ec8-4529-62be-8430" name="Ætherlabe Staff" publicationId="cf03-f607-pubN102601" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
           <characteristics>
             <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Should an enemy unit Deep Strike into play within 12&quot; of the Navigator, the Navigator and their unit may make a Snap Shot shooting attack at the arriving unit at the end of that phase, subject to the normal rules for doing so. If the enemy unit enters play by way of a Conjuration psychic power, these Snap Shots are carried out at the firers’ normal BS rather than at BS 1.</characteristic>
           </characteristics>
@@ -6014,9 +6025,9 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
         <categoryLink id="780c-7e5b-62e1-e1b1" hidden="false" targetId="485123232344415441232323" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="ab8f-8f11-7d1f-0ea5" name="May take any of the following:" hidden="false" collective="false">
+        <selectionEntryGroup id="ab8f-8f11-7d1f-0ea5" name="May take any of the following:" hidden="false" collective="false" import="true">
           <selectionEntries>
-            <selectionEntry id="52f0-4597-785c-60c3" name="Cyber Familiar" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="52f0-4597-785c-60c3" name="Cyber Familiar" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="11da-d14e-8c4a-48ac" type="max"/>
               </constraints>
@@ -6027,7 +6038,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 <cost name="pts" typeId="points" value="15.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="ddcd-5b45-4d39-89a8" name="Nuncio-vox" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="ddcd-5b45-4d39-89a8" name="Nuncio-vox" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3bfa-e233-7caf-04ab" type="max"/>
               </constraints>
@@ -6038,7 +6049,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 <cost name="pts" typeId="points" value="10.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="b642-fc6e-e412-8172" name="Digital Lasers" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="b642-fc6e-e412-8172" name="Digital Lasers" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5436-0f6f-c43f-edf7" type="max"/>
               </constraints>
@@ -6053,9 +6064,9 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
         <cost name="pts" typeId="points" value="50.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="2f28-034a-ca2c-5b9e" name="Ursarax Cohort" publicationId="cf03-f607-pubN76780" page="43" hidden="false" collective="false" type="unit">
+    <selectionEntry id="2f28-034a-ca2c-5b9e" name="Ursarax Cohort" publicationId="cf03-f607-pubN76780" page="43" hidden="false" collective="false" import="true" type="unit">
       <profiles>
-        <profile id="47fb-bdfe-8989-9696" name="Ursarax" publicationId="cf03-f607-pubN76979" page="225" hidden="false" typeId="556e697423232344415441232323" typeName="">
+        <profile id="47fb-bdfe-8989-9696" name="Ursarax" publicationId="cf03-f607-pubN76979" page="225" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
           <characteristics>
             <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Jump Infantry</characteristic>
             <characteristic name="WS" typeId="575323232344415441232323">4</characteristic>
@@ -6069,7 +6080,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
             <characteristic name="Save" typeId="5361766523232344415441232323">4+</characteristic>
           </characteristics>
         </profile>
-        <profile id="7161-c36d-f978-e774" name="Volkite Incinerator (Beam)" publicationId="cf03-f607-pubN76979" page="225" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+        <profile id="7161-c36d-f978-e774" name="Volkite Incinerator (Beam)" publicationId="cf03-f607-pubN76979" page="225" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
           <characteristics>
             <characteristic name="Range" typeId="52616e676523232344415441232323">10&quot;</characteristic>
             <characteristic name="Strength" typeId="537472656e67746823232344415441232323">5</characteristic>
@@ -6077,7 +6088,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
             <characteristic name="Type" typeId="5479706523232344415441232323">Assault 2, Deflagrate</characteristic>
           </characteristics>
         </profile>
-        <profile id="7cf5-6212-c89a-19be" name="Volkite Incinerator (Blast)" publicationId="cf03-f607-pubN76979" page="225" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+        <profile id="7cf5-6212-c89a-19be" name="Volkite Incinerator (Blast)" publicationId="cf03-f607-pubN76979" page="225" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
           <characteristics>
             <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
             <characteristic name="Strength" typeId="537472656e67746823232344415441232323">6</characteristic>
@@ -6098,7 +6109,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
         <infoLink id="c9b4-d21b-e862-cae0" name="New InfoLink" hidden="false" targetId="7be5-30af-1a02-0a89" type="rule"/>
       </infoLinks>
       <selectionEntries>
-        <selectionEntry id="4957-7ef8-5245-25b3" name="Ursarax" page="0" hidden="false" collective="false" type="model">
+        <selectionEntry id="4957-7ef8-5245-25b3" name="Ursarax" page="0" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2bfd-a995-d2e5-382c" type="min"/>
             <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f4c4-9c60-8443-d81b" type="max"/>
@@ -6109,9 +6120,9 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="80b7-5204-19ac-9fbe" name="May exchange Lightning Claws for:" hidden="false" collective="false">
+        <selectionEntryGroup id="80b7-5204-19ac-9fbe" name="May exchange Lightning Claws for:" hidden="false" collective="false" import="true">
           <selectionEntries>
-            <selectionEntry id="5267-8b4e-938c-aabc" name="Power Fist" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="5267-8b4e-938c-aabc" name="Power Fist" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="increment" field="6d2f-7ad8-dffd-ef59" value="1">
                   <repeats>
@@ -6136,7 +6147,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
         <cost name="pts" typeId="points" value="25.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="8352-9d62-82af-9642" name="Legio" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="8352-9d62-82af-9642" name="Legio" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="a31c-5898-b718-da0c" type="max"/>
       </constraints>
@@ -6144,26 +6155,26 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
         <categoryLink id="a702-5a7f-6560-9221" name="New CategoryLink" hidden="false" targetId="5297-7e0f-fa0b-3537" primary="true"/>
       </categoryLinks>
       <entryLinks>
-        <entryLink id="bdf2-b46d-0e0b-8062" name="Legio/Ordo" hidden="false" collective="false" targetId="8ea4-951b-6a14-f20c" type="selectionEntryGroup"/>
+        <entryLink id="bdf2-b46d-0e0b-8062" name="Legio/Ordo" hidden="false" collective="false" import="true" targetId="8ea4-951b-6a14-f20c" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="4934-5161-12f7-f0f8" name="Krios Battle Tank Squadron" publicationId="cf03-f607-pubN76979" page="228" hidden="false" collective="false" type="unit">
+    <selectionEntry id="4934-5161-12f7-f0f8" name="Krios Battle Tank Squadron" publicationId="cf03-f607-pubN76979" page="228" hidden="false" collective="false" import="true" type="unit">
       <selectionEntryGroups>
-        <selectionEntryGroup id="d19c-9afa-c7ef-08df" name="Krios Battle Tank Squadron" hidden="false" collective="false">
+        <selectionEntryGroup id="d19c-9afa-c7ef-08df" name="Krios Battle Tank Squadron" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6efe-99dc-6b51-d0f1" type="min"/>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8d41-f2da-dc63-62ff" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="c8f2-a6b1-ffba-f968" name="Krios" page="0" hidden="false" collective="false" type="model">
+            <selectionEntry id="c8f2-a6b1-ffba-f968" name="Krios" page="0" hidden="false" collective="false" import="true" type="model">
               <constraints>
                 <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3bfb-e2e0-f572-e69f" type="max"/>
               </constraints>
               <profiles>
-                <profile id="529d-f690-ae38-51e1" name="Krios" publicationId="cf03-f607-pubN76979" page="228" hidden="false" typeId="56656869636c6523232344415441232323" typeName="">
+                <profile id="529d-f690-ae38-51e1" name="Krios" publicationId="cf03-f607-pubN76979" page="228" hidden="false" typeId="56656869636c6523232344415441232323" typeName="Vehicle">
                   <characteristics>
                     <characteristic name="BS" typeId="425323232344415441232323">4</characteristic>
                     <characteristic name="Front" typeId="46726f6e7423232344415441232323">13</characteristic>
@@ -6183,13 +6194,13 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 <categoryLink id="84b2-75dd-7e85-ce22" name="New CategoryLink" hidden="false" targetId="53bd-99e7-aba0-e79f" primary="false"/>
               </categoryLinks>
               <selectionEntries>
-                <selectionEntry id="54da-c16a-8f5a-3c2a" name="Lightning Cannon" hidden="false" collective="false" type="upgrade">
+                <selectionEntry id="54da-c16a-8f5a-3c2a" name="Lightning Cannon" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f6fc-f5b1-b63c-2a31" type="min"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="81d0-37cc-28dc-8465" type="max"/>
                   </constraints>
                   <profiles>
-                    <profile id="a253-0f8b-9b37-705e" name="Lightning Cannon" publicationId="cf03-f607-pubN76979" page="228" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+                    <profile id="a253-0f8b-9b37-705e" name="Lightning Cannon" publicationId="cf03-f607-pubN76979" page="228" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
                       <characteristics>
                         <characteristic name="Range" typeId="52616e676523232344415441232323">48&quot;</characteristic>
                         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">7</characteristic>
@@ -6208,9 +6219,9 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 </selectionEntry>
               </selectionEntries>
               <selectionEntryGroups>
-                <selectionEntryGroup id="acff-d064-1798-9ac4" name="May take any of the following:" hidden="false" collective="false">
+                <selectionEntryGroup id="acff-d064-1798-9ac4" name="May take any of the following:" hidden="false" collective="false" import="true">
                   <selectionEntries>
-                    <selectionEntry id="d300-472d-4e0a-8dd1" name="Volkite Sentinels" page="0" hidden="false" collective="false" type="upgrade">
+                    <selectionEntry id="d300-472d-4e0a-8dd1" name="Volkite Sentinels" page="0" hidden="false" collective="false" import="true" type="upgrade">
                       <constraints>
                         <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0e47-c7ad-fd11-6f58" type="max"/>
                       </constraints>
@@ -6224,18 +6235,18 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                     </selectionEntry>
                   </selectionEntries>
                   <entryLinks>
-                    <entryLink id="08bb-3319-07e5-6e1e" name="New EntryLink" hidden="false" collective="false" targetId="d00f-81d6-1749-9499" type="selectionEntry"/>
-                    <entryLink id="d29e-ad36-afc7-0795" name="Hunter-killer Missile" hidden="false" collective="false" targetId="287b-b205-0926-5822" type="selectionEntry"/>
-                    <entryLink id="84db-9e46-48be-7dcc" name="Smoke Launchers" hidden="false" collective="false" targetId="8d58-8392-abdd-c6f1" type="selectionEntry"/>
-                    <entryLink id="efc1-60ab-3572-0196" name="Anbaric Claw" hidden="false" collective="false" targetId="deed-3c25-b77e-a0e8" type="selectionEntry"/>
+                    <entryLink id="08bb-3319-07e5-6e1e" name="New EntryLink" hidden="false" collective="false" import="true" targetId="d00f-81d6-1749-9499" type="selectionEntry"/>
+                    <entryLink id="d29e-ad36-afc7-0795" name="Hunter-killer Missile" hidden="false" collective="false" import="true" targetId="287b-b205-0926-5822" type="selectionEntry"/>
+                    <entryLink id="84db-9e46-48be-7dcc" name="Smoke Launchers" hidden="false" collective="false" import="true" targetId="8d58-8392-abdd-c6f1" type="selectionEntry"/>
+                    <entryLink id="efc1-60ab-3572-0196" name="Anbaric Claw" hidden="false" collective="false" import="true" targetId="deed-3c25-b77e-a0e8" type="selectionEntry"/>
                   </entryLinks>
                 </selectionEntryGroup>
-                <selectionEntryGroup id="5ca9-909f-f4d6-ba5b" name="Psyarkana" hidden="false" collective="false">
+                <selectionEntryGroup id="5ca9-909f-f4d6-ba5b" name="Psyarkana" hidden="false" collective="false" import="true">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8b31-3422-411e-ab96" type="max"/>
                   </constraints>
                   <entryLinks>
-                    <entryLink id="e53b-836e-4f51-2c40" name="Armatus Necrotechnica" hidden="false" collective="false" targetId="e78c-d1a1-c20f-dae8" type="selectionEntry">
+                    <entryLink id="e53b-836e-4f51-2c40" name="Armatus Necrotechnica" hidden="false" collective="false" import="true" targetId="e78c-d1a1-c20f-dae8" type="selectionEntry">
                       <modifiers>
                         <modifier type="set" field="hidden" value="false"/>
                       </modifiers>
@@ -6244,18 +6255,18 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <entryLinks>
-                <entryLink id="b3df-e16a-d58c-c1fd" name="New EntryLink" hidden="false" collective="false" targetId="776e-2ea5-2be8-fee3" type="selectionEntry"/>
+                <entryLink id="b3df-e16a-d58c-c1fd" name="New EntryLink" hidden="false" collective="false" import="true" targetId="776e-2ea5-2be8-fee3" type="selectionEntry"/>
               </entryLinks>
               <costs>
                 <cost name="pts" typeId="points" value="125.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="39c2-b610-ebd9-afaa" name="Krios Venator Tank Destroyer" page="0" hidden="false" collective="false" type="model">
+            <selectionEntry id="39c2-b610-ebd9-afaa" name="Krios Venator Tank Destroyer" page="0" hidden="false" collective="false" import="true" type="model">
               <constraints>
                 <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c54a-9ad6-384a-7a9b" type="max"/>
               </constraints>
               <profiles>
-                <profile id="82bc-52ed-59b1-81ed" name="Krios Venator" publicationId="cf03-f607-pubN76979" page="228" hidden="false" typeId="56656869636c6523232344415441232323" typeName="">
+                <profile id="82bc-52ed-59b1-81ed" name="Krios Venator" publicationId="cf03-f607-pubN76979" page="228" hidden="false" typeId="56656869636c6523232344415441232323" typeName="Vehicle">
                   <characteristics>
                     <characteristic name="BS" typeId="425323232344415441232323">4</characteristic>
                     <characteristic name="Front" typeId="46726f6e7423232344415441232323">13</characteristic>
@@ -6275,7 +6286,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 <categoryLink id="9d51-791b-0346-25de" name="New CategoryLink" hidden="false" targetId="e59c-462e-9d9c-66dd" primary="false"/>
               </categoryLinks>
               <selectionEntries>
-                <selectionEntry id="4c54-c405-7d5a-a95d" name="Pulsar-fusil" hidden="false" collective="false" type="upgrade">
+                <selectionEntry id="4c54-c405-7d5a-a95d" name="Pulsar-fusil" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5e9f-b083-a1d2-df49" type="min"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed64-0fe0-7279-286f" type="max"/>
@@ -6290,9 +6301,9 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 </selectionEntry>
               </selectionEntries>
               <selectionEntryGroups>
-                <selectionEntryGroup id="3902-3df6-4236-eb7f" name="May take any of the following:" hidden="false" collective="false">
+                <selectionEntryGroup id="3902-3df6-4236-eb7f" name="May take any of the following:" hidden="false" collective="false" import="true">
                   <selectionEntries>
-                    <selectionEntry id="f57f-7c7b-968e-b773" name="Volkite Sentinels" page="0" hidden="false" collective="false" type="upgrade">
+                    <selectionEntry id="f57f-7c7b-968e-b773" name="Volkite Sentinels" page="0" hidden="false" collective="false" import="true" type="upgrade">
                       <constraints>
                         <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="58b5-ca7f-9633-5631" type="max"/>
                       </constraints>
@@ -6306,18 +6317,18 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                     </selectionEntry>
                   </selectionEntries>
                   <entryLinks>
-                    <entryLink id="6813-df3c-e081-3d5d" name="New EntryLink" hidden="false" collective="false" targetId="d00f-81d6-1749-9499" type="selectionEntry"/>
-                    <entryLink id="a3d3-c2ca-fea9-1b1b" name="Hunter-killer Missile" hidden="false" collective="false" targetId="287b-b205-0926-5822" type="selectionEntry"/>
-                    <entryLink id="0835-6ccb-6f5c-4c6a" name="Smoke Launchers" hidden="false" collective="false" targetId="8d58-8392-abdd-c6f1" type="selectionEntry"/>
-                    <entryLink id="cb87-b27e-01cf-8ddf" name="Anbaric Claw" hidden="false" collective="false" targetId="deed-3c25-b77e-a0e8" type="selectionEntry"/>
+                    <entryLink id="6813-df3c-e081-3d5d" name="New EntryLink" hidden="false" collective="false" import="true" targetId="d00f-81d6-1749-9499" type="selectionEntry"/>
+                    <entryLink id="a3d3-c2ca-fea9-1b1b" name="Hunter-killer Missile" hidden="false" collective="false" import="true" targetId="287b-b205-0926-5822" type="selectionEntry"/>
+                    <entryLink id="0835-6ccb-6f5c-4c6a" name="Smoke Launchers" hidden="false" collective="false" import="true" targetId="8d58-8392-abdd-c6f1" type="selectionEntry"/>
+                    <entryLink id="cb87-b27e-01cf-8ddf" name="Anbaric Claw" hidden="false" collective="false" import="true" targetId="deed-3c25-b77e-a0e8" type="selectionEntry"/>
                   </entryLinks>
                 </selectionEntryGroup>
-                <selectionEntryGroup id="46d1-c305-9946-d34d" name="Psyarkana" hidden="false" collective="false">
+                <selectionEntryGroup id="46d1-c305-9946-d34d" name="Psyarkana" hidden="false" collective="false" import="true">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="16a2-c38d-033f-8df2" type="max"/>
                   </constraints>
                   <entryLinks>
-                    <entryLink id="3c26-21f7-7273-6c9c" name="Armatus Necrotechnica" hidden="false" collective="false" targetId="e78c-d1a1-c20f-dae8" type="selectionEntry">
+                    <entryLink id="3c26-21f7-7273-6c9c" name="Armatus Necrotechnica" hidden="false" collective="false" import="true" targetId="e78c-d1a1-c20f-dae8" type="selectionEntry">
                       <modifiers>
                         <modifier type="set" field="hidden" value="false"/>
                       </modifiers>
@@ -6326,7 +6337,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <entryLinks>
-                <entryLink id="a879-5892-4937-c4bb" name="Flare Shield" hidden="false" collective="false" targetId="776e-2ea5-2be8-fee3" type="selectionEntry"/>
+                <entryLink id="a879-5892-4937-c4bb" name="Flare Shield" hidden="false" collective="false" import="true" targetId="776e-2ea5-2be8-fee3" type="selectionEntry"/>
               </entryLinks>
               <costs>
                 <cost name="pts" typeId="points" value="150.0"/>
@@ -6339,35 +6350,35 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="eaf8-70d7-0806-b22e" name="Arlatax Class Battle-automata Maniple" hidden="false" collective="false" type="unit">
+    <selectionEntry id="eaf8-70d7-0806-b22e" name="Arlatax Class Battle-automata Maniple" hidden="false" collective="false" import="true" type="unit">
       <selectionEntryGroups>
-        <selectionEntryGroup id="9d1b-8ca5-c405-616a" name="A single Maniple take:" hidden="false" collective="false">
+        <selectionEntryGroup id="9d1b-8ca5-c405-616a" name="A single Maniple take:" hidden="false" collective="false" import="true">
           <entryLinks>
-            <entryLink id="954b-110f-d9b8-62b8" hidden="false" collective="false" targetId="34924deb-f4e5-7739-5606-87600d1740bb" type="selectionEntry"/>
+            <entryLink id="954b-110f-d9b8-62b8" hidden="false" collective="false" import="true" targetId="34924deb-f4e5-7739-5606-87600d1740bb" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="d243-4c26-4333-2c9a" name="Arlatax" hidden="false" collective="false" targetId="3f6b-6c3a-5855-a5ae" type="selectionEntry"/>
+        <entryLink id="d243-4c26-4333-2c9a" name="Arlatax" hidden="false" collective="false" import="true" targetId="3f6b-6c3a-5855-a5ae" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="911d-55a5-94c4-41ac" name="Domitar Class Battle-automata Maniple" hidden="false" collective="false" type="unit">
+    <selectionEntry id="911d-55a5-94c4-41ac" name="Domitar Class Battle-automata Maniple" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
         <categoryLink id="a4f5-ed7a-3379-4dbb" name="New CategoryLink" hidden="false" targetId="7fdd-2a97-d0e9-6524" primary="false"/>
         <categoryLink id="8dab-0ef9-4395-de1d" name="New CategoryLink" hidden="false" targetId="78ea-eea8-0ac5-b7de" primary="false"/>
         <categoryLink id="866c-15c1-2488-4034" name="New CategoryLink" hidden="false" targetId="8ec4-17b5-7fea-c682" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="48fe-db1c-3260-1acf" name="Domitar Class Battle-automata" publicationId="cf03-f607-pubN76780" page="35" hidden="false" collective="false" type="model">
+        <selectionEntry id="48fe-db1c-3260-1acf" name="Domitar Class Battle-automata" publicationId="cf03-f607-pubN76780" page="35" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c49b-cf2c-6fd6-8466" type="min"/>
             <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="98c2-8f7d-409f-3349" type="max"/>
           </constraints>
           <profiles>
-            <profile id="bfb5-ae03-0ddd-18d3" name="Domitar Class Battle-automata" publicationId="cf03-f607-pubN80965" page="227" hidden="false" typeId="556e697423232344415441232323" typeName="">
+            <profile id="bfb5-ae03-0ddd-18d3" name="Domitar Class Battle-automata" publicationId="cf03-f607-pubN80965" page="227" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
               <modifiers>
                 <modifier type="increment" field="4923232344415441232323" value="1">
                   <conditions>
@@ -6402,13 +6413,13 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
             <infoLink id="9c68-ab9f-1134-e7be" name="Reactor Blast" hidden="false" targetId="d5cf-bd98-2854-13cf" type="rule"/>
           </infoLinks>
           <selectionEntries>
-            <selectionEntry id="f9a2-bcd8-4b73-2820" name="Missile Launcher" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="f9a2-bcd8-4b73-2820" name="Missile Launcher" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="567b-4561-e104-d528" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="675b-7398-cc34-469f" type="min"/>
               </constraints>
               <profiles>
-                <profile id="21ef-37b0-d3e1-7491" name="Ignis-frag Missile" publicationId="cf03-f607-pubN80965" page="227" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+                <profile id="21ef-37b0-d3e1-7491" name="Ignis-frag Missile" publicationId="cf03-f607-pubN80965" page="227" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
                   <characteristics>
                     <characteristic name="Range" typeId="52616e676523232344415441232323">48&quot;</characteristic>
                     <characteristic name="Strength" typeId="537472656e67746823232344415441232323">5</characteristic>
@@ -6427,7 +6438,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
             </selectionEntry>
           </selectionEntries>
           <entryLinks>
-            <entryLink id="532d-cef2-1cd0-e22b" name="Graviton Hammer" hidden="false" collective="false" targetId="f29d-27e9-6fa7-101e" type="selectionEntry">
+            <entryLink id="532d-cef2-1cd0-e22b" name="Graviton Hammer" hidden="false" collective="false" import="true" targetId="f29d-27e9-6fa7-101e" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4a1a-421a-54f2-8cf5" type="min"/>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="51f3-e6e7-d082-75ee" type="max"/>
@@ -6440,14 +6451,14 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="508a-ac03-85ff-05f6" name="A single maniple may take:" hidden="false" collective="false">
+        <selectionEntryGroup id="508a-ac03-85ff-05f6" name="A single maniple may take:" hidden="false" collective="false" import="true">
           <entryLinks>
-            <entryLink id="dad8-bf0b-77f5-5d63" name="Paragon of Metal" hidden="false" collective="false" targetId="34924deb-f4e5-7739-5606-87600d1740bb" type="selectionEntry"/>
+            <entryLink id="dad8-bf0b-77f5-5d63" name="Paragon of Metal" hidden="false" collective="false" import="true" targetId="34924deb-f4e5-7739-5606-87600d1740bb" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="1038-fee5-e34e-92c9" name="The Maniple may take:" hidden="false" collective="false">
+        <selectionEntryGroup id="1038-fee5-e34e-92c9" name="The Maniple may take:" hidden="false" collective="false" import="true">
           <selectionEntries>
-            <selectionEntry id="4c9f-5859-0acb-cb60" name="Searchlight" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="4c9f-5859-0acb-cb60" name="Searchlight" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="increment" field="points" value="1">
                   <repeats>
@@ -6465,7 +6476,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="2136-8349-9bcd-99f5" name="Frag Grenades" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="2136-8349-9bcd-99f5" name="Frag Grenades" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="increment" field="points" value="5">
                   <repeats>
@@ -6483,7 +6494,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="3182-6707-6fc1-04c7" name="Flak Missiles" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="3182-6707-6fc1-04c7" name="Flak Missiles" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="increment" field="points" value="5">
                   <repeats>
@@ -6508,19 +6519,19 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="e35c-8e84-62ed-7814" name="Ordo Reductor Minotaur Battery" hidden="false" collective="false" type="unit">
+    <selectionEntry id="e35c-8e84-62ed-7814" name="Ordo Reductor Minotaur Battery" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
         <categoryLink id="1713-81a7-f38b-9588" name="New CategoryLink" hidden="false" targetId="e59c-462e-9d9c-66dd" primary="false"/>
         <categoryLink id="5db6-bc2e-9503-d125" name="New CategoryLink" hidden="false" targetId="53bd-99e7-aba0-e79f" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="7dd8-9d46-b08c-45ef" name="Ordo Reductor Minotaur" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="7dd8-9d46-b08c-45ef" name="Ordo Reductor Minotaur" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c86a-d7d8-efb2-e31f" type="min"/>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a6ef-57e6-44c7-43dd" type="max"/>
           </constraints>
           <profiles>
-            <profile id="d278-402b-e9bb-f971" name="Ordo Reductor Minotaur" publicationId="cf03-f607-pubN76270" page="85" hidden="false" typeId="56656869636c6523232344415441232323" typeName="">
+            <profile id="d278-402b-e9bb-f971" name="Ordo Reductor Minotaur" publicationId="cf03-f607-pubN76270" page="85" hidden="false" typeId="56656869636c6523232344415441232323" typeName="Vehicle">
               <characteristics>
                 <characteristic name="BS" typeId="425323232344415441232323">4</characteristic>
                 <characteristic name="Front" typeId="46726f6e7423232344415441232323">13</characteristic>
@@ -6530,7 +6541,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 <characteristic name="Type" typeId="5479706523232344415441232323">Tank (Heavy)</characteristic>
               </characteristics>
             </profile>
-            <profile id="b17a-2026-9571-0c88" name="Rear facing Flare Shield" publicationId="cf03-f607-pubN80892" page="89" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="">
+            <profile id="b17a-2026-9571-0c88" name="Rear facing Flare Shield" publicationId="cf03-f607-pubN80892" page="89" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
               <characteristics>
                 <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">A flare shield operates against shooting attacks that strike the vehicle&apos;s front arc.  It reduces the strength of attacks by weapons with the Templae or Blast type by -2, and other shooting attacks by -1.  A flare shield has no effect on attacks from close combat or with the Destroyer rule.  Protects rear armour facing rather than front.  </characteristic>
               </characteristics>
@@ -6550,13 +6561,13 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
             <infoLink id="c0ff-6a7d-36aa-cb12" name="Smoke Launchers" hidden="false" targetId="6875-ee73-2a85-6a97" type="profile"/>
           </infoLinks>
           <selectionEntries>
-            <selectionEntry id="9e2c-88d8-72df-c969" name="Dual Earthshaker Cannon" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="9e2c-88d8-72df-c969" name="Dual Earthshaker Cannon" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a66f-5e61-e094-7495" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="57c8-e4d0-0352-3bff" type="min"/>
               </constraints>
               <profiles>
-                <profile id="0ce5-12c4-5321-7bd1" name="Dual Earthshaker Cannon" publicationId="cf03-f607-pubN76270" page="85" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+                <profile id="0ce5-12c4-5321-7bd1" name="Dual Earthshaker Cannon" publicationId="cf03-f607-pubN76270" page="85" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
                   <characteristics>
                     <characteristic name="Range" typeId="52616e676523232344415441232323">24&quot; - 240&quot;</characteristic>
                     <characteristic name="Strength" typeId="537472656e67746823232344415441232323">9</characteristic>
@@ -6571,31 +6582,31 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
             </selectionEntry>
           </selectionEntries>
           <selectionEntryGroups>
-            <selectionEntryGroup id="ca8a-519d-b876-9c5f" name="May take a pintle-mounted weapon:" hidden="false" collective="false">
+            <selectionEntryGroup id="ca8a-519d-b876-9c5f" name="May take a pintle-mounted weapon:" hidden="false" collective="false" import="true">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="45b4-644c-ef86-a40c" type="max"/>
               </constraints>
               <entryLinks>
-                <entryLink id="7b88-07d5-530b-63fd" name="Heavy Bolter" hidden="false" collective="false" targetId="512b-a9be-50a4-c909" type="selectionEntry">
+                <entryLink id="7b88-07d5-530b-63fd" name="Heavy Bolter" hidden="false" collective="false" import="true" targetId="512b-a9be-50a4-c909" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="points" value="10"/>
                   </modifiers>
                 </entryLink>
-                <entryLink id="adf0-3c86-3844-1765" name="Heavy Flamer" hidden="false" collective="false" targetId="fc12-daad-3988-3994" type="selectionEntry">
+                <entryLink id="adf0-3c86-3844-1765" name="Heavy Flamer" hidden="false" collective="false" import="true" targetId="fc12-daad-3988-3994" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="points" value="10"/>
                   </modifiers>
                 </entryLink>
-                <entryLink id="fc84-31d8-97b6-f460" name="Phased Plasma-fusil" hidden="false" collective="false" targetId="d4ac-c006-b6fd-7901" type="selectionEntry">
+                <entryLink id="fc84-31d8-97b6-f460" name="Phased Plasma-fusil" hidden="false" collective="false" import="true" targetId="d4ac-c006-b6fd-7901" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="points" value="15"/>
                   </modifiers>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
-            <selectionEntryGroup id="d54d-126a-3fd2-d4ec" name="May take any of the following:" hidden="false" collective="false">
+            <selectionEntryGroup id="d54d-126a-3fd2-d4ec" name="May take any of the following:" hidden="false" collective="false" import="true">
               <selectionEntries>
-                <selectionEntry id="82d7-7304-a000-3470" name="Dozer Blade" page="0" hidden="false" collective="false" type="upgrade">
+                <selectionEntry id="82d7-7304-a000-3470" name="Dozer Blade" page="0" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="fee3-8f40-73c3-9a44" type="max"/>
                   </constraints>
@@ -6606,7 +6617,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                     <cost name="pts" typeId="points" value="5.0"/>
                   </costs>
                 </selectionEntry>
-                <selectionEntry id="5c5a-d722-330e-a043" name="Auxiliary Drive" page="0" hidden="false" collective="false" type="upgrade">
+                <selectionEntry id="5c5a-d722-330e-a043" name="Auxiliary Drive" page="0" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5e95-32a7-8822-2337" type="max"/>
                   </constraints>
@@ -6617,7 +6628,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                     <cost name="pts" typeId="points" value="10.0"/>
                   </costs>
                 </selectionEntry>
-                <selectionEntry id="ced0-d84b-d40c-0e75" name="Anbaric Claw" hidden="false" collective="false" type="upgrade">
+                <selectionEntry id="ced0-d84b-d40c-0e75" name="Anbaric Claw" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="cbc5-0a2e-60f1-9934" type="max"/>
                   </constraints>
@@ -6628,7 +6639,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                     <cost name="pts" typeId="points" value="15.0"/>
                   </costs>
                 </selectionEntry>
-                <selectionEntry id="4f4e-f559-9c40-d602" name="Armoured Ceramite" hidden="false" collective="false" type="upgrade">
+                <selectionEntry id="4f4e-f559-9c40-d602" name="Armoured Ceramite" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e2b3-5193-48f2-66e4" type="max"/>
                   </constraints>
@@ -6641,12 +6652,12 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 </selectionEntry>
               </selectionEntries>
             </selectionEntryGroup>
-            <selectionEntryGroup id="7e5b-9d44-b86f-8e9c" name="Psyarkana" hidden="false" collective="false">
+            <selectionEntryGroup id="7e5b-9d44-b86f-8e9c" name="Psyarkana" hidden="false" collective="false" import="true">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="585b-4d4b-baf8-df5c" type="max"/>
               </constraints>
               <entryLinks>
-                <entryLink id="c8f1-5aeb-4c47-c9fd" name="Armatus Necrotechnica" hidden="false" collective="false" targetId="e78c-d1a1-c20f-dae8" type="selectionEntry">
+                <entryLink id="c8f1-5aeb-4c47-c9fd" name="Armatus Necrotechnica" hidden="false" collective="false" import="true" targetId="e78c-d1a1-c20f-dae8" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="hidden" value="false"/>
                   </modifiers>
@@ -6663,7 +6674,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="de9f-f10c-c0a9-789b" name="Ordo Reductor Artillery Tank Battery" publicationId="cf03-f607-pubN76270" page="84" hidden="true" collective="false" type="unit">
+    <selectionEntry id="de9f-f10c-c0a9-789b" name="Ordo Reductor Artillery Tank Battery" publicationId="cf03-f607-pubN76270" page="84" hidden="true" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
@@ -6676,13 +6687,13 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
         <categoryLink id="6581-dc1a-d8ea-6f6f" name="New CategoryLink" hidden="false" targetId="53bd-99e7-aba0-e79f" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="ecca-8d08-7697-2811" name="Ordo Reductor Artillery" publicationId="cf03-f607-pubN76780" page="84" hidden="false" collective="false" type="model">
+        <selectionEntry id="ecca-8d08-7697-2811" name="Ordo Reductor Artillery" publicationId="cf03-f607-pubN76780" page="84" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b2ab-0cb7-7dff-81ad" type="min"/>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="bfc5-29df-e4ef-12d4" type="max"/>
           </constraints>
           <profiles>
-            <profile id="3a32-6175-d046-9900" name="Ordo Reductor Artillery" publicationId="cf03-f607-pubN76270" page="84" hidden="false" typeId="56656869636c6523232344415441232323" typeName="">
+            <profile id="3a32-6175-d046-9900" name="Ordo Reductor Artillery" publicationId="cf03-f607-pubN76270" page="84" hidden="false" typeId="56656869636c6523232344415441232323" typeName="Vehicle">
               <modifiers>
                 <modifier type="set" field="46726f6e7423232344415441232323" value="13">
                   <conditions>
@@ -6705,9 +6716,9 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
             <infoLink id="47f3-ff6d-56c4-ffeb" name="Smoke Launchers" hidden="false" targetId="6875-ee73-2a85-6a97" type="profile"/>
           </infoLinks>
           <selectionEntryGroups>
-            <selectionEntryGroup id="38e7-2ba9-0576-6f26" name="May take any of the following:" hidden="false" collective="false">
+            <selectionEntryGroup id="38e7-2ba9-0576-6f26" name="May take any of the following:" hidden="false" collective="false" import="true">
               <selectionEntries>
-                <selectionEntry id="e62b-6c0c-87ec-af00" name="Dozer Blade" page="0" hidden="false" collective="false" type="upgrade">
+                <selectionEntry id="e62b-6c0c-87ec-af00" name="Dozer Blade" page="0" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a451-0861-c65f-3caa" type="max"/>
                   </constraints>
@@ -6718,7 +6729,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                     <cost name="pts" typeId="points" value="5.0"/>
                   </costs>
                 </selectionEntry>
-                <selectionEntry id="7d08-eb94-8357-eb05" name="Auxiliary Drive" page="0" hidden="false" collective="false" type="upgrade">
+                <selectionEntry id="7d08-eb94-8357-eb05" name="Auxiliary Drive" page="0" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="55ec-043f-a1d4-f5d7" type="max"/>
                   </constraints>
@@ -6729,7 +6740,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                     <cost name="pts" typeId="points" value="10.0"/>
                   </costs>
                 </selectionEntry>
-                <selectionEntry id="2cf6-0050-12ab-7637" name="Siege Plating" publicationId="cf03-f607-pubN76780" page="84" hidden="false" collective="false" type="upgrade">
+                <selectionEntry id="2cf6-0050-12ab-7637" name="Siege Plating" publicationId="cf03-f607-pubN76780" page="84" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f56a-fdcb-c024-6f20" type="max"/>
                   </constraints>
@@ -6744,54 +6755,54 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 </selectionEntry>
               </selectionEntries>
               <entryLinks>
-                <entryLink id="7d9c-e9ef-e8de-5147" name="Blessed Autosimulacra" hidden="false" collective="false" targetId="fb66-11c0-3cb4-aac3" type="selectionEntry"/>
-                <entryLink id="ec4c-645e-2a6e-c955" hidden="false" collective="false" targetId="6f8e-c7a5-c784-384d" type="selectionEntry"/>
-                <entryLink id="2692-85be-ca42-0eb3" name="Extra Armour" hidden="false" collective="false" targetId="d00f-81d6-1749-9499" type="selectionEntry">
+                <entryLink id="7d9c-e9ef-e8de-5147" name="Blessed Autosimulacra" hidden="false" collective="false" import="true" targetId="fb66-11c0-3cb4-aac3" type="selectionEntry"/>
+                <entryLink id="ec4c-645e-2a6e-c955" hidden="false" collective="false" import="true" targetId="6f8e-c7a5-c784-384d" type="selectionEntry"/>
+                <entryLink id="2692-85be-ca42-0eb3" name="Extra Armour" hidden="false" collective="false" import="true" targetId="d00f-81d6-1749-9499" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="points" value="10"/>
                   </modifiers>
                 </entryLink>
-                <entryLink id="0ff7-edb3-57f7-b8be" name="Hunter-killer Missile" hidden="false" collective="false" targetId="287b-b205-0926-5822" type="selectionEntry">
+                <entryLink id="0ff7-edb3-57f7-b8be" name="Hunter-killer Missile" hidden="false" collective="false" import="true" targetId="287b-b205-0926-5822" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="6ff9-d2e2-b7de-c7e3" value="1"/>
                   </modifiers>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
-            <selectionEntryGroup id="1b34-dc7f-2aca-9921" name="May take a pintle-mounted weapon:" hidden="false" collective="false">
+            <selectionEntryGroup id="1b34-dc7f-2aca-9921" name="May take a pintle-mounted weapon:" hidden="false" collective="false" import="true">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="a046-0ad0-840b-b3e0" type="max"/>
               </constraints>
               <entryLinks>
-                <entryLink id="aac2-50a4-05d8-9118" name="Heavy Flamer" hidden="false" collective="false" targetId="fc12-daad-3988-3994" type="selectionEntry">
+                <entryLink id="aac2-50a4-05d8-9118" name="Heavy Flamer" hidden="false" collective="false" import="true" targetId="fc12-daad-3988-3994" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="points" value="10"/>
                   </modifiers>
                 </entryLink>
-                <entryLink id="b68b-8491-3d4f-88ee" name="Heavy Bolter" hidden="false" collective="false" targetId="512b-a9be-50a4-c909" type="selectionEntry">
+                <entryLink id="b68b-8491-3d4f-88ee" name="Heavy Bolter" hidden="false" collective="false" import="true" targetId="512b-a9be-50a4-c909" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="points" value="10"/>
                   </modifiers>
                 </entryLink>
-                <entryLink id="1843-2ca8-f7b9-e358" name="Twin-Linked Bolter" hidden="false" collective="false" targetId="30c2c848-c1d3-e61f-6632-a91bcee1fdc4" type="selectionEntry">
+                <entryLink id="1843-2ca8-f7b9-e358" name="Twin-Linked Bolter" hidden="false" collective="false" import="true" targetId="30c2c848-c1d3-e61f-6632-a91bcee1fdc4" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="points" value="5"/>
                   </modifiers>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
-            <selectionEntryGroup id="6524-e422-397b-d20f" name="May take a hull-mounted weapon:" hidden="false" collective="false">
+            <selectionEntryGroup id="6524-e422-397b-d20f" name="May take a hull-mounted weapon:" hidden="false" collective="false" import="true">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="31a1-733e-1a99-09a7" type="max"/>
               </constraints>
               <entryLinks>
-                <entryLink id="a3e8-aa70-0b1a-1cba" name="Heavy Bolter" hidden="false" collective="false" targetId="512b-a9be-50a4-c909" type="selectionEntry">
+                <entryLink id="a3e8-aa70-0b1a-1cba" name="Heavy Bolter" hidden="false" collective="false" import="true" targetId="512b-a9be-50a4-c909" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="name" value="Hull-mounted Heavy Bolter"/>
                     <modifier type="set" field="points" value="10"/>
                   </modifiers>
                 </entryLink>
-                <entryLink id="0856-9956-2fed-2539" name="Heavy Flamer" hidden="false" collective="false" targetId="fc12-daad-3988-3994" type="selectionEntry">
+                <entryLink id="0856-9956-2fed-2539" name="Heavy Flamer" hidden="false" collective="false" import="true" targetId="fc12-daad-3988-3994" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="name" value="Hull-mounted Heavy Flamer"/>
                     <modifier type="set" field="points" value="10"/>
@@ -6799,7 +6810,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
-            <selectionEntryGroup id="f499-35e4-3fc9-5a78" name="Equip Whirlwind Launchers with:" hidden="false" collective="false" defaultSelectionEntryId="c98d-d2f7-c36e-4ea1">
+            <selectionEntryGroup id="f499-35e4-3fc9-5a78" name="Equip Whirlwind Launchers with:" hidden="false" collective="false" import="true" defaultSelectionEntryId="c98d-d2f7-c36e-4ea1">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
@@ -6812,7 +6823,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="e2a2-5b9a-118c-3f72" type="max"/>
               </constraints>
               <selectionEntries>
-                <selectionEntry id="8f4d-b3fe-f6b2-9c66" name="Hyperios air-defence missiles" hidden="false" collective="false" type="upgrade">
+                <selectionEntry id="8f4d-b3fe-f6b2-9c66" name="Hyperios air-defence missiles" hidden="false" collective="false" import="true" type="upgrade">
                   <infoLinks>
                     <infoLink id="c60d-ac2e-1a69-12bd" name="Hyperios Missile Launcher" hidden="false" targetId="b8643d20-d7ef-7974-7261-11c7b9787be0" type="profile"/>
                     <infoLink id="bbaa-02fa-8c6e-2701" name="Skyfire" hidden="false" targetId="be7f-8146-6cb8-9a53" type="rule"/>
@@ -6822,15 +6833,15 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                     <cost name="pts" typeId="points" value="0.0"/>
                   </costs>
                 </selectionEntry>
-                <selectionEntry id="c98d-d2f7-c36e-4ea1" name="Castellan and Vengeance missiles" hidden="false" collective="false" type="upgrade">
+                <selectionEntry id="c98d-d2f7-c36e-4ea1" name="Castellan and Vengeance missiles" hidden="false" collective="false" import="true" type="upgrade">
                   <selectionEntries>
-                    <selectionEntry id="f2d2-764f-c35e-d7b0" name="Vengeance Warhead" hidden="false" collective="false" type="upgrade">
+                    <selectionEntry id="f2d2-764f-c35e-d7b0" name="Vengeance Warhead" hidden="false" collective="false" import="true" type="upgrade">
                       <constraints>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0bce-ca78-0826-31f3" type="max"/>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b7cc-8cf7-283d-0a16" type="min"/>
                       </constraints>
                       <profiles>
-                        <profile id="42ce-70b6-a4e8-17cc" name="Vengeance Warhead" publicationId="cf03-f607-pubN107623" page="125" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+                        <profile id="42ce-70b6-a4e8-17cc" name="Vengeance Warhead" publicationId="cf03-f607-pubN107623" page="125" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
                           <characteristics>
                             <characteristic name="Range" typeId="52616e676523232344415441232323">12&quot; - 48&quot;</characteristic>
                             <characteristic name="Strength" typeId="537472656e67746823232344415441232323">5</characteristic>
@@ -6843,13 +6854,13 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                         <cost name="pts" typeId="points" value="0.0"/>
                       </costs>
                     </selectionEntry>
-                    <selectionEntry id="11d6-f8b6-3434-b5e6" name="Castellan Warhead" hidden="false" collective="false" type="upgrade">
+                    <selectionEntry id="11d6-f8b6-3434-b5e6" name="Castellan Warhead" hidden="false" collective="false" import="true" type="upgrade">
                       <constraints>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="577f-8234-15a4-e4ec" type="max"/>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="96d4-5e94-d40a-b570" type="min"/>
                       </constraints>
                       <profiles>
-                        <profile id="a6b9-db50-61c0-608d" name="Castellan Warhead" publicationId="cf03-f607-pubN107623" page="125" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+                        <profile id="a6b9-db50-61c0-608d" name="Castellan Warhead" publicationId="cf03-f607-pubN107623" page="125" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
                           <characteristics>
                             <characteristic name="Range" typeId="52616e676523232344415441232323">12&quot; - 48&quot;</characteristic>
                             <characteristic name="Strength" typeId="537472656e67746823232344415441232323">4</characteristic>
@@ -6872,12 +6883,12 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 </selectionEntry>
               </selectionEntries>
             </selectionEntryGroup>
-            <selectionEntryGroup id="c376-08d7-3bb5-5a89" name="Psyarkana" hidden="false" collective="false">
+            <selectionEntryGroup id="c376-08d7-3bb5-5a89" name="Psyarkana" hidden="false" collective="false" import="true">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="036d-3dfe-4fc7-2781" type="max"/>
               </constraints>
               <entryLinks>
-                <entryLink id="19f8-616e-40ab-20d2" name="Armatus Necrotechnica" hidden="false" collective="false" targetId="e78c-d1a1-c20f-dae8" type="selectionEntry">
+                <entryLink id="19f8-616e-40ab-20d2" name="Armatus Necrotechnica" hidden="false" collective="false" import="true" targetId="e78c-d1a1-c20f-dae8" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="hidden" value="false"/>
                   </modifiers>
@@ -6891,12 +6902,12 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="253e-4bd0-cf30-65ae" name="Entire battery may exchange Whirlwind Launchers for:" hidden="false" collective="false">
+        <selectionEntryGroup id="253e-4bd0-cf30-65ae" name="Entire battery may exchange Whirlwind Launchers for:" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="c6ee-bd05-6ad4-46b0" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="3aff-0ce3-b172-5a59" name="Medusa cannons" publicationId="cf03-f607-pubN76780" page="84" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="3aff-0ce3-b172-5a59" name="Medusa cannons" publicationId="cf03-f607-pubN76780" page="84" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="increment" field="points" value="45">
                   <repeats>
@@ -6908,7 +6919,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f213-3472-442a-cdfb" type="max"/>
               </constraints>
               <profiles>
-                <profile id="dc8f-5d46-6cd5-5200" name="Medusa Siege Gun" publicationId="cf03-f607-pubN80892" page="92" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+                <profile id="dc8f-5d46-6cd5-5200" name="Medusa Siege Gun" publicationId="cf03-f607-pubN80892" page="92" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
                   <characteristics>
                     <characteristic name="Range" typeId="52616e676523232344415441232323">36&quot;</characteristic>
                     <characteristic name="Strength" typeId="537472656e67746823232344415441232323">10</characteristic>
@@ -6916,7 +6927,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                     <characteristic name="Type" typeId="5479706523232344415441232323">Ordnance 1, Barrage, Large Blast</characteristic>
                   </characteristics>
                 </profile>
-                <profile id="18b6-ac1b-a30b-08c2" name="Phospex Shell (Medusa)" publicationId="cf03-f607-pubN108016" page="126" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+                <profile id="18b6-ac1b-a30b-08c2" name="Phospex Shell (Medusa)" publicationId="cf03-f607-pubN108016" page="126" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
                   <characteristics>
                     <characteristic name="Range" typeId="52616e676523232344415441232323">36&quot;</characteristic>
                     <characteristic name="Strength" typeId="537472656e67746823232344415441232323">5</characteristic>
@@ -6934,7 +6945,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="5cd3-8e02-6d45-4e35" name="Earthshaker cannons" publicationId="cf03-f607-pubN108169" page="84" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="5cd3-8e02-6d45-4e35" name="Earthshaker cannons" publicationId="cf03-f607-pubN108169" page="84" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="increment" field="points" value="30">
                   <repeats>
@@ -6946,7 +6957,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="578b-ab90-3a65-2abf" type="max"/>
               </constraints>
               <profiles>
-                <profile id="33ab-b29f-6345-6cc1" name="Earthshaker Cannon" publicationId="cf03-f607-pubN80892" page="92" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+                <profile id="33ab-b29f-6345-6cc1" name="Earthshaker Cannon" publicationId="cf03-f607-pubN80892" page="92" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
                   <characteristics>
                     <characteristic name="Range" typeId="52616e676523232344415441232323">36&quot; -  240&quot;</characteristic>
                     <characteristic name="Strength" typeId="537472656e67746823232344415441232323">9</characteristic>
@@ -6959,7 +6970,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="3c6b-6a70-b879-534c" name="Mars-Colossus bombards" publicationId="cf03-f607-pubN76780" page="84" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="3c6b-6a70-b879-534c" name="Mars-Colossus bombards" publicationId="cf03-f607-pubN76780" page="84" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="increment" field="points" value="50.0">
                   <repeats>
@@ -6971,7 +6982,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0f7d-09cc-d9f6-1720" type="max"/>
               </constraints>
               <profiles>
-                <profile id="e28e-7241-d69a-ea95" name="Mars-Colossus bombard" publicationId="cf03-f607-pubN76780" page="84" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+                <profile id="e28e-7241-d69a-ea95" name="Mars-Colossus bombard" publicationId="cf03-f607-pubN76780" page="84" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
                   <characteristics>
                     <characteristic name="Range" typeId="52616e676523232344415441232323">12-72&quot;</characteristic>
                     <characteristic name="Strength" typeId="537472656e67746823232344415441232323">7</characteristic>
@@ -6988,7 +6999,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="8d5d-d7c3-9ad6-62d4" name="Dual Melta cannons" publicationId="cf03-f607-pubN76780" page="84" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="8d5d-d7c3-9ad6-62d4" name="Dual Melta cannons" publicationId="cf03-f607-pubN76780" page="84" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="increment" field="points" value="20.0">
                   <repeats>
@@ -7000,7 +7011,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="19d1-67a3-6f11-b945" type="max"/>
               </constraints>
               <profiles>
-                <profile id="b713-9c1f-a104-ee9d" name="Dual Melta Cannon" publicationId="cf03-f607-pubN76780" page="84" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+                <profile id="b713-9c1f-a104-ee9d" name="Dual Melta Cannon" publicationId="cf03-f607-pubN76780" page="84" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
                   <characteristics>
                     <characteristic name="Range" typeId="52616e676523232344415441232323">24</characteristic>
                     <characteristic name="Strength" typeId="537472656e67746823232344415441232323">8</characteristic>
@@ -7017,7 +7028,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="05f1-de92-19a0-45c8" name="Demolisher cannons" publicationId="cf03-f607-pubN76780" page="84" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="05f1-de92-19a0-45c8" name="Demolisher cannons" publicationId="cf03-f607-pubN76780" page="84" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="increment" field="points" value="10.0">
                   <repeats>
@@ -7029,7 +7040,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c2a2-8916-c354-b36b" type="max"/>
               </constraints>
               <profiles>
-                <profile id="ab02-66f0-4078-4230" name="Demolisher Cannon" publicationId="cf03-f607-pubN76780" page="84" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+                <profile id="ab02-66f0-4078-4230" name="Demolisher Cannon" publicationId="cf03-f607-pubN76780" page="84" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
                   <characteristics>
                     <characteristic name="Range" typeId="52616e676523232344415441232323">24</characteristic>
                     <characteristic name="Strength" typeId="537472656e67746823232344415441232323">10</characteristic>
@@ -7042,7 +7053,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="e4ac-b363-6836-2713" name="Quad Lascannons" publicationId="cf03-f607-pubN76780" page="84" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="e4ac-b363-6836-2713" name="Quad Lascannons" publicationId="cf03-f607-pubN76780" page="84" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="increment" field="points" value="15.0">
                   <repeats>
@@ -7054,7 +7065,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a6b9-ca91-690d-122c" type="max"/>
               </constraints>
               <profiles>
-                <profile id="c256-33a8-dae1-7046" name="Quad Lascannon" publicationId="cf03-f607-pubN76780" page="84" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+                <profile id="c256-33a8-dae1-7046" name="Quad Lascannon" publicationId="cf03-f607-pubN76780" page="84" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
                   <characteristics>
                     <characteristic name="Range" typeId="52616e676523232344415441232323">36</characteristic>
                     <characteristic name="Strength" typeId="537472656e67746823232344415441232323">9</characteristic>
@@ -7077,15 +7088,15 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="29c7-a5ff-4521-f4f3" name="Tarantula Sentry Gun Battery" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="29c7-a5ff-4521-f4f3" name="Tarantula Sentry Gun Battery" hidden="false" collective="false" import="true" type="upgrade">
       <selectionEntries>
-        <selectionEntry id="42c4-212f-b09f-e1e6" name="Tarantula Sentry Gun" publicationId="cf03-f607-pubN80892" page="44" hidden="false" collective="false" type="model">
+        <selectionEntry id="42c4-212f-b09f-e1e6" name="Tarantula Sentry Gun" publicationId="cf03-f607-pubN80892" page="44" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7cf4-6ee7-912e-dc40" type="min"/>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="156c-1683-0e29-5367" type="max"/>
           </constraints>
           <profiles>
-            <profile id="c20c-9d35-f142-50f5" name="Tarantula Sentry Gun" publicationId="cf03-f607-pubN80892" page="44" hidden="false" typeId="556e697423232344415441232323" typeName="">
+            <profile id="c20c-9d35-f142-50f5" name="Tarantula Sentry Gun" publicationId="cf03-f607-pubN80892" page="44" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Artillery (Immobile)</characteristic>
                 <characteristic name="WS" typeId="575323232344415441232323">-</characteristic>
@@ -7106,12 +7117,12 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="8b07-bb58-8d4e-7294" name="Entire battery may take one upgrade:" hidden="false" collective="false">
+        <selectionEntryGroup id="8b07-bb58-8d4e-7294" name="Entire battery may take one upgrade:" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e722-50c4-a15e-f9ab" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="490d-78ed-ea1c-f354" name="Concealment" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="490d-78ed-ea1c-f354" name="Concealment" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="increment" field="points" value="10.0">
                   <repeats>
@@ -7132,7 +7143,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="9955-f8bb-6012-16d0" name="Forward Deployment" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="9955-f8bb-6012-16d0" name="Forward Deployment" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="increment" field="points" value="5">
                   <repeats>
@@ -7152,7 +7163,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="3532-7a06-0e66-3f11" name="Drop Capsule" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="3532-7a06-0e66-3f11" name="Drop Capsule" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="increment" field="points" value="20.0">
                   <repeats>
@@ -7176,9 +7187,9 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="df08-36e3-b104-24cd" name="Entire battery may exchange Twin-linked heavy bolters for:" hidden="false" collective="false">
+        <selectionEntryGroup id="df08-36e3-b104-24cd" name="Entire battery may exchange Twin-linked heavy bolters for:" hidden="false" collective="false" import="true">
           <selectionEntries>
-            <selectionEntry id="44ed-55dd-1d0a-c8d2" name="Hyperios Air-defence Missile Launchers" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="44ed-55dd-1d0a-c8d2" name="Hyperios Air-defence Missile Launchers" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="increment" field="points" value="20.0">
                   <repeats>
@@ -7198,7 +7209,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="5b28-81ce-73c9-4271" name="Exchange any Twin-linked Heavy Bolter for:" hidden="false" collective="false">
+        <selectionEntryGroup id="5b28-81ce-73c9-4271" name="Exchange any Twin-linked Heavy Bolter for:" hidden="false" collective="false" import="true">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
@@ -7215,7 +7226,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
             <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0383-5ba0-fb87-2f3e" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="fb42-d235-09b2-930b" name="Twin-linked Heavy Flamers" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="fb42-d235-09b2-930b" name="Twin-linked Heavy Flamers" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2012-d0c8-c207-ebb2" type="max"/>
               </constraints>
@@ -7230,7 +7241,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="81df-4b4a-dacc-c08a" name="Two twin-linked Rotor Cannons" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="81df-4b4a-dacc-c08a" name="Two twin-linked Rotor Cannons" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="daa2-bf3b-a859-511b" type="max"/>
               </constraints>
@@ -7245,7 +7256,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="4194-62cf-e58b-c902" name="Twin-linked Lascannon" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="4194-62cf-e58b-c902" name="Twin-linked Lascannon" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ab97-1aae-b416-73ce" type="max"/>
               </constraints>
@@ -7260,7 +7271,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 <cost name="pts" typeId="points" value="10.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="4cc9-9082-71b2-2a0f" name="Multi-melta and Searchlight" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="4cc9-9082-71b2-2a0f" name="Multi-melta and Searchlight" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c7e9-6d36-8e76-dbca" type="max"/>
               </constraints>
@@ -7271,7 +7282,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 <cost name="pts" typeId="points" value="5.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="d2f5-7f4a-7bb9-e0e8" name="Twin-linked Photon Thruster" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="d2f5-7f4a-7bb9-e0e8" name="Twin-linked Photon Thruster" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="013b-9457-f912-35e0" type="max"/>
               </constraints>
@@ -7286,7 +7297,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 <cost name="pts" typeId="points" value="15.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="eac7-0d07-3822-cfe1" name="Twin-linked Volkite Culverin" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="eac7-0d07-3822-cfe1" name="Twin-linked Volkite Culverin" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f99c-3fa7-c50a-ccdb" type="max"/>
               </constraints>
@@ -7301,7 +7312,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 <cost name="pts" typeId="points" value="20.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="5d1b-61ad-2b7c-c6cb" name="Quad-gun" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="5d1b-61ad-2b7c-c6cb" name="Quad-gun" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="38da-9fb3-18b1-f1bb" type="max"/>
               </constraints>
@@ -7315,7 +7326,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 <cost name="pts" typeId="points" value="30.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="b8e9-ae1c-ef52-bfba" name="Twin-linked Mauler Bolt Cannon" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="b8e9-ae1c-ef52-bfba" name="Twin-linked Mauler Bolt Cannon" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3ce8-4b7c-1280-73ad" type="max"/>
               </constraints>
@@ -7332,7 +7343,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="4e15-e5f3-d9ec-b9cf" name="Exchange any Hyperios Air-defence Missile Launcher for:" hidden="true" collective="false">
+        <selectionEntryGroup id="4e15-e5f3-d9ec-b9cf" name="Exchange any Hyperios Air-defence Missile Launcher for:" hidden="true" collective="false" import="true">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
@@ -7344,7 +7355,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
             <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="48b4-cf89-15a2-8290" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="ede8-a25c-3c7c-d036" name="Hyperios Command Platform" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="ede8-a25c-3c7c-d036" name="Hyperios Command Platform" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="increment" field="5e0e-87aa-6149-5154" value="1">
                   <repeats>
@@ -7373,7 +7384,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="e35b-b300-7fb2-e063" name="Archmagos Dominus" publicationId="cf03-f607-pubN76780" page="75" hidden="false" collective="false" type="unit">
+    <selectionEntry id="e35b-b300-7fb2-e063" name="Archmagos Dominus" publicationId="cf03-f607-pubN76780" page="75" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="set" field="28e7-3147-1161-5deb" value="-1">
           <conditions>
@@ -7385,7 +7396,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
         <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="28e7-3147-1161-5deb" type="max"/>
       </constraints>
       <profiles>
-        <profile id="51d0-31e2-8fa6-8581" name="Archmagos Dominus" publicationId="cf03-f607-pubN76780" page="75" hidden="false" typeId="556e697423232344415441232323" typeName="">
+        <profile id="51d0-31e2-8fa6-8581" name="Archmagos Dominus" publicationId="cf03-f607-pubN76780" page="75" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
           <modifiers>
             <modifier type="increment" field="5723232344415441232323" value="1">
               <repeats>
@@ -7438,7 +7449,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
         <categoryLink id="5982-947c-b361-68bf" name="New CategoryLink" hidden="false" targetId="f74d-4679-75a6-1252" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="2f20-b197-fdf3-ea7b" name="Mastercraft a single weapon" page="0" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="2f20-b197-fdf3-ea7b" name="Mastercraft a single weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="605c-f0f3-ed0e-9e05" type="max"/>
           </constraints>
@@ -7446,7 +7457,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
             <cost name="pts" typeId="points" value="5.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="e714-7e43-a6e5-04b4" name="Power Weapon" publicationId="cf03-f607-pubN76780" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="e714-7e43-a6e5-04b4" name="Power Weapon" publicationId="cf03-f607-pubN76780" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7ec3-da59-1d69-df29" type="max"/>
           </constraints>
@@ -7454,12 +7465,12 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
             <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="954d-f1c5-971f-eba5" name="Relics of the Dark Age of Technology" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="954d-f1c5-971f-eba5" name="Relics of the Dark Age of Technology" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="135f-ed77-3978-0385" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="fa3e-f64e-8d1a-7cd1" hidden="false" collective="false" targetId="e1ca-c072-fd46-7a57" type="selectionEntryGroup"/>
+            <entryLink id="fa3e-f64e-8d1a-7cd1" hidden="false" collective="false" import="true" targetId="e1ca-c072-fd46-7a57" type="selectionEntryGroup"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0.0"/>
@@ -7467,12 +7478,12 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="d5da-2027-50ad-0a18" name="May take one of the following:" hidden="false" collective="false">
+        <selectionEntryGroup id="d5da-2027-50ad-0a18" name="May take one of the following:" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7336-edf2-54d1-ad84" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="42c1-fda0-16dd-52ec" name="Servo-arm" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="42c1-fda0-16dd-52ec" name="Servo-arm" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="107b-c809-3244-cff1" type="max"/>
               </constraints>
@@ -7483,7 +7494,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 <cost name="pts" typeId="points" value="10.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="8b52-5ba9-41ce-1a22" name="Conversion Beamer" publicationId="cf03-f607-pubN80892" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="8b52-5ba9-41ce-1a22" name="Conversion Beamer" publicationId="cf03-f607-pubN80892" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="af8e-a90a-db23-c084" type="max"/>
               </constraints>
@@ -7498,12 +7509,12 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
             </selectionEntry>
           </selectionEntries>
           <entryLinks>
-            <entryLink id="b12a-8c7a-29c8-6b85" name="Machinator Array" hidden="false" collective="false" targetId="9d9f-63d3-f635-7fd5" type="selectionEntry"/>
+            <entryLink id="b12a-8c7a-29c8-6b85" name="Machinator Array" hidden="false" collective="false" import="true" targetId="9d9f-63d3-f635-7fd5" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="c31d-db59-e6a8-d2ae" name="May take any of the following:" hidden="false" collective="false">
+        <selectionEntryGroup id="c31d-db59-e6a8-d2ae" name="May take any of the following:" hidden="false" collective="false" import="true">
           <selectionEntries>
-            <selectionEntry id="f4ce-e28c-ef89-5a03" name="Cyber-familiar" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="f4ce-e28c-ef89-5a03" name="Cyber-familiar" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4b28-dddf-2da9-dab1" type="max"/>
               </constraints>
@@ -7514,7 +7525,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 <cost name="pts" typeId="points" value="15.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="c414-25d0-663f-c997" name="Infravisor" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="c414-25d0-663f-c997" name="Infravisor" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d229-f19c-3a47-c36f" type="max"/>
               </constraints>
@@ -7527,16 +7538,16 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
             </selectionEntry>
           </selectionEntries>
           <entryLinks>
-            <entryLink id="237b-614f-9aa0-179b" name="New EntryLink" hidden="false" collective="false" targetId="2645-2048-de94-299c" type="selectionEntry"/>
-            <entryLink id="5ff9-7462-fecc-00a2" name="New EntryLink" hidden="false" collective="false" targetId="acf4-096f-2127-80a3" type="selectionEntry"/>
+            <entryLink id="237b-614f-9aa0-179b" name="New EntryLink" hidden="false" collective="false" import="true" targetId="2645-2048-de94-299c" type="selectionEntry"/>
+            <entryLink id="5ff9-7462-fecc-00a2" name="New EntryLink" hidden="false" collective="false" import="true" targetId="acf4-096f-2127-80a3" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="a3d9-dc72-fba3-af4f" name="Exchange Volkite Serpenta for" hidden="false" collective="false">
+        <selectionEntryGroup id="a3d9-dc72-fba3-af4f" name="Exchange Volkite Serpenta for" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="16bc-e9f8-5eb7-4e54" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="0503-a4ae-ce15-5632" name="Archaeotech Pistol" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="0503-a4ae-ce15-5632" name="Archaeotech Pistol" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d027-0c8e-9479-6709" type="max"/>
               </constraints>
@@ -7547,7 +7558,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 <cost name="pts" typeId="points" value="10.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="bbf0-0eb2-2926-db26" name="Photon Gauntlet" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="bbf0-0eb2-2926-db26" name="Photon Gauntlet" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4b4f-3ebf-836f-64b1" type="max"/>
               </constraints>
@@ -7558,7 +7569,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 <cost name="pts" typeId="points" value="10.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="2bb9-01ea-0661-984f" name="Plasma Pistol" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="2bb9-01ea-0661-984f" name="Plasma Pistol" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0864-d7ea-3a5a-8d93" type="max"/>
               </constraints>
@@ -7568,15 +7579,15 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
             </selectionEntry>
           </selectionEntries>
           <entryLinks>
-            <entryLink id="59cf-bdac-49bf-945f" name="New EntryLink" hidden="false" collective="false" targetId="a7ac402a-2804-0342-d16a-23c3098a57ef" type="selectionEntry"/>
+            <entryLink id="59cf-bdac-49bf-945f" name="New EntryLink" hidden="false" collective="false" import="true" targetId="a7ac402a-2804-0342-d16a-23c3098a57ef" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="eb10-d11d-fe65-4626" name="The Archmagos Dominus may take one of the following options" hidden="false" collective="false">
+        <selectionEntryGroup id="eb10-d11d-fe65-4626" name="The Archmagos Dominus may take one of the following options" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="de27-1896-f060-7c70" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="9286-3570-8297-7898" name="Rad/irad Cleanser" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="9286-3570-8297-7898" name="Rad/irad Cleanser" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="31e2-50b3-d87d-51c7" type="max"/>
               </constraints>
@@ -7587,7 +7598,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 <cost name="pts" typeId="points" value="20.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="fb44-a5f1-334c-318d" name="Rotor Cannon" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="fb44-a5f1-334c-318d" name="Rotor Cannon" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f085-b869-fa6d-95de" type="max"/>
               </constraints>
@@ -7598,7 +7609,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 <cost name="pts" typeId="points" value="5.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="5f97-efa1-492f-fd3d" name="Meltagun" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="5f97-efa1-492f-fd3d" name="Meltagun" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6dfd-351d-dc1e-334c" type="max"/>
               </constraints>
@@ -7606,7 +7617,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 <cost name="pts" typeId="points" value="10.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="0729-8fec-d8d4-58e4" name="Graviton Gun" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="0729-8fec-d8d4-58e4" name="Graviton Gun" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="91c7-1081-70e8-9220" type="max"/>
               </constraints>
@@ -7618,7 +7629,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 <cost name="pts" typeId="points" value="10.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="b053-9034-ee5c-ab3f" name="Photon Thruster" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="b053-9034-ee5c-ab3f" name="Photon Thruster" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="25a6-ef8b-70f3-0915" type="max"/>
               </constraints>
@@ -7631,12 +7642,12 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="ccde-3f6f-5488-5d49" name="Psyarkana" hidden="false" collective="false">
+        <selectionEntryGroup id="ccde-3f6f-5488-5d49" name="Psyarkana" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ef07-09af-569a-7cc5" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="fd10-f915-d561-6dbd" name="Icon of the Blazing Sun" hidden="false" collective="false" targetId="b2fe-de24-0c45-9b4d" type="selectionEntry">
+            <entryLink id="fd10-f915-d561-6dbd" name="Icon of the Blazing Sun" hidden="false" collective="false" import="true" targetId="b2fe-de24-0c45-9b4d" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="hidden" value="false">
                   <conditions>
@@ -7645,12 +7656,12 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 </modifier>
               </modifiers>
             </entryLink>
-            <entryLink id="0c35-6555-ad19-35a4" name="Terminal Lucidity Injectors" hidden="false" collective="false" targetId="66e2-6760-fb6a-edc3" type="selectionEntry">
+            <entryLink id="0c35-6555-ad19-35a4" name="Terminal Lucidity Injectors" hidden="false" collective="false" import="true" targetId="66e2-6760-fb6a-edc3" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="hidden" value="false"/>
               </modifiers>
             </entryLink>
-            <entryLink id="ee3c-cc34-83eb-263a" name="The Liber Magra Veneficarum" hidden="false" collective="false" targetId="49dd-55d6-fa07-8cb5" type="selectionEntry">
+            <entryLink id="ee3c-cc34-83eb-263a" name="The Liber Magra Veneficarum" hidden="false" collective="false" import="true" targetId="49dd-55d6-fa07-8cb5" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="hidden" value="false">
                   <conditions>
@@ -7659,7 +7670,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 </modifier>
               </modifiers>
             </entryLink>
-            <entryLink id="554e-29be-40c6-628d" name="Corpus Mymir" hidden="false" collective="false" targetId="d761-15dd-7631-ba0d" type="selectionEntry">
+            <entryLink id="554e-29be-40c6-628d" name="Corpus Mymir" hidden="false" collective="false" import="true" targetId="d761-15dd-7631-ba0d" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="hidden" value="false"/>
               </modifiers>
@@ -7668,15 +7679,15 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="47a3-6141-b585-da3e" name="May be mounted on:" hidden="false" collective="false" targetId="df18-c724-2a3d-a6e5" type="selectionEntryGroup"/>
+        <entryLink id="47a3-6141-b585-da3e" name="May be mounted on:" hidden="false" collective="false" import="true" targetId="df18-c724-2a3d-a6e5" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="155.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="93b9-6dc9-3d02-db32" name="Thanatar-Calix Class Siege-Automata" hidden="false" collective="false" type="unit">
+    <selectionEntry id="93b9-6dc9-3d02-db32" name="Thanatar-Calix Class Siege-Automata" hidden="false" collective="false" import="true" type="unit">
       <profiles>
-        <profile id="ca31-e06c-7410-8919" name="Thanatar" publicationId="cf03-f607-pubN76270" page="51" hidden="false" typeId="556e697423232344415441232323" typeName="">
+        <profile id="ca31-e06c-7410-8919" name="Thanatar" publicationId="cf03-f607-pubN76270" page="51" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
           <modifiers>
             <modifier type="increment" field="4923232344415441232323" value="1">
               <conditions>
@@ -7697,7 +7708,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
             <characteristic name="Save" typeId="5361766523232344415441232323">2+</characteristic>
           </characteristics>
         </profile>
-        <profile id="4163-4746-81ad-b125" name="Sollex Pattern Heavy Lascannon" publicationId="cf03-f607-pubN80965" page="225" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+        <profile id="4163-4746-81ad-b125" name="Sollex Pattern Heavy Lascannon" publicationId="cf03-f607-pubN80965" page="225" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
           <characteristics>
             <characteristic name="Range" typeId="52616e676523232344415441232323">60&quot;</characteristic>
             <characteristic name="Strength" typeId="537472656e67746823232344415441232323">10</characteristic>
@@ -7705,7 +7716,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
             <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 1</characteristic>
           </characteristics>
         </profile>
-        <profile id="ee9a-b74e-8569-b115" name="Graviton Ram (Assault)" publicationId="cf03-f607-pubN80965" page="225" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+        <profile id="ee9a-b74e-8569-b115" name="Graviton Ram (Assault)" publicationId="cf03-f607-pubN80965" page="225" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
           <characteristics>
             <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
             <characteristic name="Strength" typeId="537472656e67746823232344415441232323">10</characteristic>
@@ -7713,7 +7724,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
             <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Armourbane, Concussive, Structural Collapse</characteristic>
           </characteristics>
         </profile>
-        <profile id="1080-c04c-5cb1-c118" name="Graviton Ram (Shooting)" publicationId="cf03-f607-pubN80965" page="225" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+        <profile id="1080-c04c-5cb1-c118" name="Graviton Ram (Shooting)" publicationId="cf03-f607-pubN80965" page="225" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
           <characteristics>
             <characteristic name="Range" typeId="52616e676523232344415441232323">Template</characteristic>
             <characteristic name="Strength" typeId="537472656e67746823232344415441232323">*</characteristic>
@@ -7741,9 +7752,9 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
         <categoryLink id="57e5-70a0-f35a-349f" name="New CategoryLink" hidden="false" targetId="7fdd-2a97-d0e9-6524" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="d8c8-128b-ef83-219d" name="The Siege-automata may be given any of the following:" hidden="false" collective="false">
+        <selectionEntryGroup id="d8c8-128b-ef83-219d" name="The Siege-automata may be given any of the following:" hidden="false" collective="false" import="true">
           <selectionEntries>
-            <selectionEntry id="651b-c85a-d90c-19d9" name="Searchlight" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="651b-c85a-d90c-19d9" name="Searchlight" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="192c-2168-3821-a4ad" type="max"/>
               </constraints>
@@ -7751,12 +7762,12 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 <cost name="pts" typeId="points" value="1.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="154d-fcca-bda7-fbbb" name="Enhanced Targeting Array" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="154d-fcca-bda7-fbbb" name="Enhanced Targeting Array" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="26ee-de3c-5c0e-eada" type="max"/>
               </constraints>
               <profiles>
-                <profile id="d9e4-f276-42e7-da61" name="Enhanced Targeting Array" publicationId="cf03-f607-pubN76979" page="207" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="">
+                <profile id="d9e4-f276-42e7-da61" name="Enhanced Targeting Array" publicationId="cf03-f607-pubN76979" page="207" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
                   <characteristics>
                     <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">A model with this upgrade increases its BS by +1 and reduces enemy cover saves by -1. </characteristic>
                   </characteristics>
@@ -7768,9 +7779,9 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="d898-d77f-d2cc-632c" name="A single maniple may take:" hidden="false" collective="false">
+        <selectionEntryGroup id="d898-d77f-d2cc-632c" name="A single maniple may take:" hidden="false" collective="false" import="true">
           <entryLinks>
-            <entryLink id="e2f0-f206-0b1f-c40a" hidden="false" collective="false" targetId="34924deb-f4e5-7739-5606-87600d1740bb" type="selectionEntry"/>
+            <entryLink id="e2f0-f206-0b1f-c40a" hidden="false" collective="false" import="true" targetId="34924deb-f4e5-7739-5606-87600d1740bb" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
@@ -7778,9 +7789,9 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
         <cost name="pts" typeId="points" value="295.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="c888-532b-f933-ce1d" name="Thanatar-Cynis Class Siege-Automata Maniple" publicationId="cf03-f607-pubN76780" page="54" hidden="false" collective="false" type="unit">
+    <selectionEntry id="c888-532b-f933-ce1d" name="Thanatar-Cynis Class Siege-Automata Maniple" publicationId="cf03-f607-pubN76780" page="54" hidden="false" collective="false" import="true" type="unit">
       <profiles>
-        <profile id="eb31-58bc-0c7a-67dd" name="Cynis Pattern Plasma Injector" publicationId="cf03-f607-pubN80965" page="226" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+        <profile id="eb31-58bc-0c7a-67dd" name="Cynis Pattern Plasma Injector" publicationId="cf03-f607-pubN80965" page="226" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
           <characteristics>
             <characteristic name="Range" typeId="52616e676523232344415441232323">18&quot;</characteristic>
             <characteristic name="Strength" typeId="537472656e67746823232344415441232323">8</characteristic>
@@ -7802,13 +7813,13 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
         <categoryLink id="c2a5-28d9-3312-0a87" name="New CategoryLink" hidden="false" targetId="7fdd-2a97-d0e9-6524" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="f67b-2ff9-7629-1662" name="Thanatar-Cynis Class Siege-Automata" hidden="false" collective="false" type="model">
+        <selectionEntry id="f67b-2ff9-7629-1662" name="Thanatar-Cynis Class Siege-Automata" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2901-d994-5499-5792" type="min"/>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="32d1-46e4-979e-ca0a" type="max"/>
           </constraints>
           <profiles>
-            <profile id="1943-9446-88bf-f4ed" name="Thanatar-Cynis Class Siege-Automata" publicationId="cf03-f607-pubN76270" page="54" hidden="false" typeId="556e697423232344415441232323" typeName="">
+            <profile id="1943-9446-88bf-f4ed" name="Thanatar-Cynis Class Siege-Automata" publicationId="cf03-f607-pubN76270" page="54" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
               <modifiers>
                 <modifier type="increment" field="4923232344415441232323" value="1">
                   <conditions>
@@ -7836,14 +7847,14 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="9deb-7562-fa3b-f559" name="A single maniple may take:" hidden="false" collective="false">
+        <selectionEntryGroup id="9deb-7562-fa3b-f559" name="A single maniple may take:" hidden="false" collective="false" import="true">
           <entryLinks>
-            <entryLink id="88fb-73a1-5aac-4e8f" hidden="false" collective="false" targetId="34924deb-f4e5-7739-5606-87600d1740bb" type="selectionEntry"/>
+            <entryLink id="88fb-73a1-5aac-4e8f" hidden="false" collective="false" import="true" targetId="34924deb-f4e5-7739-5606-87600d1740bb" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="f3ee-debc-580c-ab71" name="The Siege-automata may be given any of the following:" hidden="false" collective="false">
+        <selectionEntryGroup id="f3ee-debc-580c-ab71" name="The Siege-automata may be given any of the following:" hidden="false" collective="false" import="true">
           <selectionEntries>
-            <selectionEntry id="f2e5-9d9c-b587-6280" name="Searchlight" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="f2e5-9d9c-b587-6280" name="Searchlight" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="increment" field="points" value="1">
                   <repeats>
@@ -7858,7 +7869,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="55e7-17e7-73dc-5283" name="Enhanced Targeting Array" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="55e7-17e7-73dc-5283" name="Enhanced Targeting Array" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="increment" field="points" value="15.0">
                   <repeats>
@@ -7870,7 +7881,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e129-d54a-7474-aac8" type="max"/>
               </constraints>
               <profiles>
-                <profile id="4952-61c2-52be-ca0f" name="Enhanced Targeting Array" publicationId="cf03-f607-pubN76979" page="207" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="">
+                <profile id="4952-61c2-52be-ca0f" name="Enhanced Targeting Array" publicationId="cf03-f607-pubN76979" page="207" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
                   <characteristics>
                     <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">A model with this upgrade increases its BS by +1 and reduces enemy cover saves by -1. </characteristic>
                   </characteristics>
@@ -7887,7 +7898,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="96be-db78-16ac-5163" name="The Homonculex" hidden="false" collective="false" type="model">
+    <selectionEntry id="96be-db78-16ac-5163" name="The Homonculex" hidden="false" collective="false" import="true" type="model">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -7901,7 +7912,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="31cf-e84d-11d3-22fd" type="max"/>
       </constraints>
       <profiles>
-        <profile id="3a6d-c2a2-4a35-88e9" name="Arlatax" publicationId="cf03-f607-pubN80487" page="274" hidden="false" typeId="556e697423232344415441232323" typeName="">
+        <profile id="3a6d-c2a2-4a35-88e9" name="Arlatax" publicationId="cf03-f607-pubN80487" page="274" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
           <modifiers>
             <modifier type="increment" field="4923232344415441232323" value="1">
               <conditions>
@@ -7922,7 +7933,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
             <characteristic name="Save" typeId="5361766523232344415441232323">3+</characteristic>
           </characteristics>
         </profile>
-        <profile id="8f29-0543-426a-221b" name="Arlatax Power Claw" publicationId="cf03-f607-pubN80487" page="274" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+        <profile id="8f29-0543-426a-221b" name="Arlatax Power Claw" publicationId="cf03-f607-pubN80487" page="274" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
           <characteristics>
             <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
             <characteristic name="Strength" typeId="537472656e67746823232344415441232323">+2</characteristic>
@@ -7930,7 +7941,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
             <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Shred</characteristic>
           </characteristics>
         </profile>
-        <profile id="b899-5245-ffac-45ea" name="Inbuilt Cannon" publicationId="cf03-f607-pubN80487" page="274" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+        <profile id="b899-5245-ffac-45ea" name="Inbuilt Cannon" publicationId="cf03-f607-pubN80487" page="274" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
           <characteristics>
             <characteristic name="Range" typeId="52616e676523232344415441232323">24&quot;</characteristic>
             <characteristic name="Strength" typeId="537472656e67746823232344415441232323">6</characteristic>
@@ -7953,14 +7964,14 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
         <categoryLink id="1449-68ac-de22-3305" name="New CategoryLink" hidden="false" targetId="7fdd-2a97-d0e9-6524" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="08a7-aba0-5e0e-709b" name="May replace one of its Power Claws with:" hidden="false" collective="false">
+        <selectionEntryGroup id="08a7-aba0-5e0e-709b" name="May replace one of its Power Claws with:" hidden="false" collective="false" import="true">
           <selectionEntries>
-            <selectionEntry id="f746-9fbc-b60c-2f23" name="Arc Scourge" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="f746-9fbc-b60c-2f23" name="Arc Scourge" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="be5c-2fa0-69b9-bf06" type="max"/>
               </constraints>
               <profiles>
-                <profile id="5f52-e9cc-a502-8970" name="Arc Scourge" publicationId="cf03-f607-pubN80487" page="274" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+                <profile id="5f52-e9cc-a502-8970" name="Arc Scourge" publicationId="cf03-f607-pubN80487" page="274" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
                   <characteristics>
                     <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
                     <characteristic name="Strength" typeId="537472656e67746823232344415441232323">User</characteristic>
@@ -7980,13 +7991,13 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
         <cost name="pts" typeId="points" value="175.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="2ff2-0526-3cea-acb2" name="Archmagos Draykavac" publicationId="cf03-f607-pubN99227" page="300" hidden="false" collective="false" type="unit">
+    <selectionEntry id="2ff2-0526-3cea-acb2" name="Archmagos Draykavac" publicationId="cf03-f607-pubN99227" page="300" hidden="false" collective="false" import="true" type="unit">
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="d70e-7d52-7354-6eb2" type="max"/>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="045d-777e-67ae-c597" type="max"/>
       </constraints>
       <profiles>
-        <profile id="271a-bd31-7c7b-dbff" name="Archmagos Draykavac" publicationId="cf03-f607-pubN99227" page="300" hidden="false" typeId="556e697423232344415441232323" typeName="">
+        <profile id="271a-bd31-7c7b-dbff" name="Archmagos Draykavac" publicationId="cf03-f607-pubN99227" page="300" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
           <characteristics>
             <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry (Character)</characteristic>
             <characteristic name="WS" typeId="575323232344415441232323">4</characteristic>
@@ -8000,7 +8011,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
             <characteristic name="Save" typeId="5361766523232344415441232323">2+</characteristic>
           </characteristics>
         </profile>
-        <profile id="9d4a-7e0f-d9cd-f6aa" name="Paragon Blade" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+        <profile id="9d4a-7e0f-d9cd-f6aa" name="Paragon Blade" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
           <characteristics>
             <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
             <characteristic name="Strength" typeId="537472656e67746823232344415441232323">+1</characteristic>
@@ -8044,12 +8055,12 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
         <categoryLink id="6ee1-5fe7-b652-3a44" name="New CategoryLink" hidden="false" targetId="f74d-4679-75a6-1252" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="10a0-94be-a5de-8053" name="May take up to four:" hidden="false" collective="false">
+        <selectionEntryGroup id="10a0-94be-a5de-8053" name="May take up to four:" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="af68-0dd5-c75a-e114" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="c563-bb7c-e7ae-23b2" name="Cyber-occularis" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="c563-bb7c-e7ae-23b2" name="Cyber-occularis" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1d6e-b27e-16b6-3b8c" type="max"/>
               </constraints>
@@ -8068,16 +8079,16 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="e9ff-c808-888a-3bd8" hidden="false" collective="false" targetId="df18-c724-2a3d-a6e5" type="selectionEntryGroup"/>
-        <entryLink id="bf87-03a2-476e-4512" name="Archmagos" hidden="false" collective="false" targetId="00cf-20ab-1b17-aad1" type="selectionEntry"/>
+        <entryLink id="e9ff-c808-888a-3bd8" hidden="false" collective="false" import="true" targetId="df18-c724-2a3d-a6e5" type="selectionEntryGroup"/>
+        <entryLink id="bf87-03a2-476e-4512" name="Archmagos" hidden="false" collective="false" import="true" targetId="00cf-20ab-1b17-aad1" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="240.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="7095-280b-9ccc-b7bc" name="Archmagos Inar Satarael" publicationId="cf03-f607-pubN76780" page="30" hidden="false" collective="false" type="unit">
+    <selectionEntry id="7095-280b-9ccc-b7bc" name="Archmagos Inar Satarael" publicationId="cf03-f607-pubN76780" page="30" hidden="false" collective="false" import="true" type="unit">
       <profiles>
-        <profile id="9138-f7a5-41ad-dacb" name="Archmagos Inar Satarael" publicationId="cf03-f607-pubN76979" page="216" hidden="false" typeId="556e697423232344415441232323" typeName="">
+        <profile id="9138-f7a5-41ad-dacb" name="Archmagos Inar Satarael" publicationId="cf03-f607-pubN76979" page="216" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
           <characteristics>
             <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Monstrous Creature (Character)</characteristic>
             <characteristic name="WS" typeId="575323232344415441232323">3</characteristic>
@@ -8091,12 +8102,12 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
             <characteristic name="Save" typeId="5361766523232344415441232323">3+</characteristic>
           </characteristics>
         </profile>
-        <profile id="ed6d-b277-d08a-c397" name="Haemonculite Cyber-corpus" publicationId="cf03-f607-pubN76979" page="217" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="">
+        <profile id="ed6d-b277-d08a-c397" name="Haemonculite Cyber-corpus" publicationId="cf03-f607-pubN76979" page="217" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
           <characteristics>
             <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Provides Feel no Pain 5 and Extremely Bulky rules. Although Satarael is otherwise a character, he may not be joined by other models to form a unit or join another unit himself unless via the Patris Cybernetica special rule. He may, however, be transported alongside other units inside Mechanicum vehicles so long as there is room.</characteristic>
           </characteristics>
         </profile>
-        <profile id="8898-786c-cc59-0816" name="Repulsion Shield" publicationId="cf03-f607-pubN76979" page="217" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="">
+        <profile id="8898-786c-cc59-0816" name="Repulsion Shield" publicationId="cf03-f607-pubN76979" page="217" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
           <characteristics>
             <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Works only against shooting attacks of St 6 or higher which to not have the Blast or Template rules.  Takes effect after hits but before wounds.  Roll a D6 for each hit, on a 4 or 5, the shot is negated.  On a 6, the shot is reflected back on the firing unit, hitting automatically. No effect on Destroyer attacks.  </characteristic>
           </characteristics>
@@ -8146,7 +8157,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
         <categoryLink id="7ae8-37ec-363d-05bb" name="New CategoryLink" hidden="false" targetId="8ec4-17b5-7fea-c682" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="89b1-265c-7a8c-b59c" name="Cyber-occularis" page="0" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="89b1-265c-7a8c-b59c" name="Cyber-occularis" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="cd14-43eb-d07d-59c7" type="max"/>
           </constraints>
@@ -8163,15 +8174,15 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink id="77c8-9884-a424-bc13" hidden="false" collective="false" targetId="00cf-20ab-1b17-aad1" type="selectionEntry"/>
+        <entryLink id="77c8-9884-a424-bc13" hidden="false" collective="false" import="true" targetId="00cf-20ab-1b17-aad1" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="295.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="f891-cee8-321e-f159" name="Magos Dominus" publicationId="cf03-f607-pubN76780" hidden="false" collective="false" type="unit">
+    <selectionEntry id="f891-cee8-321e-f159" name="Magos Dominus" publicationId="cf03-f607-pubN76780" hidden="false" collective="false" import="true" type="unit">
       <profiles>
-        <profile id="594a-289b-a120-b0fe" name="Magos Dominus" publicationId="cf03-f607-pubN76979" page="218" hidden="false" typeId="556e697423232344415441232323" typeName="">
+        <profile id="594a-289b-a120-b0fe" name="Magos Dominus" publicationId="cf03-f607-pubN76979" page="218" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
           <modifiers>
             <modifier type="increment" field="5423232344415441232323" value="1">
               <conditions>
@@ -8209,7 +8220,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
         <categoryLink id="0660-0453-4e23-8d07" name="New CategoryLink" hidden="false" targetId="f74d-4679-75a6-1252" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="259c-0b8c-8b1e-2b60" name="Mastercraft a single weapon" page="0" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="259c-0b8c-8b1e-2b60" name="Mastercraft a single weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="86d4-3acb-742e-f72e" type="max"/>
           </constraints>
@@ -8220,7 +8231,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
             <cost name="pts" typeId="points" value="5.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="6d7e-7a63-6213-1866" name="Cortex Controller" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="6d7e-7a63-6213-1866" name="Cortex Controller" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9265-7614-f474-75a3" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1ce9-d549-3672-3424" type="max"/>
@@ -8240,7 +8251,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
             <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="1d72-24d9-ac53-1e03" name="Refractor field" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="1d72-24d9-ac53-1e03" name="Refractor field" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3e05-09f7-75c9-5b8e" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6fc8-8755-9bc9-5f3a" type="max"/>
@@ -8254,12 +8265,12 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="5c26-5bbd-1cb2-059c" name="May take one of the following:" hidden="false" collective="false">
+        <selectionEntryGroup id="5c26-5bbd-1cb2-059c" name="May take one of the following:" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d0c7-2805-c363-49c5" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="8b63-de7c-cc9a-7bb1" name="Servo-arm" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="8b63-de7c-cc9a-7bb1" name="Servo-arm" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <infoLinks>
                 <infoLink id="8faa-be62-ef0b-511b" name="Servo-arm" hidden="false" targetId="f4404a95-506e-bcef-1420-21d2d6e9013b" type="profile"/>
               </infoLinks>
@@ -8269,17 +8280,17 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
             </selectionEntry>
           </selectionEntries>
           <entryLinks>
-            <entryLink id="9d44-5977-43ea-9c65" name="Conversion Beamer" hidden="false" collective="false" targetId="56fc88c5-200c-7d1b-dc29-64471bbf63bf" type="selectionEntry">
+            <entryLink id="9d44-5977-43ea-9c65" name="Conversion Beamer" hidden="false" collective="false" import="true" targetId="56fc88c5-200c-7d1b-dc29-64471bbf63bf" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="points" value="25"/>
               </modifiers>
             </entryLink>
-            <entryLink id="fd25-794a-04f3-54e0" name="Machinator Array" hidden="false" collective="false" targetId="9d9f-63d3-f635-7fd5" type="selectionEntry"/>
+            <entryLink id="fd25-794a-04f3-54e0" name="Machinator Array" hidden="false" collective="false" import="true" targetId="9d9f-63d3-f635-7fd5" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="d70a-ccf8-c7eb-0a4a" name="May take any of the following:" hidden="false" collective="false">
+        <selectionEntryGroup id="d70a-ccf8-c7eb-0a4a" name="May take any of the following:" hidden="false" collective="false" import="true">
           <selectionEntries>
-            <selectionEntry id="72fd-d462-81df-114f" name="Cyber-familiar" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="72fd-d462-81df-114f" name="Cyber-familiar" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b8af-d510-ff38-ab06" type="max"/>
               </constraints>
@@ -8290,7 +8301,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 <cost name="pts" typeId="points" value="15.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="99bc-dd23-539f-21a0" name="Infravisor" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="99bc-dd23-539f-21a0" name="Infravisor" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2f3e-390b-455e-418f" type="max"/>
               </constraints>
@@ -8303,17 +8314,17 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
             </selectionEntry>
           </selectionEntries>
           <entryLinks>
-            <entryLink id="956b-25cb-9eac-8971" name="New EntryLink" hidden="false" collective="false" targetId="2645-2048-de94-299c" type="selectionEntry"/>
-            <entryLink id="562c-e0fc-1558-210a" name="New EntryLink" hidden="false" collective="false" targetId="acf4-096f-2127-80a3" type="selectionEntry"/>
+            <entryLink id="956b-25cb-9eac-8971" name="New EntryLink" hidden="false" collective="false" import="true" targetId="2645-2048-de94-299c" type="selectionEntry"/>
+            <entryLink id="562c-e0fc-1558-210a" name="New EntryLink" hidden="false" collective="false" import="true" targetId="acf4-096f-2127-80a3" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="1fc3-6b29-d5c9-e39a" name="Ranged Weapon:" hidden="false" collective="false" defaultSelectionEntryId="9215-e924-50c1-c56a">
+        <selectionEntryGroup id="1fc3-6b29-d5c9-e39a" name="Ranged Weapon:" hidden="false" collective="false" import="true" defaultSelectionEntryId="9215-e924-50c1-c56a">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c601-378a-38b2-b02e" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f687-0d8c-b946-7371" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="9cff-2bee-b5d3-9028" name="Photon Gauntlet" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="9cff-2bee-b5d3-9028" name="Photon Gauntlet" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <infoLinks>
                 <infoLink id="4f2e-154f-844b-d45d" name="Photon Gauntlet" hidden="false" targetId="54b8d1d6-d443-4571-936f-aca7c3c451db" type="profile"/>
                 <infoLink id="87da-23b3-f22f-fc08" name="Blind" hidden="false" targetId="7dae-4d12-baba-e529" type="rule"/>
@@ -8323,7 +8334,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 <cost name="pts" typeId="points" value="10.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="e121-c521-afa8-5c64" name="Plasma Pistol" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="e121-c521-afa8-5c64" name="Plasma Pistol" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <infoLinks>
                 <infoLink id="da0f-57a1-6256-9a0a" name="Plasma Pistol" hidden="false" targetId="f4a1-b459-ba82-3789" type="profile"/>
               </infoLinks>
@@ -8331,7 +8342,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 <cost name="pts" typeId="points" value="10.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="e310-2f4a-eacb-222f" name="Bolt Pistol" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="e310-2f4a-eacb-222f" name="Bolt Pistol" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <infoLinks>
                 <infoLink id="8b28-f7a7-9a77-259c" name="Bolt Pistol" hidden="false" targetId="ec83-0776-ef74-9cc2" type="profile"/>
               </infoLinks>
@@ -8339,7 +8350,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 <cost name="pts" typeId="points" value="1.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="9215-e924-50c1-c56a" name="Laspistol" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="9215-e924-50c1-c56a" name="Laspistol" hidden="false" collective="false" import="true" type="upgrade">
               <infoLinks>
                 <infoLink id="6074-2566-9ded-de48" name="Laspistol" hidden="false" targetId="9f00-4f6d-0ddb-4e69" type="profile"/>
               </infoLinks>
@@ -8349,24 +8360,24 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
             </selectionEntry>
           </selectionEntries>
           <entryLinks>
-            <entryLink id="1adc-bf55-d9bd-b211" name="Archaeotech Pistol" hidden="false" collective="false" targetId="e884-dd64-6171-4c9a" type="selectionEntry">
+            <entryLink id="1adc-bf55-d9bd-b211" name="Archaeotech Pistol" hidden="false" collective="false" import="true" targetId="e884-dd64-6171-4c9a" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="points" value="10"/>
               </modifiers>
             </entryLink>
-            <entryLink id="da77-6da4-1c5d-8cf2" name="Volkite Serpentia" hidden="false" collective="false" targetId="a7ac402a-2804-0342-d16a-23c3098a57ef" type="selectionEntry">
+            <entryLink id="da77-6da4-1c5d-8cf2" name="Volkite Serpentia" hidden="false" collective="false" import="true" targetId="a7ac402a-2804-0342-d16a-23c3098a57ef" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="points" value="5"/>
               </modifiers>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="ecdc-405a-2189-2d5a" name="May take of the following additional weapons:" hidden="false" collective="false">
+        <selectionEntryGroup id="ecdc-405a-2189-2d5a" name="May take of the following additional weapons:" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1c3c-6f40-095c-a9b9" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="3e77-139c-318c-aaa3" name="Rotor Cannon" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="3e77-139c-318c-aaa3" name="Rotor Cannon" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0f7f-863b-ad5e-99d0" type="max"/>
               </constraints>
@@ -8377,7 +8388,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 <cost name="pts" typeId="points" value="10.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="a432-c8ed-a0b7-cb29" name="Meltagun" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="a432-c8ed-a0b7-cb29" name="Meltagun" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e21c-8e84-f87f-c0c8" type="max"/>
               </constraints>
@@ -8385,7 +8396,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 <cost name="pts" typeId="points" value="15.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="cdd1-ab10-f165-49db" name="Phased Plasma-fusil" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="cdd1-ab10-f165-49db" name="Phased Plasma-fusil" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e040-f22b-8036-d2b2" type="max"/>
               </constraints>
@@ -8396,7 +8407,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 <cost name="pts" typeId="points" value="20.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="d649-cfa0-dc7f-abf0" name="Graviton Gun" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="d649-cfa0-dc7f-abf0" name="Graviton Gun" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d5db-4be0-9d2d-0aef" type="max"/>
               </constraints>
@@ -8408,7 +8419,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 <cost name="pts" typeId="points" value="15.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="74ed-641a-173c-25c7" name="Rad/irad Cleanser" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="74ed-641a-173c-25c7" name="Rad/irad Cleanser" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d8d4-44a9-0d4c-59a0" type="max"/>
               </constraints>
@@ -8419,7 +8430,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 <cost name="pts" typeId="points" value="20.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="4660-ae81-9868-5cc8" name="Photon Thruster" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="4660-ae81-9868-5cc8" name="Photon Thruster" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="994c-e452-b698-1e32" type="max"/>
               </constraints>
@@ -8432,12 +8443,12 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="00e6-8133-3806-7039" name="Psyarkana" hidden="false" collective="false">
+        <selectionEntryGroup id="00e6-8133-3806-7039" name="Psyarkana" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fca9-9310-7191-0fb9" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="4ede-fbb0-9ac9-a1b2" name="Corpus Mymir" hidden="false" collective="false" targetId="d761-15dd-7631-ba0d" type="selectionEntry">
+            <entryLink id="4ede-fbb0-9ac9-a1b2" name="Corpus Mymir" hidden="false" collective="false" import="true" targetId="d761-15dd-7631-ba0d" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="hidden" value="false"/>
               </modifiers>
@@ -8446,16 +8457,16 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="ab7e-c741-1e8e-0b4f" name="May be mounted on:" hidden="false" collective="false" targetId="df18-c724-2a3d-a6e5" type="selectionEntryGroup"/>
-        <entryLink id="2dd4-c353-19b3-9a2c" name="Power Weapon" hidden="false" collective="false" targetId="9d3d-aef5-6635-b0c6" type="selectionEntryGroup"/>
+        <entryLink id="ab7e-c741-1e8e-0b4f" name="May be mounted on:" hidden="false" collective="false" import="true" targetId="df18-c724-2a3d-a6e5" type="selectionEntryGroup"/>
+        <entryLink id="2dd4-c353-19b3-9a2c" name="Power Weapon" hidden="false" collective="false" import="true" targetId="9d3d-aef5-6635-b0c6" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="75.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="aa74-77f4-7266-36b6" name="Magos Prime" publicationId="cf03-f607-pubN76780" page="26-27" hidden="false" collective="false" type="model">
+    <selectionEntry id="aa74-77f4-7266-36b6" name="Magos Prime" publicationId="cf03-f607-pubN76780" page="26-27" hidden="false" collective="false" import="true" type="model">
       <profiles>
-        <profile id="494b-f6c5-1304-ab14" name="Magos Prime" publicationId="cf03-f607-pubN76979" page="214" hidden="false" typeId="556e697423232344415441232323" typeName="">
+        <profile id="494b-f6c5-1304-ab14" name="Magos Prime" publicationId="cf03-f607-pubN76979" page="214" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
@@ -8507,13 +8518,13 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
         <categoryLink id="72d6-c9fd-22ce-d2df" name="New CategoryLink" hidden="false" targetId="f74d-4679-75a6-1252" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="076b-2276-b456-9d6f" name="Archmagos Prime" page="0" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="076b-2276-b456-9d6f" name="Archmagos Prime" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7c36-dbe9-b868-830a" type="max"/>
             <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="5a76-725f-93af-28fe" type="max"/>
           </constraints>
           <profiles>
-            <profile id="fa6c-41f2-66df-2115" name="Archmagos Prime" publicationId="cf03-f607-pubN76979" page="214" hidden="false" typeId="556e697423232344415441232323" typeName="">
+            <profile id="fa6c-41f2-66df-2115" name="Archmagos Prime" publicationId="cf03-f607-pubN76979" page="214" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
               <modifiers>
                 <modifier type="increment" field="5423232344415441232323" value="1">
                   <conditions>
@@ -8554,13 +8565,13 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
             <infoLink id="99ae-f555-2fb7-f10d" name="Relentless" hidden="false" targetId="3c7d-a1fa-c68b-caad" type="rule"/>
           </infoLinks>
           <entryLinks>
-            <entryLink id="98ff-bbd1-310b-d2ad" name="Archmagos" hidden="false" collective="false" targetId="00cf-20ab-1b17-aad1" type="selectionEntry"/>
+            <entryLink id="98ff-bbd1-310b-d2ad" name="Archmagos" hidden="false" collective="false" import="true" targetId="00cf-20ab-1b17-aad1" type="selectionEntry"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="35.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="97d3-33bd-d2db-0859" name="Mastercraft a single weapon" page="0" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="97d3-33bd-d2db-0859" name="Mastercraft a single weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0a70-7b50-ec25-050a" type="max"/>
           </constraints>
@@ -8571,18 +8582,18 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
             <cost name="pts" typeId="points" value="5.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="f99c-14b9-a450-a228" name="Relics of the Dark Age of Technology" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="f99c-14b9-a450-a228" name="Relics of the Dark Age of Technology" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6022-4d73-3523-ad79" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="0c77-9ab0-e472-5840" hidden="false" collective="false" targetId="e1ca-c072-fd46-7a57" type="selectionEntryGroup"/>
+            <entryLink id="0c77-9ab0-e472-5840" hidden="false" collective="false" import="true" targetId="e1ca-c072-fd46-7a57" type="selectionEntryGroup"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="1268-f42c-aba2-a2a9" name="Mechanicum protectiva" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="1268-f42c-aba2-a2a9" name="Mechanicum protectiva" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6d9f-6c84-6b59-eb26" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="878c-9396-6fc0-cf00" type="max"/>
@@ -8596,9 +8607,9 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="c365-bcb4-95bf-2a07" name="May take any of the following:" hidden="false" collective="false">
+        <selectionEntryGroup id="c365-bcb4-95bf-2a07" name="May take any of the following:" hidden="false" collective="false" import="true">
           <selectionEntries>
-            <selectionEntry id="ecfe-6bb7-bbdb-552d" name="Cyber-familiar" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="ecfe-6bb7-bbdb-552d" name="Cyber-familiar" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="df9d-b458-9c09-973a" type="max"/>
               </constraints>
@@ -8609,7 +8620,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 <cost name="pts" typeId="points" value="15.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="3d94-2abf-7795-443c" name="Infravisor" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="3d94-2abf-7795-443c" name="Infravisor" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c924-8eaa-5b81-c1c3" type="max"/>
               </constraints>
@@ -8620,7 +8631,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 <cost name="pts" typeId="points" value="5.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="1ae2-7d37-c6da-fb53" name="Rad Grenades" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="1ae2-7d37-c6da-fb53" name="Rad Grenades" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e36d-c7c4-e3f6-3ef9" type="max"/>
               </constraints>
@@ -8631,7 +8642,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 <cost name="pts" typeId="points" value="10.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="6e05-7a93-5ef5-116e" name="Cortex Controller" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="6e05-7a93-5ef5-116e" name="Cortex Controller" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c6eb-abdf-5b9b-76d8" type="max"/>
               </constraints>
@@ -8650,7 +8661,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 <cost name="pts" typeId="points" value="15.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="7322-f822-3aa7-45d8" name="Cyber-occularis" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="7322-f822-3aa7-45d8" name="Cyber-occularis" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8aa9-7209-a414-f0cf" type="max"/>
               </constraints>
@@ -8665,7 +8676,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 <cost name="pts" typeId="points" value="15.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="2298-74a8-06ce-3069" name="Djinn-skein" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="2298-74a8-06ce-3069" name="Djinn-skein" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
@@ -8678,7 +8689,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1eef-66a5-7125-139c" type="max"/>
               </constraints>
               <profiles>
-                <profile id="accb-30d1-328e-384b" name="Djinn-skein" publicationId="cf03-f607-pubN76979" page="215" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="">
+                <profile id="accb-30d1-328e-384b" name="Djinn-skein" publicationId="cf03-f607-pubN76979" page="215" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
                   <characteristics>
                     <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Provides the following:  - At the start of his shooting phase, the Archmagos Prime may nominate a single unit from his primary detachment (including himself) within 6&quot; of him or any Cyber-occularis purchased as a part of his wargear to benefit from +1 BS. - Friendly units from the primary detachment including the Archmagos who deep strike within 6&quot; do not scatter - Barrage weapons in the same detachment may draw line of sight from the Archmagos or any of his Cyrber-occularis</characteristic>
                   </characteristics>
@@ -8690,11 +8701,11 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
             </selectionEntry>
           </selectionEntries>
           <entryLinks>
-            <entryLink id="9986-60cb-f9bd-7af4" name="New EntryLink" hidden="false" collective="false" targetId="2645-2048-de94-299c" type="selectionEntry"/>
-            <entryLink id="0528-9016-03a1-e977" name="New EntryLink" hidden="false" collective="false" targetId="acf4-096f-2127-80a3" type="selectionEntry"/>
+            <entryLink id="9986-60cb-f9bd-7af4" name="New EntryLink" hidden="false" collective="false" import="true" targetId="2645-2048-de94-299c" type="selectionEntry"/>
+            <entryLink id="0528-9016-03a1-e977" name="New EntryLink" hidden="false" collective="false" import="true" targetId="acf4-096f-2127-80a3" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="d2fe-5252-15d0-a938" name="May take one of the following additional weapons:" hidden="false" collective="false">
+        <selectionEntryGroup id="d2fe-5252-15d0-a938" name="May take one of the following additional weapons:" hidden="false" collective="false" import="true">
           <modifiers>
             <modifier type="set" field="ce45-98e3-9c90-0cbc" value="2">
               <conditions>
@@ -8706,7 +8717,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ce45-98e3-9c90-0cbc" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="0edb-6d28-ddb7-b30f" name="Rotor Cannon" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="0edb-6d28-ddb7-b30f" name="Rotor Cannon" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="945f-3dec-2e0f-f9ac" type="max"/>
               </constraints>
@@ -8717,7 +8728,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 <cost name="pts" typeId="points" value="10.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="dea6-e75f-0d21-e4c3" name="Meltagun" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="dea6-e75f-0d21-e4c3" name="Meltagun" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7da0-e4e8-1bf6-0dc2" type="max"/>
               </constraints>
@@ -8725,7 +8736,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 <cost name="pts" typeId="points" value="15.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="1a1e-87d0-034b-f3d0" name="Phased Plasma-fusil" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="1a1e-87d0-034b-f3d0" name="Phased Plasma-fusil" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c259-e347-ee58-5b39" type="max"/>
               </constraints>
@@ -8736,7 +8747,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 <cost name="pts" typeId="points" value="20.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="c825-f371-5cf5-4b84" name="Graviton Gun" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="c825-f371-5cf5-4b84" name="Graviton Gun" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8cf3-cfa2-6cfe-fe79" type="max"/>
               </constraints>
@@ -8748,7 +8759,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 <cost name="pts" typeId="points" value="15.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="f0cf-2ff1-961f-340b" name="Rad/irad Cleanser" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="f0cf-2ff1-961f-340b" name="Rad/irad Cleanser" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8b5c-9cfe-8c55-fbdf" type="max"/>
               </constraints>
@@ -8759,7 +8770,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 <cost name="pts" typeId="points" value="20.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="da5c-2b07-05f2-3bb4" name="Rad Furnace" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="da5c-2b07-05f2-3bb4" name="Rad Furnace" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="994d-1ae7-9308-08e0" type="max"/>
               </constraints>
@@ -8770,7 +8781,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 <cost name="pts" typeId="points" value="30.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="b131-7592-b907-1465" name="Photon Thruster" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="b131-7592-b907-1465" name="Photon Thruster" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="536c-6ff1-e869-6d18" type="max"/>
               </constraints>
@@ -8783,49 +8794,49 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="bbb3-70b3-eb8d-0601" name="May take one of the following:" hidden="false" collective="false">
+        <selectionEntryGroup id="bbb3-70b3-eb8d-0601" name="May take one of the following:" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4288-c4ef-9242-9e43" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="c99c-9afd-7c2f-d361" name="Jet Pack" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="c99c-9afd-7c2f-d361" name="Jet Pack" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
           <entryLinks>
-            <entryLink id="a981-e209-7e65-62cc" name="Conversion Beamer" hidden="false" collective="false" targetId="56fc88c5-200c-7d1b-dc29-64471bbf63bf" type="selectionEntry">
+            <entryLink id="a981-e209-7e65-62cc" name="Conversion Beamer" hidden="false" collective="false" import="true" targetId="56fc88c5-200c-7d1b-dc29-64471bbf63bf" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="points" value="25"/>
               </modifiers>
             </entryLink>
-            <entryLink id="c0d7-ca99-c60d-789b" name="Machinator Array" hidden="false" collective="false" targetId="9d9f-63d3-f635-7fd5" type="selectionEntry"/>
-            <entryLink id="46c7-ca34-134e-5734" name="Servo-arm" hidden="false" collective="false" targetId="5c5c-13cd-a75e-3b15" type="selectionEntry"/>
-            <entryLink id="5195-a3b7-58d5-c8fd" name="Graviton Imploder" hidden="false" collective="false" targetId="231a-26e7-f47f-6f5a" type="selectionEntry">
+            <entryLink id="c0d7-ca99-c60d-789b" name="Machinator Array" hidden="false" collective="false" import="true" targetId="9d9f-63d3-f635-7fd5" type="selectionEntry"/>
+            <entryLink id="46c7-ca34-134e-5734" name="Servo-arm" hidden="false" collective="false" import="true" targetId="5c5c-13cd-a75e-3b15" type="selectionEntry"/>
+            <entryLink id="5195-a3b7-58d5-c8fd" name="Graviton Imploder" hidden="false" collective="false" import="true" targetId="231a-26e7-f47f-6f5a" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="points" value="15"/>
               </modifiers>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="f263-9228-0e13-d26f" name="Weapons" hidden="false" collective="false">
+        <selectionEntryGroup id="f263-9228-0e13-d26f" name="Weapons" hidden="false" collective="false" import="true">
           <selectionEntryGroups>
-            <selectionEntryGroup id="c3d5-cda8-937f-f56d" name="Melee Weapon:" hidden="false" collective="false">
+            <selectionEntryGroup id="c3d5-cda8-937f-f56d" name="Melee Weapon:" hidden="false" collective="false" import="true">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9522-65d2-0d7d-97b3" type="max"/>
               </constraints>
               <entryLinks>
-                <entryLink id="6da6-a620-f3f1-73e3" name="Power Weapon" hidden="false" collective="false" targetId="5123-2580-422c-33f8" type="selectionEntry"/>
-                <entryLink id="bf62-65d4-b292-7349" name="Archaeotech Pistol" hidden="false" collective="false" targetId="e884-dd64-6171-4c9a" type="selectionEntry"/>
-                <entryLink id="275c-a2d7-1f2e-60b1" name="Corposant stave" hidden="false" collective="false" targetId="4327-a78f-a2cf-17f7" type="selectionEntry">
+                <entryLink id="6da6-a620-f3f1-73e3" name="Power Weapon" hidden="false" collective="false" import="true" targetId="5123-2580-422c-33f8" type="selectionEntry"/>
+                <entryLink id="bf62-65d4-b292-7349" name="Archaeotech Pistol" hidden="false" collective="false" import="true" targetId="e884-dd64-6171-4c9a" type="selectionEntry"/>
+                <entryLink id="275c-a2d7-1f2e-60b1" name="Corposant stave" hidden="false" collective="false" import="true" targetId="4327-a78f-a2cf-17f7" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="points" value="5"/>
                   </modifiers>
                 </entryLink>
-                <entryLink id="a43e-8c47-e0ef-6728" name="Photon Gauntlet" hidden="false" collective="false" targetId="544a-70f1-4560-482b" type="selectionEntry"/>
-                <entryLink id="7844-cd75-8aac-0ab2" name="Maxim Bolter" hidden="false" collective="false" targetId="5f0f-e635-7ceb-44f9" type="selectionEntry"/>
-                <entryLink id="f32e-7e6c-aba0-840e" name="Paragon Blade" hidden="false" collective="false" targetId="b4b1-1973-4aa3-bbd2" type="selectionEntry">
+                <entryLink id="a43e-8c47-e0ef-6728" name="Photon Gauntlet" hidden="false" collective="false" import="true" targetId="544a-70f1-4560-482b" type="selectionEntry"/>
+                <entryLink id="7844-cd75-8aac-0ab2" name="Maxim Bolter" hidden="false" collective="false" import="true" targetId="5f0f-e635-7ceb-44f9" type="selectionEntry"/>
+                <entryLink id="f32e-7e6c-aba0-840e" name="Paragon Blade" hidden="false" collective="false" import="true" targetId="b4b1-1973-4aa3-bbd2" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="hidden" value="false">
                       <conditions>
@@ -8834,11 +8845,11 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                     </modifier>
                   </modifiers>
                 </entryLink>
-                <entryLink id="583f-7786-ef53-c230" name="Plasma Pistol" hidden="false" collective="false" targetId="f65a-de84-8c56-723c" type="selectionEntry"/>
-                <entryLink id="0867-4ce9-0747-28ec" name="Lucifex" hidden="false" collective="false" targetId="722d-7306-0e19-f7df" type="selectionEntry"/>
-                <entryLink id="eb1f-6f3c-c080-442d" name="Chainfist" hidden="false" collective="false" targetId="914e-e579-13d7-d272" type="selectionEntry"/>
-                <entryLink id="cc24-65b8-2ee7-2b54" name="Power Fist" hidden="false" collective="false" targetId="f993-0633-9583-d8ed" type="selectionEntry"/>
-                <entryLink id="a517-4d10-57dd-7c1c" name="Divining Blades" hidden="false" collective="false" targetId="3812-6e1b-33c3-9a88" type="selectionEntry">
+                <entryLink id="583f-7786-ef53-c230" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="f65a-de84-8c56-723c" type="selectionEntry"/>
+                <entryLink id="0867-4ce9-0747-28ec" name="Lucifex" hidden="false" collective="false" import="true" targetId="722d-7306-0e19-f7df" type="selectionEntry"/>
+                <entryLink id="eb1f-6f3c-c080-442d" name="Chainfist" hidden="false" collective="false" import="true" targetId="914e-e579-13d7-d272" type="selectionEntry"/>
+                <entryLink id="cc24-65b8-2ee7-2b54" name="Power Fist" hidden="false" collective="false" import="true" targetId="f993-0633-9583-d8ed" type="selectionEntry"/>
+                <entryLink id="a517-4d10-57dd-7c1c" name="Divining Blades" hidden="false" collective="false" import="true" targetId="3812-6e1b-33c3-9a88" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="hidden" value="false">
                       <conditionGroups>
@@ -8856,21 +8867,21 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
-            <selectionEntryGroup id="2939-5889-6c61-caef" name="Ranged Weapon:" hidden="false" collective="false" defaultSelectionEntryId="97f7-35c5-fd82-1c40">
+            <selectionEntryGroup id="2939-5889-6c61-caef" name="Ranged Weapon:" hidden="false" collective="false" import="true" defaultSelectionEntryId="97f7-35c5-fd82-1c40">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e5e2-23aa-2868-9ba4" type="max"/>
               </constraints>
               <entryLinks>
-                <entryLink id="97f7-35c5-fd82-1c40" name="Volkite Serpentia" hidden="false" collective="false" targetId="a7ac402a-2804-0342-d16a-23c3098a57ef" type="selectionEntry"/>
-                <entryLink id="414c-6c0c-f7c4-d934" name="Archaeotech Pistol" hidden="false" collective="false" targetId="e884-dd64-6171-4c9a" type="selectionEntry"/>
-                <entryLink id="d65a-eccb-a193-5909" name="Corposant stave" hidden="false" collective="false" targetId="4327-a78f-a2cf-17f7" type="selectionEntry">
+                <entryLink id="97f7-35c5-fd82-1c40" name="Volkite Serpentia" hidden="false" collective="false" import="true" targetId="a7ac402a-2804-0342-d16a-23c3098a57ef" type="selectionEntry"/>
+                <entryLink id="414c-6c0c-f7c4-d934" name="Archaeotech Pistol" hidden="false" collective="false" import="true" targetId="e884-dd64-6171-4c9a" type="selectionEntry"/>
+                <entryLink id="d65a-eccb-a193-5909" name="Corposant stave" hidden="false" collective="false" import="true" targetId="4327-a78f-a2cf-17f7" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="points" value="5"/>
                   </modifiers>
                 </entryLink>
-                <entryLink id="8854-df79-ff5c-d553" name="Photon Gauntlet" hidden="false" collective="false" targetId="544a-70f1-4560-482b" type="selectionEntry"/>
-                <entryLink id="a911-cdc0-233d-0afe" name="Maxim Bolter" hidden="false" collective="false" targetId="5f0f-e635-7ceb-44f9" type="selectionEntry"/>
-                <entryLink id="72c7-f4f6-ff3f-8cf0" name="Paragon Blade" hidden="false" collective="false" targetId="b4b1-1973-4aa3-bbd2" type="selectionEntry">
+                <entryLink id="8854-df79-ff5c-d553" name="Photon Gauntlet" hidden="false" collective="false" import="true" targetId="544a-70f1-4560-482b" type="selectionEntry"/>
+                <entryLink id="a911-cdc0-233d-0afe" name="Maxim Bolter" hidden="false" collective="false" import="true" targetId="5f0f-e635-7ceb-44f9" type="selectionEntry"/>
+                <entryLink id="72c7-f4f6-ff3f-8cf0" name="Paragon Blade" hidden="false" collective="false" import="true" targetId="b4b1-1973-4aa3-bbd2" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="hidden" value="false">
                       <conditions>
@@ -8879,11 +8890,11 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                     </modifier>
                   </modifiers>
                 </entryLink>
-                <entryLink id="633a-bd6a-cb40-d144" name="Plasma Pistol" hidden="false" collective="false" targetId="f65a-de84-8c56-723c" type="selectionEntry"/>
-                <entryLink id="7f9f-fb93-4648-e9da" name="Lucifex" hidden="false" collective="false" targetId="722d-7306-0e19-f7df" type="selectionEntry"/>
-                <entryLink id="55ba-619f-1970-ff00" name="Chainfist" hidden="false" collective="false" targetId="914e-e579-13d7-d272" type="selectionEntry"/>
-                <entryLink id="3370-3719-e355-e624" name="Power Fist" hidden="false" collective="false" targetId="f993-0633-9583-d8ed" type="selectionEntry"/>
-                <entryLink id="2387-a7aa-67d7-2589" name="Divining Blades" hidden="false" collective="false" targetId="3812-6e1b-33c3-9a88" type="selectionEntry">
+                <entryLink id="633a-bd6a-cb40-d144" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="f65a-de84-8c56-723c" type="selectionEntry"/>
+                <entryLink id="7f9f-fb93-4648-e9da" name="Lucifex" hidden="false" collective="false" import="true" targetId="722d-7306-0e19-f7df" type="selectionEntry"/>
+                <entryLink id="55ba-619f-1970-ff00" name="Chainfist" hidden="false" collective="false" import="true" targetId="914e-e579-13d7-d272" type="selectionEntry"/>
+                <entryLink id="3370-3719-e355-e624" name="Power Fist" hidden="false" collective="false" import="true" targetId="f993-0633-9583-d8ed" type="selectionEntry"/>
+                <entryLink id="2387-a7aa-67d7-2589" name="Divining Blades" hidden="false" collective="false" import="true" targetId="3812-6e1b-33c3-9a88" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="hidden" value="false">
                       <conditionGroups>
@@ -8903,7 +8914,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
             </selectionEntryGroup>
           </selectionEntryGroups>
         </selectionEntryGroup>
-        <selectionEntryGroup id="8093-b175-1b06-0915" name="Psyarkana" hidden="false" collective="false">
+        <selectionEntryGroup id="8093-b175-1b06-0915" name="Psyarkana" hidden="false" collective="false" import="true">
           <modifiers>
             <modifier type="set" field="c261-1343-94a0-73f3" value="0.0">
               <conditionGroups>
@@ -8930,7 +8941,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c261-1343-94a0-73f3" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="f387-91d1-8fe3-a671" name="Icon of the Blazing Sun" hidden="false" collective="false" targetId="b2fe-de24-0c45-9b4d" type="selectionEntry">
+            <entryLink id="f387-91d1-8fe3-a671" name="Icon of the Blazing Sun" hidden="false" collective="false" import="true" targetId="b2fe-de24-0c45-9b4d" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="hidden" value="false">
                   <conditions>
@@ -8939,12 +8950,12 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 </modifier>
               </modifiers>
             </entryLink>
-            <entryLink id="af3b-c065-9bd0-39c2" name="Terminal Lucidity Injectors" hidden="false" collective="false" targetId="66e2-6760-fb6a-edc3" type="selectionEntry">
+            <entryLink id="af3b-c065-9bd0-39c2" name="Terminal Lucidity Injectors" hidden="false" collective="false" import="true" targetId="66e2-6760-fb6a-edc3" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="hidden" value="false"/>
               </modifiers>
             </entryLink>
-            <entryLink id="6bb1-2832-954d-32a1" name="The Liber Magra Veneficarum" hidden="false" collective="false" targetId="49dd-55d6-fa07-8cb5" type="selectionEntry">
+            <entryLink id="6bb1-2832-954d-32a1" name="The Liber Magra Veneficarum" hidden="false" collective="false" import="true" targetId="49dd-55d6-fa07-8cb5" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="hidden" value="false">
                   <conditions>
@@ -8953,7 +8964,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 </modifier>
               </modifiers>
             </entryLink>
-            <entryLink id="0788-1510-e40f-77d9" name="Corpus Mymir" hidden="false" collective="false" targetId="d761-15dd-7631-ba0d" type="selectionEntry">
+            <entryLink id="0788-1510-e40f-77d9" name="Corpus Mymir" hidden="false" collective="false" import="true" targetId="d761-15dd-7631-ba0d" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="hidden" value="false"/>
               </modifiers>
@@ -8962,9 +8973,9 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="1ad6-9042-a001-972b" name="May be mounted on:" hidden="false" collective="false" targetId="df18-c724-2a3d-a6e5" type="selectionEntryGroup"/>
-        <entryLink id="ebd2-ffe1-0095-0eff" name="The Orders of High Techno-Arcana" hidden="false" collective="false" targetId="70aa-19eb-c232-8e3d" type="selectionEntryGroup"/>
-        <entryLink id="114e-84fe-b970-0289" name="Djinn-skein (Warlord-Only)" hidden="true" collective="false" targetId="91ea-9aa8-13dd-7775" type="selectionEntry">
+        <entryLink id="1ad6-9042-a001-972b" name="May be mounted on:" hidden="false" collective="false" import="true" targetId="df18-c724-2a3d-a6e5" type="selectionEntryGroup"/>
+        <entryLink id="ebd2-ffe1-0095-0eff" name="The Orders of High Techno-Arcana" hidden="false" collective="false" import="true" targetId="70aa-19eb-c232-8e3d" type="selectionEntryGroup"/>
+        <entryLink id="114e-84fe-b970-0289" name="Djinn-skein (Warlord-Only)" hidden="true" collective="false" import="true" targetId="91ea-9aa8-13dd-7775" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
@@ -8978,7 +8989,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
         <cost name="pts" typeId="points" value="95.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="04e8-11de-2eb4-67e0" name="Magos Reductor" publicationId="cf03-f607-pubN76780" page="82" hidden="false" collective="false" type="unit">
+    <selectionEntry id="04e8-11de-2eb4-67e0" name="Magos Reductor" publicationId="cf03-f607-pubN76780" page="82" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -8987,7 +8998,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
         </modifier>
       </modifiers>
       <profiles>
-        <profile id="5376-98b0-610b-fc8f" name="Magos Reductor" publicationId="cf03-f607-pubN76780" page="82" hidden="false" typeId="556e697423232344415441232323" typeName="">
+        <profile id="5376-98b0-610b-fc8f" name="Magos Reductor" publicationId="cf03-f607-pubN76780" page="82" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
@@ -9018,7 +9029,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
             <characteristic name="Save" typeId="5361766523232344415441232323">3+</characteristic>
           </characteristics>
         </profile>
-        <profile id="e2d5-2e3c-b100-b267" name="Archmagos Reductor" publicationId="cf03-f607-pubN76780" page="82" hidden="false" typeId="556e697423232344415441232323" typeName="">
+        <profile id="e2d5-2e3c-b100-b267" name="Archmagos Reductor" publicationId="cf03-f607-pubN76780" page="82" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
@@ -9069,7 +9080,7 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
         <categoryLink id="5dcb-93db-cc36-1e5d" name="New CategoryLink" hidden="false" targetId="f74d-4679-75a6-1252" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="372f-6490-ca41-0d32" name="Mastercraft a single weapon" page="0" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="372f-6490-ca41-0d32" name="Mastercraft a single weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="45d6-ab42-9a45-8a53" type="max"/>
           </constraints>
@@ -9077,7 +9088,7 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
             <cost name="pts" typeId="points" value="5.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="8952-ed12-5b98-7de7" name="Archmagos Reductor" page="0" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="8952-ed12-5b98-7de7" name="Archmagos Reductor" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="04e8-11de-2eb4-67e0" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6cfc-6f64-906f-012b" type="max"/>
             <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="75c5-daec-c572-06af" type="max"/>
@@ -9095,12 +9106,12 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="b2c2-f5cf-3b39-fce0" name="The Magos Reductor may take one of the following options:" hidden="false" collective="false">
+        <selectionEntryGroup id="b2c2-f5cf-3b39-fce0" name="The Magos Reductor may take one of the following options:" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ef05-d664-a0ef-178c" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="3142-0301-523e-e420" name="Rad/irad Cleanser" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="3142-0301-523e-e420" name="Rad/irad Cleanser" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6ac5-0786-8085-80cb" type="max"/>
               </constraints>
@@ -9111,7 +9122,7 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
                 <cost name="pts" typeId="points" value="20.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="9463-358c-b67b-483f" name="Meltagun" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="9463-358c-b67b-483f" name="Meltagun" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="38de-95a0-0b1a-dba2" type="max"/>
               </constraints>
@@ -9119,7 +9130,7 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
                 <cost name="pts" typeId="points" value="15.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="1086-cca9-7515-d06f" name="Photon Thruster" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="1086-cca9-7515-d06f" name="Photon Thruster" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ebe7-6e58-cada-e0e5" type="max"/>
               </constraints>
@@ -9130,7 +9141,7 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
                 <cost name="pts" typeId="points" value="30.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="7b6a-f36e-0fa8-b2be" name="Phased Plasma Fusil" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="7b6a-f36e-0fa8-b2be" name="Phased Plasma Fusil" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5050-bb61-9a14-e002" type="max"/>
               </constraints>
@@ -9143,7 +9154,7 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
             </selectionEntry>
           </selectionEntries>
           <entryLinks>
-            <entryLink id="42d5-ff1c-179b-7be3" name="Chainfist" hidden="false" collective="false" targetId="914e-e579-13d7-d272" type="selectionEntry">
+            <entryLink id="42d5-ff1c-179b-7be3" name="Chainfist" hidden="false" collective="false" import="true" targetId="914e-e579-13d7-d272" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="points" value="20"/>
               </modifiers>
@@ -9151,7 +9162,7 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="31f3-4193-6a09-d3d3" type="max"/>
               </constraints>
             </entryLink>
-            <entryLink id="43e2-0180-b576-3124" name="Paragon Blade" hidden="false" collective="false" targetId="b4b1-1973-4aa3-bbd2" type="selectionEntry">
+            <entryLink id="43e2-0180-b576-3124" name="Paragon Blade" hidden="false" collective="false" import="true" targetId="b4b1-1973-4aa3-bbd2" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="hidden" value="false">
                   <conditions>
@@ -9160,12 +9171,12 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
                 </modifier>
               </modifiers>
             </entryLink>
-            <entryLink id="16dc-d9b0-ed42-674e" name="Graviton Gun" hidden="false" collective="false" targetId="4e6055a9-83c9-d85b-e657-0cb85f3f1fcc" type="selectionEntry">
+            <entryLink id="16dc-d9b0-ed42-674e" name="Graviton Gun" hidden="false" collective="false" import="true" targetId="4e6055a9-83c9-d85b-e657-0cb85f3f1fcc" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="points" value="15"/>
               </modifiers>
             </entryLink>
-            <entryLink id="b88b-242f-e5f0-460b" name="Divining Blades" hidden="false" collective="false" targetId="3812-6e1b-33c3-9a88" type="selectionEntry">
+            <entryLink id="b88b-242f-e5f0-460b" name="Divining Blades" hidden="false" collective="false" import="true" targetId="3812-6e1b-33c3-9a88" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="hidden" value="false">
                   <conditions>
@@ -9178,9 +9189,9 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="0d38-2a53-4395-130f" name="May take any of the following:" hidden="false" collective="false">
+        <selectionEntryGroup id="0d38-2a53-4395-130f" name="May take any of the following:" hidden="false" collective="false" import="true">
           <selectionEntries>
-            <selectionEntry id="71bb-299d-de81-f3fd" name="Cyber-familiar" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="71bb-299d-de81-f3fd" name="Cyber-familiar" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1eb7-5f44-6642-90a5" type="max"/>
               </constraints>
@@ -9191,7 +9202,7 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
                 <cost name="pts" typeId="points" value="15.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="c407-ef6e-c1e4-d44a" name="Infravisor" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="c407-ef6e-c1e4-d44a" name="Infravisor" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="91dc-c58a-7602-d81d" type="max"/>
               </constraints>
@@ -9202,7 +9213,7 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
                 <cost name="pts" typeId="points" value="5.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="2c0d-10ec-d1c6-8325" name="Rad Grenades" publicationId="cf03-f607-pubN76780" page="83" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="2c0d-10ec-d1c6-8325" name="Rad Grenades" publicationId="cf03-f607-pubN76780" page="83" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a021-493e-4136-ca28" type="max"/>
               </constraints>
@@ -9213,7 +9224,7 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
                 <cost name="pts" typeId="points" value="10.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="4b92-12b4-08e0-3e58" name="Cortex controller" publicationId="cf03-f607-pubN76780" page="83" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="4b92-12b4-08e0-3e58" name="Cortex controller" publicationId="cf03-f607-pubN76780" page="83" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e5fa-f97c-f5f2-fa2b" type="max"/>
               </constraints>
@@ -9224,12 +9235,12 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
                 <cost name="pts" typeId="points" value="15.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="7e7d-3e63-715f-f094" name="Breacher Charges" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="7e7d-3e63-715f-f094" name="Breacher Charges" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="dfc6-5784-ad81-2c3b" type="max"/>
               </constraints>
               <profiles>
-                <profile id="c7a0-6ee7-9f8c-0aef" name="Breacher Charge" publicationId="cf03-f607-pubN80892" page="86" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+                <profile id="c7a0-6ee7-9f8c-0aef" name="Breacher Charge" publicationId="cf03-f607-pubN80892" page="86" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
                   <characteristics>
                     <characteristic name="Range" typeId="52616e676523232344415441232323">Special</characteristic>
                     <characteristic name="Strength" typeId="537472656e67746823232344415441232323">8</characteristic>
@@ -9242,7 +9253,7 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
                 <cost name="pts" typeId="points" value="10.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="a4f0-b466-b617-7425" name="Phosphex Bombs" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="a4f0-b466-b617-7425" name="Phosphex Bombs" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8c43-7cf5-ab71-4ddc" type="max"/>
               </constraints>
@@ -9254,7 +9265,7 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
                 <cost name="pts" typeId="points" value="10.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="39fe-8885-f48e-21d9" name="Cyber-occularis" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="39fe-8885-f48e-21d9" name="Cyber-occularis" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b9a7-1295-dbd2-0d3f" type="max"/>
               </constraints>
@@ -9269,7 +9280,7 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
                 <cost name="pts" typeId="points" value="15.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="c651-1c6e-1bb3-2e0a" name="Djinn-skein" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="c651-1c6e-1bb3-2e0a" name="Djinn-skein" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
@@ -9282,7 +9293,7 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e791-c34e-cb50-ae0a" type="max"/>
               </constraints>
               <profiles>
-                <profile id="b6fd-18e2-a87b-70f1" name="Djinn-skein" publicationId="cf03-f607-pubN76979" page="215" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="">
+                <profile id="b6fd-18e2-a87b-70f1" name="Djinn-skein" publicationId="cf03-f607-pubN76979" page="215" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
                   <characteristics>
                     <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Provides the following:  - At the start of his shooting phase, the Archmagos Prime may nominate a single unit from his primary detachment (including himself) within 6&quot; of him or any Cyber-occularis purchased as a part of his wargear to benefit from +1 BS. - Friendly units from the primary detachment including the Archmagos who deep strike within 6&quot; do not scatter - Barrage weapons in the same detachment may draw line of sight from the Archmagos or any of his Cyrber-occularis</characteristic>
                   </characteristics>
@@ -9294,16 +9305,16 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
             </selectionEntry>
           </selectionEntries>
           <entryLinks>
-            <entryLink id="4ac3-cda7-73fd-173d" name="New EntryLink" hidden="false" collective="false" targetId="2645-2048-de94-299c" type="selectionEntry"/>
-            <entryLink id="b5aa-728c-0688-9e50" name="New EntryLink" hidden="false" collective="false" targetId="acf4-096f-2127-80a3" type="selectionEntry"/>
+            <entryLink id="4ac3-cda7-73fd-173d" name="New EntryLink" hidden="false" collective="false" import="true" targetId="2645-2048-de94-299c" type="selectionEntry"/>
+            <entryLink id="b5aa-728c-0688-9e50" name="New EntryLink" hidden="false" collective="false" import="true" targetId="acf4-096f-2127-80a3" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="e3c1-c1dc-a079-b4c5" name="The Magos Reductor may also take one of the following options:" hidden="false" collective="false">
+        <selectionEntryGroup id="e3c1-c1dc-a079-b4c5" name="The Magos Reductor may also take one of the following options:" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4841-991e-ae49-0b22" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="fd3b-b773-c669-c4a2" name="Servo-arm" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="fd3b-b773-c669-c4a2" name="Servo-arm" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="65b5-1ee9-f2f4-89dd" type="max"/>
               </constraints>
@@ -9314,7 +9325,7 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
                 <cost name="pts" typeId="points" value="10.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="0300-1e0d-d30d-bed1" name="Graviton Imploder" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="0300-1e0d-d30d-bed1" name="Graviton Imploder" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="51a6-beea-896e-c0c5" type="max"/>
               </constraints>
@@ -9325,7 +9336,7 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
                 <cost name="pts" typeId="points" value="25.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="2307-15d7-cc6e-7a3b" name="Rad Furnace" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="2307-15d7-cc6e-7a3b" name="Rad Furnace" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e9e0-690b-9e8b-687d" type="max"/>
               </constraints>
@@ -9338,96 +9349,96 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
             </selectionEntry>
           </selectionEntries>
           <entryLinks>
-            <entryLink id="919a-ac57-084f-a5c5" name="Machinator Array" hidden="false" collective="false" targetId="9d9f-63d3-f635-7fd5" type="selectionEntry"/>
-            <entryLink id="dbf2-a20c-2c5a-f821" name="Conversion Beamer" hidden="false" collective="false" targetId="56fc88c5-200c-7d1b-dc29-64471bbf63bf" type="selectionEntry">
+            <entryLink id="919a-ac57-084f-a5c5" name="Machinator Array" hidden="false" collective="false" import="true" targetId="9d9f-63d3-f635-7fd5" type="selectionEntry"/>
+            <entryLink id="dbf2-a20c-2c5a-f821" name="Conversion Beamer" hidden="false" collective="false" import="true" targetId="56fc88c5-200c-7d1b-dc29-64471bbf63bf" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="points" value="25"/>
               </modifiers>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="3bae-d3a8-42e6-2797" name="Weapons" hidden="false" collective="false">
+        <selectionEntryGroup id="3bae-d3a8-42e6-2797" name="Weapons" hidden="false" collective="false" import="true">
           <selectionEntryGroups>
-            <selectionEntryGroup id="aedf-9d68-cf6e-dc67" name="Exchange Lucifex for:" hidden="false" collective="false" defaultSelectionEntryId="27b9-9c95-c287-3902">
+            <selectionEntryGroup id="aedf-9d68-cf6e-dc67" name="Exchange Lucifex for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="27b9-9c95-c287-3902">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="d0b0-11c9-9060-6251" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="35c4-4205-aab5-693e" type="min"/>
               </constraints>
               <entryLinks>
-                <entryLink id="27b9-9c95-c287-3902" name="Lucifex" hidden="false" collective="false" targetId="722d-7306-0e19-f7df" type="selectionEntry">
+                <entryLink id="27b9-9c95-c287-3902" name="Lucifex" hidden="false" collective="false" import="true" targetId="722d-7306-0e19-f7df" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="points" value="0.0"/>
                   </modifiers>
                 </entryLink>
-                <entryLink id="a57b-a04e-959a-506b" name="Archaeotech Pistol" hidden="false" collective="false" targetId="e884-dd64-6171-4c9a" type="selectionEntry"/>
-                <entryLink id="f2c6-bd6d-d42e-4fac" name="Corposant stave" hidden="false" collective="false" targetId="4327-a78f-a2cf-17f7" type="selectionEntry">
+                <entryLink id="a57b-a04e-959a-506b" name="Archaeotech Pistol" hidden="false" collective="false" import="true" targetId="e884-dd64-6171-4c9a" type="selectionEntry"/>
+                <entryLink id="f2c6-bd6d-d42e-4fac" name="Corposant stave" hidden="false" collective="false" import="true" targetId="4327-a78f-a2cf-17f7" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="points" value="5"/>
                   </modifiers>
                 </entryLink>
-                <entryLink id="059a-99b4-542f-5064" name="Maxim Bolter" hidden="false" collective="false" targetId="5f0f-e635-7ceb-44f9" type="selectionEntry"/>
-                <entryLink id="3696-8aa9-3aaf-1b02" name="Photon Gauntlet" hidden="false" collective="false" targetId="544a-70f1-4560-482b" type="selectionEntry"/>
-                <entryLink id="5cda-1e60-2e3e-96a6" name="Plasma Pistol" hidden="false" collective="false" targetId="f65a-de84-8c56-723c" type="selectionEntry"/>
-                <entryLink id="6919-0198-196f-4779" name="Volkite Charger" hidden="false" collective="false" targetId="2075c6c6-b54d-2d3e-fce9-0543efa392f8" type="selectionEntry">
+                <entryLink id="059a-99b4-542f-5064" name="Maxim Bolter" hidden="false" collective="false" import="true" targetId="5f0f-e635-7ceb-44f9" type="selectionEntry"/>
+                <entryLink id="3696-8aa9-3aaf-1b02" name="Photon Gauntlet" hidden="false" collective="false" import="true" targetId="544a-70f1-4560-482b" type="selectionEntry"/>
+                <entryLink id="5cda-1e60-2e3e-96a6" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="f65a-de84-8c56-723c" type="selectionEntry"/>
+                <entryLink id="6919-0198-196f-4779" name="Volkite Charger" hidden="false" collective="false" import="true" targetId="2075c6c6-b54d-2d3e-fce9-0543efa392f8" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="points" value="10"/>
                   </modifiers>
                 </entryLink>
-                <entryLink id="855b-a53e-be6b-9ae8" name="Power Fist" hidden="false" collective="false" targetId="f993-0633-9583-d8ed" type="selectionEntry">
+                <entryLink id="855b-a53e-be6b-9ae8" name="Power Fist" hidden="false" collective="false" import="true" targetId="f993-0633-9583-d8ed" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="points" value="15"/>
                   </modifiers>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
-            <selectionEntryGroup id="6b38-ab10-fd94-4917" name="Exchange Power axe for:" hidden="false" collective="false" defaultSelectionEntryId="d42a-fbda-1c76-f129">
+            <selectionEntryGroup id="6b38-ab10-fd94-4917" name="Exchange Power axe for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="d42a-fbda-1c76-f129">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="b997-a833-d9e6-fa3f" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="8e50-6c7b-963f-2ff8" type="min"/>
               </constraints>
               <entryLinks>
-                <entryLink id="e95e-2930-b537-29eb" name="Archaeotech Pistol" hidden="false" collective="false" targetId="e884-dd64-6171-4c9a" type="selectionEntry"/>
-                <entryLink id="7392-0536-13d0-4281" name="Corposant stave" hidden="false" collective="false" targetId="4327-a78f-a2cf-17f7" type="selectionEntry">
+                <entryLink id="e95e-2930-b537-29eb" name="Archaeotech Pistol" hidden="false" collective="false" import="true" targetId="e884-dd64-6171-4c9a" type="selectionEntry"/>
+                <entryLink id="7392-0536-13d0-4281" name="Corposant stave" hidden="false" collective="false" import="true" targetId="4327-a78f-a2cf-17f7" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="points" value="5"/>
                   </modifiers>
                 </entryLink>
-                <entryLink id="25eb-e279-2c91-458a" name="Maxim Bolter" hidden="false" collective="false" targetId="5f0f-e635-7ceb-44f9" type="selectionEntry"/>
-                <entryLink id="f695-5424-dbd9-43bf" name="Photon Gauntlet" hidden="false" collective="false" targetId="544a-70f1-4560-482b" type="selectionEntry"/>
-                <entryLink id="89d8-b14d-8d0e-3b05" name="Plasma Pistol" hidden="false" collective="false" targetId="f65a-de84-8c56-723c" type="selectionEntry"/>
-                <entryLink id="d811-bd6b-cbc4-55d7" name="Volkite Charger" hidden="false" collective="false" targetId="2075c6c6-b54d-2d3e-fce9-0543efa392f8" type="selectionEntry">
+                <entryLink id="25eb-e279-2c91-458a" name="Maxim Bolter" hidden="false" collective="false" import="true" targetId="5f0f-e635-7ceb-44f9" type="selectionEntry"/>
+                <entryLink id="f695-5424-dbd9-43bf" name="Photon Gauntlet" hidden="false" collective="false" import="true" targetId="544a-70f1-4560-482b" type="selectionEntry"/>
+                <entryLink id="89d8-b14d-8d0e-3b05" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="f65a-de84-8c56-723c" type="selectionEntry"/>
+                <entryLink id="d811-bd6b-cbc4-55d7" name="Volkite Charger" hidden="false" collective="false" import="true" targetId="2075c6c6-b54d-2d3e-fce9-0543efa392f8" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="points" value="10"/>
                   </modifiers>
                 </entryLink>
-                <entryLink id="c2a8-25b9-f9dd-66cf" name="Power Fist" hidden="false" collective="false" targetId="f993-0633-9583-d8ed" type="selectionEntry">
+                <entryLink id="c2a8-25b9-f9dd-66cf" name="Power Fist" hidden="false" collective="false" import="true" targetId="f993-0633-9583-d8ed" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="points" value="15"/>
                   </modifiers>
                 </entryLink>
-                <entryLink id="d42a-fbda-1c76-f129" name="Power Axe" hidden="false" collective="false" targetId="1695-a895-5233-71db" type="selectionEntry"/>
+                <entryLink id="d42a-fbda-1c76-f129" name="Power Axe" hidden="false" collective="false" import="true" targetId="1695-a895-5233-71db" type="selectionEntry"/>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
         </selectionEntryGroup>
-        <selectionEntryGroup id="ec8e-fabd-a379-01bb" name="Bodyguard" hidden="false" collective="false">
+        <selectionEntryGroup id="ec8e-fabd-a379-01bb" name="Bodyguard" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="e45c-385b-373f-0636" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="189d-08db-a19d-dbcc" name="Scyllax Guardian-Automata Covenant" hidden="false" collective="false" targetId="314b-bec3-5501-a0aa" type="selectionEntry">
+            <entryLink id="189d-08db-a19d-dbcc" name="Scyllax Guardian-Automata Covenant" hidden="false" collective="false" import="true" targetId="314b-bec3-5501-a0aa" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="maxSelections" value="1"/>
               </modifiers>
             </entryLink>
-            <entryLink id="a3f2-955c-b525-5114" hidden="false" collective="false" targetId="bcad-45c9-3b27-a7ca" type="selectionEntry">
+            <entryLink id="a3f2-955c-b525-5114" hidden="false" collective="false" import="true" targetId="bcad-45c9-3b27-a7ca" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="maxSelections" value="1"/>
               </modifiers>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="9911-2ef9-e724-b235" name="Psyarkana" hidden="false" collective="false">
+        <selectionEntryGroup id="9911-2ef9-e724-b235" name="Psyarkana" hidden="false" collective="false" import="true">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
@@ -9444,7 +9455,7 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f462-934a-c045-2f7a" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="b6c3-2a6f-ef56-6634" name="Icon of the Blazing Sun" hidden="false" collective="false" targetId="b2fe-de24-0c45-9b4d" type="selectionEntry">
+            <entryLink id="b6c3-2a6f-ef56-6634" name="Icon of the Blazing Sun" hidden="false" collective="false" import="true" targetId="b2fe-de24-0c45-9b4d" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="hidden" value="false">
                   <conditions>
@@ -9453,12 +9464,12 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
                 </modifier>
               </modifiers>
             </entryLink>
-            <entryLink id="3e2f-1bb4-b795-07c4" name="Terminal Lucidity Injectors" hidden="false" collective="false" targetId="66e2-6760-fb6a-edc3" type="selectionEntry">
+            <entryLink id="3e2f-1bb4-b795-07c4" name="Terminal Lucidity Injectors" hidden="false" collective="false" import="true" targetId="66e2-6760-fb6a-edc3" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="hidden" value="false"/>
               </modifiers>
             </entryLink>
-            <entryLink id="856a-6228-5871-8d41" name="The Liber Magra Veneficarum" hidden="false" collective="false" targetId="49dd-55d6-fa07-8cb5" type="selectionEntry">
+            <entryLink id="856a-6228-5871-8d41" name="The Liber Magra Veneficarum" hidden="false" collective="false" import="true" targetId="49dd-55d6-fa07-8cb5" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="hidden" value="false">
                   <conditions>
@@ -9471,8 +9482,8 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="85b6-d34f-8949-cb91" name="May be mounted on:" hidden="false" collective="false" targetId="df18-c724-2a3d-a6e5" type="selectionEntryGroup"/>
-        <entryLink id="5132-18be-4d0c-2cda" name="Djinn-skein (Warlord-Only)" hidden="true" collective="false" targetId="91ea-9aa8-13dd-7775" type="selectionEntry">
+        <entryLink id="85b6-d34f-8949-cb91" name="May be mounted on:" hidden="false" collective="false" import="true" targetId="df18-c724-2a3d-a6e5" type="selectionEntryGroup"/>
+        <entryLink id="5132-18be-4d0c-2cda" name="Djinn-skein (Warlord-Only)" hidden="true" collective="false" import="true" targetId="91ea-9aa8-13dd-7775" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
@@ -9486,7 +9497,7 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
         <cost name="pts" typeId="points" value="125.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="a087-30ae-b858-1c8e" name="Magos Reductor Calleb Decima" publicationId="cf03-f607-pubN76780" page="32-33" hidden="false" collective="false" type="unit">
+    <selectionEntry id="a087-30ae-b858-1c8e" name="Magos Reductor Calleb Decima" publicationId="cf03-f607-pubN76780" page="32-33" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -9500,7 +9511,7 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
         </modifier>
       </modifiers>
       <profiles>
-        <profile id="1bd8-a33d-63f8-c779" name="Calleb Decima" publicationId="cf03-f607-pubN123006" page="277" hidden="false" typeId="556e697423232344415441232323" typeName="">
+        <profile id="1bd8-a33d-63f8-c779" name="Calleb Decima" publicationId="cf03-f607-pubN123006" page="277" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
           <characteristics>
             <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry (Character)</characteristic>
             <characteristic name="WS" typeId="575323232344415441232323">3</characteristic>
@@ -9514,7 +9525,7 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
             <characteristic name="Save" typeId="5361766523232344415441232323">3+</characteristic>
           </characteristics>
         </profile>
-        <profile id="28b3-4026-5390-e0fc" name="Curse of the Omnissiah" publicationId="cf03-f607-pubN123006" page="278" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+        <profile id="28b3-4026-5390-e0fc" name="Curse of the Omnissiah" publicationId="cf03-f607-pubN123006" page="278" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
           <characteristics>
             <characteristic name="Range" typeId="52616e676523232344415441232323">18&quot;</characteristic>
             <characteristic name="Strength" typeId="537472656e67746823232344415441232323">3</characteristic>
@@ -9548,7 +9559,7 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
         <categoryLink id="532f-7d82-85e8-0e9d" name="New CategoryLink" hidden="false" targetId="becd-7a6d-e80f-878e" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="b3da-c8e4-6c50-942b" name="Decima Invictus" publicationId="cf03-f607-pubN76780" page="33" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="b3da-c8e4-6c50-942b" name="Decima Invictus" publicationId="cf03-f607-pubN76780" page="33" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b493-c397-6858-8ad1" type="max"/>
           </constraints>
@@ -9565,9 +9576,9 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="3344-d63a-eac2-8b8e" name="Servo-automata" hidden="false" collective="false">
+        <selectionEntryGroup id="3344-d63a-eac2-8b8e" name="Servo-automata" hidden="false" collective="false" import="true">
           <selectionEntries>
-            <selectionEntry id="54a1-21ba-7266-af78" name="Servo-automata" page="0" hidden="false" collective="false" type="model">
+            <selectionEntry id="54a1-21ba-7266-af78" name="Servo-automata" page="0" hidden="false" collective="false" import="true" type="model">
               <constraints>
                 <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d575-98f3-12ad-5fd7" type="max"/>
               </constraints>
@@ -9581,7 +9592,7 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
             </selectionEntry>
           </selectionEntries>
           <selectionEntryGroups>
-            <selectionEntryGroup id="e8d5-dcbb-7dd0-7eb5" name="Exchange bolter for:" hidden="false" collective="false">
+            <selectionEntryGroup id="e8d5-dcbb-7dd0-7eb5" name="Exchange bolter for:" hidden="false" collective="false" import="true">
               <modifiers>
                 <modifier type="increment" field="77d4-e2f9-a158-c59d" value="1">
                   <repeats>
@@ -9593,7 +9604,7 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
                 <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="77d4-e2f9-a158-c59d" type="max"/>
               </constraints>
               <selectionEntries>
-                <selectionEntry id="8c2a-e841-2033-5401" name="Power fist" page="0" hidden="false" collective="false" type="upgrade">
+                <selectionEntry id="8c2a-e841-2033-5401" name="Power fist" page="0" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
                     <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="40c3-d958-1a55-ad3d" type="max"/>
                   </constraints>
@@ -9601,7 +9612,7 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
                     <cost name="pts" typeId="points" value="15.0"/>
                   </costs>
                 </selectionEntry>
-                <selectionEntry id="1ed6-f190-24ee-6950" name="Lascutter" page="0" hidden="false" collective="false" type="upgrade">
+                <selectionEntry id="1ed6-f190-24ee-6950" name="Lascutter" page="0" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
                     <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="693a-212f-c19f-fe52" type="max"/>
                   </constraints>
@@ -9613,7 +9624,7 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
                     <cost name="pts" typeId="points" value="5.0"/>
                   </costs>
                 </selectionEntry>
-                <selectionEntry id="4423-ec6a-2333-4b58" name="Flamer" page="0" hidden="false" collective="false" type="upgrade">
+                <selectionEntry id="4423-ec6a-2333-4b58" name="Flamer" page="0" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
                     <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3a27-28dd-450e-a726" type="max"/>
                   </constraints>
@@ -9621,7 +9632,7 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
                     <cost name="pts" typeId="points" value="5.0"/>
                   </costs>
                 </selectionEntry>
-                <selectionEntry id="fe16-5051-82fd-0cf9" name="Rotor Cannon" page="0" hidden="false" collective="false" type="upgrade">
+                <selectionEntry id="fe16-5051-82fd-0cf9" name="Rotor Cannon" page="0" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
                     <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0151-7f85-c979-f4ce" type="max"/>
                   </constraints>
@@ -9638,14 +9649,14 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="fc9b-b619-b8cd-bf76" name="Cyber-familiar" hidden="false" collective="false" targetId="dd09a633-0c59-7ea7-d62e-e978aefb3cff" type="selectionEntry"/>
-        <entryLink id="c692-95ee-a268-68e5" hidden="false" collective="false" targetId="0de5-5b51-907d-e5e2" type="selectionEntry"/>
+        <entryLink id="fc9b-b619-b8cd-bf76" name="Cyber-familiar" hidden="false" collective="false" import="true" targetId="dd09a633-0c59-7ea7-d62e-e978aefb3cff" type="selectionEntry"/>
+        <entryLink id="c692-95ee-a268-68e5" hidden="false" collective="false" import="true" targetId="0de5-5b51-907d-e5e2" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="175.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="c89b-889f-bb97-a271" name="Myrmidon Destructors" publicationId="cf03-f607-pubN76979" page="229" hidden="false" collective="false" type="unit">
+    <selectionEntry id="c89b-889f-bb97-a271" name="Myrmidon Destructors" publicationId="cf03-f607-pubN76979" page="229" hidden="false" collective="false" import="true" type="unit">
       <rules>
         <rule id="700e-5378-627e-a333" name="Preferred Enemy (Everything)" page="0" hidden="false"/>
       </rules>
@@ -9659,13 +9670,13 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
         <categoryLink id="5092-523d-1a51-bc00" name="New CategoryLink" hidden="false" targetId="f74d-4679-75a6-1252" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="3fbd-4d31-f416-80e8" name="Myrmidon Destructor" hidden="false" collective="false" type="model">
+        <selectionEntry id="3fbd-4d31-f416-80e8" name="Myrmidon Destructor" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f41f-7135-0c52-4373" type="min"/>
             <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9106-aa7f-2b38-f001" type="max"/>
           </constraints>
           <profiles>
-            <profile id="ead8-11f9-2edd-9b5d" name="Myrmidon Destructors" publicationId="cf03-f607-pubN76979" page="229" hidden="false" typeId="556e697423232344415441232323" typeName="">
+            <profile id="ead8-11f9-2edd-9b5d" name="Myrmidon Destructors" publicationId="cf03-f607-pubN76979" page="229" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry</characteristic>
                 <characteristic name="WS" typeId="575323232344415441232323">4</characteristic>
@@ -9681,36 +9692,36 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
             </profile>
           </profiles>
           <selectionEntryGroups>
-            <selectionEntryGroup id="c194-5d1a-b22a-7771" name="Each Myrmidon Destructor must choose one:" hidden="false" collective="false">
+            <selectionEntryGroup id="c194-5d1a-b22a-7771" name="Each Myrmidon Destructor must choose one:" hidden="false" collective="false" import="true">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="9589-275d-0b9c-cb5a" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="d8f0-c089-006a-2354" type="max"/>
               </constraints>
               <entryLinks>
-                <entryLink id="22d8-16f4-9679-5b93" name="Conversion Beamer" hidden="false" collective="false" targetId="56fc88c5-200c-7d1b-dc29-64471bbf63bf" type="selectionEntry">
+                <entryLink id="22d8-16f4-9679-5b93" name="Conversion Beamer" hidden="false" collective="false" import="true" targetId="56fc88c5-200c-7d1b-dc29-64471bbf63bf" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="maxSelections" value="9"/>
                     <modifier type="set" field="points" value="35"/>
                   </modifiers>
                 </entryLink>
-                <entryLink id="36f9-45cf-2de3-8713" name="Graviton Imploder" hidden="false" collective="false" targetId="231a-26e7-f47f-6f5a" type="selectionEntry">
+                <entryLink id="36f9-45cf-2de3-8713" name="Graviton Imploder" hidden="false" collective="false" import="true" targetId="231a-26e7-f47f-6f5a" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="points" value="35"/>
                   </modifiers>
                 </entryLink>
-                <entryLink id="e6fd-dba7-b0ca-1efa" name="Irradiation engines" hidden="false" collective="false" targetId="3cd4-7aba-24a0-37b8" type="selectionEntry"/>
-                <entryLink id="e766-3eeb-9d0f-3f76" name="Volkite Culverin" hidden="false" collective="false" targetId="edadef72-c786-ab75-6888-15d0cc090857" type="selectionEntry">
+                <entryLink id="e6fd-dba7-b0ca-1efa" name="Irradiation engines" hidden="false" collective="false" import="true" targetId="3cd4-7aba-24a0-37b8" type="selectionEntry"/>
+                <entryLink id="e766-3eeb-9d0f-3f76" name="Volkite Culverin" hidden="false" collective="false" import="true" targetId="edadef72-c786-ab75-6888-15d0cc090857" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="points" value="25"/>
                     <modifier type="set" field="maxSelections" value="9"/>
                   </modifiers>
                 </entryLink>
-                <entryLink id="cfb9-9381-faee-8c0d" name="Photon Thruster Cannon" hidden="false" collective="false" targetId="761b-4ac7-370a-3c47" type="selectionEntry"/>
+                <entryLink id="cfb9-9381-faee-8c0d" name="Photon Thruster Cannon" hidden="false" collective="false" import="true" targetId="761b-4ac7-370a-3c47" type="selectionEntry"/>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks>
-            <entryLink id="c7f5-2d14-c775-679a" name="Power Fist" hidden="false" collective="false" targetId="f993-0633-9583-d8ed" type="selectionEntry">
+            <entryLink id="c7f5-2d14-c775-679a" name="Power Fist" hidden="false" collective="false" import="true" targetId="f993-0633-9583-d8ed" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="points" value="0.0"/>
               </modifiers>
@@ -9719,9 +9730,9 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b864-b797-09b4-0624" type="min"/>
               </constraints>
             </entryLink>
-            <entryLink id="424d-b6d2-ed34-5d22" name="Frag and Krak grenades" hidden="false" collective="false" targetId="e8ea-b5c1-7636-cbb3" type="selectionEntry"/>
-            <entryLink id="c43e-be6c-653d-079d" name="Infravisor" hidden="false" collective="false" targetId="f921-3533-183e-c741" type="selectionEntry"/>
-            <entryLink id="f860-0cb3-3969-924d" name="Refractor Field" hidden="false" collective="false" targetId="40e37f6e-a984-4232-4dc4-807ed9028f62" type="selectionEntry">
+            <entryLink id="424d-b6d2-ed34-5d22" name="Frag and Krak grenades" hidden="false" collective="false" import="true" targetId="e8ea-b5c1-7636-cbb3" type="selectionEntry"/>
+            <entryLink id="c43e-be6c-653d-079d" name="Infravisor" hidden="false" collective="false" import="true" targetId="f921-3533-183e-c741" type="selectionEntry"/>
+            <entryLink id="f860-0cb3-3969-924d" name="Refractor Field" hidden="false" collective="false" import="true" targetId="40e37f6e-a984-4232-4dc4-807ed9028f62" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="points" value="0.0"/>
               </modifiers>
@@ -9734,13 +9745,13 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
             <cost name="pts" typeId="points" value="40.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="39cb-27f0-9047-527e" name="Myrmidon Lord" page="0" hidden="false" collective="false" type="model">
+        <selectionEntry id="39cb-27f0-9047-527e" name="Myrmidon Lord" page="0" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7b6a-c137-80c9-a64d" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b0d8-1333-324c-51c5" type="max"/>
           </constraints>
           <profiles>
-            <profile id="2637-d9db-8352-0d8b" name="Myrmidon Lord" publicationId="cf03-f607-pubN76979" page="229" hidden="false" typeId="556e697423232344415441232323" typeName="">
+            <profile id="2637-d9db-8352-0d8b" name="Myrmidon Lord" publicationId="cf03-f607-pubN76979" page="229" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry (Character)</characteristic>
                 <characteristic name="WS" typeId="575323232344415441232323">4</characteristic>
@@ -9759,34 +9770,34 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
             <infoLink id="3647-d605-5662-7aaa" name="Refractor Field" hidden="false" targetId="4845-0bfe-2c22-883f" type="profile"/>
           </infoLinks>
           <selectionEntryGroups>
-            <selectionEntryGroup id="17d0-4fb5-f87a-12f9" name="Myrmidon Lord must choose one:" hidden="false" collective="false">
+            <selectionEntryGroup id="17d0-4fb5-f87a-12f9" name="Myrmidon Lord must choose one:" hidden="false" collective="false" import="true">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="ec35-f22b-fdaa-5e8a" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="b3a1-f488-bc2b-427b" type="max"/>
               </constraints>
               <entryLinks>
-                <entryLink id="1fb3-6394-1ac4-3b50" name="Conversion Beamer" hidden="false" collective="false" targetId="56fc88c5-200c-7d1b-dc29-64471bbf63bf" type="selectionEntry">
+                <entryLink id="1fb3-6394-1ac4-3b50" name="Conversion Beamer" hidden="false" collective="false" import="true" targetId="56fc88c5-200c-7d1b-dc29-64471bbf63bf" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="points" value="35"/>
                   </modifiers>
                 </entryLink>
-                <entryLink id="7bef-fcd7-f214-575d" name="Graviton Imploder" hidden="false" collective="false" targetId="231a-26e7-f47f-6f5a" type="selectionEntry">
+                <entryLink id="7bef-fcd7-f214-575d" name="Graviton Imploder" hidden="false" collective="false" import="true" targetId="231a-26e7-f47f-6f5a" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="points" value="35"/>
                   </modifiers>
                 </entryLink>
-                <entryLink id="e13f-9b98-3a60-33af" name="Irradiation engines" hidden="false" collective="false" targetId="3cd4-7aba-24a0-37b8" type="selectionEntry"/>
-                <entryLink id="abc0-cb5b-b57f-738c" name="Volkite Culverin" hidden="false" collective="false" targetId="edadef72-c786-ab75-6888-15d0cc090857" type="selectionEntry">
+                <entryLink id="e13f-9b98-3a60-33af" name="Irradiation engines" hidden="false" collective="false" import="true" targetId="3cd4-7aba-24a0-37b8" type="selectionEntry"/>
+                <entryLink id="abc0-cb5b-b57f-738c" name="Volkite Culverin" hidden="false" collective="false" import="true" targetId="edadef72-c786-ab75-6888-15d0cc090857" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="points" value="25"/>
                   </modifiers>
                 </entryLink>
-                <entryLink id="7bf6-9653-044a-c167" name="Photon Thruster Cannon" hidden="false" collective="false" targetId="761b-4ac7-370a-3c47" type="selectionEntry"/>
+                <entryLink id="7bf6-9653-044a-c167" name="Photon Thruster Cannon" hidden="false" collective="false" import="true" targetId="761b-4ac7-370a-3c47" type="selectionEntry"/>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks>
-            <entryLink id="ba84-4fc7-4ed2-b821" name="Power Fist" hidden="false" collective="false" targetId="f993-0633-9583-d8ed" type="selectionEntry">
+            <entryLink id="ba84-4fc7-4ed2-b821" name="Power Fist" hidden="false" collective="false" import="true" targetId="f993-0633-9583-d8ed" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="points" value="0.0"/>
               </modifiers>
@@ -9795,9 +9806,9 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7da9-85c9-5058-56fc" type="min"/>
               </constraints>
             </entryLink>
-            <entryLink id="f660-075b-3bb3-32cd" name="Frag and Krak grenades" hidden="false" collective="false" targetId="e8ea-b5c1-7636-cbb3" type="selectionEntry"/>
-            <entryLink id="7f32-722a-1c86-8998" name="Infravisor" hidden="false" collective="false" targetId="f921-3533-183e-c741" type="selectionEntry"/>
-            <entryLink id="9d94-a35c-eb02-d896" name="Refractor Field" hidden="false" collective="false" targetId="40e37f6e-a984-4232-4dc4-807ed9028f62" type="selectionEntry">
+            <entryLink id="f660-075b-3bb3-32cd" name="Frag and Krak grenades" hidden="false" collective="false" import="true" targetId="e8ea-b5c1-7636-cbb3" type="selectionEntry"/>
+            <entryLink id="7f32-722a-1c86-8998" name="Infravisor" hidden="false" collective="false" import="true" targetId="f921-3533-183e-c741" type="selectionEntry"/>
+            <entryLink id="9d94-a35c-eb02-d896" name="Refractor Field" hidden="false" collective="false" import="true" targetId="40e37f6e-a984-4232-4dc4-807ed9028f62" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="points" value="0.0"/>
               </modifiers>
@@ -9812,13 +9823,13 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink id="e5fd-46fb-a9e6-61d5" name="Triaros Armoured Conveyor" hidden="false" collective="false" targetId="bb6538b0-0f23-8a43-9752-dd356ba76e46" type="selectionEntry"/>
+        <entryLink id="e5fd-46fb-a9e6-61d5" name="Triaros Armoured Conveyor" hidden="false" collective="false" import="true" targetId="bb6538b0-0f23-8a43-9752-dd356ba76e46" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="75ff-b7a9-dfbf-502e" name="Myrmidon Secutors" publicationId="cf03-f607-pubN76979" page="220" hidden="false" collective="false" type="unit">
+    <selectionEntry id="75ff-b7a9-dfbf-502e" name="Myrmidon Secutors" publicationId="cf03-f607-pubN76979" page="220" hidden="false" collective="false" import="true" type="unit">
       <infoLinks>
         <infoLink id="48cf-8f80-14e4-fbb2" hidden="false" targetId="8e53a9a8-1408-23bf-5be8-4601caec5d10" type="rule"/>
         <infoLink id="ee26-1bcb-47f4-a01a" hidden="false" targetId="797e55b1-251e-6606-9cb3-64661b0b18a3" type="rule"/>
@@ -9827,13 +9838,13 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
         <infoLink id="3bda-5958-f731-3c9c" name="New InfoLink" hidden="false" targetId="38d5-b6eb-bda8-2497" type="rule"/>
       </infoLinks>
       <selectionEntries>
-        <selectionEntry id="57e1-f506-4b94-3ec0" name="Myrmidon Secutor" page="0" hidden="false" collective="false" type="model">
+        <selectionEntry id="57e1-f506-4b94-3ec0" name="Myrmidon Secutor" page="0" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="314b-1bda-831c-ddbc" type="min"/>
             <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9229-f60b-abbe-0d98" type="max"/>
           </constraints>
           <profiles>
-            <profile id="7d00-15b4-62fd-3703" name="Myrmidon Secutors" publicationId="cf03-f607-pubN76979" page="220" hidden="false" typeId="556e697423232344415441232323" typeName="">
+            <profile id="7d00-15b4-62fd-3703" name="Myrmidon Secutors" publicationId="cf03-f607-pubN76979" page="220" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry</characteristic>
                 <characteristic name="WS" typeId="575323232344415441232323">4</characteristic>
@@ -9849,7 +9860,7 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
             </profile>
           </profiles>
           <selectionEntries>
-            <selectionEntry id="66cb-85cf-2883-759d" name="Power axe" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="66cb-85cf-2883-759d" name="Power axe" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1c41-3a16-c8a0-6199" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0a11-5908-4885-3edc" type="max"/>
@@ -9863,42 +9874,42 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
             </selectionEntry>
           </selectionEntries>
           <selectionEntryGroups>
-            <selectionEntryGroup id="b585-2a93-ae85-3d97" name="Must take two:" hidden="false" collective="false">
+            <selectionEntryGroup id="b585-2a93-ae85-3d97" name="Must take two:" hidden="false" collective="false" import="true">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="f68b-678a-4900-29aa" type="min"/>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="4f22-68eb-7178-5bcf" type="max"/>
               </constraints>
               <entryLinks>
-                <entryLink id="d19e-9300-9382-7271" name="Graviton Gun" hidden="false" collective="false" targetId="4e6055a9-83c9-d85b-e657-0cb85f3f1fcc" type="selectionEntry">
+                <entryLink id="d19e-9300-9382-7271" name="Graviton Gun" hidden="false" collective="false" import="true" targetId="4e6055a9-83c9-d85b-e657-0cb85f3f1fcc" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="maxSelections" value="2"/>
                     <modifier type="set" field="points" value="15"/>
                   </modifiers>
                 </entryLink>
-                <entryLink id="1a13-5e1c-28bc-8128" name="Maxima Bolter" hidden="false" collective="false" targetId="5f0f-e635-7ceb-44f9" type="selectionEntry">
+                <entryLink id="1a13-5e1c-28bc-8128" name="Maxima Bolter" hidden="false" collective="false" import="true" targetId="5f0f-e635-7ceb-44f9" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="points" value="10"/>
                   </modifiers>
                 </entryLink>
-                <entryLink id="511e-28e9-081d-b6da" name="Volkite Charger" hidden="false" collective="false" targetId="2075c6c6-b54d-2d3e-fce9-0543efa392f8" type="selectionEntry">
+                <entryLink id="511e-28e9-081d-b6da" name="Volkite Charger" hidden="false" collective="false" import="true" targetId="2075c6c6-b54d-2d3e-fce9-0543efa392f8" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="maxSelections" value="2"/>
                     <modifier type="set" field="points" value="10"/>
                   </modifiers>
                 </entryLink>
-                <entryLink id="5d3b-e0da-0d05-59d5" name="Irad-Cleanser" hidden="false" collective="false" targetId="32e0-80f7-982d-b29a" type="selectionEntry">
+                <entryLink id="5d3b-e0da-0d05-59d5" name="Irad-Cleanser" hidden="false" collective="false" import="true" targetId="32e0-80f7-982d-b29a" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="points" value="20"/>
                   </modifiers>
                 </entryLink>
-                <entryLink id="c28a-1d4e-208e-c05f" name="Phased Plasma-fusil" hidden="false" collective="false" targetId="d4ac-c006-b6fd-7901" type="selectionEntry"/>
+                <entryLink id="c28a-1d4e-208e-c05f" name="Phased Plasma-fusil" hidden="false" collective="false" import="true" targetId="d4ac-c006-b6fd-7901" type="selectionEntry"/>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks>
-            <entryLink id="909e-07ac-38f8-8149" name="Frag and Krak grenades" hidden="false" collective="false" targetId="e8ea-b5c1-7636-cbb3" type="selectionEntry"/>
-            <entryLink id="b832-043d-777a-1276" name="Infravisor" hidden="false" collective="false" targetId="f921-3533-183e-c741" type="selectionEntry"/>
-            <entryLink id="835b-30bc-6902-efa3" name="Refractor Field" hidden="false" collective="false" targetId="40e37f6e-a984-4232-4dc4-807ed9028f62" type="selectionEntry">
+            <entryLink id="909e-07ac-38f8-8149" name="Frag and Krak grenades" hidden="false" collective="false" import="true" targetId="e8ea-b5c1-7636-cbb3" type="selectionEntry"/>
+            <entryLink id="b832-043d-777a-1276" name="Infravisor" hidden="false" collective="false" import="true" targetId="f921-3533-183e-c741" type="selectionEntry"/>
+            <entryLink id="835b-30bc-6902-efa3" name="Refractor Field" hidden="false" collective="false" import="true" targetId="40e37f6e-a984-4232-4dc4-807ed9028f62" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="points" value="0.0"/>
               </modifiers>
@@ -9911,13 +9922,13 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
             <cost name="pts" typeId="points" value="35.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="238a-c6a0-32a3-2fd4" name="Myrmidon Lord" page="0" hidden="false" collective="false" type="model">
+        <selectionEntry id="238a-c6a0-32a3-2fd4" name="Myrmidon Lord" page="0" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6eff-1366-1329-088b" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="41f1-8c51-5c78-1ac4" type="max"/>
           </constraints>
           <profiles>
-            <profile id="d772-2831-9ca7-7de8" name="Myrmidon Lord" publicationId="cf03-f607-pubN76979" page="220" hidden="false" typeId="556e697423232344415441232323" typeName="">
+            <profile id="d772-2831-9ca7-7de8" name="Myrmidon Lord" publicationId="cf03-f607-pubN76979" page="220" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry (Character)</characteristic>
                 <characteristic name="WS" typeId="575323232344415441232323">4</characteristic>
@@ -9933,7 +9944,7 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
             </profile>
           </profiles>
           <selectionEntries>
-            <selectionEntry id="0c68-1b4f-2f25-a8ea" name="Power axe" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="0c68-1b4f-2f25-a8ea" name="Power axe" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d55b-552a-6189-5e0b" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="736b-82ff-f887-2369" type="max"/>
@@ -9947,42 +9958,42 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
             </selectionEntry>
           </selectionEntries>
           <selectionEntryGroups>
-            <selectionEntryGroup id="0265-2351-def4-0381" name="Must take two:" hidden="false" collective="false">
+            <selectionEntryGroup id="0265-2351-def4-0381" name="Must take two:" hidden="false" collective="false" import="true">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="dcf4-4604-b522-2d77" type="min"/>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8966-5bd7-02c8-26fd" type="max"/>
               </constraints>
               <entryLinks>
-                <entryLink id="dd06-11c7-aca5-3e84" name="Graviton Gun" hidden="false" collective="false" targetId="4e6055a9-83c9-d85b-e657-0cb85f3f1fcc" type="selectionEntry">
+                <entryLink id="dd06-11c7-aca5-3e84" name="Graviton Gun" hidden="false" collective="false" import="true" targetId="4e6055a9-83c9-d85b-e657-0cb85f3f1fcc" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="maxSelections" value="2"/>
                     <modifier type="set" field="points" value="15"/>
                   </modifiers>
                 </entryLink>
-                <entryLink id="aaad-ff54-38f5-aea4" name="Maxima Bolter" hidden="false" collective="false" targetId="5f0f-e635-7ceb-44f9" type="selectionEntry">
+                <entryLink id="aaad-ff54-38f5-aea4" name="Maxima Bolter" hidden="false" collective="false" import="true" targetId="5f0f-e635-7ceb-44f9" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="points" value="10"/>
                   </modifiers>
                 </entryLink>
-                <entryLink id="23e7-843c-94fe-b4cd" name="Volkite Charger" hidden="false" collective="false" targetId="2075c6c6-b54d-2d3e-fce9-0543efa392f8" type="selectionEntry">
+                <entryLink id="23e7-843c-94fe-b4cd" name="Volkite Charger" hidden="false" collective="false" import="true" targetId="2075c6c6-b54d-2d3e-fce9-0543efa392f8" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="maxSelections" value="2"/>
                     <modifier type="set" field="points" value="10"/>
                   </modifiers>
                 </entryLink>
-                <entryLink id="b6c6-3e74-800b-ba45" name="Irad-Cleanser" hidden="false" collective="false" targetId="32e0-80f7-982d-b29a" type="selectionEntry">
+                <entryLink id="b6c6-3e74-800b-ba45" name="Irad-Cleanser" hidden="false" collective="false" import="true" targetId="32e0-80f7-982d-b29a" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="points" value="20"/>
                   </modifiers>
                 </entryLink>
-                <entryLink id="d1d0-3669-a365-dfca" name="Phased Plasma-fusil" hidden="false" collective="false" targetId="d4ac-c006-b6fd-7901" type="selectionEntry"/>
+                <entryLink id="d1d0-3669-a365-dfca" name="Phased Plasma-fusil" hidden="false" collective="false" import="true" targetId="d4ac-c006-b6fd-7901" type="selectionEntry"/>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks>
-            <entryLink id="7f1e-fb0d-94d3-08a4" name="Frag and Krak grenades" hidden="false" collective="false" targetId="e8ea-b5c1-7636-cbb3" type="selectionEntry"/>
-            <entryLink id="00aa-4d63-68af-f44f" name="Infravisor" hidden="false" collective="false" targetId="f921-3533-183e-c741" type="selectionEntry"/>
-            <entryLink id="c7eb-7961-691c-0cd0" name="Refractor Field" hidden="false" collective="false" targetId="40e37f6e-a984-4232-4dc4-807ed9028f62" type="selectionEntry">
+            <entryLink id="7f1e-fb0d-94d3-08a4" name="Frag and Krak grenades" hidden="false" collective="false" import="true" targetId="e8ea-b5c1-7636-cbb3" type="selectionEntry"/>
+            <entryLink id="00aa-4d63-68af-f44f" name="Infravisor" hidden="false" collective="false" import="true" targetId="f921-3533-183e-c741" type="selectionEntry"/>
+            <entryLink id="c7eb-7961-691c-0cd0" name="Refractor Field" hidden="false" collective="false" import="true" targetId="40e37f6e-a984-4232-4dc4-807ed9028f62" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="points" value="0.0"/>
               </modifiers>
@@ -9997,13 +10008,13 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink id="168c-ee53-370d-e4af" hidden="false" collective="false" targetId="bb6538b0-0f23-8a43-9752-dd356ba76e46" type="selectionEntry"/>
+        <entryLink id="168c-ee53-370d-e4af" hidden="false" collective="false" import="true" targetId="bb6538b0-0f23-8a43-9752-dd356ba76e46" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="0f0e-f31e-a91c-3798" name="Occular Augmetics" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="0f0e-f31e-a91c-3798" name="Occular Augmetics" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="fd00-5cbb-3034-b4c6" type="max"/>
       </constraints>
@@ -10014,19 +10025,19 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
         <cost name="pts" typeId="points" value="10.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="4798-67b6-5f51-b275" name="War Machine Detachment" hidden="false" collective="false" type="unit">
+    <selectionEntry id="4798-67b6-5f51-b275" name="War Machine Detachment" hidden="false" collective="false" import="true" type="unit">
       <selectionEntryGroups>
-        <selectionEntryGroup id="543d-21ab-e9dc-df8a" name="War Machine Detachment" hidden="false" collective="false">
+        <selectionEntryGroup id="543d-21ab-e9dc-df8a" name="War Machine Detachment" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="4a01-e8c9-d0b2-06a8" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="e9f4-aaf2-48cf-37e4" name="Mechanicum Indentured Knight Styrix" hidden="false" collective="false" type="model">
+            <selectionEntry id="e9f4-aaf2-48cf-37e4" name="Mechanicum Indentured Knight Styrix" hidden="false" collective="false" import="true" type="model">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="deb5-625a-cbcc-3326" type="max"/>
               </constraints>
               <profiles>
-                <profile id="035c-aae9-601b-73f7" name="Indentured Knight Styrix" publicationId="cf03-f607-pubN76270" page="67" hidden="false" typeId="57616c6b657223232344415441232323" typeName="">
+                <profile id="035c-aae9-601b-73f7" name="Indentured Knight Styrix" publicationId="cf03-f607-pubN76270" page="67" hidden="false" typeId="57616c6b657223232344415441232323" typeName="Walker">
                   <characteristics>
                     <characteristic name="WS" typeId="575323232344415441232323">4</characteristic>
                     <characteristic name="BS" typeId="425323232344415441232323">4</characteristic>
@@ -10040,7 +10051,7 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
                     <characteristic name="Type" typeId="5479706523232344415441232323">Super-Heavy Walker</characteristic>
                   </characteristics>
                 </profile>
-                <profile id="f09d-a0a7-724f-52ae" name="Volkite Chieorovile" publicationId="cf03-f607-pubN99227" page="308" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+                <profile id="f09d-a0a7-724f-52ae" name="Volkite Chieorovile" publicationId="cf03-f607-pubN99227" page="308" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
                   <characteristics>
                     <characteristic name="Range" typeId="52616e676523232344415441232323">45&quot;</characteristic>
                     <characteristic name="Strength" typeId="537472656e67746823232344415441232323">8</characteristic>
@@ -10060,14 +10071,14 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
                 <categoryLink id="a7e6-660e-0783-5df8" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
               </categoryLinks>
               <selectionEntryGroups>
-                <selectionEntryGroup id="57ac-0c80-b0f6-87a4" name="May exchange its Reaper Chainsword for:" hidden="false" collective="false">
+                <selectionEntryGroup id="57ac-0c80-b0f6-87a4" name="May exchange its Reaper Chainsword for:" hidden="false" collective="false" import="true">
                   <selectionEntries>
-                    <selectionEntry id="740a-0521-fd0d-ea2c" name="Hekaton Siege Claw with twin-linked Rad Cleanser" hidden="false" collective="false" type="upgrade">
+                    <selectionEntry id="740a-0521-fd0d-ea2c" name="Hekaton Siege Claw with twin-linked Rad Cleanser" hidden="false" collective="false" import="true" type="upgrade">
                       <constraints>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="06c6-7a8e-b5df-a071" type="max"/>
                       </constraints>
                       <profiles>
-                        <profile id="435d-6ff3-f065-62c9" name="Hekaton Siege Claw" publicationId="cf03-f607-pubN99227" page="308" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+                        <profile id="435d-6ff3-f065-62c9" name="Hekaton Siege Claw" publicationId="cf03-f607-pubN99227" page="308" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
                           <characteristics>
                             <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
                             <characteristic name="Strength" typeId="537472656e67746823232344415441232323">D</characteristic>
@@ -10087,9 +10098,9 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
                     </selectionEntry>
                   </selectionEntries>
                 </selectionEntryGroup>
-                <selectionEntryGroup id="960a-1b5a-0d3e-b5b4" name="May be upgraded with:" hidden="false" collective="false">
+                <selectionEntryGroup id="960a-1b5a-0d3e-b5b4" name="May be upgraded with:" hidden="false" collective="false" import="true">
                   <entryLinks>
-                    <entryLink id="df3b-4f34-5dd0-ae5f" name="Occular Augmetics" hidden="false" collective="false" targetId="0f0e-f31e-a91c-3798" type="selectionEntry"/>
+                    <entryLink id="df3b-4f34-5dd0-ae5f" name="Occular Augmetics" hidden="false" collective="false" import="true" targetId="0f0e-f31e-a91c-3798" type="selectionEntry"/>
                   </entryLinks>
                 </selectionEntryGroup>
               </selectionEntryGroups>
@@ -10097,12 +10108,12 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
                 <cost name="pts" typeId="points" value="405.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="2966-ea71-6127-5966" name="Mechanicum Indentured Knight Paladin" hidden="false" collective="false" type="model">
+            <selectionEntry id="2966-ea71-6127-5966" name="Mechanicum Indentured Knight Paladin" hidden="false" collective="false" import="true" type="model">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3cab-d811-e8ba-ef22" type="max"/>
               </constraints>
               <profiles>
-                <profile id="d144-eb43-048e-b586" name="Indentured Knight Paladin" publicationId="cf03-f607-pubN76270" page="65" hidden="false" typeId="57616c6b657223232344415441232323" typeName="">
+                <profile id="d144-eb43-048e-b586" name="Indentured Knight Paladin" publicationId="cf03-f607-pubN76270" page="65" hidden="false" typeId="57616c6b657223232344415441232323" typeName="Walker">
                   <characteristics>
                     <characteristic name="WS" typeId="575323232344415441232323">4</characteristic>
                     <characteristic name="BS" typeId="425323232344415441232323">4</characteristic>
@@ -10116,7 +10127,7 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
                     <characteristic name="Type" typeId="5479706523232344415441232323">Super-heavy Walker</characteristic>
                   </characteristics>
                 </profile>
-                <profile id="d13e-933c-8b5e-cfe1" name="Questoris battlecannon" publicationId="cf03-f607-pubN99227" page="308" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+                <profile id="d13e-933c-8b5e-cfe1" name="Questoris battlecannon" publicationId="cf03-f607-pubN99227" page="308" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
                   <modifiers>
                     <modifier type="set" field="hidden" value="true">
                       <conditions>
@@ -10140,14 +10151,14 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
                 <categoryLink id="57a7-b62a-516d-deda" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
               </categoryLinks>
               <selectionEntryGroups>
-                <selectionEntryGroup id="b0d9-caa2-0c79-a754" name="May exchange Questoris battlecannon for:" hidden="false" collective="false">
+                <selectionEntryGroup id="b0d9-caa2-0c79-a754" name="May exchange Questoris battlecannon for:" hidden="false" collective="false" import="true">
                   <selectionEntries>
-                    <selectionEntry id="e3f2-3bdf-ea42-2a60" name="Rapid-fire battlecannon" hidden="false" collective="false" type="upgrade">
+                    <selectionEntry id="e3f2-3bdf-ea42-2a60" name="Rapid-fire battlecannon" hidden="false" collective="false" import="true" type="upgrade">
                       <constraints>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="692b-323f-4996-d35c" type="max"/>
                       </constraints>
                       <profiles>
-                        <profile id="bbeb-f785-6938-ae46" name="Rapid-fire battlecannon" publicationId="cf03-f607-pubN99227" page="308" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+                        <profile id="bbeb-f785-6938-ae46" name="Rapid-fire battlecannon" publicationId="cf03-f607-pubN99227" page="308" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
                           <characteristics>
                             <characteristic name="Range" typeId="52616e676523232344415441232323">72&quot;</characteristic>
                             <characteristic name="Strength" typeId="537472656e67746823232344415441232323">8</characteristic>
@@ -10162,14 +10173,14 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
                     </selectionEntry>
                   </selectionEntries>
                 </selectionEntryGroup>
-                <selectionEntryGroup id="1c49-9911-d73d-deb3" name="May be upgraded with:" hidden="false" collective="false">
+                <selectionEntryGroup id="1c49-9911-d73d-deb3" name="May be upgraded with:" hidden="false" collective="false" import="true">
                   <selectionEntries>
-                    <selectionEntry id="3a5c-d350-e9f9-3ab3" name="Bio-corrosive rounds for Heavy Stubber" hidden="false" collective="false" type="upgrade">
+                    <selectionEntry id="3a5c-d350-e9f9-3ab3" name="Bio-corrosive rounds for Heavy Stubber" hidden="false" collective="false" import="true" type="upgrade">
                       <constraints>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ad05-3e20-95a8-2bfc" type="max"/>
                       </constraints>
                       <profiles>
-                        <profile id="d3b4-11ec-672d-9b24" name="Bio-corrosive rounds for Heavy Stubber" publicationId="cf03-f607-pubN76270" page="64" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+                        <profile id="d3b4-11ec-672d-9b24" name="Bio-corrosive rounds for Heavy Stubber" publicationId="cf03-f607-pubN76270" page="64" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
                           <characteristics>
                             <characteristic name="Range" typeId="52616e676523232344415441232323">30&quot;</characteristic>
                             <characteristic name="Strength" typeId="537472656e67746823232344415441232323">2</characteristic>
@@ -10184,8 +10195,8 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
                     </selectionEntry>
                   </selectionEntries>
                   <entryLinks>
-                    <entryLink id="a268-5a78-d4d3-c79b" name="Occular Augmetics" hidden="false" collective="false" targetId="0f0e-f31e-a91c-3798" type="selectionEntry"/>
-                    <entryLink id="a4ae-4e4c-f64a-33e5" name="Blessed Autosimulacra" hidden="false" collective="false" targetId="fb66-11c0-3cb4-aac3" type="selectionEntry"/>
+                    <entryLink id="a268-5a78-d4d3-c79b" name="Occular Augmetics" hidden="false" collective="false" import="true" targetId="0f0e-f31e-a91c-3798" type="selectionEntry"/>
+                    <entryLink id="a4ae-4e4c-f64a-33e5" name="Blessed Autosimulacra" hidden="false" collective="false" import="true" targetId="fb66-11c0-3cb4-aac3" type="selectionEntry"/>
                   </entryLinks>
                 </selectionEntryGroup>
               </selectionEntryGroups>
@@ -10193,12 +10204,12 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
                 <cost name="pts" typeId="points" value="375.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="1139-5902-3c06-8c93" name="Mechanicum Indentured Knight Magaera" hidden="false" collective="false" type="model">
+            <selectionEntry id="1139-5902-3c06-8c93" name="Mechanicum Indentured Knight Magaera" hidden="false" collective="false" import="true" type="model">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ab4c-3cc4-ff5e-98ed" type="max"/>
               </constraints>
               <profiles>
-                <profile id="c491-1039-b060-25d0" name="Mechanicum Indentured Knight Magaera" publicationId="cf03-f607-pubN76270" page="68" hidden="false" typeId="57616c6b657223232344415441232323" typeName="">
+                <profile id="c491-1039-b060-25d0" name="Mechanicum Indentured Knight Magaera" publicationId="cf03-f607-pubN76270" page="68" hidden="false" typeId="57616c6b657223232344415441232323" typeName="Walker">
                   <characteristics>
                     <characteristic name="WS" typeId="575323232344415441232323">4</characteristic>
                     <characteristic name="BS" typeId="425323232344415441232323">4</characteristic>
@@ -10224,14 +10235,14 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
                 <categoryLink id="ffbb-2718-f8e5-e383" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
               </categoryLinks>
               <selectionEntryGroups>
-                <selectionEntryGroup id="bee6-be5d-a769-567f" name="May exchange its Reaper Chainsword for:" hidden="false" collective="false">
+                <selectionEntryGroup id="bee6-be5d-a769-567f" name="May exchange its Reaper Chainsword for:" hidden="false" collective="false" import="true">
                   <selectionEntries>
-                    <selectionEntry id="b7ad-400a-5f92-3fbe" name="Hekaton Siege Claw with twin-linked Rad Cleanser" hidden="false" collective="false" type="upgrade">
+                    <selectionEntry id="b7ad-400a-5f92-3fbe" name="Hekaton Siege Claw with twin-linked Rad Cleanser" hidden="false" collective="false" import="true" type="upgrade">
                       <constraints>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9e07-bc49-783e-ddb9" type="max"/>
                       </constraints>
                       <profiles>
-                        <profile id="1bf4-072d-64ab-3cda" name="Hekaton Siege Claw" publicationId="cf03-f607-pubN99227" page="308" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+                        <profile id="1bf4-072d-64ab-3cda" name="Hekaton Siege Claw" publicationId="cf03-f607-pubN99227" page="308" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
                           <characteristics>
                             <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
                             <characteristic name="Strength" typeId="537472656e67746823232344415441232323">D</characteristic>
@@ -10251,9 +10262,9 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
                     </selectionEntry>
                   </selectionEntries>
                 </selectionEntryGroup>
-                <selectionEntryGroup id="621e-cb2a-7317-9eff" name="May be upgraded with:" hidden="false" collective="false">
+                <selectionEntryGroup id="621e-cb2a-7317-9eff" name="May be upgraded with:" hidden="false" collective="false" import="true">
                   <entryLinks>
-                    <entryLink id="e166-e473-b89e-8f28" name="Occular Augmetics" hidden="false" collective="false" targetId="0f0e-f31e-a91c-3798" type="selectionEntry"/>
+                    <entryLink id="e166-e473-b89e-8f28" name="Occular Augmetics" hidden="false" collective="false" import="true" targetId="0f0e-f31e-a91c-3798" type="selectionEntry"/>
                   </entryLinks>
                 </selectionEntryGroup>
               </selectionEntryGroups>
@@ -10261,12 +10272,12 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
                 <cost name="pts" typeId="points" value="395.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="eeee-aaf7-78b1-577b" name="Mechanicum Indentured Knight Lancer" hidden="false" collective="false" type="model">
+            <selectionEntry id="eeee-aaf7-78b1-577b" name="Mechanicum Indentured Knight Lancer" hidden="false" collective="false" import="true" type="model">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="646b-4553-f2fe-08a3" type="max"/>
               </constraints>
               <profiles>
-                <profile id="542e-a372-9413-a1b5" name="Indentured Cerastus Knight-Lancer" publicationId="cf03-f607-pubN76270" page="69" hidden="false" typeId="57616c6b657223232344415441232323" typeName="">
+                <profile id="542e-a372-9413-a1b5" name="Indentured Cerastus Knight-Lancer" publicationId="cf03-f607-pubN76270" page="69" hidden="false" typeId="57616c6b657223232344415441232323" typeName="Walker">
                   <characteristics>
                     <characteristic name="WS" typeId="575323232344415441232323">4</characteristic>
                     <characteristic name="BS" typeId="425323232344415441232323">4</characteristic>
@@ -10280,7 +10291,7 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
                     <characteristic name="Type" typeId="5479706523232344415441232323">Super-heavy Walker</characteristic>
                   </characteristics>
                 </profile>
-                <profile id="bb7d-575c-f42f-0446" name="Cerastus Shock Lance (Melee)" publicationId="cf03-f607-pubN76979" page="231" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+                <profile id="bb7d-575c-f42f-0446" name="Cerastus Shock Lance (Melee)" publicationId="cf03-f607-pubN76979" page="231" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
                   <characteristics>
                     <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
                     <characteristic name="Strength" typeId="537472656e67746823232344415441232323">D</characteristic>
@@ -10288,7 +10299,7 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
                     <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Swift Strike</characteristic>
                   </characteristics>
                 </profile>
-                <profile id="032a-e68a-cb27-bb09" name="Cerastus Shock Lance (Ranged)" publicationId="cf03-f607-pubN76979" page="231" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+                <profile id="032a-e68a-cb27-bb09" name="Cerastus Shock Lance (Ranged)" publicationId="cf03-f607-pubN76979" page="231" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
                   <characteristics>
                     <characteristic name="Range" typeId="52616e676523232344415441232323">18&quot;</characteristic>
                     <characteristic name="Strength" typeId="537472656e67746823232344415441232323">7</characteristic>
@@ -10296,7 +10307,7 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
                     <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 6, Concussive</characteristic>
                   </characteristics>
                 </profile>
-                <profile id="bf51-5ebd-8e9f-7225" name="Ion Gauntlet Shield" publicationId="cf03-f607-pubN76979" page="2310" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="">
+                <profile id="bf51-5ebd-8e9f-7225" name="Ion Gauntlet Shield" publicationId="cf03-f607-pubN76979" page="2310" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
                   <characteristics>
                     <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Operates as a Knights Ion Shield with the following exceptions:  - May not protect Rear armour - Provides 5++ Invulnerable save in close combat - Forces close combat attacks by other Super-heavy Walkers or Gargantuan Creatures to suffer a -1 to hit. </characteristic>
                   </characteristics>
@@ -10315,10 +10326,10 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
                 <categoryLink id="21bb-2b2b-44d6-9f21" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
               </categoryLinks>
               <selectionEntryGroups>
-                <selectionEntryGroup id="eca0-d746-363b-041d" name="May be upgraded with:" hidden="false" collective="false">
+                <selectionEntryGroup id="eca0-d746-363b-041d" name="May be upgraded with:" hidden="false" collective="false" import="true">
                   <entryLinks>
-                    <entryLink id="2387-0420-afb8-0ab5" name="Occular Augmetics" hidden="false" collective="false" targetId="0f0e-f31e-a91c-3798" type="selectionEntry"/>
-                    <entryLink id="7e12-f145-22c6-76ce" name="Blessed Autosimulacra" hidden="false" collective="false" targetId="fb66-11c0-3cb4-aac3" type="selectionEntry"/>
+                    <entryLink id="2387-0420-afb8-0ab5" name="Occular Augmetics" hidden="false" collective="false" import="true" targetId="0f0e-f31e-a91c-3798" type="selectionEntry"/>
+                    <entryLink id="7e12-f145-22c6-76ce" name="Blessed Autosimulacra" hidden="false" collective="false" import="true" targetId="fb66-11c0-3cb4-aac3" type="selectionEntry"/>
                   </entryLinks>
                 </selectionEntryGroup>
               </selectionEntryGroups>
@@ -10326,12 +10337,12 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
                 <cost name="pts" typeId="points" value="400.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="038c-f24d-74f8-8bdd" name="Mechanicum Indentured Knight Errant" hidden="false" collective="false" type="model">
+            <selectionEntry id="038c-f24d-74f8-8bdd" name="Mechanicum Indentured Knight Errant" hidden="false" collective="false" import="true" type="model">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2832-ea46-1b20-079d" type="max"/>
               </constraints>
               <profiles>
-                <profile id="f1af-f58d-1272-cddb" name="Thermal Cannon" publicationId="cf03-f607-pubN99227" page="308" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+                <profile id="f1af-f58d-1272-cddb" name="Thermal Cannon" publicationId="cf03-f607-pubN99227" page="308" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
                   <characteristics>
                     <characteristic name="Range" typeId="52616e676523232344415441232323">36&quot;</characteristic>
                     <characteristic name="Strength" typeId="537472656e67746823232344415441232323">9</characteristic>
@@ -10339,7 +10350,7 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
                     <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 1, Melta, Large Blast</characteristic>
                   </characteristics>
                 </profile>
-                <profile id="f26b-a7e9-4586-bf19" name="Indentured Knight Errant" publicationId="cf03-f607-pubN76270" page="64" hidden="false" typeId="57616c6b657223232344415441232323" typeName="">
+                <profile id="f26b-a7e9-4586-bf19" name="Indentured Knight Errant" publicationId="cf03-f607-pubN76270" page="64" hidden="false" typeId="57616c6b657223232344415441232323" typeName="Walker">
                   <characteristics>
                     <characteristic name="WS" typeId="575323232344415441232323">4</characteristic>
                     <characteristic name="BS" typeId="425323232344415441232323">4</characteristic>
@@ -10363,14 +10374,14 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
                 <categoryLink id="251d-2be9-9ed7-372f" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
               </categoryLinks>
               <selectionEntryGroups>
-                <selectionEntryGroup id="902c-f511-4f24-c05f" name="May be upgraded with:" hidden="false" collective="false">
+                <selectionEntryGroup id="902c-f511-4f24-c05f" name="May be upgraded with:" hidden="false" collective="false" import="true">
                   <selectionEntries>
-                    <selectionEntry id="de20-2d40-8a29-0272" name="Bio-corrosive rounds for Heavy Stubber" hidden="false" collective="false" type="upgrade">
+                    <selectionEntry id="de20-2d40-8a29-0272" name="Bio-corrosive rounds for Heavy Stubber" hidden="false" collective="false" import="true" type="upgrade">
                       <constraints>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8e0d-08a3-52fc-655c" type="max"/>
                       </constraints>
                       <profiles>
-                        <profile id="5042-d066-d355-7eb8" name="Bio-corrosive rounds for Heavy Stubber" publicationId="cf03-f607-pubN76270" page="64" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+                        <profile id="5042-d066-d355-7eb8" name="Bio-corrosive rounds for Heavy Stubber" publicationId="cf03-f607-pubN76270" page="64" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
                           <characteristics>
                             <characteristic name="Range" typeId="52616e676523232344415441232323">30&quot;</characteristic>
                             <characteristic name="Strength" typeId="537472656e67746823232344415441232323">2</characteristic>
@@ -10385,8 +10396,8 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
                     </selectionEntry>
                   </selectionEntries>
                   <entryLinks>
-                    <entryLink id="8f32-af16-e690-8bcc" name="Occular Augmetics" hidden="false" collective="false" targetId="0f0e-f31e-a91c-3798" type="selectionEntry"/>
-                    <entryLink id="c9ac-7818-d8c0-97b3" name="Blessed Autosimulacra" hidden="false" collective="false" targetId="fb66-11c0-3cb4-aac3" type="selectionEntry"/>
+                    <entryLink id="8f32-af16-e690-8bcc" name="Occular Augmetics" hidden="false" collective="false" import="true" targetId="0f0e-f31e-a91c-3798" type="selectionEntry"/>
+                    <entryLink id="c9ac-7818-d8c0-97b3" name="Blessed Autosimulacra" hidden="false" collective="false" import="true" targetId="fb66-11c0-3cb4-aac3" type="selectionEntry"/>
                   </entryLinks>
                 </selectionEntryGroup>
               </selectionEntryGroups>
@@ -10394,12 +10405,12 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
                 <cost name="pts" typeId="points" value="370.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="9086-334b-e639-f041" name="Mechanicum Indentured Knight Castigator" hidden="false" collective="false" type="model">
+            <selectionEntry id="9086-334b-e639-f041" name="Mechanicum Indentured Knight Castigator" hidden="false" collective="false" import="true" type="model">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9893-f5d2-4bbb-3581" type="max"/>
               </constraints>
               <profiles>
-                <profile id="b517-03be-37f2-7565" name="Castigator pattern bolt cannon" publicationId="cf03-f607-pubN99227" page="308" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+                <profile id="b517-03be-37f2-7565" name="Castigator pattern bolt cannon" publicationId="cf03-f607-pubN99227" page="308" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
                   <characteristics>
                     <characteristic name="Range" typeId="52616e676523232344415441232323">36&quot;</characteristic>
                     <characteristic name="Strength" typeId="537472656e67746823232344415441232323">7</characteristic>
@@ -10407,7 +10418,7 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
                     <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 8</characteristic>
                   </characteristics>
                 </profile>
-                <profile id="bf45-800e-e996-a43a" name="Indentured Cerastus Knight-Castigator" publicationId="cf03-f607-pubN76270" page="70" hidden="false" typeId="57616c6b657223232344415441232323" typeName="">
+                <profile id="bf45-800e-e996-a43a" name="Indentured Cerastus Knight-Castigator" publicationId="cf03-f607-pubN76270" page="70" hidden="false" typeId="57616c6b657223232344415441232323" typeName="Walker">
                   <characteristics>
                     <characteristic name="WS" typeId="575323232344415441232323">4</characteristic>
                     <characteristic name="BS" typeId="425323232344415441232323">4</characteristic>
@@ -10421,7 +10432,7 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
                     <characteristic name="Type" typeId="5479706523232344415441232323">Super-heavy Walker</characteristic>
                   </characteristics>
                 </profile>
-                <profile id="36e9-c295-f165-2787" name="Tempest Warblade" publicationId="cf03-f607-pubN99227" page="308" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+                <profile id="36e9-c295-f165-2787" name="Tempest Warblade" publicationId="cf03-f607-pubN99227" page="308" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
                   <characteristics>
                     <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
                     <characteristic name="Strength" typeId="537472656e67746823232344415441232323">10</characteristic>
@@ -10444,10 +10455,10 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
                 <categoryLink id="fe7b-acc8-c980-4c37" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
               </categoryLinks>
               <selectionEntryGroups>
-                <selectionEntryGroup id="948e-b081-a207-773f" name="May be upgraded with:" hidden="false" collective="false">
+                <selectionEntryGroup id="948e-b081-a207-773f" name="May be upgraded with:" hidden="false" collective="false" import="true">
                   <entryLinks>
-                    <entryLink id="8c8f-4673-135c-2a21" name="Occular Augmetics" hidden="false" collective="false" targetId="0f0e-f31e-a91c-3798" type="selectionEntry"/>
-                    <entryLink id="4e7c-6c35-6eb0-2ef4" name="Blessed Autosimulacra" hidden="false" collective="false" targetId="fb66-11c0-3cb4-aac3" type="selectionEntry"/>
+                    <entryLink id="8c8f-4673-135c-2a21" name="Occular Augmetics" hidden="false" collective="false" import="true" targetId="0f0e-f31e-a91c-3798" type="selectionEntry"/>
+                    <entryLink id="4e7c-6c35-6eb0-2ef4" name="Blessed Autosimulacra" hidden="false" collective="false" import="true" targetId="fb66-11c0-3cb4-aac3" type="selectionEntry"/>
                   </entryLinks>
                 </selectionEntryGroup>
               </selectionEntryGroups>
@@ -10455,12 +10466,12 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
                 <cost name="pts" typeId="points" value="380.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="e5b2-0a11-f043-1920" name="Mechanicum Indentured Knight Acheron" hidden="false" collective="false" type="model">
+            <selectionEntry id="e5b2-0a11-f043-1920" name="Mechanicum Indentured Knight Acheron" hidden="false" collective="false" import="true" type="model">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9144-a17d-2720-7ff1" type="max"/>
               </constraints>
               <profiles>
-                <profile id="5765-29a9-20f4-9adb" name="Acheron pattern flame cannon" publicationId="cf03-f607-pubN99227" page="308" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+                <profile id="5765-29a9-20f4-9adb" name="Acheron pattern flame cannon" publicationId="cf03-f607-pubN99227" page="308" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
                   <characteristics>
                     <characteristic name="Range" typeId="52616e676523232344415441232323">Hellstorm</characteristic>
                     <characteristic name="Strength" typeId="537472656e67746823232344415441232323">7</characteristic>
@@ -10468,7 +10479,7 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
                     <characteristic name="Type" typeId="5479706523232344415441232323">Ordnance 1</characteristic>
                   </characteristics>
                 </profile>
-                <profile id="8630-de3a-5509-373d" name="Indentured Cerastus Knight-Acheron" publicationId="cf03-f607-pubN76270" page="71" hidden="false" typeId="57616c6b657223232344415441232323" typeName="">
+                <profile id="8630-de3a-5509-373d" name="Indentured Cerastus Knight-Acheron" publicationId="cf03-f607-pubN76270" page="71" hidden="false" typeId="57616c6b657223232344415441232323" typeName="Walker">
                   <characteristics>
                     <characteristic name="WS" typeId="575323232344415441232323">4</characteristic>
                     <characteristic name="BS" typeId="425323232344415441232323">4</characteristic>
@@ -10482,7 +10493,7 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
                     <characteristic name="Type" typeId="5479706523232344415441232323">Super-heavy Walker</characteristic>
                   </characteristics>
                 </profile>
-                <profile id="d772-02d8-8b8a-d889" name="Reaper Chainfist" publicationId="cf03-f607-pubN99227" page="308" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+                <profile id="d772-02d8-8b8a-d889" name="Reaper Chainfist" publicationId="cf03-f607-pubN99227" page="308" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
                   <characteristics>
                     <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
                     <characteristic name="Strength" typeId="537472656e67746823232344415441232323">D</characteristic>
@@ -10504,10 +10515,10 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
                 <categoryLink id="6611-80c3-4ef3-577a" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
               </categoryLinks>
               <selectionEntryGroups>
-                <selectionEntryGroup id="e54b-4101-6ebd-8f02" name="May be upgraded with:" hidden="false" collective="false">
+                <selectionEntryGroup id="e54b-4101-6ebd-8f02" name="May be upgraded with:" hidden="false" collective="false" import="true">
                   <entryLinks>
-                    <entryLink id="6fc7-cab4-a201-079d" name="Occular Augmetics" hidden="false" collective="false" targetId="0f0e-f31e-a91c-3798" type="selectionEntry"/>
-                    <entryLink id="b3d0-e207-c645-42bb" name="Blessed Autosimulacra" hidden="false" collective="false" targetId="fb66-11c0-3cb4-aac3" type="selectionEntry"/>
+                    <entryLink id="6fc7-cab4-a201-079d" name="Occular Augmetics" hidden="false" collective="false" import="true" targetId="0f0e-f31e-a91c-3798" type="selectionEntry"/>
+                    <entryLink id="b3d0-e207-c645-42bb" name="Blessed Autosimulacra" hidden="false" collective="false" import="true" targetId="fb66-11c0-3cb4-aac3" type="selectionEntry"/>
                   </entryLinks>
                 </selectionEntryGroup>
               </selectionEntryGroups>
@@ -10515,12 +10526,12 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
                 <cost name="pts" typeId="points" value="415.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="80da-b251-d095-a823" name="Mechanicum Indentured Knight Atrapos" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="80da-b251-d095-a823" name="Mechanicum Indentured Knight Atrapos" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e223-0122-19f5-1302" type="max"/>
               </constraints>
               <profiles>
-                <profile id="282b-ba4d-ee95-46ab" name="Indentured Knight Atrapos" publicationId="cf03-f607-pubN80487" page="278" hidden="false" typeId="57616c6b657223232344415441232323" typeName="">
+                <profile id="282b-ba4d-ee95-46ab" name="Indentured Knight Atrapos" publicationId="cf03-f607-pubN80487" page="278" hidden="false" typeId="57616c6b657223232344415441232323" typeName="Walker">
                   <characteristics>
                     <characteristic name="WS" typeId="575323232344415441232323">4</characteristic>
                     <characteristic name="BS" typeId="425323232344415441232323">4</characteristic>
@@ -10534,7 +10545,7 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
                     <characteristic name="Type" typeId="5479706523232344415441232323">Super-heavy Walker</characteristic>
                   </characteristics>
                 </profile>
-                <profile id="f4a2-6a77-8d11-4c79" name="Graviton Singularity Cannon" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+                <profile id="f4a2-6a77-8d11-4c79" name="Graviton Singularity Cannon" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
                   <characteristics>
                     <characteristic name="Range" typeId="52616e676523232344415441232323">38&quot;</characteristic>
                     <characteristic name="Strength" typeId="537472656e67746823232344415441232323">8</characteristic>
@@ -10542,7 +10553,7 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
                     <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 1, Large Blast, Armourbane, Concussive, Collapsing Singularity</characteristic>
                   </characteristics>
                 </profile>
-                <profile id="7427-c06c-d26d-fb54" name="Atrapos Lascutter (Beam)" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+                <profile id="7427-c06c-d26d-fb54" name="Atrapos Lascutter (Beam)" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
                   <characteristics>
                     <characteristic name="Range" typeId="52616e676523232344415441232323">8&quot;</characteristic>
                     <characteristic name="Strength" typeId="537472656e67746823232344415441232323">D</characteristic>
@@ -10550,7 +10561,7 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
                     <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 1</characteristic>
                   </characteristics>
                 </profile>
-                <profile id="07d2-e61f-fa39-55a5" name="Atrapos Lascutter (Close Combat)" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+                <profile id="07d2-e61f-fa39-55a5" name="Atrapos Lascutter (Close Combat)" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
                   <characteristics>
                     <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
                     <characteristic name="Strength" typeId="537472656e67746823232344415441232323">D</characteristic>
@@ -10583,9 +10594,9 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
                 <infoLink id="27f7-1497-1bf1-48d5" hidden="false" targetId="fe2f-3220-3fef-b177" type="rule"/>
               </infoLinks>
               <selectionEntryGroups>
-                <selectionEntryGroup id="7037-61bf-2476-72e6" name="May be upgraded with:" hidden="false" collective="false">
+                <selectionEntryGroup id="7037-61bf-2476-72e6" name="May be upgraded with:" hidden="false" collective="false" import="true">
                   <entryLinks>
-                    <entryLink id="20b8-3e5d-f4bb-833b" name="Occular Augmetics" hidden="false" collective="false" targetId="0f0e-f31e-a91c-3798" type="selectionEntry"/>
+                    <entryLink id="20b8-3e5d-f4bb-833b" name="Occular Augmetics" hidden="false" collective="false" import="true" targetId="0f0e-f31e-a91c-3798" type="selectionEntry"/>
                   </entryLinks>
                 </selectionEntryGroup>
               </selectionEntryGroups>
@@ -10595,18 +10606,18 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
             </selectionEntry>
           </selectionEntries>
           <entryLinks>
-            <entryLink id="d361-925e-8003-a7f6" name="Cerastus Knight-Atrapos" hidden="false" collective="false" targetId="baad-77d0-04c2-e05f" type="selectionEntry"/>
-            <entryLink id="61bb-50bc-159f-1605" name="Cerastus Knight-Acheron" hidden="false" collective="false" targetId="b4ddbe68-7095-397e-dec4-162170dbdbcd" type="selectionEntry"/>
-            <entryLink id="eca6-2e0a-7d47-220e" name="Cerastus Knight-Castigator" hidden="false" collective="false" targetId="b1cf8528-c9d0-2c2a-3f19-522e5532f273" type="selectionEntry"/>
-            <entryLink id="86cd-cf97-3239-c05a" name="Questoris Knight Crusader" hidden="false" collective="false" targetId="09ee-4370-1462-2cb5" type="selectionEntry"/>
-            <entryLink id="2adf-1751-43ba-2ca1" name="Questoris Knight Errant" hidden="false" collective="false" targetId="4b70feb1-a2e7-2f93-8320-1d6775bf5a59" type="selectionEntry"/>
-            <entryLink id="0933-7f87-da84-a9fe" name="Questoris Knight Gallant" hidden="false" collective="false" targetId="74b8-f485-4b58-0071" type="selectionEntry"/>
-            <entryLink id="ebc8-eb30-111e-b3d4" name="Questoris Knight Magaera" hidden="false" collective="false" targetId="fb7cd031-7573-eb28-4446-d709eb5acdbc" type="selectionEntry"/>
-            <entryLink id="a4c4-24e4-186d-cc43" name="Questoris Knight Paladin" hidden="false" collective="false" targetId="02eb28bb-1883-8603-0af7-b8bf2b7b69c8" type="selectionEntry"/>
-            <entryLink id="eae7-ab94-76b8-7e27" name="Questoris Knight Styrix" hidden="false" collective="false" targetId="a5b350ff-895e-4557-70a6-d24a936919c2" type="selectionEntry"/>
-            <entryLink id="9291-22af-b60c-8f0b" name="Questoris Knight Warden" hidden="false" collective="false" targetId="f4f1-dad6-0596-ca5a" type="selectionEntry"/>
-            <entryLink id="f73d-6c6a-8a8a-9dd9" name="Cerastus Knight-Lancer" hidden="false" collective="false" targetId="ca45ca55-eae1-1a81-8afc-1330611055a6" type="selectionEntry"/>
-            <entryLink id="593f-5de1-07e1-a4cb" name="Acastus Knight Porphyrion" hidden="false" collective="false" targetId="4ded-9de3-f964-33a7" type="selectionEntry"/>
+            <entryLink id="d361-925e-8003-a7f6" name="Cerastus Knight-Atrapos" hidden="false" collective="false" import="true" targetId="baad-77d0-04c2-e05f" type="selectionEntry"/>
+            <entryLink id="61bb-50bc-159f-1605" name="Cerastus Knight-Acheron" hidden="false" collective="false" import="true" targetId="b4ddbe68-7095-397e-dec4-162170dbdbcd" type="selectionEntry"/>
+            <entryLink id="eca6-2e0a-7d47-220e" name="Cerastus Knight-Castigator" hidden="false" collective="false" import="true" targetId="b1cf8528-c9d0-2c2a-3f19-522e5532f273" type="selectionEntry"/>
+            <entryLink id="86cd-cf97-3239-c05a" name="Questoris Knight Crusader" hidden="false" collective="false" import="true" targetId="09ee-4370-1462-2cb5" type="selectionEntry"/>
+            <entryLink id="2adf-1751-43ba-2ca1" name="Questoris Knight Errant" hidden="false" collective="false" import="true" targetId="4b70feb1-a2e7-2f93-8320-1d6775bf5a59" type="selectionEntry"/>
+            <entryLink id="0933-7f87-da84-a9fe" name="Questoris Knight Gallant" hidden="false" collective="false" import="true" targetId="74b8-f485-4b58-0071" type="selectionEntry"/>
+            <entryLink id="ebc8-eb30-111e-b3d4" name="Questoris Knight Magaera" hidden="false" collective="false" import="true" targetId="fb7cd031-7573-eb28-4446-d709eb5acdbc" type="selectionEntry"/>
+            <entryLink id="a4c4-24e4-186d-cc43" name="Questoris Knight Paladin" hidden="false" collective="false" import="true" targetId="02eb28bb-1883-8603-0af7-b8bf2b7b69c8" type="selectionEntry"/>
+            <entryLink id="eae7-ab94-76b8-7e27" name="Questoris Knight Styrix" hidden="false" collective="false" import="true" targetId="a5b350ff-895e-4557-70a6-d24a936919c2" type="selectionEntry"/>
+            <entryLink id="9291-22af-b60c-8f0b" name="Questoris Knight Warden" hidden="false" collective="false" import="true" targetId="f4f1-dad6-0596-ca5a" type="selectionEntry"/>
+            <entryLink id="f73d-6c6a-8a8a-9dd9" name="Cerastus Knight-Lancer" hidden="false" collective="false" import="true" targetId="ca45ca55-eae1-1a81-8afc-1330611055a6" type="selectionEntry"/>
+            <entryLink id="593f-5de1-07e1-a4cb" name="Acastus Knight Porphyrion" hidden="false" collective="false" import="true" targetId="4ded-9de3-f964-33a7" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
@@ -10614,27 +10625,27 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="91f0-3f18-50b7-ed4e" name="Engines of Destruction" hidden="false" collective="false" type="unit">
+    <selectionEntry id="91f0-3f18-50b7-ed4e" name="Engines of Destruction" hidden="false" collective="false" import="true" type="unit">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="0cd3-e53a-514d-b271" type="max"/>
       </constraints>
       <entryLinks>
-        <entryLink id="bce6-28fe-ce41-60de" name="Legio Titanicus Reaver Battle Titan" hidden="false" collective="false" targetId="1fa3-1f86-94a6-bf48" type="selectionEntry">
+        <entryLink id="bce6-28fe-ce41-60de" name="Legio Titanicus Reaver Battle Titan" hidden="false" collective="false" import="true" targetId="1fa3-1f86-94a6-bf48" type="selectionEntry">
           <categoryLinks>
             <categoryLink id="0544-ff69-00fc-4359" name="New CategoryLink" hidden="false" targetId="896b-3586-a126-d985" primary="false"/>
           </categoryLinks>
         </entryLink>
-        <entryLink id="be60-2292-b519-4e32" name="Legio Titanicus Warlord Battle Titan" hidden="false" collective="false" targetId="ab80-0fef-3e93-8e64" type="selectionEntry">
+        <entryLink id="be60-2292-b519-4e32" name="Legio Titanicus Warlord Battle Titan" hidden="false" collective="false" import="true" targetId="ab80-0fef-3e93-8e64" type="selectionEntry">
           <categoryLinks>
             <categoryLink id="c4fd-b09c-a062-ed96" name="New CategoryLink" hidden="false" targetId="896b-3586-a126-d985" primary="false"/>
           </categoryLinks>
         </entryLink>
-        <entryLink id="fa43-23b8-15ad-aec4" name="Legio Titanicus Warhound Scout Titan" hidden="false" collective="false" targetId="b894-adfc-6d3d-fde4" type="selectionEntry">
+        <entryLink id="fa43-23b8-15ad-aec4" name="Legio Titanicus Warhound Scout Titan" hidden="false" collective="false" import="true" targetId="b894-adfc-6d3d-fde4" type="selectionEntry">
           <categoryLinks>
             <categoryLink id="784b-a14b-ae8a-6d61" name="New CategoryLink" hidden="false" targetId="896b-3586-a126-d985" primary="false"/>
           </categoryLinks>
         </entryLink>
-        <entryLink id="7eb7-52d9-e828-45ea" name="Warlord-Sinister Pattern Battle Psi-Titan" hidden="true" collective="false" targetId="fb92-d215-2011-f911" type="selectionEntry">
+        <entryLink id="7eb7-52d9-e828-45ea" name="Warlord-Sinister Pattern Battle Psi-Titan" hidden="true" collective="false" import="true" targetId="fb92-d215-2011-f911" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
@@ -10646,24 +10657,24 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
             <categoryLink id="dacc-ebb0-2825-c5af" name="New CategoryLink" hidden="false" targetId="896b-3586-a126-d985" primary="false"/>
           </categoryLinks>
         </entryLink>
-        <entryLink id="6bde-f954-83f2-5a12" name="Ordinatus Minoris Macro Engine" hidden="false" collective="false" targetId="7cdb-8db0-bfd6-ce3c" type="selectionEntry"/>
-        <entryLink id="5132-e115-57d8-48f2" name="Stormlord" hidden="false" collective="false" targetId="7d56-481b-6478-681e" type="selectionEntry"/>
-        <entryLink id="7cec-ff9c-8216-ae53" name="Shadowsword" hidden="false" collective="false" targetId="ed2c-8dcf-d0d2-720e" type="selectionEntry"/>
-        <entryLink id="5621-ff8f-f192-db16" name="Stormsword" hidden="false" collective="false" targetId="e5ad-07be-63c1-71e3" type="selectionEntry"/>
-        <entryLink id="dfcc-fd77-694e-f821" name="Banehammer" hidden="false" collective="false" targetId="3663-a86a-0957-9a6a" type="selectionEntry"/>
-        <entryLink id="c32f-ef83-dbc6-ed0d" name="Baneblade" hidden="false" collective="false" targetId="093f-6472-95d0-553f" type="selectionEntry"/>
-        <entryLink id="e2e5-c4cf-9c48-6bd8" name="Doomhammer" hidden="false" collective="false" targetId="b04c-44bf-53d8-352c" type="selectionEntry"/>
-        <entryLink id="e497-8836-3c5b-fdfb" name="Macharius" hidden="false" collective="false" targetId="48cf-f73d-a3c0-e911" type="selectionEntry"/>
-        <entryLink id="d746-1e2e-8c7d-8bf3" name="Macharius Vulcan" publicationId="cf03-f607-pubN130172" page="230" hidden="false" collective="false" targetId="0be5-7f1a-2281-5671" type="selectionEntry"/>
-        <entryLink id="356f-8bd2-3fd7-e983" name="Macharius Vanquisher" hidden="false" collective="false" targetId="07a7-a3a5-d46e-b873" type="selectionEntry"/>
+        <entryLink id="6bde-f954-83f2-5a12" name="Ordinatus Minoris Macro Engine" hidden="false" collective="false" import="true" targetId="7cdb-8db0-bfd6-ce3c" type="selectionEntry"/>
+        <entryLink id="5132-e115-57d8-48f2" name="Stormlord" hidden="false" collective="false" import="true" targetId="7d56-481b-6478-681e" type="selectionEntry"/>
+        <entryLink id="7cec-ff9c-8216-ae53" name="Shadowsword" hidden="false" collective="false" import="true" targetId="ed2c-8dcf-d0d2-720e" type="selectionEntry"/>
+        <entryLink id="5621-ff8f-f192-db16" name="Stormsword" hidden="false" collective="false" import="true" targetId="e5ad-07be-63c1-71e3" type="selectionEntry"/>
+        <entryLink id="dfcc-fd77-694e-f821" name="Banehammer" hidden="false" collective="false" import="true" targetId="3663-a86a-0957-9a6a" type="selectionEntry"/>
+        <entryLink id="c32f-ef83-dbc6-ed0d" name="Baneblade" hidden="false" collective="false" import="true" targetId="093f-6472-95d0-553f" type="selectionEntry"/>
+        <entryLink id="e2e5-c4cf-9c48-6bd8" name="Doomhammer" hidden="false" collective="false" import="true" targetId="b04c-44bf-53d8-352c" type="selectionEntry"/>
+        <entryLink id="e497-8836-3c5b-fdfb" name="Macharius" hidden="false" collective="false" import="true" targetId="48cf-f73d-a3c0-e911" type="selectionEntry"/>
+        <entryLink id="d746-1e2e-8c7d-8bf3" name="Macharius Vulcan" publicationId="cf03-f607-pubN130172" page="230" hidden="false" collective="false" import="true" targetId="0be5-7f1a-2281-5671" type="selectionEntry"/>
+        <entryLink id="356f-8bd2-3fd7-e983" name="Macharius Vanquisher" hidden="false" collective="false" import="true" targetId="07a7-a3a5-d46e-b873" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="7d56-481b-6478-681e" name="Stormlord" publicationId="cf03-f607-pubN130224" page="50" hidden="false" collective="false" type="unit">
+    <selectionEntry id="7d56-481b-6478-681e" name="Stormlord" publicationId="cf03-f607-pubN130224" page="50" hidden="false" collective="false" import="true" type="unit">
       <profiles>
-        <profile id="b5c1-ea37-0dfe-51b0" name="Stormlord" publicationId="cf03-f607-pubN130235" page="50" hidden="false" typeId="56656869636c6523232344415441232323" typeName="">
+        <profile id="b5c1-ea37-0dfe-51b0" name="Stormlord" publicationId="cf03-f607-pubN130235" page="50" hidden="false" typeId="56656869636c6523232344415441232323" typeName="Vehicle">
           <modifiers>
             <modifier type="increment" field="425323232344415441232323" value="1">
               <repeats>
@@ -10680,7 +10691,7 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
             <characteristic name="Type" typeId="5479706523232344415441232323">Super-heavy Vehicle, Transport</characteristic>
           </characteristics>
         </profile>
-        <profile id="dac5-81ea-2fe1-adb4" name="All Power to Weapons" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="">
+        <profile id="dac5-81ea-2fe1-adb4" name="All Power to Weapons" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
           <characteristics>
             <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">All Power to Weapons!: If the Stormlord does not move, it may fire its Vulcan mega-bolter twice in the following Shooting phase (at the same target or at different ones).</characteristic>
           </characteristics>
@@ -10702,7 +10713,7 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
         <categoryLink id="3705-d61f-8f30-45e8" name="New CategoryLink" hidden="false" targetId="8d56-b8fc-9b94-9cc9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="f723-185a-c2eb-6b58" name="2 Heavy stubbers" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="f723-185a-c2eb-6b58" name="2 Heavy stubbers" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="551c-eb0b-00f0-1366" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b1d9-702f-226b-c705" type="max"/>
@@ -10714,7 +10725,7 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
             <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="764d-74e7-b602-16d6" name="Hull-Mounted Twin-Linked Heavy Bolter" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="764d-74e7-b602-16d6" name="Hull-Mounted Twin-Linked Heavy Bolter" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8a8d-4239-5732-81e5" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9612-4e2c-377d-ead5" type="max"/>
@@ -10728,12 +10739,12 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="4395-c456-436d-0f63" name="May take any of the following:" hidden="false" collective="false">
+        <selectionEntryGroup id="4395-c456-436d-0f63" name="May take any of the following:" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="856b-d46e-6a34-046b" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="e3ac-e545-a292-fc04" name="Hunter-killer Missile" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="e3ac-e545-a292-fc04" name="Hunter-killer Missile" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2d43-2a73-6d6e-8ad3" type="max"/>
               </constraints>
@@ -10741,7 +10752,7 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
                 <cost name="pts" typeId="points" value="10.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="0ea8-b29c-1fc7-3c1a" name="Heavy Stubber" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="0ea8-b29c-1fc7-3c1a" name="Heavy Stubber" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e88d-ea30-8471-3701" type="max"/>
               </constraints>
@@ -10756,16 +10767,16 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="5ee3-5493-6377-9a4c" name="Searchlight" hidden="false" collective="false" targetId="1e27e511-cf75-d55a-6807-b67be6f7474f" type="selectionEntry"/>
-        <entryLink id="81a5-5b07-50d0-f183" name="May take up to two: (Baneblade/Shadowsword Sponsons)" hidden="false" collective="false" targetId="8ffb-2a32-888b-41ef" type="selectionEntryGroup"/>
+        <entryLink id="5ee3-5493-6377-9a4c" name="Searchlight" hidden="false" collective="false" import="true" targetId="1e27e511-cf75-d55a-6807-b67be6f7474f" type="selectionEntry"/>
+        <entryLink id="81a5-5b07-50d0-f183" name="May take up to two: (Baneblade/Shadowsword Sponsons)" hidden="false" collective="false" import="true" targetId="8ffb-2a32-888b-41ef" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="490.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="ed2c-8dcf-d0d2-720e" name="Shadowsword" publicationId="cf03-f607-pubN130224" page="49" hidden="false" collective="false" type="unit">
+    <selectionEntry id="ed2c-8dcf-d0d2-720e" name="Shadowsword" publicationId="cf03-f607-pubN130224" page="49" hidden="false" collective="false" import="true" type="unit">
       <profiles>
-        <profile id="579e-ecea-a30c-2d38" name="Shadowsword" publicationId="cf03-f607-pubN99227" page="286" hidden="false" typeId="56656869636c6523232344415441232323" typeName="">
+        <profile id="579e-ecea-a30c-2d38" name="Shadowsword" publicationId="cf03-f607-pubN99227" page="286" hidden="false" typeId="56656869636c6523232344415441232323" typeName="Vehicle">
           <modifiers>
             <modifier type="increment" field="425323232344415441232323" value="1">
               <repeats>
@@ -10782,7 +10793,7 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
             <characteristic name="Type" typeId="5479706523232344415441232323">Super-heavy</characteristic>
           </characteristics>
         </profile>
-        <profile id="bd25-1d59-7abf-a370" name="Volcano Cannon" publicationId="cf03-f607-pubN99227" page="286" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+        <profile id="bd25-1d59-7abf-a370" name="Volcano Cannon" publicationId="cf03-f607-pubN99227" page="286" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
           <characteristics>
             <characteristic name="Range" typeId="52616e676523232344415441232323">120&quot;</characteristic>
             <characteristic name="Strength" typeId="537472656e67746823232344415441232323">D</characteristic>
@@ -10796,12 +10807,12 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
         <categoryLink id="d626-b1c7-42af-f933" name="New CategoryLink" hidden="false" targetId="8d56-b8fc-9b94-9cc9" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="fb49-74ca-9e7f-6262" name="May take any of the following:" hidden="false" collective="false">
+        <selectionEntryGroup id="fb49-74ca-9e7f-6262" name="May take any of the following:" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2f77-3f2c-22bb-21bc" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="adda-e3f4-c046-c782" name="Hunter-killer Missile" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="adda-e3f4-c046-c782" name="Hunter-killer Missile" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6b73-9920-0755-ea4d" type="max"/>
               </constraints>
@@ -10809,7 +10820,7 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
                 <cost name="pts" typeId="points" value="10.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="ef8c-80f9-2dfe-ef7a" name=" Heavy Stubber" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="ef8c-80f9-2dfe-ef7a" name=" Heavy Stubber" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="cf6a-e327-da1a-3b09" type="max"/>
               </constraints>
@@ -10824,15 +10835,15 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="4242-e43b-c304-189d" name="May take up to two: (Baneblade/Shadowsword Sponsons)" hidden="false" collective="false" targetId="8ffb-2a32-888b-41ef" type="selectionEntryGroup"/>
+        <entryLink id="4242-e43b-c304-189d" name="May take up to two: (Baneblade/Shadowsword Sponsons)" hidden="false" collective="false" import="true" targetId="8ffb-2a32-888b-41ef" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="455.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="e5ad-07be-63c1-71e3" name="Stormsword" publicationId="cf03-f607-pubN131159" hidden="false" collective="false" type="unit">
+    <selectionEntry id="e5ad-07be-63c1-71e3" name="Stormsword" publicationId="cf03-f607-pubN131159" hidden="false" collective="false" import="true" type="unit">
       <profiles>
-        <profile id="6154-6951-1106-ee9b" name="Legion Stormsword" hidden="false" typeId="56656869636c6523232344415441232323" typeName="">
+        <profile id="6154-6951-1106-ee9b" name="Legion Stormsword" hidden="false" typeId="56656869636c6523232344415441232323" typeName="Vehicle">
           <modifiers>
             <modifier type="increment" field="425323232344415441232323" value="1">
               <repeats>
@@ -10849,7 +10860,7 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
             <characteristic name="Type" typeId="5479706523232344415441232323">Super-heavy Vehicle</characteristic>
           </characteristics>
         </profile>
-        <profile id="e70a-7533-edfa-dbd4" name="Stormsword Siege Cannon" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+        <profile id="e70a-7533-edfa-dbd4" name="Stormsword Siege Cannon" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
           <characteristics>
             <characteristic name="Range" typeId="52616e676523232344415441232323">36&quot;</characteristic>
             <characteristic name="Strength" typeId="537472656e67746823232344415441232323">10</characteristic>
@@ -10863,12 +10874,12 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
         <categoryLink id="34b1-f962-ad42-a3b7" name="New CategoryLink" hidden="false" targetId="53bd-99e7-aba0-e79f" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="d2fa-c119-4cca-5263" name="May take any of the following:" hidden="false" collective="false">
+        <selectionEntryGroup id="d2fa-c119-4cca-5263" name="May take any of the following:" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2222-fc29-907e-8876" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="45ae-098e-b951-68a0" name="Hunter-killer Missile" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="45ae-098e-b951-68a0" name="Hunter-killer Missile" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="cec8-ede8-a0dc-45d0" type="max"/>
               </constraints>
@@ -10876,7 +10887,7 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
                 <cost name="pts" typeId="points" value="10.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="6510-f356-8556-b70d" name="Heavy Stubber" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="6510-f356-8556-b70d" name="Heavy Stubber" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3bc9-b5f2-76ca-5d8c" type="max"/>
               </constraints>
@@ -10891,16 +10902,16 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="8a9d-1158-c2b2-516e" name="Searchlight" hidden="false" collective="false" targetId="1e27e511-cf75-d55a-6807-b67be6f7474f" type="selectionEntry"/>
-        <entryLink id="e78f-a03f-b160-f57a" name="May take up to two: (Baneblade/Shadowsword Sponsons)" hidden="false" collective="false" targetId="8ffb-2a32-888b-41ef" type="selectionEntryGroup"/>
+        <entryLink id="8a9d-1158-c2b2-516e" name="Searchlight" hidden="false" collective="false" import="true" targetId="1e27e511-cf75-d55a-6807-b67be6f7474f" type="selectionEntry"/>
+        <entryLink id="e78f-a03f-b160-f57a" name="May take up to two: (Baneblade/Shadowsword Sponsons)" hidden="false" collective="false" import="true" targetId="8ffb-2a32-888b-41ef" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="485.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="093f-6472-95d0-553f" name="Baneblade" publicationId="cf03-f607-pubN130224" page="44" hidden="false" collective="false" type="unit">
+    <selectionEntry id="093f-6472-95d0-553f" name="Baneblade" publicationId="cf03-f607-pubN130224" page="44" hidden="false" collective="false" import="true" type="unit">
       <profiles>
-        <profile id="8db8-1aae-d50b-5f8a" name="Baneblade" publicationId="cf03-f607-pubN99227" page="284" hidden="false" typeId="56656869636c6523232344415441232323" typeName="">
+        <profile id="8db8-1aae-d50b-5f8a" name="Baneblade" publicationId="cf03-f607-pubN99227" page="284" hidden="false" typeId="56656869636c6523232344415441232323" typeName="Vehicle">
           <modifiers>
             <modifier type="increment" field="425323232344415441232323" value="1">
               <repeats>
@@ -10917,7 +10928,7 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
             <characteristic name="Type" typeId="5479706523232344415441232323">Super-Heavy</characteristic>
           </characteristics>
         </profile>
-        <profile id="e699-a5d4-0db7-a77b" name="Baneblade Cannon" publicationId="cf03-f607-pubN99227" page="284" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+        <profile id="e699-a5d4-0db7-a77b" name="Baneblade Cannon" publicationId="cf03-f607-pubN99227" page="284" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
           <characteristics>
             <characteristic name="Range" typeId="52616e676523232344415441232323">72&quot;</characteristic>
             <characteristic name="Strength" typeId="537472656e67746823232344415441232323">9</characteristic>
@@ -10931,12 +10942,12 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
         <categoryLink id="f212-3585-5d60-4b1b" name="New CategoryLink" hidden="false" targetId="53bd-99e7-aba0-e79f" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="c51f-2073-5531-2fae" name="May take any of the following:" hidden="false" collective="false">
+        <selectionEntryGroup id="c51f-2073-5531-2fae" name="May take any of the following:" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5cb3-e8d1-bab9-c89f" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="3da0-d445-f4e7-8a84" name="Hunter-killer Missile" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="3da0-d445-f4e7-8a84" name="Hunter-killer Missile" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="18b6-8f13-ffd7-5d3b" type="max"/>
               </constraints>
@@ -10944,7 +10955,7 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
                 <cost name="pts" typeId="points" value="10.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="91b8-088c-acf5-d9db" name=" Heavy Stubber" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="91b8-088c-acf5-d9db" name=" Heavy Stubber" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="60e3-6425-1a34-f422" type="max"/>
               </constraints>
@@ -10959,16 +10970,16 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="1691-6e24-9f77-6c7a" name="Searchlight" hidden="false" collective="false" targetId="1e27e511-cf75-d55a-6807-b67be6f7474f" type="selectionEntry"/>
-        <entryLink id="7ba2-86ab-6924-c571" name="May take up to two: (Baneblade/Shadowsword Sponsons)" hidden="false" collective="false" targetId="8ffb-2a32-888b-41ef" type="selectionEntryGroup"/>
+        <entryLink id="1691-6e24-9f77-6c7a" name="Searchlight" hidden="false" collective="false" import="true" targetId="1e27e511-cf75-d55a-6807-b67be6f7474f" type="selectionEntry"/>
+        <entryLink id="7ba2-86ab-6924-c571" name="May take up to two: (Baneblade/Shadowsword Sponsons)" hidden="false" collective="false" import="true" targetId="8ffb-2a32-888b-41ef" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="535.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="3663-a86a-0957-9a6a" name="Banehammer" publicationId="cf03-f607-pubN130224" page="45" hidden="false" collective="false" type="unit">
+    <selectionEntry id="3663-a86a-0957-9a6a" name="Banehammer" publicationId="cf03-f607-pubN130224" page="45" hidden="false" collective="false" import="true" type="unit">
       <profiles>
-        <profile id="bfb6-7c23-a3c3-bc0e" name="Banehammer" publicationId="cf03-f607-pubN99227" page="284" hidden="false" typeId="56656869636c6523232344415441232323" typeName="">
+        <profile id="bfb6-7c23-a3c3-bc0e" name="Banehammer" publicationId="cf03-f607-pubN99227" page="284" hidden="false" typeId="56656869636c6523232344415441232323" typeName="Vehicle">
           <modifiers>
             <modifier type="increment" field="425323232344415441232323" value="1">
               <repeats>
@@ -10991,12 +11002,12 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
         <categoryLink id="ba97-b4c1-ffb1-9730" name="New CategoryLink" hidden="false" targetId="53bd-99e7-aba0-e79f" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="2c35-cd8e-bd11-fa46" name="May take any of the following:" hidden="false" collective="false">
+        <selectionEntryGroup id="2c35-cd8e-bd11-fa46" name="May take any of the following:" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4310-13b8-92b2-88af" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="45f5-b700-5a5e-9fc7" name="Hunter-killer Missile" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="45f5-b700-5a5e-9fc7" name="Hunter-killer Missile" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3a3d-84b9-b6d1-a6a5" type="max"/>
               </constraints>
@@ -11004,7 +11015,7 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
                 <cost name="pts" typeId="points" value="10.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="9ef2-0342-14c4-0223" name=" Heavy Stubber" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="9ef2-0342-14c4-0223" name=" Heavy Stubber" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="32d5-080e-4443-8085" type="max"/>
               </constraints>
@@ -11019,16 +11030,16 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="422c-6e30-2762-6330" name="Searchlight" hidden="false" collective="false" targetId="1e27e511-cf75-d55a-6807-b67be6f7474f" type="selectionEntry"/>
-        <entryLink id="b3f3-7db3-10d8-7144" name="May take up to two: (Baneblade/Shadowsword Sponsons)" hidden="false" collective="false" targetId="8ffb-2a32-888b-41ef" type="selectionEntryGroup"/>
+        <entryLink id="422c-6e30-2762-6330" name="Searchlight" hidden="false" collective="false" import="true" targetId="1e27e511-cf75-d55a-6807-b67be6f7474f" type="selectionEntry"/>
+        <entryLink id="b3f3-7db3-10d8-7144" name="May take up to two: (Baneblade/Shadowsword Sponsons)" hidden="false" collective="false" import="true" targetId="8ffb-2a32-888b-41ef" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="410.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="b04c-44bf-53d8-352c" name="Doomhammer" publicationId="cf03-f607-pubN130224" page="45" hidden="false" collective="false" type="unit">
+    <selectionEntry id="b04c-44bf-53d8-352c" name="Doomhammer" publicationId="cf03-f607-pubN130224" page="45" hidden="false" collective="false" import="true" type="unit">
       <profiles>
-        <profile id="5256-0080-e7cf-b9cf" name="Doomhammer" publicationId="cf03-f607-pubN99227" page="284" hidden="false" typeId="56656869636c6523232344415441232323" typeName="">
+        <profile id="5256-0080-e7cf-b9cf" name="Doomhammer" publicationId="cf03-f607-pubN99227" page="284" hidden="false" typeId="56656869636c6523232344415441232323" typeName="Vehicle">
           <modifiers>
             <modifier type="increment" field="425323232344415441232323" value="1">
               <repeats>
@@ -11051,12 +11062,12 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
         <categoryLink id="2684-1b30-347e-bd73" name="New CategoryLink" hidden="false" targetId="53bd-99e7-aba0-e79f" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="1041-2c19-1195-ca77" name="May take any of the following:" hidden="false" collective="false">
+        <selectionEntryGroup id="1041-2c19-1195-ca77" name="May take any of the following:" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b95b-1516-092c-bd27" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="30b7-4c94-444e-aed4" name="Hunter-killer Missile" page="0" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="30b7-4c94-444e-aed4" name="Hunter-killer Missile" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2462-b158-a483-10d6" type="max"/>
               </constraints>
@@ -11064,7 +11075,7 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
                 <cost name="pts" typeId="points" value="10.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="3fbe-9ec9-1dc5-f9c1" name=" Heavy Stubber" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="3fbe-9ec9-1dc5-f9c1" name=" Heavy Stubber" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="830f-c8a6-b223-dada" type="max"/>
               </constraints>
@@ -11079,16 +11090,16 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="9a65-a1e0-0064-b1f8" name="Searchlight" hidden="false" collective="false" targetId="1e27e511-cf75-d55a-6807-b67be6f7474f" type="selectionEntry"/>
-        <entryLink id="91f1-1e22-7eae-9eac" name="May take up to two: (Baneblade/Shadowsword Sponsons)" hidden="false" collective="false" targetId="8ffb-2a32-888b-41ef" type="selectionEntryGroup"/>
+        <entryLink id="9a65-a1e0-0064-b1f8" name="Searchlight" hidden="false" collective="false" import="true" targetId="1e27e511-cf75-d55a-6807-b67be6f7474f" type="selectionEntry"/>
+        <entryLink id="91f1-1e22-7eae-9eac" name="May take up to two: (Baneblade/Shadowsword Sponsons)" hidden="false" collective="false" import="true" targetId="8ffb-2a32-888b-41ef" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="420.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="f29d-27e9-6fa7-101e" name="Graviton Hammer" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="f29d-27e9-6fa7-101e" name="Graviton Hammer" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
-        <profile id="3334-7012-0462-eb3d" name="Graviton Hammer (Assault)" publicationId="cf03-f607-pubN80965" page="227" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+        <profile id="3334-7012-0462-eb3d" name="Graviton Hammer (Assault)" publicationId="cf03-f607-pubN80965" page="227" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
           <characteristics>
             <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
             <characteristic name="Strength" typeId="537472656e67746823232344415441232323">10</characteristic>
@@ -11123,7 +11134,7 @@ In addition to its weapon attacks, units assaulting a model or unit with a gravi
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="deed-3c25-b77e-a0e8" name="Anbaric Claw" page="0" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="deed-3c25-b77e-a0e8" name="Anbaric Claw" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="bc7f-25df-0964-b289" type="max"/>
       </constraints>
@@ -11134,7 +11145,7 @@ In addition to its weapon attacks, units assaulting a model or unit with a gravi
         <cost name="pts" typeId="points" value="15.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="5f67-828c-a452-e97e" name="Mauler Bolt Cannon" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="5f67-828c-a452-e97e" name="Mauler Bolt Cannon" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="592e-b785-b9da-7c25" name="Mauler Bolt Cannon" hidden="false" targetId="0225-fc80-29f1-09db" type="profile"/>
         <infoLink id="116d-4b1b-3701-0889" name="New InfoLink" hidden="false" targetId="f624-f475-e5ec-0dfa" type="rule"/>
@@ -11143,7 +11154,7 @@ In addition to its weapon attacks, units assaulting a model or unit with a gravi
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="5f0f-e635-7ceb-44f9" name="Maxima Bolter" page="0" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="5f0f-e635-7ceb-44f9" name="Maxima Bolter" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="4fee-5fa4-2272-024c" name="Maxima Bolter" hidden="false" targetId="8043abca-b8b1-2694-0fc0-4e3d58910eca" type="profile"/>
       </infoLinks>
@@ -11151,7 +11162,7 @@ In addition to its weapon attacks, units assaulting a model or unit with a gravi
         <cost name="pts" typeId="points" value="5.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="b4b1-1973-4aa3-bbd2" name="Paragon Blade" page="0" hidden="true" collective="false" type="upgrade">
+    <selectionEntry id="b4b1-1973-4aa3-bbd2" name="Paragon Blade" page="0" hidden="true" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="b6ce-f5c5-fff3-0d57" name="Murderous Strike" hidden="false" targetId="6f86-b495-7a94-a7c7" type="rule"/>
         <infoLink id="081f-96be-5ee4-9803" name="Specialist Weapon" hidden="false" targetId="7ee3-d437-bc44-3630" type="rule"/>
@@ -11161,7 +11172,7 @@ In addition to its weapon attacks, units assaulting a model or unit with a gravi
         <cost name="pts" typeId="points" value="15.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="f65a-de84-8c56-723c" name="Plasma Pistol" page="0" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="f65a-de84-8c56-723c" name="Plasma Pistol" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="c56d-4192-c4b6-2037" name="Plasma Pistol" hidden="false" targetId="f4a1-b459-ba82-3789" type="profile"/>
         <infoLink id="c603-8b29-8a1b-819b" name="Gets Hot" hidden="false" targetId="f4fd-d519-4769-5510" type="rule"/>
@@ -11170,7 +11181,7 @@ In addition to its weapon attacks, units assaulting a model or unit with a gravi
         <cost name="pts" typeId="points" value="5.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="722d-7306-0e19-f7df" name="Lucifex" page="0" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="722d-7306-0e19-f7df" name="Lucifex" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="5ced-b179-58fa-796e" name="Lucifex" hidden="false" targetId="bbe4567f-45d7-cbfe-23f5-10edcb96e895" type="profile"/>
         <infoLink id="65af-8d6d-722f-e542" hidden="false" targetId="eefe-09e4-17aa-deb2" type="rule"/>
@@ -11180,7 +11191,7 @@ In addition to its weapon attacks, units assaulting a model or unit with a gravi
         <cost name="pts" typeId="points" value="5.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="914e-e579-13d7-d272" name="Chainfist" page="0" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="914e-e579-13d7-d272" name="Chainfist" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="02fa-6b30-d798-ded1" name="Chainfist" hidden="false" targetId="8194-4688-65b3-f996" type="profile"/>
         <infoLink id="7f6c-1366-70bd-6c73" name="Armourbane" hidden="false" targetId="e182-50cd-0867-9a8d" type="rule"/>
@@ -11191,7 +11202,7 @@ In addition to its weapon attacks, units assaulting a model or unit with a gravi
         <cost name="pts" typeId="points" value="10.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="f993-0633-9583-d8ed" name="Power Fist" page="0" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="f993-0633-9583-d8ed" name="Power Fist" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="0703-8a50-5c5b-3d7a" name="Power Fist" hidden="false" targetId="4ddd-399c-d71c-4ac1" type="profile"/>
         <infoLink id="fb41-6ac8-d2e2-2088" name="Specialist Weapon" hidden="false" targetId="7ee3-d437-bc44-3630" type="rule"/>
@@ -11201,7 +11212,7 @@ In addition to its weapon attacks, units assaulting a model or unit with a gravi
         <cost name="pts" typeId="points" value="5.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="5c5c-13cd-a75e-3b15" name="Servo-arm" page="0" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="5c5c-13cd-a75e-3b15" name="Servo-arm" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="ff2d-6622-772d-06a9" name="Servo-arm" hidden="false" targetId="f4404a95-506e-bcef-1420-21d2d6e9013b" type="profile"/>
         <infoLink id="5dbb-3756-d8b8-6cf2" name="Unwieldy" hidden="false" targetId="5eea-958c-d623-c3c9" type="rule"/>
@@ -11210,7 +11221,7 @@ In addition to its weapon attacks, units assaulting a model or unit with a gravi
         <cost name="pts" typeId="points" value="10.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="231a-26e7-f47f-6f5a" name="Graviton Imploder" page="0" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="231a-26e7-f47f-6f5a" name="Graviton Imploder" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="26a8-346c-dc0e-bd11" name="Graviton Imploder" hidden="false" targetId="c73d6a53-afb0-ccb6-8977-c5eb88576611" type="profile"/>
         <infoLink id="3f94-8962-1bc9-3728" name="Graviton" hidden="false" targetId="9cf8-e693-2882-a2ca" type="rule"/>
@@ -11220,7 +11231,7 @@ In addition to its weapon attacks, units assaulting a model or unit with a gravi
         <cost name="pts" typeId="points" value="25.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="3cd4-7aba-24a0-37b8" name="Irradiation engines" page="0" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="3cd4-7aba-24a0-37b8" name="Irradiation engines" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="258f-edfe-04f5-5205" name="Irradiation Engine" hidden="false" targetId="926a370f-f4c1-b644-34f2-c348a5ce36c0" type="profile"/>
         <infoLink id="bb65-2df2-825f-5044" name="Fleshbane" hidden="false" targetId="4575-0a0a-caaf-e4bf" type="rule"/>
@@ -11231,7 +11242,7 @@ In addition to its weapon attacks, units assaulting a model or unit with a gravi
         <cost name="pts" typeId="points" value="40.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="761b-4ac7-370a-3c47" name="Photon Thruster Cannon" page="0" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="761b-4ac7-370a-3c47" name="Photon Thruster Cannon" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="9fc7-3fbc-a05c-cd77" name="Photon Thruster Cannon" hidden="false" targetId="194c1d88-db84-98aa-de86-f88e5ff46af2" type="profile"/>
         <infoLink id="cee9-228b-efb7-ea76" name="Lance" hidden="false" targetId="98ed-3a29-c86b-455d" type="rule"/>
@@ -11242,7 +11253,7 @@ In addition to its weapon attacks, units assaulting a model or unit with a gravi
         <cost name="pts" typeId="points" value="35.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="e8ea-b5c1-7636-cbb3" name="Frag and Krak grenades" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="e8ea-b5c1-7636-cbb3" name="Frag and Krak grenades" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9c4a-71c7-68fa-e7b9" type="max"/>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a4b0-9aa0-0305-568f" type="min"/>
@@ -11255,7 +11266,7 @@ In addition to its weapon attacks, units assaulting a model or unit with a gravi
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="f921-3533-183e-c741" name="Infravisor" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="f921-3533-183e-c741" name="Infravisor" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e13a-b3c9-1a6a-0089" type="min"/>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="97f8-89a8-f75d-6fb3" type="max"/>
@@ -11267,7 +11278,7 @@ In addition to its weapon attacks, units assaulting a model or unit with a gravi
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="d4ac-c006-b6fd-7901" name="Phased Plasma-fusil" page="0" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="d4ac-c006-b6fd-7901" name="Phased Plasma-fusil" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="66a2-cd60-ecdc-b474" name="Phased-Plasma Fusil" hidden="false" targetId="71ed050b-073d-852a-e50a-425b96eb71cd" type="profile"/>
       </infoLinks>
@@ -11275,7 +11286,7 @@ In addition to its weapon attacks, units assaulting a model or unit with a gravi
         <cost name="pts" typeId="points" value="20.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="1695-a895-5233-71db" name="Power Axe" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="1695-a895-5233-71db" name="Power Axe" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="0c53-5ae7-dcbd-5dfb" name="Power Axe" hidden="false" targetId="b3af-1eca-6629-4894" type="profile"/>
         <infoLink id="fc65-bd43-92fc-5da2" name="Unwieldy" hidden="false" targetId="5eea-958c-d623-c3c9" type="rule"/>
@@ -11284,7 +11295,7 @@ In addition to its weapon attacks, units assaulting a model or unit with a gravi
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="91ea-9aa8-13dd-7775" name="Djinn-skein (Warlord-Only)" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="91ea-9aa8-13dd-7775" name="Djinn-skein (Warlord-Only)" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="cf6d-81ee-ff43-0b38" type="max"/>
       </constraints>
@@ -11295,7 +11306,7 @@ In addition to its weapon attacks, units assaulting a model or unit with a gravi
         <cost name="pts" typeId="points" value="25.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="d3d9-21fc-ec42-270a" name="Terrax Pattern Termite Assault Drill" hidden="false" collective="false" type="unit">
+    <selectionEntry id="d3d9-21fc-ec42-270a" name="Terrax Pattern Termite Assault Drill" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="14d8-2140-c2f0-5d6f" name="Terrax Pattern Termite Assault Drill" hidden="false" typeId="56656869636c6523232344415441232323" typeName="Vehicle">
           <characteristics>
@@ -11364,51 +11375,51 @@ Assault rules unless otherwise noted.</description>
         <infoLink id="2d3a-2f3e-8a80-bc54" name="Deep Strike" hidden="false" targetId="d219-2314-4834-c054" type="rule"/>
       </infoLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="ddda-a37a-0bff-45df" name="May take any of the following" hidden="false" collective="false">
+        <selectionEntryGroup id="ddda-a37a-0bff-45df" name="May take any of the following" hidden="false" collective="false" import="true">
           <entryLinks>
-            <entryLink id="8d05-7716-ed12-a8da" name="Armoured Ceramite" hidden="false" collective="false" targetId="7da5-088b-4d9e-66b6" type="selectionEntry"/>
-            <entryLink id="8626-a780-90db-9508" name="Blessed Autosimulacra" hidden="false" collective="false" targetId="fb66-11c0-3cb4-aac3" type="selectionEntry">
+            <entryLink id="8d05-7716-ed12-a8da" name="Armoured Ceramite" hidden="false" collective="false" import="true" targetId="7da5-088b-4d9e-66b6" type="selectionEntry"/>
+            <entryLink id="8626-a780-90db-9508" name="Blessed Autosimulacra" hidden="false" collective="false" import="true" targetId="fb66-11c0-3cb4-aac3" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="points" value="5"/>
               </modifiers>
             </entryLink>
-            <entryLink id="107d-afb5-3ac6-6e02" name="Extra Armour" hidden="false" collective="false" targetId="d00f-81d6-1749-9499" type="selectionEntry"/>
+            <entryLink id="107d-afb5-3ac6-6e02" name="Extra Armour" hidden="false" collective="false" import="true" targetId="d00f-81d6-1749-9499" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="ffe1-2187-577f-5dca" name="Gun 1" hidden="false" collective="false" defaultSelectionEntryId="fec2-709f-6893-a828">
+        <selectionEntryGroup id="ffe1-2187-577f-5dca" name="Gun 1" hidden="false" collective="false" import="true" defaultSelectionEntryId="fec2-709f-6893-a828">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="dbb6-3829-6d77-e642" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6aac-e43f-16cc-6cb4" type="min"/>
           </constraints>
           <entryLinks>
-            <entryLink id="fec2-709f-6893-a828" name="Volkite Charger" hidden="false" collective="false" targetId="2075c6c6-b54d-2d3e-fce9-0543efa392f8" type="selectionEntry">
+            <entryLink id="fec2-709f-6893-a828" name="Volkite Charger" hidden="false" collective="false" import="true" targetId="2075c6c6-b54d-2d3e-fce9-0543efa392f8" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="name" value="Twin-linked Volkite Charger"/>
               </modifiers>
             </entryLink>
-            <entryLink id="e62b-0279-10be-0a46" name="Heavy Flamer" hidden="false" collective="false" targetId="fc12-daad-3988-3994" type="selectionEntry"/>
+            <entryLink id="e62b-0279-10be-0a46" name="Heavy Flamer" hidden="false" collective="false" import="true" targetId="fc12-daad-3988-3994" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="c2d7-c4da-0181-8acc" name="Gun 2" hidden="false" collective="false" defaultSelectionEntryId="423a-1145-96fa-dc9b">
+        <selectionEntryGroup id="c2d7-c4da-0181-8acc" name="Gun 2" hidden="false" collective="false" import="true" defaultSelectionEntryId="423a-1145-96fa-dc9b">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d394-4347-30be-4f43" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b465-2736-c1be-c694" type="min"/>
           </constraints>
           <entryLinks>
-            <entryLink id="423a-1145-96fa-dc9b" name="Volkite Charger" hidden="false" collective="false" targetId="2075c6c6-b54d-2d3e-fce9-0543efa392f8" type="selectionEntry">
+            <entryLink id="423a-1145-96fa-dc9b" name="Volkite Charger" hidden="false" collective="false" import="true" targetId="2075c6c6-b54d-2d3e-fce9-0543efa392f8" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="name" value="Twin-linked Volkite Charger"/>
               </modifiers>
             </entryLink>
-            <entryLink id="40ef-a884-6de4-9092" name="Heavy Flamer" hidden="false" collective="false" targetId="fc12-daad-3988-3994" type="selectionEntry"/>
+            <entryLink id="40ef-a884-6de4-9092" name="Heavy Flamer" hidden="false" collective="false" import="true" targetId="fc12-daad-3988-3994" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="8084-63c5-8250-2217" name="Psyarkana" hidden="false" collective="false">
+        <selectionEntryGroup id="8084-63c5-8250-2217" name="Psyarkana" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9254-1c72-843d-a44d" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="515c-4a53-510c-7fe9" name="Armatus Necrotechnica" hidden="false" collective="false" targetId="e78c-d1a1-c20f-dae8" type="selectionEntry">
+            <entryLink id="515c-4a53-510c-7fe9" name="Armatus Necrotechnica" hidden="false" collective="false" import="true" targetId="e78c-d1a1-c20f-dae8" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="hidden" value="false"/>
               </modifiers>
@@ -11420,7 +11431,7 @@ Assault rules unless otherwise noted.</description>
         <cost name="pts" typeId="points" value="85.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="7da5-088b-4d9e-66b6" name="Armoured Ceramite" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="7da5-088b-4d9e-66b6" name="Armoured Ceramite" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4e4f-fc99-55ce-7810" type="max"/>
       </constraints>
@@ -11432,7 +11443,7 @@ Assault rules unless otherwise noted.</description>
         <cost name="pts" typeId="points" value="20.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="48cf-f73d-a3c0-e911" name="Macharius" publicationId="cf03-f607-pubN134767" page="229" hidden="false" collective="false" type="model">
+    <selectionEntry id="48cf-f73d-a3c0-e911" name="Macharius" publicationId="cf03-f607-pubN134767" page="229" hidden="false" collective="false" import="true" type="model">
       <profiles>
         <profile id="5a78-9752-23ee-6dc2" name="Macharius" hidden="false" typeId="56656869636c6523232344415441232323" typeName="Vehicle">
           <characteristics>
@@ -11459,9 +11470,9 @@ Assault rules unless otherwise noted.</description>
         <categoryLink id="f442-93f5-8e8e-dd69" name="New CategoryLink" hidden="false" targetId="53bd-99e7-aba0-e79f" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="8ad3-f776-e1d1-0f32" name="May take:" hidden="false" collective="false">
+        <selectionEntryGroup id="8ad3-f776-e1d1-0f32" name="May take:" hidden="false" collective="false" import="true">
           <entryLinks>
-            <entryLink id="40b0-a4b8-3f20-9eaa" name="Hunter-killer Missile" hidden="false" collective="false" targetId="287b-b205-0926-5822" type="selectionEntry">
+            <entryLink id="40b0-a4b8-3f20-9eaa" name="Hunter-killer Missile" hidden="false" collective="false" import="true" targetId="287b-b205-0926-5822" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="points" value="10"/>
               </modifiers>
@@ -11471,18 +11482,18 @@ Assault rules unless otherwise noted.</description>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="120e-ecdd-18c3-4fd2" name="May be given one pintle-mounted" publicationId="cf03-f607-pubN135015" page="120" hidden="false" collective="false">
+        <selectionEntryGroup id="120e-ecdd-18c3-4fd2" name="May be given one pintle-mounted" publicationId="cf03-f607-pubN135015" page="120" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="742a-b8b0-388e-e390" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="5ff1-9282-07ba-8ff2" name="Heavy Stubber" hidden="false" collective="false" targetId="0cbc-ea7d-05e7-2d5c" type="selectionEntry">
+            <entryLink id="5ff1-9282-07ba-8ff2" name="Heavy Stubber" hidden="false" collective="false" import="true" targetId="0cbc-ea7d-05e7-2d5c" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="points" value="10"/>
                 <modifier type="set" field="name" value="Pintle-mounted Heavy Stubber"/>
               </modifiers>
             </entryLink>
-            <entryLink id="7735-6748-4ead-6e62" name="Storm bolter" hidden="false" collective="false" targetId="8758-0d01-2cf7-3371" type="selectionEntry">
+            <entryLink id="7735-6748-4ead-6e62" name="Storm bolter" hidden="false" collective="false" import="true" targetId="8758-0d01-2cf7-3371" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="points" value="10"/>
                 <modifier type="set" field="name" value="Pintle-mounted Storm bolter"/>
@@ -11490,25 +11501,25 @@ Assault rules unless otherwise noted.</description>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="224d-2574-5520-bbed" name="Sponsons" hidden="false" collective="false" defaultSelectionEntryId="2c1a-eeef-aff7-7682">
+        <selectionEntryGroup id="224d-2574-5520-bbed" name="Sponsons" hidden="false" collective="false" import="true" defaultSelectionEntryId="2c1a-eeef-aff7-7682">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="22b0-48ad-2dca-1c3b" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c3ab-55e0-83f5-fa57" type="min"/>
           </constraints>
           <entryLinks>
-            <entryLink id="2c1a-eeef-aff7-7682" name="Heavy Stubber" hidden="false" collective="false" targetId="0cbc-ea7d-05e7-2d5c" type="selectionEntry">
+            <entryLink id="2c1a-eeef-aff7-7682" name="Heavy Stubber" hidden="false" collective="false" import="true" targetId="0cbc-ea7d-05e7-2d5c" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="points" value="0.0"/>
                 <modifier type="set" field="name" value="Two Sponson-mounted Heavy Stubbers"/>
               </modifiers>
             </entryLink>
-            <entryLink id="3c66-c7b8-a291-0ba9" name="Heavy Bolter" hidden="false" collective="false" targetId="512b-a9be-50a4-c909" type="selectionEntry">
+            <entryLink id="3c66-c7b8-a291-0ba9" name="Heavy Bolter" hidden="false" collective="false" import="true" targetId="512b-a9be-50a4-c909" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="points" value="10"/>
                 <modifier type="set" field="name" value="Two Sponson-mounted Heavy Bolters"/>
               </modifiers>
             </entryLink>
-            <entryLink id="4148-fe7d-32bb-f6de" name="Heavy Flamer" hidden="false" collective="false" targetId="ead9-305c-a7e7-323e" type="selectionEntry">
+            <entryLink id="4148-fe7d-32bb-f6de" name="Heavy Flamer" hidden="false" collective="false" import="true" targetId="ead9-305c-a7e7-323e" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="name" value="Two Sponson-mounted Heavy Flamers"/>
                 <modifier type="set" field="points" value="10"/>
@@ -11521,7 +11532,7 @@ Assault rules unless otherwise noted.</description>
         <cost name="pts" typeId="points" value="325.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="0cbc-ea7d-05e7-2d5c" name="Heavy Stubber" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="0cbc-ea7d-05e7-2d5c" name="Heavy Stubber" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="9417-d368-6420-29f1" name="Heavy Stubber" hidden="false" targetId="012e-a738-c943-5c1d" type="profile"/>
       </infoLinks>
@@ -11529,7 +11540,7 @@ Assault rules unless otherwise noted.</description>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="8758-0d01-2cf7-3371" name="Storm bolter" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="8758-0d01-2cf7-3371" name="Storm bolter" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="d22a-18eb-4714-61a0" name="Storm bolter" hidden="false" targetId="f420-fb52-a596-fd89" type="profile"/>
       </infoLinks>
@@ -11537,7 +11548,7 @@ Assault rules unless otherwise noted.</description>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="0be5-7f1a-2281-5671" name="Macharius Vulcan" publicationId="cf03-f607-pubN134767" page="230" hidden="false" collective="false" type="model">
+    <selectionEntry id="0be5-7f1a-2281-5671" name="Macharius Vulcan" publicationId="cf03-f607-pubN134767" page="230" hidden="false" collective="false" import="true" type="model">
       <profiles>
         <profile id="845a-a61e-6901-2a84" name="Macharius Vulcan" publicationId="cf03-f607-pubN134767" page="230" hidden="false" typeId="56656869636c6523232344415441232323" typeName="Vehicle">
           <characteristics>
@@ -11569,25 +11580,25 @@ Assault rules unless otherwise noted.</description>
         <categoryLink id="8da7-3a1b-9877-1f82" name="New CategoryLink" hidden="false" targetId="53bd-99e7-aba0-e79f" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="42d1-c0d7-c941-1875" name="Sponsons" hidden="false" collective="false" defaultSelectionEntryId="7c79-ce78-c993-284f">
+        <selectionEntryGroup id="42d1-c0d7-c941-1875" name="Sponsons" hidden="false" collective="false" import="true" defaultSelectionEntryId="7c79-ce78-c993-284f">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="be76-7fea-64e3-7521" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1c07-e663-4556-075f" type="min"/>
           </constraints>
           <entryLinks>
-            <entryLink id="7c79-ce78-c993-284f" name="Heavy Stubber" hidden="false" collective="false" targetId="0cbc-ea7d-05e7-2d5c" type="selectionEntry">
+            <entryLink id="7c79-ce78-c993-284f" name="Heavy Stubber" hidden="false" collective="false" import="true" targetId="0cbc-ea7d-05e7-2d5c" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="points" value="0.0"/>
                 <modifier type="set" field="name" value="Two Sponson-mounted Heavy Stubbers"/>
               </modifiers>
             </entryLink>
-            <entryLink id="56ce-91c9-d0ef-dae8" name="Heavy Bolter" hidden="false" collective="false" targetId="512b-a9be-50a4-c909" type="selectionEntry">
+            <entryLink id="56ce-91c9-d0ef-dae8" name="Heavy Bolter" hidden="false" collective="false" import="true" targetId="512b-a9be-50a4-c909" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="points" value="10"/>
                 <modifier type="set" field="name" value="Two Sponson-mounted Heavy Bolters"/>
               </modifiers>
             </entryLink>
-            <entryLink id="66df-5ec7-61cd-d0dd" name="Heavy Flamer" hidden="false" collective="false" targetId="ead9-305c-a7e7-323e" type="selectionEntry">
+            <entryLink id="66df-5ec7-61cd-d0dd" name="Heavy Flamer" hidden="false" collective="false" import="true" targetId="ead9-305c-a7e7-323e" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="name" value="Two Sponson-mounted Heavy Flamers"/>
                 <modifier type="set" field="points" value="10"/>
@@ -11595,18 +11606,18 @@ Assault rules unless otherwise noted.</description>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="e2c1-0695-ac06-5a19" name="May be given one pintle-mounted" publicationId="cf03-f607-pubN135015" page="120" hidden="false" collective="false">
+        <selectionEntryGroup id="e2c1-0695-ac06-5a19" name="May be given one pintle-mounted" publicationId="cf03-f607-pubN135015" page="120" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f9c7-3948-5ec8-2055" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="6a36-7bf6-83cf-fdb7" name="Heavy Stubber" hidden="false" collective="false" targetId="0cbc-ea7d-05e7-2d5c" type="selectionEntry">
+            <entryLink id="6a36-7bf6-83cf-fdb7" name="Heavy Stubber" hidden="false" collective="false" import="true" targetId="0cbc-ea7d-05e7-2d5c" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="points" value="10"/>
                 <modifier type="set" field="name" value="Pintle-mounted Heavy Stubber"/>
               </modifiers>
             </entryLink>
-            <entryLink id="d40a-781c-ddb2-d15f" name="Storm bolter" hidden="false" collective="false" targetId="8758-0d01-2cf7-3371" type="selectionEntry">
+            <entryLink id="d40a-781c-ddb2-d15f" name="Storm bolter" hidden="false" collective="false" import="true" targetId="8758-0d01-2cf7-3371" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="points" value="10"/>
                 <modifier type="set" field="name" value="Pintle-mounted Storm bolter"/>
@@ -11614,9 +11625,9 @@ Assault rules unless otherwise noted.</description>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="7938-3f3c-477c-7163" name="May take:" hidden="false" collective="false">
+        <selectionEntryGroup id="7938-3f3c-477c-7163" name="May take:" hidden="false" collective="false" import="true">
           <entryLinks>
-            <entryLink id="4b85-abee-e013-252b" name="Hunter-killer Missile" hidden="false" collective="false" targetId="287b-b205-0926-5822" type="selectionEntry">
+            <entryLink id="4b85-abee-e013-252b" name="Hunter-killer Missile" hidden="false" collective="false" import="true" targetId="287b-b205-0926-5822" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="points" value="10"/>
               </modifiers>
@@ -11631,7 +11642,7 @@ Assault rules unless otherwise noted.</description>
         <cost name="pts" typeId="points" value="405.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="07a7-a3a5-d46e-b873" name="Macharius Vanquisher" publicationId="cf03-f607-pubN130172" page="231" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="07a7-a3a5-d46e-b873" name="Macharius Vanquisher" publicationId="cf03-f607-pubN130172" page="231" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="80e5-06be-b43a-99fd" name="Macharius Vanquisher" publicationId="cf03-f607-pubN130172" page="231" hidden="false" typeId="56656869636c6523232344415441232323" typeName="Vehicle">
           <characteristics>
@@ -11672,18 +11683,18 @@ Any abilities that allow the vehicle to fire multiple shots will use the same sh
         <categoryLink id="9510-9461-1622-9ba3" name="New CategoryLink" hidden="false" targetId="53bd-99e7-aba0-e79f" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="bf11-6a37-9128-d805" name="May be given one pintle-mounted" publicationId="cf03-f607-pubN135015" page="120" hidden="false" collective="false">
+        <selectionEntryGroup id="bf11-6a37-9128-d805" name="May be given one pintle-mounted" publicationId="cf03-f607-pubN135015" page="120" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f4db-77c0-f319-f3bb" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="d218-e6a8-2c9e-d2ed" name="Heavy Stubber" hidden="false" collective="false" targetId="0cbc-ea7d-05e7-2d5c" type="selectionEntry">
+            <entryLink id="d218-e6a8-2c9e-d2ed" name="Heavy Stubber" hidden="false" collective="false" import="true" targetId="0cbc-ea7d-05e7-2d5c" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="points" value="10"/>
                 <modifier type="set" field="name" value="Pintle-mounted Heavy Stubber"/>
               </modifiers>
             </entryLink>
-            <entryLink id="40d0-e391-4044-5f0e" name="Storm bolter" hidden="false" collective="false" targetId="8758-0d01-2cf7-3371" type="selectionEntry">
+            <entryLink id="40d0-e391-4044-5f0e" name="Storm bolter" hidden="false" collective="false" import="true" targetId="8758-0d01-2cf7-3371" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="points" value="10"/>
                 <modifier type="set" field="name" value="Pintle-mounted Storm bolter"/>
@@ -11691,18 +11702,18 @@ Any abilities that allow the vehicle to fire multiple shots will use the same sh
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="ab2e-b1b6-0b9b-3276" name="May be given one pintle-mounted" publicationId="cf03-f607-pubN135015" page="120" hidden="false" collective="false">
+        <selectionEntryGroup id="ab2e-b1b6-0b9b-3276" name="May be given one pintle-mounted" publicationId="cf03-f607-pubN135015" page="120" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bad1-d044-5e2e-f157" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="bec8-6c14-ce81-3334" name="Heavy Stubber" hidden="false" collective="false" targetId="0cbc-ea7d-05e7-2d5c" type="selectionEntry">
+            <entryLink id="bec8-6c14-ce81-3334" name="Heavy Stubber" hidden="false" collective="false" import="true" targetId="0cbc-ea7d-05e7-2d5c" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="points" value="10"/>
                 <modifier type="set" field="name" value="Pintle-mounted Heavy Stubber"/>
               </modifiers>
             </entryLink>
-            <entryLink id="10fe-e9c7-1cc3-4320" name="Storm bolter" hidden="false" collective="false" targetId="8758-0d01-2cf7-3371" type="selectionEntry">
+            <entryLink id="10fe-e9c7-1cc3-4320" name="Storm bolter" hidden="false" collective="false" import="true" targetId="8758-0d01-2cf7-3371" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="points" value="10"/>
                 <modifier type="set" field="name" value="Pintle-mounted Storm bolter"/>
@@ -11710,25 +11721,25 @@ Any abilities that allow the vehicle to fire multiple shots will use the same sh
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="cddf-b360-06cf-6d3c" name="Sponsons" hidden="false" collective="false" defaultSelectionEntryId="dce1-3df5-e97f-1376">
+        <selectionEntryGroup id="cddf-b360-06cf-6d3c" name="Sponsons" hidden="false" collective="false" import="true" defaultSelectionEntryId="dce1-3df5-e97f-1376">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b6d0-39bf-8cb1-0019" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ce3e-21a5-0f8d-6e66" type="min"/>
           </constraints>
           <entryLinks>
-            <entryLink id="dce1-3df5-e97f-1376" name="Heavy Stubber" hidden="false" collective="false" targetId="0cbc-ea7d-05e7-2d5c" type="selectionEntry">
+            <entryLink id="dce1-3df5-e97f-1376" name="Heavy Stubber" hidden="false" collective="false" import="true" targetId="0cbc-ea7d-05e7-2d5c" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="points" value="0.0"/>
                 <modifier type="set" field="name" value="Two Sponson-mounted Heavy Stubbers"/>
               </modifiers>
             </entryLink>
-            <entryLink id="a76c-6997-0b55-6182" name="Heavy Bolter" hidden="false" collective="false" targetId="512b-a9be-50a4-c909" type="selectionEntry">
+            <entryLink id="a76c-6997-0b55-6182" name="Heavy Bolter" hidden="false" collective="false" import="true" targetId="512b-a9be-50a4-c909" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="points" value="10"/>
                 <modifier type="set" field="name" value="Two Sponson-mounted Heavy Bolters"/>
               </modifiers>
             </entryLink>
-            <entryLink id="cc80-b309-77f9-b5b8" name="Heavy Flamer" hidden="false" collective="false" targetId="ead9-305c-a7e7-323e" type="selectionEntry">
+            <entryLink id="cc80-b309-77f9-b5b8" name="Heavy Flamer" hidden="false" collective="false" import="true" targetId="ead9-305c-a7e7-323e" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="name" value="Two Sponson-mounted Heavy Flamers"/>
                 <modifier type="set" field="points" value="10"/>
@@ -11741,7 +11752,7 @@ Any abilities that allow the vehicle to fire multiple shots will use the same sh
         <cost name="pts" typeId="points" value="375.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="d893-4871-06f4-d2a9" name="Thallax Cohort (Icarian)" hidden="false" collective="false" type="unit">
+    <selectionEntry id="d893-4871-06f4-d2a9" name="Thallax Cohort (Icarian)" hidden="false" collective="false" import="true" type="unit">
       <rules>
         <rule id="355c-4fbc-d3c6-5e77" name="Icarian*" publicationId="cf03-f607-pubN76270" page="39" hidden="false">
           <description>If stationary that turn, the Cohort may, if wished, count as having the
@@ -11750,13 +11761,13 @@ Any abilities that allow the vehicle to fire multiple shots will use the same sh
         </rule>
       </rules>
       <selectionEntries>
-        <selectionEntry id="d31f-ce89-11a2-099d" name="Thallax" hidden="false" collective="false" type="model">
+        <selectionEntry id="d31f-ce89-11a2-099d" name="Thallax" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4ef9-70c5-d32a-be59" type="min"/>
             <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6cf1-b5a6-3045-4c38" type="max"/>
           </constraints>
           <profiles>
-            <profile id="5b08-6ef8-3674-064f" name="Thallax" publicationId="cf03-f607-pubN99227" page="290" hidden="false" typeId="556e697423232344415441232323" typeName="">
+            <profile id="5b08-6ef8-3674-064f" name="Thallax" publicationId="cf03-f607-pubN99227" page="290" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Jet Pack Infantry</characteristic>
                 <characteristic name="WS" typeId="575323232344415441232323">3</characteristic>
@@ -11781,7 +11792,7 @@ Any abilities that allow the vehicle to fire multiple shots will use the same sh
             <cost name="pts" typeId="points" value="40.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="1c71-0413-95eb-5412" name="Lightning gun" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="1c71-0413-95eb-5412" name="Lightning gun" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4d9a-272e-70ff-478f" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6117-03d9-c308-f90b" type="max"/>
@@ -11797,9 +11808,9 @@ Any abilities that allow the vehicle to fire multiple shots will use the same sh
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="83ad-8404-1f92-1134" name="Any Thallax may exchange their close combat weapon for:" hidden="false" collective="false">
+        <selectionEntryGroup id="83ad-8404-1f92-1134" name="Any Thallax may exchange their close combat weapon for:" hidden="false" collective="false" import="true">
           <selectionEntries>
-            <selectionEntry id="edbf-9c9b-ffcb-e2f2" name="Heavy Chainblade" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="edbf-9c9b-ffcb-e2f2" name="Heavy Chainblade" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="increment" field="8f04-5ec2-75ae-cf21" value="1">
                   <repeats>
@@ -11819,9 +11830,9 @@ Any abilities that allow the vehicle to fire multiple shots will use the same sh
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="75e5-54c9-6a89-0f4d" name="Entire squad may take:" hidden="false" collective="false">
+        <selectionEntryGroup id="75e5-54c9-6a89-0f4d" name="Entire squad may take:" hidden="false" collective="false" import="true">
           <selectionEntries>
-            <selectionEntry id="43ae-5618-7c59-f987" name="Melta bombs" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="43ae-5618-7c59-f987" name="Melta bombs" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="increment" field="points" value="5">
                   <repeats>
@@ -11841,7 +11852,7 @@ Any abilities that allow the vehicle to fire multiple shots will use the same sh
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="614d-295c-2617-24f9" name="One in three may exchange their Lightning Gun for:" hidden="false" collective="false">
+        <selectionEntryGroup id="614d-295c-2617-24f9" name="One in three may exchange their Lightning Gun for:" hidden="false" collective="false" import="true">
           <modifiers>
             <modifier type="increment" field="a726-01e2-ae2e-233a" value="1">
               <repeats>
@@ -11853,7 +11864,7 @@ Any abilities that allow the vehicle to fire multiple shots will use the same sh
             <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a726-01e2-ae2e-233a" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="0a60-6b61-f71b-d420" name="Multi-laser" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="0a60-6b61-f71b-d420" name="Multi-laser" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a2d1-2d62-35fb-ba48" type="max"/>
               </constraints>
@@ -11864,7 +11875,7 @@ Any abilities that allow the vehicle to fire multiple shots will use the same sh
                 <cost name="pts" typeId="points" value="5.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="1e5f-5e8e-70e9-0a73" name="Phase Plasma-fusil" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="1e5f-5e8e-70e9-0a73" name="Phase Plasma-fusil" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="93ba-0b95-0968-ced6" type="max"/>
               </constraints>
@@ -11875,7 +11886,7 @@ Any abilities that allow the vehicle to fire multiple shots will use the same sh
                 <cost name="pts" typeId="points" value="10.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="4920-147d-4bb2-b9c5" name="Irad-cleanser" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="4920-147d-4bb2-b9c5" name="Irad-cleanser" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8ea3-5875-e944-8087" type="max"/>
               </constraints>
@@ -11886,7 +11897,7 @@ Any abilities that allow the vehicle to fire multiple shots will use the same sh
                 <cost name="pts" typeId="points" value="10.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="292c-844d-ce4b-60e8" name="Multi-melta" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="292c-844d-ce4b-60e8" name="Multi-melta" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d3e7-e7cd-1bb5-ef82" type="max"/>
               </constraints>
@@ -11897,7 +11908,7 @@ Any abilities that allow the vehicle to fire multiple shots will use the same sh
                 <cost name="pts" typeId="points" value="15.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="08eb-767a-4f2b-2e11" name="Photon Thruster" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="08eb-767a-4f2b-2e11" name="Photon Thruster" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c851-e00a-7a01-43a2" type="max"/>
               </constraints>
@@ -11912,13 +11923,13 @@ Any abilities that allow the vehicle to fire multiple shots will use the same sh
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="17ec-e320-3e40-61cd" name="Triaros Armoured Conveyor" hidden="false" collective="false" targetId="bb6538b0-0f23-8a43-9752-dd356ba76e46" type="selectionEntry"/>
+        <entryLink id="17ec-e320-3e40-61cd" name="Triaros Armoured Conveyor" hidden="false" collective="false" import="true" targetId="bb6538b0-0f23-8a43-9752-dd356ba76e46" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="40.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="3812-6e1b-33c3-9a88" name="Divining Blades" hidden="true" collective="false" type="upgrade">
+    <selectionEntry id="3812-6e1b-33c3-9a88" name="Divining Blades" hidden="true" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d96c-d599-5ed9-8998" type="max"/>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="7747-cbc1-4591-9720" type="max"/>
@@ -11943,7 +11954,7 @@ Any abilities that allow the vehicle to fire multiple shots will use the same sh
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="6ad8-fbf2-07a8-237c" name="Mechanicum Knight Moirax Talon" publicationId="ece2-a265-6237-7efa" page="" hidden="false" collective="false" type="model">
+    <selectionEntry id="6ad8-fbf2-07a8-237c" name="Mechanicum Knight Moirax Talon" publicationId="ece2-a265-6237-7efa" page="" hidden="false" collective="false" import="true" type="model">
       <constraints>
         <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="deb7-d6bb-7e7d-6076" type="max"/>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c2ff-3d6f-b15f-722a" type="min"/>
@@ -11993,18 +12004,18 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <infoLink id="bdb7-6eef-efe3-b6e6" name="Move Through Cover" hidden="false" targetId="6d06-5ea0-9a17-ca97" type="rule"/>
       </infoLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="46f5-89e0-8075-664c" name="Must take Two weapons for the following" hidden="false" collective="false" defaultSelectionEntryId="9b43-2dc8-3dc6-6e46">
+        <selectionEntryGroup id="46f5-89e0-8075-664c" name="Must take Two weapons for the following" hidden="false" collective="false" import="true" defaultSelectionEntryId="9b43-2dc8-3dc6-6e46">
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="857f-70d5-0d82-a2bd" type="max"/>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0782-d5fd-b95e-8f3a" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="757a-2b90-c1c0-ac80" name="Gyges Siege Claw with in-built Rad Cleanser" publicationId="ece2-a265-6237-7efa" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="757a-2b90-c1c0-ac80" name="Gyges Siege Claw with in-built Rad Cleanser" publicationId="ece2-a265-6237-7efa" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8ae6-0e0e-7fb6-a6a0" type="max"/>
               </constraints>
               <profiles>
-                <profile id="60e5-5e47-2c4d-a460" name="Gyges Siege Claw" publicationId="ece2-a265-6237-7efa" page="" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+                <profile id="60e5-5e47-2c4d-a460" name="Gyges Siege Claw" publicationId="ece2-a265-6237-7efa" page="" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
                   <characteristics>
                     <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
                     <characteristic name="Strength" typeId="537472656e67746823232344415441232323">X2</characteristic>
@@ -12020,12 +12031,12 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="9b43-2dc8-3dc6-6e46" name="Volkite Veuglaire" publicationId="ece2-a265-6237-7efa" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="9b43-2dc8-3dc6-6e46" name="Volkite Veuglaire" publicationId="ece2-a265-6237-7efa" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f99e-3606-8aff-1c5a" type="max"/>
               </constraints>
               <profiles>
-                <profile id="8f0e-43af-5c02-5659" name="Volkite Veuglaire" publicationId="ece2-a265-6237-7efa" page="" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+                <profile id="8f0e-43af-5c02-5659" name="Volkite Veuglaire" publicationId="ece2-a265-6237-7efa" page="" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
                   <characteristics>
                     <characteristic name="Range" typeId="52616e676523232344415441232323">36&quot;</characteristic>
                     <characteristic name="Strength" typeId="537472656e67746823232344415441232323">6</characteristic>
@@ -12041,12 +12052,12 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="68e0-8f85-94ec-6d77" name="Lightning Lock" publicationId="ece2-a265-6237-7efa" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="68e0-8f85-94ec-6d77" name="Lightning Lock" publicationId="ece2-a265-6237-7efa" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7420-82bc-34d2-51ed" type="max"/>
               </constraints>
               <profiles>
-                <profile id="3349-a4be-718b-fb96" name="Lightning Lock" publicationId="ece2-a265-6237-7efa" page="" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+                <profile id="3349-a4be-718b-fb96" name="Lightning Lock" publicationId="ece2-a265-6237-7efa" page="" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
                   <characteristics>
                     <characteristic name="Range" typeId="52616e676523232344415441232323">36&quot;</characteristic>
                     <characteristic name="Strength" typeId="537472656e67746823232344415441232323">6</characteristic>
@@ -12063,6 +12074,63 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
                 <cost name="pts" typeId="points" value="5.0"/>
               </costs>
             </selectionEntry>
+            <selectionEntry id="67bd-048c-1403-44ba" name="Armiger Conversion Beam Cannon" publicationId="ece2-a265-6237-7efa" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f015-c8e7-5bd5-b704" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="466a-dfc1-95c1-18aa" name="Armiger Conversion Beam Cannon (3)" publicationId="ece2-a265-6237-7efa" page="" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="52616e676523232344415441232323">42&quot; – 72&quot;</characteristic>
+                    <characteristic name="Strength" typeId="537472656e67746823232344415441232323">10</characteristic>
+                    <characteristic name="AP" typeId="415023232344415441232323">1</characteristic>
+                    <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 1, Blast (3&quot;)</characteristic>
+                  </characteristics>
+                </profile>
+                <profile id="5381-cd2c-c962-7d4c" name="Armiger Conversion Beam Cannon (2)" publicationId="ece2-a265-6237-7efa" page="" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="52616e676523232344415441232323">18&quot; – 42&quot;</characteristic>
+                    <characteristic name="Strength" typeId="537472656e67746823232344415441232323">8</characteristic>
+                    <characteristic name="AP" typeId="415023232344415441232323">4</characteristic>
+                    <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 1, Blast (3&quot;)</characteristic>
+                  </characteristics>
+                </profile>
+                <profile id="6148-e629-5637-7c79" name="Armiger Conversion Beam Cannon (1)" publicationId="ece2-a265-6237-7efa" page="" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="52616e676523232344415441232323">Up to 18&quot;</characteristic>
+                    <characteristic name="Strength" typeId="537472656e67746823232344415441232323">6</characteristic>
+                    <characteristic name="AP" typeId="415023232344415441232323">-</characteristic>
+                    <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 1, Blast (3&quot;)</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="c723-6071-afaa-32c6" name="Graviton pulsar" publicationId="ece2-a265-6237-7efa" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5f68-5015-5f52-f176" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="e1fa-f5b5-6f4c-9ccb" name="Graviton pulsar" publicationId="ece2-a265-6237-7efa" page="" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="52616e676523232344415441232323">24&quot;</characteristic>
+                    <characteristic name="Strength" typeId="537472656e67746823232344415441232323">-</characteristic>
+                    <characteristic name="AP" typeId="415023232344415441232323">4</characteristic>
+                    <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 2, Blast (3&quot;), Concussive, Graviton Pulse, Haywire</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink id="8a2a-4952-a033-a3e8" name="Graviton Pulse" hidden="false" targetId="2d57-8425-0ec0-a9cf" type="rule"/>
+                <infoLink id="9b32-44c1-a1a6-9056" name="Haywire" hidden="false" targetId="6970-1bf3-b33e-5dce" type="rule"/>
+                <infoLink id="f52e-27ee-c1ac-fa07" name="Concussive" hidden="false" targetId="9d85-46f7-f5e6-a5f7" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
@@ -12070,7 +12138,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <cost name="pts" typeId="points" value="155.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="678d-0533-f5f7-2e43" name="Questoris Knight Armiger Talon" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="678d-0533-f5f7-2e43" name="Questoris Knight Armiger Talon" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f378-f460-6e34-0907" type="max"/>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b0a6-77ed-aa3a-1717" type="min"/>
@@ -12102,7 +12170,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         </rule>
       </rules>
       <selectionEntryGroups>
-        <selectionEntryGroup id="43bc-fe37-8a37-138a" name="May Take Bio-Corrosive Rounds for Heavy Stubber" hidden="false" collective="false">
+        <selectionEntryGroup id="43bc-fe37-8a37-138a" name="May Take Bio-Corrosive Rounds for Heavy Stubber" hidden="false" collective="false" import="true">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
@@ -12114,7 +12182,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b6d1-ec03-6220-0a45" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="3dd1-dc8a-e422-e2ed" name="Bio-Corrosive Rounds" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="3dd1-dc8a-e422-e2ed" name="Bio-Corrosive Rounds" hidden="false" collective="false" import="true" type="upgrade">
               <profiles>
                 <profile id="2b88-6098-2911-315e" name="Bio-Corrosive Rounds" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
                   <characteristics>
@@ -12131,13 +12199,13 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="b721-b3de-538d-32bb" name="May take One weapon for the following" hidden="false" collective="false">
+        <selectionEntryGroup id="b721-b3de-538d-32bb" name="May take One weapon for the following" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="bc96-c72e-bd17-05bb" type="max"/>
             <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ee2a-2492-78ca-5b61" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="3753-3e45-7b0f-08a0" name="Heavy Stubber" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="3753-3e45-7b0f-08a0" name="Heavy Stubber" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1799-b313-10cd-dba8" type="max"/>
               </constraints>
@@ -12155,7 +12223,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
                 <cost name="pts" typeId="points" value="5.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="e8ff-b261-e1e5-5eec" name="Meltagun" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="e8ff-b261-e1e5-5eec" name="Meltagun" hidden="false" collective="false" import="true" type="upgrade">
               <profiles>
                 <profile id="ce49-da0d-59ba-091d" name="Meltagun" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
                   <characteristics>
@@ -12172,18 +12240,18 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="0097-afa1-77ae-c36d" name="Must take Two weapons for the following" hidden="false" collective="false">
+        <selectionEntryGroup id="0097-afa1-77ae-c36d" name="Must take Two weapons for the following" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a29e-8ba5-b7f4-5aee" type="max"/>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a07b-395d-b722-275e" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="1ed3-f7db-c8dc-9629" name="Dreadnaught Close Combat Weapon" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="1ed3-f7db-c8dc-9629" name="Dreadnaught Close Combat Weapon" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cffe-e432-e9a6-7c83" type="max"/>
               </constraints>
               <profiles>
-                <profile id="8ef9-eb92-7632-bec7" name="Dreadnaught Close Combat Weapon" page="" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+                <profile id="8ef9-eb92-7632-bec7" name="Dreadnaught Close Combat Weapon" page="" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
                   <characteristics>
                     <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
                     <characteristic name="Strength" typeId="537472656e67746823232344415441232323">10</characteristic>
@@ -12196,12 +12264,12 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="da28-1df1-fc7a-837e" name="Armiger Autocannon" publicationId="cf03-f607-pubN70802" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="da28-1df1-fc7a-837e" name="Armiger Autocannon" publicationId="cf03-f607-pubN70802" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0907-883b-6d7e-d5ee" type="max"/>
               </constraints>
               <profiles>
-                <profile id="4c7b-b78a-57eb-5926" name="Armiger Autocannon (Armour Piercing Rounds)" publicationId="cf03-f607-pubN70679" page="" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+                <profile id="4c7b-b78a-57eb-5926" name="Armiger Autocannon (Armour Piercing Rounds)" publicationId="cf03-f607-pubN70679" page="" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
                   <characteristics>
                     <characteristic name="Range" typeId="52616e676523232344415441232323">64&quot;</characteristic>
                     <characteristic name="Strength" typeId="537472656e67746823232344415441232323">7</characteristic>
@@ -12209,7 +12277,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
                     <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 2, Sunder</characteristic>
                   </characteristics>
                 </profile>
-                <profile id="217a-f86a-2eaa-d583" name="Armiger Autocannon (Incediary Rounds)" publicationId="cf03-f607-pubN70679" page="" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+                <profile id="217a-f86a-2eaa-d583" name="Armiger Autocannon (Incediary Rounds)" publicationId="cf03-f607-pubN70679" page="" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
                   <characteristics>
                     <characteristic name="Range" typeId="52616e676523232344415441232323">64&quot;</characteristic>
                     <characteristic name="Strength" typeId="537472656e67746823232344415441232323">7</characteristic>
@@ -12222,12 +12290,12 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
                 <cost name="pts" typeId="points" value="15.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="0d6e-0d40-e026-f17b" name="Armiger Thermal Spear" publicationId="cf03-f607-pubN70802" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="0d6e-0d40-e026-f17b" name="Armiger Thermal Spear" publicationId="cf03-f607-pubN70802" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7b8b-e8be-bee9-1017" type="max"/>
               </constraints>
               <profiles>
-                <profile id="de69-5bf1-6797-f514" name="Armiger Thermal Spear" publicationId="cf03-f607-pubN70679" page="" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+                <profile id="de69-5bf1-6797-f514" name="Armiger Thermal Spear" publicationId="cf03-f607-pubN70679" page="" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
                   <characteristics>
                     <characteristic name="Range" typeId="52616e676523232344415441232323">36&quot;</characteristic>
                     <characteristic name="Strength" typeId="537472656e67746823232344415441232323">8</characteristic>
@@ -12249,23 +12317,23 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
-    <selectionEntryGroup id="d696-042d-2afa-b026" name="Heavy Bolter or Heavy Flamer" hidden="false" collective="false">
+    <selectionEntryGroup id="d696-042d-2afa-b026" name="Heavy Bolter or Heavy Flamer" hidden="false" collective="false" import="true">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
       </constraints>
       <entryLinks>
-        <entryLink id="b99d-ce23-2205-09da" hidden="false" collective="false" targetId="fc12-daad-3988-3994" type="selectionEntry"/>
-        <entryLink id="3598-8a39-2b5f-2c8a" hidden="false" collective="false" targetId="512b-a9be-50a4-c909" type="selectionEntry"/>
+        <entryLink id="b99d-ce23-2205-09da" hidden="false" collective="false" import="true" targetId="fc12-daad-3988-3994" type="selectionEntry"/>
+        <entryLink id="3598-8a39-2b5f-2c8a" hidden="false" collective="false" import="true" targetId="512b-a9be-50a4-c909" type="selectionEntry"/>
       </entryLinks>
     </selectionEntryGroup>
-    <selectionEntryGroup id="df18-c724-2a3d-a6e5" name="May be mounted on:" hidden="false" collective="false">
+    <selectionEntryGroup id="df18-c724-2a3d-a6e5" name="May be mounted on:" hidden="false" collective="false" import="true">
       <constraints>
         <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
         <constraint field="selections" scope="parent" value="-1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
       </constraints>
       <selectionEntries>
-        <selectionEntry id="b64f-0f26-64a5-8298" name="Abeyant" page="0" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="b64f-0f26-64a5-8298" name="Abeyant" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
@@ -12281,7 +12349,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         </selectionEntry>
       </selectionEntries>
     </selectionEntryGroup>
-    <selectionEntryGroup id="e1ca-c072-fd46-7a57" name="Relics of the Dark Age of Technology" hidden="false" collective="false">
+    <selectionEntryGroup id="e1ca-c072-fd46-7a57" name="Relics of the Dark Age of Technology" hidden="false" collective="false" import="true">
       <constraints>
         <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
         <constraint field="selections" scope="parent" value="-1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
@@ -12293,14 +12361,14 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <constraint field="points" scope="parent" value="-1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxPoints" type="max"/>
       </constraints>
       <selectionEntries>
-        <selectionEntry id="a5e6-98e2-7dc4-6db2" name="Nanyte Blaster" publicationId="cf03-f607-pubN99227" page="223" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="a5e6-98e2-7dc4-6db2" name="Nanyte Blaster" publicationId="cf03-f607-pubN99227" page="223" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
             <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
             <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
           </constraints>
           <profiles>
-            <profile id="12a5-8c0d-1273-c1ee" name="Nanyte Blaster" publicationId="cf03-f607-pubN99227" page="223" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+            <profile id="12a5-8c0d-1273-c1ee" name="Nanyte Blaster" publicationId="cf03-f607-pubN99227" page="223" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
               <characteristics>
                 <characteristic name="Range" typeId="52616e676523232344415441232323">12&quot;</characteristic>
                 <characteristic name="Strength" typeId="537472656e67746823232344415441232323">5</characteristic>
@@ -12320,7 +12388,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
             <cost name="pts" typeId="points" value="40.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="d129-5ede-d4fc-cd6d" name="Warp Shunt Field" publicationId="cf03-f607-pubN99227" page="223" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="d129-5ede-d4fc-cd6d" name="Warp Shunt Field" publicationId="cf03-f607-pubN99227" page="223" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
             <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
@@ -12330,7 +12398,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
             <cost name="pts" typeId="points" value="35.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="0a39-a278-a3c5-5b3d" name="Phase-Walker" publicationId="cf03-f607-pubN99227" page="223" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="0a39-a278-a3c5-5b3d" name="Phase-Walker" publicationId="cf03-f607-pubN99227" page="223" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
             <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
@@ -12340,7 +12408,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
             <cost name="pts" typeId="points" value="45.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="c242-f2cd-0500-ebb3" name="Combat Augment Array" publicationId="cf03-f607-pubN99227" page="223" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="c242-f2cd-0500-ebb3" name="Combat Augment Array" publicationId="cf03-f607-pubN99227" page="223" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
             <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
@@ -12350,7 +12418,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
             <cost name="pts" typeId="points" value="35.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="201f-dc79-3340-16a8" name="Cloaking Array" publicationId="cf03-f607-pubN99227" page="223" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="201f-dc79-3340-16a8" name="Cloaking Array" publicationId="cf03-f607-pubN99227" page="223" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
             <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
@@ -12360,7 +12428,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
             <cost name="pts" typeId="points" value="40.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="4d83-9726-1961-fae1" name="Void Shield Harness" publicationId="cf03-f607-pubN99227" page="223" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="4d83-9726-1961-fae1" name="Void Shield Harness" publicationId="cf03-f607-pubN99227" page="223" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
             <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
@@ -12370,14 +12438,14 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
             <cost name="pts" typeId="points" value="40.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="de56-08f9-fd47-a951" name="Contagium Mechanica" publicationId="cf03-f607-pubN99227" page="224" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="de56-08f9-fd47-a951" name="Contagium Mechanica" publicationId="cf03-f607-pubN99227" page="224" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
             <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
             <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
           </constraints>
           <profiles>
-            <profile id="072a-3dc9-b752-7b0e" name="Contagium Mechanica" publicationId="cf03-f607-pubN99227" page="224" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+            <profile id="072a-3dc9-b752-7b0e" name="Contagium Mechanica" publicationId="cf03-f607-pubN99227" page="224" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
               <characteristics>
                 <characteristic name="Range" typeId="52616e676523232344415441232323">12&quot;</characteristic>
                 <characteristic name="Strength" typeId="537472656e67746823232344415441232323">-</characteristic>
@@ -12393,7 +12461,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
             <cost name="pts" typeId="points" value="30.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="2c7a-d4dd-d5fe-59a6" name="Cortica Primus" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="2c7a-d4dd-d5fe-59a6" name="Cortica Primus" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
             <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
@@ -12405,12 +12473,12 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         </selectionEntry>
       </selectionEntries>
     </selectionEntryGroup>
-    <selectionEntryGroup id="9d3d-aef5-6635-b0c6" name="Power Weapon" hidden="false" collective="false" defaultSelectionEntryId="90f3-4ab5-4201-ddfa">
+    <selectionEntryGroup id="9d3d-aef5-6635-b0c6" name="Power Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="90f3-4ab5-4201-ddfa">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="502f-9c4a-f632-80ad" type="max"/>
       </constraints>
       <selectionEntries>
-        <selectionEntry id="90f3-4ab5-4201-ddfa" name="Power axe" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="90f3-4ab5-4201-ddfa" name="Power axe" hidden="false" collective="false" import="true" type="upgrade">
           <infoLinks>
             <infoLink id="06bf-22de-9a79-b8c4" name="New InfoLink" hidden="false" targetId="b3af-1eca-6629-4894" type="profile"/>
           </infoLinks>
@@ -12418,7 +12486,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
             <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="027a-354c-d52c-a07d" name="Power Lance" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="027a-354c-d52c-a07d" name="Power Lance" hidden="false" collective="false" import="true" type="upgrade">
           <infoLinks>
             <infoLink id="522d-c429-a6ed-5a65" name="New InfoLink" hidden="false" targetId="fdd4-9bf3-da9d-5479" type="profile"/>
           </infoLinks>
@@ -12426,7 +12494,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
             <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="e5bb-8b05-e54c-6860" name="Power Maul" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="e5bb-8b05-e54c-6860" name="Power Maul" hidden="false" collective="false" import="true" type="upgrade">
           <infoLinks>
             <infoLink id="b404-bafc-59fa-5a50" name="New InfoLink" hidden="false" targetId="6bbe-f2c1-78e2-da59" type="profile"/>
           </infoLinks>
@@ -12434,7 +12502,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
             <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="9464-6bbc-da24-d996" name="Power sword" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="9464-6bbc-da24-d996" name="Power sword" hidden="false" collective="false" import="true" type="upgrade">
           <infoLinks>
             <infoLink id="8510-36fb-98ef-4951" name="New InfoLink" hidden="false" targetId="038e-23ec-4886-8b00" type="profile"/>
           </infoLinks>
@@ -12444,26 +12512,26 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         </selectionEntry>
       </selectionEntries>
     </selectionEntryGroup>
-    <selectionEntryGroup id="04fc-9823-28ea-591d" name="Dedicated Transport" hidden="false" collective="false">
+    <selectionEntryGroup id="04fc-9823-28ea-591d" name="Dedicated Transport" hidden="false" collective="false" import="true">
       <entryLinks>
-        <entryLink id="5463-6ffb-af3e-757a" name="" hidden="false" collective="false" targetId="bb6538b0-0f23-8a43-9752-dd356ba76e46" type="selectionEntry"/>
+        <entryLink id="5463-6ffb-af3e-757a" name="" hidden="false" collective="false" import="true" targetId="bb6538b0-0f23-8a43-9752-dd356ba76e46" type="selectionEntry"/>
       </entryLinks>
     </selectionEntryGroup>
-    <selectionEntryGroup id="4e41-e567-a14d-8e3a" name="Triaros/Karacnos optionals:" hidden="false" collective="false">
+    <selectionEntryGroup id="4e41-e567-a14d-8e3a" name="Triaros/Karacnos optionals:" hidden="false" collective="false" import="true">
       <entryLinks>
-        <entryLink id="36ab-ebde-d1c5-3d30" name="New EntryLink" hidden="false" collective="false" targetId="d00f-81d6-1749-9499" type="selectionEntry"/>
-        <entryLink id="0331-2746-380f-6ca8" name="Blessed Autosimulacra" hidden="false" collective="false" targetId="fb66-11c0-3cb4-aac3" type="selectionEntry"/>
-        <entryLink id="6025-3bae-68c7-aa19" name="New EntryLink" hidden="false" collective="false" targetId="8d58-8392-abdd-c6f1" type="selectionEntry"/>
-        <entryLink id="4537-9bc4-624b-0f1e" name="New EntryLink" hidden="false" collective="false" targetId="287b-b205-0926-5822" type="selectionEntry"/>
+        <entryLink id="36ab-ebde-d1c5-3d30" name="New EntryLink" hidden="false" collective="false" import="true" targetId="d00f-81d6-1749-9499" type="selectionEntry"/>
+        <entryLink id="0331-2746-380f-6ca8" name="Blessed Autosimulacra" hidden="false" collective="false" import="true" targetId="fb66-11c0-3cb4-aac3" type="selectionEntry"/>
+        <entryLink id="6025-3bae-68c7-aa19" name="New EntryLink" hidden="false" collective="false" import="true" targetId="8d58-8392-abdd-c6f1" type="selectionEntry"/>
+        <entryLink id="4537-9bc4-624b-0f1e" name="New EntryLink" hidden="false" collective="false" import="true" targetId="287b-b205-0926-5822" type="selectionEntry"/>
       </entryLinks>
     </selectionEntryGroup>
-    <selectionEntryGroup id="7722-2a80-cea6-fc30" name="Allegiance" hidden="false" collective="false">
+    <selectionEntryGroup id="7722-2a80-cea6-fc30" name="Allegiance" hidden="false" collective="false" import="true">
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="98b5-1974-a342-9759" type="max"/>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c09a-59b7-fe36-d0ad" type="min"/>
       </constraints>
       <selectionEntries>
-        <selectionEntry id="3a27-636b-b01b-24f8" name="Traitor" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="3a27-636b-b01b-24f8" name="Traitor" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5783-6204-d570-a11b" type="max"/>
           </constraints>
@@ -12471,7 +12539,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
             <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="85ff-bacf-a331-1022" name="Loyalist" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="85ff-bacf-a331-1022" name="Loyalist" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a14f-f162-e504-2299" type="max"/>
           </constraints>
@@ -12481,7 +12549,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         </selectionEntry>
       </selectionEntries>
     </selectionEntryGroup>
-    <selectionEntryGroup id="8ea4-951b-6a14-f20c" name="Legio/Ordo" hidden="false" collective="false" defaultSelectionEntryId="66fa-9471-1b2a-7809">
+    <selectionEntryGroup id="8ea4-951b-6a14-f20c" name="Legio/Ordo" hidden="false" collective="false" import="true" defaultSelectionEntryId="66fa-9471-1b2a-7809">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="76e0-b8a8-5fd2-69b9" type="min"/>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="242a-0b6c-9350-74f4" type="max"/>
@@ -12489,18 +12557,18 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ea80-a6e7-c514-56aa" type="min"/>
       </constraints>
       <entryLinks>
-        <entryLink id="36d1-78cf-285b-64b7" name="Legio Cybernetica" hidden="false" collective="false" targetId="d266-0416-a5a6-881e" type="selectionEntry"/>
-        <entryLink id="f3ff-eb33-9943-b47c" name="Ordo Reductor" hidden="false" collective="false" targetId="0199-0faf-34c8-fbee" type="selectionEntry"/>
-        <entryLink id="66fa-9471-1b2a-7809" name="Taghmata Omnissiah" hidden="false" collective="false" targetId="d76d-0097-d56b-e6bf" type="selectionEntry"/>
+        <entryLink id="36d1-78cf-285b-64b7" name="Legio Cybernetica" hidden="false" collective="false" import="true" targetId="d266-0416-a5a6-881e" type="selectionEntry"/>
+        <entryLink id="f3ff-eb33-9943-b47c" name="Ordo Reductor" hidden="false" collective="false" import="true" targetId="0199-0faf-34c8-fbee" type="selectionEntry"/>
+        <entryLink id="66fa-9471-1b2a-7809" name="Taghmata Omnissiah" hidden="false" collective="false" import="true" targetId="d76d-0097-d56b-e6bf" type="selectionEntry"/>
       </entryLinks>
     </selectionEntryGroup>
-    <selectionEntryGroup id="34ef-5d4f-eacc-55f7" name="May be upgraded with one of the following augment upgrades:" hidden="false" collective="false">
+    <selectionEntryGroup id="34ef-5d4f-eacc-55f7" name="May be upgraded with one of the following augment upgrades:" hidden="false" collective="false" import="true">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="20e8-1786-3d83-984c" type="max"/>
         <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d38b-8b3a-51f3-2db1" type="min"/>
       </constraints>
       <selectionEntries>
-        <selectionEntry id="73fd-45ff-5b7f-7980" name="Ferrox" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="73fd-45ff-5b7f-7980" name="Ferrox" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2edf-ee4a-8af5-f1a8" type="max"/>
           </constraints>
@@ -12515,7 +12583,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
             <cost name="pts" typeId="points" value="25.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="c6bb-c518-4f4f-4314" name="Destructor" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="c6bb-c518-4f4f-4314" name="Destructor" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="526d-46de-2d3e-5ce2" type="max"/>
           </constraints>
@@ -12531,7 +12599,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
             <cost name="pts" typeId="points" value="15.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="ab4b-d466-4717-b7af" name="Empyrite" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="ab4b-d466-4717-b7af" name="Empyrite" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1fce-3c93-c2e5-fe4c" type="max"/>
           </constraints>
@@ -12551,26 +12619,26 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         </selectionEntry>
       </selectionEntries>
     </selectionEntryGroup>
-    <selectionEntryGroup id="70aa-19eb-c232-8e3d" name="The Orders of High Techno-Arcana" hidden="false" collective="false">
+    <selectionEntryGroup id="70aa-19eb-c232-8e3d" name="The Orders of High Techno-Arcana" hidden="false" collective="false" import="true">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a8d3-c7b8-6470-aa27" type="min"/>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="152e-36b4-ec69-0c55" type="max"/>
       </constraints>
       <entryLinks>
-        <entryLink id="8283-e14d-6142-2b36" name="Archimandrite" hidden="false" collective="false" targetId="46a4-3ef5-bcaf-b561" type="selectionEntry"/>
-        <entryLink id="3cf9-905d-b72c-38e5" name="Malagra" hidden="false" collective="false" targetId="c615-024f-f3f7-78e6" type="selectionEntry"/>
-        <entryLink id="3263-edb0-ab8e-4ebe" name="Myrmidax" hidden="false" collective="false" targetId="1b7f-df93-0cbf-cf8c" type="selectionEntry"/>
-        <entryLink id="97a5-0d78-c584-79ee" name="Macrotek" hidden="false" collective="false" targetId="0330-6762-6797-0a42" type="selectionEntry"/>
-        <entryLink id="8922-219a-d998-083b" name="Lachrimallus" hidden="false" collective="false" targetId="02dc-3228-2e92-c3a8" type="selectionEntry"/>
-        <entryLink id="933c-6460-8a8d-3416" name="Ordinator" hidden="false" collective="false" targetId="0065-6fab-1d05-84eb" type="selectionEntry"/>
+        <entryLink id="8283-e14d-6142-2b36" name="Archimandrite" hidden="false" collective="false" import="true" targetId="46a4-3ef5-bcaf-b561" type="selectionEntry"/>
+        <entryLink id="3cf9-905d-b72c-38e5" name="Malagra" hidden="false" collective="false" import="true" targetId="c615-024f-f3f7-78e6" type="selectionEntry"/>
+        <entryLink id="3263-edb0-ab8e-4ebe" name="Myrmidax" hidden="false" collective="false" import="true" targetId="1b7f-df93-0cbf-cf8c" type="selectionEntry"/>
+        <entryLink id="97a5-0d78-c584-79ee" name="Macrotek" hidden="false" collective="false" import="true" targetId="0330-6762-6797-0a42" type="selectionEntry"/>
+        <entryLink id="8922-219a-d998-083b" name="Lachrimallus" hidden="false" collective="false" import="true" targetId="02dc-3228-2e92-c3a8" type="selectionEntry"/>
+        <entryLink id="933c-6460-8a8d-3416" name="Ordinator" hidden="false" collective="false" import="true" targetId="0065-6fab-1d05-84eb" type="selectionEntry"/>
       </entryLinks>
     </selectionEntryGroup>
-    <selectionEntryGroup id="8ffb-2a32-888b-41ef" name="May take up to two: (Baneblade/Shadowsword Sponsons)" hidden="false" collective="false">
+    <selectionEntryGroup id="8ffb-2a32-888b-41ef" name="May take up to two: (Baneblade/Shadowsword Sponsons)" hidden="false" collective="false" import="true">
       <constraints>
         <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6d80-2297-b3f0-5308" type="max"/>
       </constraints>
       <selectionEntries>
-        <selectionEntry id="1e33-f07d-ed5f-aaa8" name="Pairs of side sponsons, each with one Lascannon and one twin-linked Heavy Bolter" page="0" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="1e33-f07d-ed5f-aaa8" name="Pairs of side sponsons, each with one Lascannon and one twin-linked Heavy Bolter" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8f23-a008-52ee-2fff" type="max"/>
           </constraints>
@@ -12582,7 +12650,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
             <cost name="pts" typeId="points" value="50.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="2d08-c42e-843d-5e8c" name="Targeters" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="2d08-c42e-843d-5e8c" name="Targeters" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9944-9fc9-a568-ce49" type="max"/>
           </constraints>
@@ -12592,9 +12660,9 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         </selectionEntry>
       </selectionEntries>
     </selectionEntryGroup>
-    <selectionEntryGroup id="5527-f4ef-035b-11c2" name="Wargear" hidden="false" collective="false">
+    <selectionEntryGroup id="5527-f4ef-035b-11c2" name="Wargear" hidden="false" collective="false" import="true">
       <selectionEntries>
-        <selectionEntry id="b4ea-a586-86a9-02eb" name="Nuncio-vox" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="b4ea-a586-86a9-02eb" name="Nuncio-vox" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8ccf-07cb-9064-9762" type="max"/>
           </constraints>
@@ -12605,7 +12673,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
             <cost name="pts" typeId="points" value="10.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="91c7-90a8-a1ae-cde0" name="Legion Vexilla" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="91c7-90a8-a1ae-cde0" name="Legion Vexilla" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a592-1d66-c299-b987" type="max"/>
           </constraints>
@@ -12616,7 +12684,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
             <cost name="pts" typeId="points" value="10.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="dd74-ccdb-9bc6-7069" name="Artificer Armour" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="dd74-ccdb-9bc6-7069" name="Artificer Armour" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="535d-a0a7-ce4e-6ab5" type="max"/>
           </constraints>
@@ -12631,7 +12699,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
             <cost name="pts" typeId="points" value="10.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="ab39-d41c-7f2d-a92b" name="Combat Shield" publicationId="cf03-f607-pubN140385" page="131" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="ab39-d41c-7f2d-a92b" name="Combat Shield" publicationId="cf03-f607-pubN140385" page="131" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8e0d-f89e-8c8d-2d29" type="max"/>
           </constraints>
@@ -12646,7 +12714,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
             <cost name="pts" typeId="points" value="5.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="1c30-47c5-950a-e3df" name="Boarding Shield" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="1c30-47c5-950a-e3df" name="Boarding Shield" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4f5f-b5eb-eb91-d212" type="max"/>
           </constraints>
@@ -12657,7 +12725,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
             <cost name="pts" typeId="points" value="10.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="131a-f920-a4da-1196" name="Jump Pack" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="131a-f920-a4da-1196" name="Jump Pack" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="bb9a-1adf-8c3d-0560" type="max"/>
             <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c90e-f674-9793-926a" type="min"/>
@@ -12672,7 +12740,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
             <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="5b17-8f37-be37-1146" name="Space Marine Bike" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="5b17-8f37-be37-1146" name="Space Marine Bike" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d441-c235-b1b9-eb8f" type="max"/>
             <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8c45-d376-3ee9-a6f7" type="min"/>
@@ -12869,7 +12937,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
     </rule>
   </sharedRules>
   <sharedProfiles>
-    <profile id="2db60061-47bc-2922-17b3-88cd261bac40" name="Anbaric Claw" publicationId="cf03-f607-pubN123006" page="238" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+    <profile id="2db60061-47bc-2922-17b3-88cd261bac40" name="Anbaric Claw" publicationId="cf03-f607-pubN123006" page="238" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">5</characteristic>
@@ -12877,7 +12945,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Rending</characteristic>
       </characteristics>
     </profile>
-    <profile id="f4ffca2c-8bb4-2d0a-9f48-d0babbde81e7" name="Apocalypse Launcher" publicationId="cf03-f607-pubN123006" page="274" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+    <profile id="f4ffca2c-8bb4-2d0a-9f48-d0babbde81e7" name="Apocalypse Launcher" publicationId="cf03-f607-pubN123006" page="274" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">24&quot; - 360&quot;</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">7</characteristic>
@@ -12885,7 +12953,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323">Apocalyptic Barrage 5</characteristic>
       </characteristics>
     </profile>
-    <profile id="5dd1-7b54-96c3-ff36" name="Arioch Titan Power Claw" publicationId="cf03-f607-pubN80965" page="264" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+    <profile id="5dd1-7b54-96c3-ff36" name="Arioch Titan Power Claw" publicationId="cf03-f607-pubN80965" page="264" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">D</characteristic>
@@ -12893,12 +12961,12 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323">Melee, +1 Attack, Machine Destroyer</characteristic>
       </characteristics>
     </profile>
-    <profile id="6eb5b812-8b8b-9e7c-279e-c9e9c93fefe9" name="Atomantic Shielding" publicationId="cf03-f607-pubN76979" page="207" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="">
+    <profile id="6eb5b812-8b8b-9e7c-279e-c9e9c93fefe9" name="Atomantic Shielding" publicationId="cf03-f607-pubN76979" page="207" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
       <characteristics>
         <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Gains 5++ Invulnerable save from shooting attacks and explosions, and a 6++ Invulnerable save in close combat.  In addition, add +1 to the range of explosions from the Reactor Blast rule.  </characteristic>
       </characteristics>
     </profile>
-    <profile id="99a47c75-0410-1c54-8124-3adcbd64aa7e" name="Breacher Charge" publicationId="cf03-f607-pubN80892" page="86" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+    <profile id="99a47c75-0410-1c54-8124-3adcbd64aa7e" name="Breacher Charge" publicationId="cf03-f607-pubN80892" page="86" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">Special</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">8</characteristic>
@@ -12906,7 +12974,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323">Melee, One Use, Blast, Wrecker</characteristic>
       </characteristics>
     </profile>
-    <profile id="50707f97-ecd0-785e-cccc-8f866cac5ecb" name="Charnabal Sabre" publicationId="cf03-f607-pubN80892" page="86" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+    <profile id="50707f97-ecd0-785e-cccc-8f866cac5ecb" name="Charnabal Sabre" publicationId="cf03-f607-pubN80892" page="86" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">User</characteristic>
@@ -12914,17 +12982,17 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Rending, Deullist&apos;s Edge</characteristic>
       </characteristics>
     </profile>
-    <profile id="4687f5b1-f0b1-12bd-8cc7-27f9f25befaf" name="Cognis-signum" publicationId="cf03-f607-pubN80892" page="88" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="">
+    <profile id="4687f5b1-f0b1-12bd-8cc7-27f9f25befaf" name="Cognis-signum" publicationId="cf03-f607-pubN80892" page="88" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
       <characteristics>
         <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Model equipped with Cognis-sigum gains Night Vision special rule.  In addition, in lieu of firing a weapon in the Shooting phase, a single designated unit of the controlling player&apos;s choice withing 6&quot; of the signum-equipped model (excluding Independent Characters and Super-Heavies) gains a bonus of +1 to their BS for that shooting phase.  </characteristic>
       </characteristics>
     </profile>
-    <profile id="244f6dcc-d526-1cef-a743-6120614e3898" name="Combat Shield" publicationId="cf03-f607-pubN80892" page="89" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="">
+    <profile id="244f6dcc-d526-1cef-a743-6120614e3898" name="Combat Shield" publicationId="cf03-f607-pubN80892" page="89" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
       <characteristics>
         <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Confers 6++ invulnverable save, increasing to a 5++ in close combat.  User is treated as having defensive grenades, but may never claim the extra attack for being armed with an additional close combat weapon.  </characteristic>
       </characteristics>
     </profile>
-    <profile id="21f23fa8-cf11-b9c3-d613-1b711b0897d7" name="Combi-bolter" publicationId="cf03-f607-pubN80892" page="82" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+    <profile id="21f23fa8-cf11-b9c3-d613-1b711b0897d7" name="Combi-bolter" publicationId="cf03-f607-pubN80892" page="82" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">24&quot;</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">4</characteristic>
@@ -12932,7 +13000,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323">Rapid Fire, Twin-linked</characteristic>
       </characteristics>
     </profile>
-    <profile id="0ae81fbd-a9d1-4327-f3df-1fc26dce2ab1" name="Conversion Beamer (1)" publicationId="cf03-f607-pubN80892" page="82" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+    <profile id="0ae81fbd-a9d1-4327-f3df-1fc26dce2ab1" name="Conversion Beamer (1)" publicationId="cf03-f607-pubN80892" page="82" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">&lt; 18&quot;</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">6</characteristic>
@@ -12940,7 +13008,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 1, Blast</characteristic>
       </characteristics>
     </profile>
-    <profile id="bf49e57d-4c20-456e-40fc-2325493da257" name="Conversion Beamer (2)" publicationId="cf03-f607-pubN80892" page="82" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+    <profile id="bf49e57d-4c20-456e-40fc-2325493da257" name="Conversion Beamer (2)" publicationId="cf03-f607-pubN80892" page="82" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">18&quot; - 42&quot;</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">8</characteristic>
@@ -12948,7 +13016,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 1, Blast</characteristic>
       </characteristics>
     </profile>
-    <profile id="b2930d75-e708-3443-a9ba-fbba33fdf5a7" name="Conversion Beamer (3)" publicationId="cf03-f607-pubN80892" page="82" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+    <profile id="b2930d75-e708-3443-a9ba-fbba33fdf5a7" name="Conversion Beamer (3)" publicationId="cf03-f607-pubN80892" page="82" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">42&quot; - 72&quot;</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">10</characteristic>
@@ -12956,7 +13024,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 1, Blast</characteristic>
       </characteristics>
     </profile>
-    <profile id="0d17-72cb-264b-ea3e" name="Corposant Stave" publicationId="cf03-f607-pubN76979" page="206" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+    <profile id="0d17-72cb-264b-ea3e" name="Corposant Stave" publicationId="cf03-f607-pubN76979" page="206" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">+1</characteristic>
@@ -12964,12 +13032,12 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Two-handed, Concussive, Haywire*</characteristic>
       </characteristics>
     </profile>
-    <profile id="67e9d995-de3f-f033-9026-c1faa0a9433a" name="Cyber-familiar" publicationId="cf03-f607-pubN80892" page="89" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="">
+    <profile id="67e9d995-de3f-f033-9026-c1faa0a9433a" name="Cyber-familiar" publicationId="cf03-f607-pubN80892" page="89" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
       <characteristics>
         <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">A Cyber-familiar adds +1 to its owners Invulnerable save (to a maximum of 3++) or provides an Invulnerable save of a 6++.   In addition they allow the owner to re-roll failed characteristic tests other than Leadership tests and failed Dangerous Terrain tests.  </characteristic>
       </characteristics>
     </profile>
-    <profile id="72412ca2-baf9-c015-aa79-27348c37fda2" name="Cyber-occularis" publicationId="cf03-f607-pubN76979" page="207" hidden="false" typeId="556e697423232344415441232323" typeName="">
+    <profile id="72412ca2-baf9-c015-aa79-27348c37fda2" name="Cyber-occularis" publicationId="cf03-f607-pubN76979" page="207" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
       <characteristics>
         <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Jet Pack Infantry</characteristic>
         <characteristic name="WS" typeId="575323232344415441232323">2</characteristic>
@@ -12983,7 +13051,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Save" typeId="5361766523232344415441232323">3+</characteristic>
       </characteristics>
     </profile>
-    <profile id="4e785d0e-85ad-2d40-bd57-9a3eab413431" name="Darkfire Cannon" publicationId="cf03-f607-pubN76979" page="209" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+    <profile id="4e785d0e-85ad-2d40-bd57-9a3eab413431" name="Darkfire Cannon" publicationId="cf03-f607-pubN76979" page="209" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">60&quot;</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">7</characteristic>
@@ -12991,12 +13059,12 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 2, Lance, Blind, Gets Hot</characteristic>
       </characteristics>
     </profile>
-    <profile id="0f5f4d88-fe1f-092e-ef2a-1601bcb2fc9d" name="Digital Lasers" publicationId="cf03-f607-pubN80892" page="87" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="">
+    <profile id="0f5f4d88-fe1f-092e-ef2a-1601bcb2fc9d" name="Digital Lasers" publicationId="cf03-f607-pubN80892" page="87" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
       <characteristics>
         <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Provides +1 Attack in close combat</characteristic>
       </characteristics>
     </profile>
-    <profile id="2160e9dc-0bd4-805f-95ff-311ab8045e01" name="Double-barrelled Turbo-laser Destructor" publicationId="cf03-f607-pubN123006" page="274" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+    <profile id="2160e9dc-0bd4-805f-95ff-311ab8045e01" name="Double-barrelled Turbo-laser Destructor" publicationId="cf03-f607-pubN123006" page="274" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">96&quot;</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">D</characteristic>
@@ -13004,22 +13072,22 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 2, Large Blast</characteristic>
       </characteristics>
     </profile>
-    <profile id="32d0aafa-fa2b-fac9-e5f7-d0b6660bd6df" name="Enhanced Targeting Array" publicationId="cf03-f607-pubN76979" page="207" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="">
+    <profile id="32d0aafa-fa2b-fac9-e5f7-d0b6660bd6df" name="Enhanced Targeting Array" publicationId="cf03-f607-pubN76979" page="207" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
       <characteristics>
         <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">A model with this upgrade increases its BS by +1 and reduces enemy cover saves by -1. </characteristic>
       </characteristics>
     </profile>
-    <profile id="a7069849-cdd7-ffb1-8088-8300704afcae" name="Flare Shield" publicationId="cf03-f607-pubN80892" page="89" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="">
+    <profile id="a7069849-cdd7-ffb1-8088-8300704afcae" name="Flare Shield" publicationId="cf03-f607-pubN80892" page="89" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
       <characteristics>
         <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">A flare shield operates against shooting attacks that strike the vehicle&apos;s front arc.  It reduces the strength of attacks by weapons with the Templae or Blast type by -2, and other shooting attacks by -1.  A flare shield has no effect on attacks from close combat or with the Destroyer rule.   Note that for Vultarax (and other monstrous creatures) the flare shield applies to all ranged attacks against the automata as it has no &apos;Front Arc&apos;.</characteristic>
       </characteristics>
     </profile>
-    <profile id="a820a8ed-f726-09ac-2a57-9caf6cdb42de" name="Galvanic Traction Drive" publicationId="cf03-f607-pubN76979" page="228" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="">
+    <profile id="a820a8ed-f726-09ac-2a57-9caf6cdb42de" name="Galvanic Traction Drive" publicationId="cf03-f607-pubN76979" page="228" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
       <characteristics>
         <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">This unit must re-roll failed Dangerous Terrain tests.  </characteristic>
       </characteristics>
     </profile>
-    <profile id="2b6ad4a5-3835-33fe-c049-456fd3b1ee4b" name="Gatling Blaster" publicationId="cf03-f607-pubN123006" page="274" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+    <profile id="2b6ad4a5-3835-33fe-c049-456fd3b1ee4b" name="Gatling Blaster" publicationId="cf03-f607-pubN123006" page="274" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">72&quot;</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">8</characteristic>
@@ -13027,7 +13095,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 6, Large Blast</characteristic>
       </characteristics>
     </profile>
-    <profile id="f2f72945-09db-4b7c-e6aa-c50dfd7bdd72" name="Graviton Cannon" publicationId="cf03-f607-pubN80892" page="83" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+    <profile id="f2f72945-09db-4b7c-e6aa-c50dfd7bdd72" name="Graviton Cannon" publicationId="cf03-f607-pubN80892" page="83" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">36&quot;</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">*</characteristic>
@@ -13035,7 +13103,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 1, Large Blast, Concussive, Graviton Pulse, Haywire</characteristic>
       </characteristics>
     </profile>
-    <profile id="48a06170-d952-045d-a033-bd04d1122b59" name="Graviton Gun" publicationId="cf03-f607-pubN80892" page="83" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+    <profile id="48a06170-d952-045d-a033-bd04d1122b59" name="Graviton Gun" publicationId="cf03-f607-pubN80892" page="83" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">18&quot;</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">*</characteristic>
@@ -13043,7 +13111,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 1, Blast, Concussion, Graviton Pulse, Haywire</characteristic>
       </characteristics>
     </profile>
-    <profile id="c73d6a53-afb0-ccb6-8977-c5eb88576611" name="Graviton Imploder" publicationId="cf03-f607-pubN76979" page="209" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+    <profile id="c73d6a53-afb0-ccb6-8977-c5eb88576611" name="Graviton Imploder" publicationId="cf03-f607-pubN76979" page="209" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">18&quot;</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">**</characteristic>
@@ -13051,7 +13119,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323">Salvo 2/4, Concussive, Graviton Implosion</characteristic>
       </characteristics>
     </profile>
-    <profile id="889ea663-40f5-0ecc-7ba9-4b68e2955022" name="Grenade Harness" publicationId="cf03-f607-pubN80892" page="83" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+    <profile id="889ea663-40f5-0ecc-7ba9-4b68e2955022" name="Grenade Harness" publicationId="cf03-f607-pubN80892" page="83" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">8&quot;</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">3</characteristic>
@@ -13059,12 +13127,12 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323">Assault 2, Blast, One use</characteristic>
       </characteristics>
     </profile>
-    <profile id="abdf1422-184a-f8f9-9544-621c2e1c646f" name="Ground Tracking Auguries" publicationId="cf03-f607-pubN80892" page="43" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="">
+    <profile id="abdf1422-184a-f8f9-9544-621c2e1c646f" name="Ground Tracking Auguries" publicationId="cf03-f607-pubN80892" page="43" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
       <characteristics>
         <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Provides Strafing Run special rule.  </characteristic>
       </characteristics>
     </profile>
-    <profile id="b3ea1d32-ba66-0585-d7f7-0dc56e707736" name="Havoc Launcher" publicationId="cf03-f607-pubN80892" page="83" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+    <profile id="b3ea1d32-ba66-0585-d7f7-0dc56e707736" name="Havoc Launcher" publicationId="cf03-f607-pubN80892" page="83" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">48&quot;</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">5</characteristic>
@@ -13072,7 +13140,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 1, Blast, Twin-linked</characteristic>
       </characteristics>
     </profile>
-    <profile id="fed8-2dba-f78c-5bcc" name="Heavy Chainblade" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+    <profile id="fed8-2dba-f78c-5bcc" name="Heavy Chainblade" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">+2</characteristic>
@@ -13080,7 +13148,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Two-handed</characteristic>
       </characteristics>
     </profile>
-    <profile id="0ee6cae6-b6fa-f0e7-6a77-0112ac6710a1" name="Heavy Conversion Beamer (1)" publicationId="cf03-f607-pubN80892" page="82" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+    <profile id="0ee6cae6-b6fa-f0e7-6a77-0112ac6710a1" name="Heavy Conversion Beamer (1)" publicationId="cf03-f607-pubN80892" page="82" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">&lt; 18&quot;</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">6</characteristic>
@@ -13088,7 +13156,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 1, Large Blast, Firing Calibration</characteristic>
       </characteristics>
     </profile>
-    <profile id="08ebafcd-366d-43ca-2591-21133dd130d2" name="Heavy Conversion Beamer (2)" publicationId="cf03-f607-pubN80892" page="82" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+    <profile id="08ebafcd-366d-43ca-2591-21133dd130d2" name="Heavy Conversion Beamer (2)" publicationId="cf03-f607-pubN80892" page="82" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">18&quot; - 42&quot;</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">8</characteristic>
@@ -13096,7 +13164,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 1, Large Blast, Firing Calibration</characteristic>
       </characteristics>
     </profile>
-    <profile id="9b7588a6-5b9a-a011-dbb2-ed73a34a521f" name="Heavy Conversion Beamer (3)" publicationId="cf03-f607-pubN80892" page="82" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+    <profile id="9b7588a6-5b9a-a011-dbb2-ed73a34a521f" name="Heavy Conversion Beamer (3)" publicationId="cf03-f607-pubN80892" page="82" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">42&quot; - 72&quot;</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">10</characteristic>
@@ -13104,7 +13172,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 1, Large Blast, Firing Calibration</characteristic>
       </characteristics>
     </profile>
-    <profile id="012e-a738-c943-5c1d" name="Heavy Stubber" publicationId="cf03-f607-pubN99227" page="308" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+    <profile id="012e-a738-c943-5c1d" name="Heavy Stubber" publicationId="cf03-f607-pubN99227" page="308" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">36&quot;</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">4</characteristic>
@@ -13112,7 +13180,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 3</characteristic>
       </characteristics>
     </profile>
-    <profile id="ab4aca3e-a4f8-8057-5d15-6c93943a4d26" name="Hellstrike Missiles" publicationId="cf03-f607-pubN123006" page="0" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+    <profile id="ab4aca3e-a4f8-8057-5d15-6c93943a4d26" name="Hellstrike Missiles" publicationId="cf03-f607-pubN123006" page="0" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323"/>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323"/>
@@ -13120,7 +13188,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323"/>
       </characteristics>
     </profile>
-    <profile id="b8643d20-d7ef-7974-7261-11c7b9787be0" name="Hyperios Missile Launcher" publicationId="cf03-f607-pubN80892" page="44" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+    <profile id="b8643d20-d7ef-7974-7261-11c7b9787be0" name="Hyperios Missile Launcher" publicationId="cf03-f607-pubN80892" page="44" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">48&quot;</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">8</characteristic>
@@ -13128,12 +13196,12 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 1, Skyfire, Interceptor, Heat Seeker</characteristic>
       </characteristics>
     </profile>
-    <profile id="b4c9d27d-b3cf-28bd-3367-b1bfddd5c401" name="Illum Flares" publicationId="cf03-f607-pubN80892" page="90" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="">
+    <profile id="b4c9d27d-b3cf-28bd-3367-b1bfddd5c401" name="Illum Flares" publicationId="cf03-f607-pubN80892" page="90" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
       <characteristics>
         <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">May drop a single flare per turn.  Fired just as bombs - flare is placed after scattering.  Leave in place until the end of the turn.  Any unit targeting an enemy within 12&quot; of the flare gains Night Vision for the shooting phase.  Split fire does not apply.  </characteristic>
       </characteristics>
     </profile>
-    <profile id="17c19758-29ee-7153-06bc-34e5091c7a5e" name="Inferno Cannon" publicationId="cf03-f607-pubN123006" page="274" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+    <profile id="17c19758-29ee-7153-06bc-34e5091c7a5e" name="Inferno Cannon" publicationId="cf03-f607-pubN123006" page="274" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">Hellstorm*</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">7</characteristic>
@@ -13141,22 +13209,22 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 1</characteristic>
       </characteristics>
     </profile>
-    <profile id="d94ec38f-20c8-84b8-79e6-6aba811aae26" name="Infravisor" publicationId="cf03-f607-pubN76979" page="208" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="">
+    <profile id="d94ec38f-20c8-84b8-79e6-6aba811aae26" name="Infravisor" publicationId="cf03-f607-pubN76979" page="208" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
       <characteristics>
         <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Confers Night Vision, but counts as I1 for blind tests.  </characteristic>
       </characteristics>
     </profile>
-    <profile id="33e5-3347-0c00-4244" name="Ion Shield" publicationId="cf03-f607-pubN99227" page="301" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="">
+    <profile id="33e5-3347-0c00-4244" name="Ion Shield" publicationId="cf03-f607-pubN99227" page="301" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
       <characteristics>
         <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">When deployed, and at the start of each subsequent opposing side&apos;s shooting phase, the Knight&apos;s controlling player must declare a facing for the ion shield.  Choices are front, left, right, or rear.    The Knight has a 4+ invulnerable save  against all hits on that facing until the start of the opposing side&apos;s next shooting phase.  Ion shields are repositioned before any attacks are carried out and may not protect against close combat attacks.  </characteristic>
       </characteristics>
     </profile>
-    <profile id="54b5-df3e-a811-b7b9" name="Ionic Flare Shield" publicationId="cf03-f607-pubN99227" page="303" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="">
+    <profile id="54b5-df3e-a811-b7b9" name="Ionic Flare Shield" publicationId="cf03-f607-pubN99227" page="303" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
       <characteristics>
         <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">When deployed, and at the start of each subsequent opposing side&apos;s shooting phase, the Knight&apos;s controlling player must declare a facing for the ionic flare shield.  Choices are front, left, right, or rear.    The Knight has a 4+ invulnerable save  against all hits on that facing until the start of the opposing side&apos;s next shooting phase.  The strength of any shooting attack is reduced by -1, increasing to -2 if the weapon has the blast or template rule.  This does not effect Destroyer or Haywire attacks.  Ionic flare shields are repositioned before any attacks are carried out and may not protect against close combat attacks.  </characteristic>
       </characteristics>
     </profile>
-    <profile id="087e3cad-c849-204a-b83a-29093869a431" name="Irad-cleanser" publicationId="cf03-f607-pubN123006" page="240" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+    <profile id="087e3cad-c849-204a-b83a-29093869a431" name="Irad-cleanser" publicationId="cf03-f607-pubN123006" page="240" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">Template</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">2</characteristic>
@@ -13164,12 +13232,12 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323">Assault 1, Fleshbane, Rad-Phage</characteristic>
       </characteristics>
     </profile>
-    <profile id="10b59cf4-3c97-e3e0-2185-853bcde6d112" name="Iron Halo" page="0" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="">
+    <profile id="10b59cf4-3c97-e3e0-2185-853bcde6d112" name="Iron Halo" page="0" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
       <characteristics>
         <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Confers 4++ Invulnerable Save</characteristic>
       </characteristics>
     </profile>
-    <profile id="926a370f-f4c1-b644-34f2-c348a5ce36c0" name="Irradiation Engine" publicationId="cf03-f607-pubN123006" page="240" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+    <profile id="926a370f-f4c1-b644-34f2-c348a5ce36c0" name="Irradiation Engine" publicationId="cf03-f607-pubN123006" page="240" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">Template</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">4</characteristic>
@@ -13177,7 +13245,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 1, Fleshbane, Rad-Phage, Torrent</characteristic>
       </characteristics>
     </profile>
-    <profile id="65bf6242-8fa0-55f7-92ac-71f4a8fba433" name="Las-lock" publicationId="cf03-f607-pubN76979" page="221" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+    <profile id="65bf6242-8fa0-55f7-92ac-71f4a8fba433" name="Las-lock" publicationId="cf03-f607-pubN76979" page="221" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">18&quot;</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">4</characteristic>
@@ -13185,7 +13253,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323">Assault 1</characteristic>
       </characteristics>
     </profile>
-    <profile id="862daa6c-e901-58a5-03e7-a5303413dfe9" name="Lascutter" publicationId="cf03-f607-pubN80892" page="87" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+    <profile id="862daa6c-e901-58a5-03e7-a5303413dfe9" name="Lascutter" publicationId="cf03-f607-pubN80892" page="87" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">9</characteristic>
@@ -13193,7 +13261,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Unwieldy, Cumbersome</characteristic>
       </characteristics>
     </profile>
-    <profile id="2360f5e0-bdc0-fa9e-1f7c-f91c03aa5308" name="Laser Blaster" publicationId="cf03-f607-pubN123006" page="274" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+    <profile id="2360f5e0-bdc0-fa9e-1f7c-f91c03aa5308" name="Laser Blaster" publicationId="cf03-f607-pubN123006" page="274" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">96&quot;</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">D</characteristic>
@@ -13201,7 +13269,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 3, Large Blast</characteristic>
       </characteristics>
     </profile>
-    <profile id="c4094da7-8d2e-8d6a-8af8-4cf88f5d7c06" name="Laser Destroyer" publicationId="cf03-f607-pubN80892" page="84" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+    <profile id="c4094da7-8d2e-8d6a-8af8-4cf88f5d7c06" name="Laser Destroyer" publicationId="cf03-f607-pubN80892" page="84" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">36&quot;</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">9</characteristic>
@@ -13209,7 +13277,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323">Ordnance 1, Twin-linked</characteristic>
       </characteristics>
     </profile>
-    <profile id="0549fb57-3ec6-8bd4-830a-85fb240cb1d7" name="Lightning Cannon" publicationId="cf03-f607-pubN76979" page="228" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+    <profile id="0549fb57-3ec6-8bd4-830a-85fb240cb1d7" name="Lightning Cannon" publicationId="cf03-f607-pubN76979" page="228" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">48&quot;</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">7</characteristic>
@@ -13217,7 +13285,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 1, Rending, Shred, Large Blast</characteristic>
       </characteristics>
     </profile>
-    <profile id="ec450cd6-6dba-ca68-091c-9c48fcbc2112" name="Lightning Gun" publicationId="cf03-f607-pubN123006" page="240" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+    <profile id="ec450cd6-6dba-ca68-091c-9c48fcbc2112" name="Lightning Gun" publicationId="cf03-f607-pubN123006" page="240" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">18&quot;</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">7</characteristic>
@@ -13225,12 +13293,12 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 1, Shred, Rending</characteristic>
       </characteristics>
     </profile>
-    <profile id="405d3ced-c3a6-9f99-2018-9ab90162b6b1" name="Lorica Thallax" publicationId="cf03-f607-pubN123006" page="240" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="">
+    <profile id="405d3ced-c3a6-9f99-2018-9ab90162b6b1" name="Lorica Thallax" publicationId="cf03-f607-pubN123006" page="240" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
       <characteristics>
         <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Provides 4+ Armour and FNP 6+ but may not make Sweeping Advances</characteristic>
       </characteristics>
     </profile>
-    <profile id="bbe4567f-45d7-cbfe-23f5-10edcb96e895" name="Lucifex" publicationId="cf03-f607-pubN76979" page="208" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+    <profile id="bbe4567f-45d7-cbfe-23f5-10edcb96e895" name="Lucifex" publicationId="cf03-f607-pubN76979" page="208" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">6&quot;</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">2</characteristic>
@@ -13238,7 +13306,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323">Pistol, Fleshbane, Rad-phage</characteristic>
       </characteristics>
     </profile>
-    <profile id="3ffc1f76-719b-bc95-a3c9-15614a8c94bc" name="Machinator Array" publicationId="cf03-f607-pubN76979" page="240" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+    <profile id="3ffc1f76-719b-bc95-a3c9-15614a8c94bc" name="Machinator Array" publicationId="cf03-f607-pubN76979" page="240" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">+1</characteristic>
@@ -13246,7 +13314,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Unwieldy, Shred, Armourbane</characteristic>
       </characteristics>
     </profile>
-    <profile id="a037-b03b-2c2b-23c3" name="Macro-gatling Blaster" publicationId="cf03-f607-pubN80965" page="264" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+    <profile id="a037-b03b-2c2b-23c3" name="Macro-gatling Blaster" publicationId="cf03-f607-pubN80965" page="264" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">72&quot;</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">10</characteristic>
@@ -13254,7 +13322,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323">Primary Weapon 6, Large Blast, Pinning</characteristic>
       </characteristics>
     </profile>
-    <profile id="8043abca-b8b1-2694-0fc0-4e3d58910eca" name="Maxima Bolter" publicationId="cf03-f607-pubN76780" page="135" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+    <profile id="8043abca-b8b1-2694-0fc0-4e3d58910eca" name="Maxima Bolter" publicationId="cf03-f607-pubN76780" page="135" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">12&quot;</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">4</characteristic>
@@ -13262,12 +13330,12 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323">Assault 3</characteristic>
       </characteristics>
     </profile>
-    <profile id="ec8086ee-40ef-30cb-d8ed-2138991ab56b" name="Mechanicum Protectiva" publicationId="cf03-f607-pubN76979" page="207" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="">
+    <profile id="ec8086ee-40ef-30cb-d8ed-2138991ab56b" name="Mechanicum Protectiva" publicationId="cf03-f607-pubN76979" page="207" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
       <characteristics>
         <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Provides 4++ Invulnerable save</characteristic>
       </characteristics>
     </profile>
-    <profile id="5bed8e68-c2db-1f09-9ea4-bfca1a3f3be3" name="Melta Cannon" publicationId="cf03-f607-pubN123006" page="274" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+    <profile id="5bed8e68-c2db-1f09-9ea4-bfca1a3f3be3" name="Melta Cannon" publicationId="cf03-f607-pubN123006" page="274" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">72&quot;</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">10</characteristic>
@@ -13275,7 +13343,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323">Ordnance 1, Apocalyptic Blast (10&quot;)</characteristic>
       </characteristics>
     </profile>
-    <profile id="5090-b1d2-e9ae-ffa2" name="Melta Cannon" publicationId="cf03-f607-pubN123006" page="274" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+    <profile id="5090-b1d2-e9ae-ffa2" name="Melta Cannon" publicationId="cf03-f607-pubN123006" page="274" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">72&quot;</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">10</characteristic>
@@ -13283,7 +13351,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323">Ordnance 1, Apocalyptic Blast (10&quot;)</characteristic>
       </characteristics>
     </profile>
-    <profile id="47b334bb-cad7-a46c-c2eb-95ce7cd7bcd2" name="Mitralock" publicationId="cf03-f607-pubN76979" page="221" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+    <profile id="47b334bb-cad7-a46c-c2eb-95ce7cd7bcd2" name="Mitralock" publicationId="cf03-f607-pubN76979" page="221" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">8&quot;</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">4</characteristic>
@@ -13291,7 +13359,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323">Assault 1, Shred</characteristic>
       </characteristics>
     </profile>
-    <profile id="ed91-7534-4852-fb7a" name="Multi-melta" publicationId="cf03-f607-pubN143724" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+    <profile id="ed91-7534-4852-fb7a" name="Multi-melta" publicationId="cf03-f607-pubN143724" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">24&quot;</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">8</characteristic>
@@ -13299,12 +13367,12 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 1, Melta</characteristic>
       </characteristics>
     </profile>
-    <profile id="b4632691-8dcc-7fe7-b324-18b20f07c4ab" name="Narthecium" page="0" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="">
+    <profile id="b4632691-8dcc-7fe7-b324-18b20f07c4ab" name="Narthecium" page="0" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
       <characteristics>
         <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323"/>
       </characteristics>
     </profile>
-    <profile id="7bc689cc-398d-f1f4-2359-ddbdf3af8968" name="Needle Pistol" publicationId="cf03-f607-pubN80892" page="84" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+    <profile id="7bc689cc-398d-f1f4-2359-ddbdf3af8968" name="Needle Pistol" publicationId="cf03-f607-pubN80892" page="84" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">12&quot;</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">2</characteristic>
@@ -13312,17 +13380,17 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323">Pistol, Poisoned, Rending</characteristic>
       </characteristics>
     </profile>
-    <profile id="9a458a3c-a9b5-db5e-a218-2041a3a49004" name="Nuncio-vox" publicationId="cf03-f607-pubN80892" page="91" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="">
+    <profile id="9a458a3c-a9b5-db5e-a218-2041a3a49004" name="Nuncio-vox" publicationId="cf03-f607-pubN80892" page="91" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
       <characteristics>
         <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Units arriving via Deep Strike within 6&quot;  of a Nuncio-vox do not scatter.  When barrage weapons are used by the controlling player, line of sight may be drawn from any model equipped with a Nuncio-vox as well as the firing model itself. Range is still drawn from the firing model.  It may not be used inside a vehicle.   </characteristic>
       </characteristics>
     </profile>
-    <profile id="1283-e198-796c-b406" name="Occular Augmetics" publicationId="cf03-f607-pubN99227" page="301" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="">
+    <profile id="1283-e198-796c-b406" name="Occular Augmetics" publicationId="cf03-f607-pubN99227" page="301" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
       <characteristics>
         <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Has Night Vision special rule, and may re-roll results of a 1 on the Vehicle Damage table and Destroyer Weapon Attack table which are inflicted by their shooting attacks at a range of 12&quot; or less.  </characteristic>
       </characteristics>
     </profile>
-    <profile id="4d09-af3d-aad0-0729" name="Paragon Blade" publicationId="cf03-f607-pubN123006" page="235" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+    <profile id="4d09-af3d-aad0-0729" name="Paragon Blade" publicationId="cf03-f607-pubN123006" page="235" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">+1</characteristic>
@@ -13330,7 +13398,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Murderous Strike, Specialist Weapon</characteristic>
       </characteristics>
     </profile>
-    <profile id="71ed050b-073d-852a-e50a-425b96eb71cd" name="Phased-Plasma Fusil" publicationId="cf03-f607-pubN143916" page="232" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+    <profile id="71ed050b-073d-852a-e50a-425b96eb71cd" name="Phased-Plasma Fusil" publicationId="cf03-f607-pubN143916" page="232" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">24&quot;</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">6</characteristic>
@@ -13338,7 +13406,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323">Salvo 2/3</characteristic>
       </characteristics>
     </profile>
-    <profile id="a9557337-b134-0000-3cb9-6e735eec5e5f" name="Phosphex Bomb" publicationId="cf03-f607-pubN80892" page="84" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+    <profile id="a9557337-b134-0000-3cb9-6e735eec5e5f" name="Phosphex Bomb" publicationId="cf03-f607-pubN80892" page="84" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">6&quot;</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">5</characteristic>
@@ -13346,7 +13414,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323">Assault 1, One Use, Blast, Poisoned (3+), Crawling Fire, Lingering Death</characteristic>
       </characteristics>
     </profile>
-    <profile id="54b8d1d6-d443-4571-936f-aca7c3c451db" name="Photon Gauntlet" publicationId="cf03-f607-pubN76979" page="209" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+    <profile id="54b8d1d6-d443-4571-936f-aca7c3c451db" name="Photon Gauntlet" publicationId="cf03-f607-pubN76979" page="209" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">12&quot;</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">5</characteristic>
@@ -13354,7 +13422,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323">Assault 2, Blind, Gets Hot</characteristic>
       </characteristics>
     </profile>
-    <profile id="43648289-5a0f-99d3-1cfc-55b689750afa" name="Photon Thruster" publicationId="cf03-f607-pubN76979" page="209" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+    <profile id="43648289-5a0f-99d3-1cfc-55b689750afa" name="Photon Thruster" publicationId="cf03-f607-pubN76979" page="209" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">48&quot;</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">6</characteristic>
@@ -13362,7 +13430,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 2, Lance, Blind, Gets Hot</characteristic>
       </characteristics>
     </profile>
-    <profile id="194c1d88-db84-98aa-de86-f88e5ff46af2" name="Photon Thruster Cannon" publicationId="cf03-f607-pubN123006" page="240" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+    <profile id="194c1d88-db84-98aa-de86-f88e5ff46af2" name="Photon Thruster Cannon" publicationId="cf03-f607-pubN123006" page="240" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">48&quot;</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">6</characteristic>
@@ -13370,7 +13438,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 2, Lance, Blind, Gets Hot!</characteristic>
       </characteristics>
     </profile>
-    <profile id="2c169963-d356-aa63-60bd-eee2ee1afcc0" name="Plasma Blaster" publicationId="cf03-f607-pubN80892" page="84" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+    <profile id="2c169963-d356-aa63-60bd-eee2ee1afcc0" name="Plasma Blaster" publicationId="cf03-f607-pubN80892" page="84" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">18&quot;</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">7</characteristic>
@@ -13378,7 +13446,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323">Assault 2, Gets Hot!</characteristic>
       </characteristics>
     </profile>
-    <profile id="0d83ac2f-7e3a-3363-98ed-320e3316b94c" name="Plasma Blastgun (Overload)" publicationId="cf03-f607-pubN80892" page="65" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+    <profile id="0d83ac2f-7e3a-3363-98ed-320e3316b94c" name="Plasma Blastgun (Overload)" publicationId="cf03-f607-pubN80892" page="65" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">96&quot;</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">10</characteristic>
@@ -13386,7 +13454,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323">Primary Weapon 1, Apocalyptic Blast (10&quot;)</characteristic>
       </characteristics>
     </profile>
-    <profile id="d67c0bb3-8feb-6863-4d75-507b49d2ca86" name="Plasma Blastgun (Rapid)" publicationId="cf03-f607-pubN80892" page="65" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+    <profile id="d67c0bb3-8feb-6863-4d75-507b49d2ca86" name="Plasma Blastgun (Rapid)" publicationId="cf03-f607-pubN80892" page="65" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">72&quot;</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">8</characteristic>
@@ -13394,7 +13462,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323">Primary Weapon 2, Massive Blast (7&quot;)</characteristic>
       </characteristics>
     </profile>
-    <profile id="f4a1-b459-ba82-3789" name="Plasma Pistol" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+    <profile id="f4a1-b459-ba82-3789" name="Plasma Pistol" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">12</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">7</characteristic>
@@ -13402,7 +13470,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323">Pistol 1, Gets Hot</characteristic>
       </characteristics>
     </profile>
-    <profile id="6e9c4f42-34a8-9253-3f68-8b582ee5830b" name="Power Blades" publicationId="cf03-f607-pubN76979" page="208" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+    <profile id="6e9c4f42-34a8-9253-3f68-8b582ee5830b" name="Power Blades" publicationId="cf03-f607-pubN76979" page="208" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">User</characteristic>
@@ -13410,7 +13478,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Rending</characteristic>
       </characteristics>
     </profile>
-    <profile id="3a3ff98f-d81d-ba25-797b-d88b293189c5" name="Pulsar-fusil" publicationId="cf03-f607-pubN76979" page="228" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+    <profile id="3a3ff98f-d81d-ba25-797b-d88b293189c5" name="Pulsar-fusil" publicationId="cf03-f607-pubN76979" page="228" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">36&quot;</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">9</characteristic>
@@ -13418,7 +13486,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323">Ordnance 4, Pinning</characteristic>
       </characteristics>
     </profile>
-    <profile id="6d02b74f-b832-0249-9ba0-01ac9c192099" name="Quad Mortar" publicationId="cf03-f607-pubN80892" page="83" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+    <profile id="6d02b74f-b832-0249-9ba0-01ac9c192099" name="Quad Mortar" publicationId="cf03-f607-pubN80892" page="83" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">12&quot; - 60&quot;</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">5</characteristic>
@@ -13426,7 +13494,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 4, Barrage, Blast, Shell Shock</characteristic>
       </characteristics>
     </profile>
-    <profile id="69c7-9b79-399f-b7a9" name="Rad cleanser" publicationId="cf03-f607-pubN99227" page="308" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+    <profile id="69c7-9b79-399f-b7a9" name="Rad cleanser" publicationId="cf03-f607-pubN99227" page="308" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">Template</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">2</characteristic>
@@ -13434,17 +13502,17 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323">Assault 1, Fleshbane, Rad-Phage</characteristic>
       </characteristics>
     </profile>
-    <profile id="7f32-3376-7246-eeb0" name="Rad Furnace" publicationId="cf03-f607-pubN80965" page="223" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="">
+    <profile id="7f32-3376-7246-eeb0" name="Rad Furnace" publicationId="cf03-f607-pubN80965" page="223" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
       <characteristics>
         <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">All models locked in combat with this unit suffer -1 to their Toughness for the duration of the combat. Models equiped with Rad Furnace are immune to this effect as well as to Rad Grenades. Any weapon with Poison or Rad-phage only woulds a model with a Rad Furnace on a 6.</characteristic>
       </characteristics>
     </profile>
-    <profile id="bf7edb98-902e-c8a7-e818-4a6ba05f12f2" name="Rad Grenades" publicationId="cf03-f607-pubN80892" page="84" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="">
+    <profile id="bf7edb98-902e-c8a7-e818-4a6ba05f12f2" name="Rad Grenades" publicationId="cf03-f607-pubN80892" page="84" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
       <characteristics>
         <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">During a turn in which a unit equipped with Rad Grenades assaults or is assaulted, the enemy unit(s) suffer a -1 penalty to the Toughness until the end of the Assault Phase.  This does affect the victim&apos;s Instant Death thresholds.  </characteristic>
       </characteristics>
     </profile>
-    <profile id="042efe45-dff8-3d5f-bb7f-f84c2a09a4b7" name="Rad Missiles" publicationId="cf03-f607-pubN80892" page="85" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+    <profile id="042efe45-dff8-3d5f-bb7f-f84c2a09a4b7" name="Rad Missiles" publicationId="cf03-f607-pubN80892" page="85" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">48&quot;</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">4</characteristic>
@@ -13452,7 +13520,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 1, Blast, Fleshbane, Rad-phage</characteristic>
       </characteristics>
     </profile>
-    <profile id="22d2c64e-3873-429f-5cf8-27e022bb1d6a" name="Reaper Autocannon" publicationId="cf03-f607-pubN80892" page="85" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+    <profile id="22d2c64e-3873-429f-5cf8-27e022bb1d6a" name="Reaper Autocannon" publicationId="cf03-f607-pubN80892" page="85" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">36&quot;</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">7</characteristic>
@@ -13460,7 +13528,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 2, Twin-linked</characteristic>
       </characteristics>
     </profile>
-    <profile id="8bc8-94ff-73be-5959" name="Reaper Chainsword" publicationId="cf03-f607-pubN99227" page="308" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+    <profile id="8bc8-94ff-73be-5959" name="Reaper Chainsword" publicationId="cf03-f607-pubN99227" page="308" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">D</characteristic>
@@ -13468,7 +13536,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323">Melee</characteristic>
       </characteristics>
     </profile>
-    <profile id="75683330-6490-c0bf-560c-2e58617425a1" name="Rotor Cannon" publicationId="cf03-f607-pubN80892" page="85" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+    <profile id="75683330-6490-c0bf-560c-2e58617425a1" name="Rotor Cannon" publicationId="cf03-f607-pubN80892" page="85" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">30&quot;</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">3</characteristic>
@@ -13476,7 +13544,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323">Salvo 3/4</characteristic>
       </characteristics>
     </profile>
-    <profile id="ddb8-921a-2d03-af32" name="Saturnyne Lascutter (Assault)" publicationId="cf03-f607-pubN80965" page="264" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+    <profile id="ddb8-921a-2d03-af32" name="Saturnyne Lascutter (Assault)" publicationId="cf03-f607-pubN80965" page="264" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">D</characteristic>
@@ -13484,7 +13552,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Machine Destroyer, Instant Death</characteristic>
       </characteristics>
     </profile>
-    <profile id="711c-495a-28a6-5d64" name="Saturnyne Lascutter (Shooting)" publicationId="cf03-f607-pubN80965" page="264" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+    <profile id="711c-495a-28a6-5d64" name="Saturnyne Lascutter (Shooting)" publicationId="cf03-f607-pubN80965" page="264" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">Hellstorm</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">9</characteristic>
@@ -13492,7 +13560,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323">Primary Weapon 1, Instant Death</characteristic>
       </characteristics>
     </profile>
-    <profile id="067e9186-0fba-6430-507f-4fbaaecd0d17" name="Scorpius Bolt Shells" publicationId="cf03-f607-pubN80892" page="85" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+    <profile id="067e9186-0fba-6430-507f-4fbaaecd0d17" name="Scorpius Bolt Shells" publicationId="cf03-f607-pubN80892" page="85" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">24&quot;</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">4</characteristic>
@@ -13500,7 +13568,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 1, Rending, Shred</characteristic>
       </characteristics>
     </profile>
-    <profile id="f4404a95-506e-bcef-1420-21d2d6e9013b" name="Servo-arm" publicationId="cf03-f607-pubN76979" page="208" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+    <profile id="f4404a95-506e-bcef-1420-21d2d6e9013b" name="Servo-arm" publicationId="cf03-f607-pubN76979" page="208" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">8</characteristic>
@@ -13508,7 +13576,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Unwieldy</characteristic>
       </characteristics>
     </profile>
-    <profile id="9458b91c-55d7-ac17-21a3-4235e153b328" name="Servo-automata" publicationId="cf03-f607-pubN80892" page="23" hidden="false" typeId="556e697423232344415441232323" typeName="">
+    <profile id="9458b91c-55d7-ac17-21a3-4235e153b328" name="Servo-automata" publicationId="cf03-f607-pubN80892" page="23" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
       <characteristics>
         <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry</characteristic>
         <characteristic name="WS" typeId="575323232344415441232323">3</characteristic>
@@ -13522,7 +13590,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Save" typeId="5361766523232344415441232323">5+</characteristic>
       </characteristics>
     </profile>
-    <profile id="6cda-9c8f-b85a-7b78" name="Sunfury Plasma Annihilator" publicationId="cf03-f607-pubN80965" page="264" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+    <profile id="6cda-9c8f-b85a-7b78" name="Sunfury Plasma Annihilator" publicationId="cf03-f607-pubN80965" page="264" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">72&quot;</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">9</characteristic>
@@ -13530,7 +13598,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323">Primary Weapon 4, Apocalyptic Barrage, Plasma Wave</characteristic>
       </characteristics>
     </profile>
-    <profile id="8da7d342-de6d-8cdc-4717-b1ca42c16400" name="Turbo-laser Destructor" publicationId="cf03-f607-pubN80892" page="73" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+    <profile id="8da7d342-de6d-8cdc-4717-b1ca42c16400" name="Turbo-laser Destructor" publicationId="cf03-f607-pubN80892" page="73" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">96&quot;</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">D</characteristic>
@@ -13538,7 +13606,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323">Primary Weapon 1,  Large Blast</characteristic>
       </characteristics>
     </profile>
-    <profile id="7c5c8197-a8a5-3334-4453-54d6cc4aa3bd" name="Volcano Cannon" publicationId="cf03-f607-pubN123006" page="274" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+    <profile id="7c5c8197-a8a5-3334-4453-54d6cc4aa3bd" name="Volcano Cannon" publicationId="cf03-f607-pubN123006" page="274" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">180&quot;</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">D</characteristic>
@@ -13546,7 +13614,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323">Ordnance 1, Massive Blast (7&quot;)</characteristic>
       </characteristics>
     </profile>
-    <profile id="402babca-fc14-e4b0-c135-a078ce95d036" name="Volkite Caliver" publicationId="cf03-f607-pubN80892" page="85" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+    <profile id="402babca-fc14-e4b0-c135-a078ce95d036" name="Volkite Caliver" publicationId="cf03-f607-pubN80892" page="85" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">30&quot;</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">6</characteristic>
@@ -13554,7 +13622,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 2, Deflagrate</characteristic>
       </characteristics>
     </profile>
-    <profile id="9c9de857-ac5e-11ff-ead6-1df8480d3f28" name="Volkite Charger" publicationId="cf03-f607-pubN80892" page="85" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+    <profile id="9c9de857-ac5e-11ff-ead6-1df8480d3f28" name="Volkite Charger" publicationId="cf03-f607-pubN80892" page="85" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">15&quot;</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">5</characteristic>
@@ -13562,7 +13630,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323">Assault 2, Deflagrate</characteristic>
       </characteristics>
     </profile>
-    <profile id="c7838603-9e18-8756-26b1-222a294c5c2c" name="Volkite Culverin" publicationId="cf03-f607-pubN80892" page="85" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+    <profile id="c7838603-9e18-8756-26b1-222a294c5c2c" name="Volkite Culverin" publicationId="cf03-f607-pubN80892" page="85" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">45&quot;</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">6</characteristic>
@@ -13570,7 +13638,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 4, Deflagrate</characteristic>
       </characteristics>
     </profile>
-    <profile id="e811e6ee-aa3f-fff6-9bba-513d01878fe3" name="Volkite Incinerator (Beam)" publicationId="cf03-f607-pubN76979" page="225" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+    <profile id="e811e6ee-aa3f-fff6-9bba-513d01878fe3" name="Volkite Incinerator (Beam)" publicationId="cf03-f607-pubN76979" page="225" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">10&quot;</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">5</characteristic>
@@ -13578,7 +13646,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323">Assault 2, Deflagrate</characteristic>
       </characteristics>
     </profile>
-    <profile id="13b7b920-7b99-96b1-6c13-9de5323ecd83" name="Volkite Incinerator (Blast)" publicationId="cf03-f607-pubN76979" page="225" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+    <profile id="13b7b920-7b99-96b1-6c13-9de5323ecd83" name="Volkite Incinerator (Blast)" publicationId="cf03-f607-pubN76979" page="225" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">6</characteristic>
@@ -13586,12 +13654,12 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Instant Death, Prisoned</characteristic>
       </characteristics>
     </profile>
-    <profile id="bf17bd51-e354-8b3e-f047-c772e08346d4" name="Volkite Sentinels" publicationId="cf03-f607-pubN76979" page="224" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="">
+    <profile id="bf17bd51-e354-8b3e-f047-c772e08346d4" name="Volkite Sentinels" publicationId="cf03-f607-pubN76979" page="224" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
       <characteristics>
         <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Each is a pintle-mounted Volkite Charger which can be fired in addition to any other weapons the vehicle is carrying without penalty and may target units separately from the vehicles main armament.  </characteristic>
       </characteristics>
     </profile>
-    <profile id="2c6ee84f-08d4-4e84-2468-6f39375d509b" name="Volkite Serpenta" publicationId="cf03-f607-pubN80892" page="85" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+    <profile id="2c6ee84f-08d4-4e84-2468-6f39375d509b" name="Volkite Serpenta" publicationId="cf03-f607-pubN80892" page="85" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">10&quot;</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">5</characteristic>
@@ -13599,7 +13667,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323">Pistol, Deflagrate</characteristic>
       </characteristics>
     </profile>
-    <profile id="d4c95d4c-654b-618a-6543-3bb787d0cddb" name="Vortex Missile" publicationId="cf03-f607-pubN123006" page="274" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+    <profile id="d4c95d4c-654b-618a-6543-3bb787d0cddb" name="Vortex Missile" publicationId="cf03-f607-pubN123006" page="274" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">48&quot; - 480&quot;</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">*</characteristic>
@@ -13607,7 +13675,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323">Ordnance 1, Apocalyptic Blast (10&quot;), One Shot</characteristic>
       </characteristics>
     </profile>
-    <profile id="e072-4756-f9c6-fdf0" name="Vortex Missile Bank" publicationId="cf03-f607-pubN80965" page="264" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+    <profile id="e072-4756-f9c6-fdf0" name="Vortex Missile Bank" publicationId="cf03-f607-pubN80965" page="264" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">12&quot; - 360&quot;</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">D</characteristic>
@@ -13615,7 +13683,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323">Primary Weapon 1, Large Blast, Vortex, 2x One Use</characteristic>
       </characteristics>
     </profile>
-    <profile id="0725d9e4-9558-7135-8059-379ac7a62e19" name="Vulcan Mega-bolter" publicationId="cf03-f607-pubN123006" page="274" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+    <profile id="0725d9e4-9558-7135-8059-379ac7a62e19" name="Vulcan Mega-bolter" publicationId="cf03-f607-pubN123006" page="274" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">60&quot;</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">6</characteristic>
@@ -13628,7 +13696,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">A model equipped with shock chargers gains teh Concussive special rule added to all of their close combat attacks regardless of type (including Hammer of Wrath, Smash, etc.)  Shock chargers are not a weapon as such in themselves and so do not have a profile of their own, nor do they add additional attacks in conjunction with other weapons. </characteristic>
       </characteristics>
     </profile>
-    <profile id="9f00-4f6d-0ddb-4e69" name="Laspistol" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+    <profile id="9f00-4f6d-0ddb-4e69" name="Laspistol" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">12</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">3</characteristic>
@@ -13772,7 +13840,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 1, Rending</characteristic>
       </characteristics>
     </profile>
-    <profile id="fda8-891c-9dc6-8f59" name="Triaros Armoured Conveyor" publicationId="cf03-f607-pubN76979" page="224" hidden="false" typeId="56656869636c6523232344415441232323" typeName="">
+    <profile id="fda8-891c-9dc6-8f59" name="Triaros Armoured Conveyor" publicationId="cf03-f607-pubN76979" page="224" hidden="false" typeId="56656869636c6523232344415441232323" typeName="Vehicle">
       <characteristics>
         <characteristic name="BS" typeId="425323232344415441232323">4</characteristic>
         <characteristic name="Front" typeId="46726f6e7423232344415441232323">14</characteristic>
@@ -13782,7 +13850,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323">Tank, Transport</characteristic>
       </characteristics>
     </profile>
-    <profile id="9f8f-f861-4e60-a46f" name="Shock Ram" publicationId="cf03-f607-pubN76979" page="224" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="">
+    <profile id="9f8f-f861-4e60-a46f" name="Shock Ram" publicationId="cf03-f607-pubN76979" page="224" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
       <characteristics>
         <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">When Ramming or being rammed, the Triaros counts as Front Armour 15 and rolls once on the Haywire table in addition to any damage it causes normally. When conduction Tank Shock attacks, any unit automatically suffers D6 Str 6 AP 5 hits in addition to resolving the tank shock as normal. It is not a weapon and may not be destroyed.  </characteristic>
       </characteristics>
@@ -13802,7 +13870,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 3, Shred, Rending</characteristic>
       </characteristics>
     </profile>
-    <profile id="e571-5701-104d-9e3d" name="Lightning Blaster Sentinels" publicationId="cf03-f607-pubN76979" page="224" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="">
+    <profile id="e571-5701-104d-9e3d" name="Lightning Blaster Sentinels" publicationId="cf03-f607-pubN76979" page="224" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
       <characteristics>
         <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Each is a pintle-mounted Sentinel which can be fired in addition to any other weapons the vehicle is carrying without penalty and may target units separately from the vehicles main armament. If reduced to firing snap shots, it may do so at BS 2.</characteristic>
       </characteristics>
@@ -13839,7 +13907,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Save" typeId="5361766523232344415441232323">3+/5++</characteristic>
       </characteristics>
     </profile>
-    <profile id="9045e242-71f8-6029-fc57-2b7cbedcc398" name="Archaeotech Pistol" publicationId="cf03-f607-pubN80892" page="82" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+    <profile id="9045e242-71f8-6029-fc57-2b7cbedcc398" name="Archaeotech Pistol" publicationId="cf03-f607-pubN80892" page="82" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">12&quot;</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">6</characteristic>
@@ -13847,7 +13915,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323">Pistol, Master-crafted</characteristic>
       </characteristics>
     </profile>
-    <profile id="552f-c41a-a253-113e" name="Castellan Warhead" publicationId="cf03-f607-pubN107623" page="125" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+    <profile id="552f-c41a-a253-113e" name="Castellan Warhead" publicationId="cf03-f607-pubN107623" page="125" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">12&quot; - 48&quot;</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">4</characteristic>
@@ -13855,7 +13923,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323">Ordnance 1, Barrage, Large Blast, Ignores Cover</characteristic>
       </characteristics>
     </profile>
-    <profile id="9130-2563-4eba-8ded" name="Vengeance Warhead" publicationId="cf03-f607-pubN107623" page="125" hidden="false" typeId="576561706f6e23232344415441232323" typeName="">
+    <profile id="9130-2563-4eba-8ded" name="Vengeance Warhead" publicationId="cf03-f607-pubN107623" page="125" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">12&quot; - 48&quot;</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">5</characteristic>
@@ -13863,7 +13931,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <characteristic name="Type" typeId="5479706523232344415441232323">Ordnance 1, Barrage, Large Blast</characteristic>
       </characteristics>
     </profile>
-    <profile id="c96b-c345-a620-5b2b" name="Djinn-skein" publicationId="cf03-f607-pubN76979" page="215" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="">
+    <profile id="c96b-c345-a620-5b2b" name="Djinn-skein" publicationId="cf03-f607-pubN76979" page="215" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
       <characteristics>
         <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">  Provides the following:    - At the start of his shooting phase, the Archmagos Prime may nominate a single unit from his primary detachment (including himself) within 6&quot; of him or any Cyber-occularis purchased as a part of his wargear to benefit from +1 BS.   - Friendly units from the primary detachment including the Archmagos who deep strike within 6&quot; do not scatter  - Barrage weapons in the same detachment may draw line of sight from the Archmagos and any Cyber-occularis purchased as part of their wargear.</characteristic>
       </characteristics>


### PR DESCRIPTION
#1570 Mara Skara fixed, issued was allowing use of illegal lists
#1571 RoW no longer hidden before a Master of Legion is chosen. But will now just flag an error that one will be required.
#1572 New Moirax weapons added.
Additionally an issue for Thrall units for Mech was discovered and fixed relating to revenant alchemy.

Fixed issues from previous pull request, was throwing up an unexpected issue, now solved and remade.
