### PR TITLE
Various Fixes

### DIFF
--- a/(HH) Daemons of the Ruinstorm Army List.cat
+++ b/(HH) Daemons of the Ruinstorm Army List.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="8700-b3bb-a471-a0ad" name="Daemons of the Ruinstorm" revision="9" battleScribeVersion="2.02" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="85" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="8700-b3bb-a471-a0ad" name="Daemons of the Ruinstorm" revision="10" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="85" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="8700-b3bb-pubN65537" name="HH8: Malevolence"/>
     <publication id="8700-b3bb-pubN75780" name="BRB"/>
@@ -12,9 +12,9 @@
     <categoryEntry id="54726f6f707323232344415441232323" name="Troops" hidden="false"/>
     <categoryEntry id="466173742041747461636b23232344415441232323" name="Fast Attack" hidden="false"/>
     <categoryEntry id="486561767920537570706f727423232344415441232323" name="Heavy Support" hidden="false"/>
-    <categoryEntry id="5297-7e0f-fa0b-3537" name="Aetheric Dominion" hidden="false">
+    <categoryEntry id="2271-1b9a-5c30-9676" name="Aetheric Dominion" hidden="false">
       <constraints>
-        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c9fb-b8e5-20db-b9b9" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c9fb-b8e5-20db-b9b9" type="max"/>
       </constraints>
     </categoryEntry>
     <categoryEntry id="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" name="Lords of War" hidden="false"/>
@@ -58,12 +58,12 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="25ba-08c7-f871-f88c" type="max"/>
           </constraints>
         </categoryLink>
-        <categoryLink id="7a11-130d-e08e-65be" name="Aetheric Dominion" hidden="false" targetId="5297-7e0f-fa0b-3537" primary="false"/>
+        <categoryLink id="7a11-130d-e08e-65be" name="Aetheric Dominion" hidden="false" targetId="2271-1b9a-5c30-9676" primary="false"/>
       </categoryLinks>
     </forceEntry>
     <forceEntry id="4086-2dd6-c49c-2445" name="Crusade Detachment" hidden="false">
       <categoryLinks>
-        <categoryLink id="5936-60c0-10a5-dbd8" name="Aetheric Dominion" hidden="false" targetId="5297-7e0f-fa0b-3537" primary="false">
+        <categoryLink id="5936-60c0-10a5-dbd8" name="Aetheric Dominion" hidden="false" targetId="2271-1b9a-5c30-9676" primary="false">
           <constraints>
             <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2ce0-a2b7-e89c-8cd4" type="max"/>
           </constraints>
@@ -109,103 +109,103 @@
     </forceEntry>
   </forceEntries>
   <entryLinks>
-    <entryLink id="29ef-6d56-9d3f-5c98" name="Imperial Castelum Stronghold" hidden="false" collective="false" targetId="e40b-468f-f1d7-d05d" type="selectionEntry">
+    <entryLink id="29ef-6d56-9d3f-5c98" name="Imperial Castelum Stronghold" hidden="false" collective="false" import="true" targetId="e40b-468f-f1d7-d05d" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="a1f2-c87d-dd58-10bb" name="New CategoryLink" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="115d-dd09-66b2-6c31" name="Manufactorum" hidden="false" collective="false" targetId="6140-dc64-5896-957f" type="selectionEntry">
+    <entryLink id="115d-dd09-66b2-6c31" name="Manufactorum" hidden="false" collective="false" import="true" targetId="6140-dc64-5896-957f" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="c693-e076-4cc8-b105" name="New CategoryLink" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="070b-1b44-05a7-3eb5" name="Sanctum Imperialis" hidden="false" collective="false" targetId="e0b3-77ca-af76-bd8b" type="selectionEntry">
+    <entryLink id="070b-1b44-05a7-3eb5" name="Sanctum Imperialis" hidden="false" collective="false" import="true" targetId="e0b3-77ca-af76-bd8b" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="77d3-faf4-2341-bd38" name="New CategoryLink" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="4b47-d70e-36a5-bd6c" name="Plasma Obliterator" hidden="false" collective="false" targetId="3015-0b77-e848-c0f5" type="selectionEntry">
+    <entryLink id="4b47-d70e-36a5-bd6c" name="Plasma Obliterator" hidden="false" collective="false" import="true" targetId="3015-0b77-e848-c0f5" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="e142-8254-2406-c925" name="New CategoryLink" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="b3dc-03a0-38c7-5ddb" name="Wall of Martyrs Vengeance Weapon Battery" hidden="false" collective="false" targetId="04bf-6c22-19fb-4e46" type="selectionEntry">
+    <entryLink id="b3dc-03a0-38c7-5ddb" name="Wall of Martyrs Vengeance Weapon Battery" hidden="false" collective="false" import="true" targetId="04bf-6c22-19fb-4e46" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="606a-9cb6-c6dd-0072" name="New CategoryLink" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="f188-372e-516a-cffd" name="Shrine of the Aquila" hidden="false" collective="false" targetId="595a-908e-96a1-f121" type="selectionEntry">
+    <entryLink id="f188-372e-516a-cffd" name="Shrine of the Aquila" hidden="false" collective="false" import="true" targetId="595a-908e-96a1-f121" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="df5e-db09-64a6-c4f0" name="New CategoryLink" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="c248-b0e3-3965-def0" name="Imperial Primus Redoubt" hidden="false" collective="false" targetId="c05d-2231-2481-4037" type="selectionEntry">
+    <entryLink id="c248-b0e3-3965-def0" name="Imperial Primus Redoubt" hidden="false" collective="false" import="true" targetId="c05d-2231-2481-4037" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="9737-b39b-35b0-996e" name="New CategoryLink" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="8ed3-70f3-4a74-6a67" name="Wall of Martyrs Imperial Defence Line" hidden="false" collective="false" targetId="0f73-97f2-b832-f6d0" type="selectionEntry">
+    <entryLink id="8ed3-70f3-4a74-6a67" name="Wall of Martyrs Imperial Defence Line" hidden="false" collective="false" import="true" targetId="0f73-97f2-b832-f6d0" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="1dae-c6fa-6367-e4f6" name="New CategoryLink" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="fe9d-fd2f-0609-4d17" name="Defence Emplacement" hidden="false" collective="false" targetId="df05-8179-624e-f8b2" type="selectionEntry">
+    <entryLink id="fe9d-fd2f-0609-4d17" name="Defence Emplacement" hidden="false" collective="false" import="true" targetId="df05-8179-624e-f8b2" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="6df8-14fa-4322-2d50" name="New CategoryLink" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="ae16-1579-6931-7d17" name="Firestorm Redoubt" hidden="false" collective="false" targetId="a172-78de-aaa6-2201" type="selectionEntry">
+    <entryLink id="ae16-1579-6931-7d17" name="Firestorm Redoubt" hidden="false" collective="false" import="true" targetId="a172-78de-aaa6-2201" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="f5a1-83e4-4037-0f57" name="New CategoryLink" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="7c96-69f8-24eb-4e39" name="Fortification" hidden="false" collective="false" targetId="66c9-eaa6-a91a-00ed" type="selectionEntry">
+    <entryLink id="7c96-69f8-24eb-4e39" name="Fortification" hidden="false" collective="false" import="true" targetId="66c9-eaa6-a91a-00ed" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="3b57-3adb-66a8-6260" name="New CategoryLink" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="9463-14b2-5a43-17b0" name="Maddening Swarms" hidden="false" collective="false" targetId="5c39-d5e2-e0eb-3280" type="selectionEntry"/>
-    <entryLink id="af06-f020-4889-c926" name="Ruinstorm Lesser Daemons" hidden="false" collective="false" targetId="9ad5-5b92-5f1f-e661" type="selectionEntry">
+    <entryLink id="9463-14b2-5a43-17b0" name="Maddening Swarms" hidden="false" collective="false" import="true" targetId="5c39-d5e2-e0eb-3280" type="selectionEntry"/>
+    <entryLink id="af06-f020-4889-c926" name="Ruinstorm Lesser Daemons" hidden="false" collective="false" import="true" targetId="9ad5-5b92-5f1f-e661" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="e3a9-522f-2f9a-6060" name="Troops" hidden="false" targetId="54726f6f707323232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="b7a3-4ed3-ee52-15ea" name="Daemon Lord" hidden="false" collective="false" targetId="92c6-2146-8ca7-bd35" type="selectionEntry"/>
-    <entryLink id="390e-66e4-54dd-2d48" name="Ruinstorm Greater Daemon" hidden="false" collective="false" targetId="b13b-5247-2078-4daf" type="selectionEntry"/>
-    <entryLink id="7e6c-e6d3-8cd8-4bab" name="Ruinstorm Daemon Chosen" hidden="false" collective="false" targetId="721a-409b-1ce8-0c50" type="selectionEntry"/>
-    <entryLink id="6abd-85be-2dde-6e52" name="Ruinstorm Daemon Brutes" hidden="false" collective="false" targetId="5eaf-49f3-f745-fd30" type="selectionEntry"/>
-    <entryLink id="21b0-f212-e2bd-cd24" name="Ruinstorm Daemon Beasts" hidden="false" collective="false" targetId="c877-3df6-7393-c32b" type="selectionEntry"/>
-    <entryLink id="39f3-6d6f-e05f-0c31" name="Ruinstorm Daemon Cavalry" hidden="false" collective="false" targetId="1137-8ddd-d812-1e70" type="selectionEntry"/>
-    <entryLink id="049d-b9de-3c25-91d5" name="Ruinstorm Daemon Shrike" hidden="false" collective="false" targetId="1f45-4da0-7891-e2cc" type="selectionEntry"/>
-    <entryLink id="2ec0-500d-4029-9f83" name="Ruinstorm Daemon Swarms" hidden="false" collective="false" targetId="ae3c-2429-b663-dcbc" type="selectionEntry"/>
-    <entryLink id="a67e-9984-e65c-a43a" name="Ruinstorm Arch-Daemon" hidden="false" collective="false" targetId="ea70-5e79-b1a0-3256" type="selectionEntry"/>
-    <entryLink id="2f27-5108-1a63-a58f" name="Ruinstorm Daemon Behemoth" hidden="false" collective="false" targetId="bf7e-0c26-b8b8-758a" type="selectionEntry"/>
-    <entryLink id="0dc1-e444-dfc2-52c6" name="Greater Ruinstorm Daemon Beast" hidden="false" collective="false" targetId="b7a8-a1e3-5f05-fc69" type="selectionEntry"/>
-    <entryLink id="b1f5-228b-2edc-93d5" name="Crimson Fury" hidden="false" collective="false" targetId="1c0c-a8bb-13c6-daea" type="selectionEntry"/>
-    <entryLink id="c40c-cbf9-905c-29e9" name="Creeping Scourge" hidden="false" collective="false" targetId="5a0b-2e45-8c90-360e" type="selectionEntry"/>
-    <entryLink id="f00e-f8ec-a67c-eb40" name="Lurid Onslaught" hidden="false" collective="false" targetId="0946-b1da-a2c7-12f9" type="selectionEntry"/>
-    <entryLink id="fdb5-4797-2bd0-efcd" name="Mirror of Hatred" hidden="false" collective="false" targetId="73dd-f79e-10cf-dc2f" type="selectionEntry"/>
-    <entryLink id="394c-38b0-fa5d-0598" name="Presplendend Terror" hidden="false" collective="false" targetId="dc24-bd44-bce4-a7f1" type="selectionEntry"/>
-    <entryLink id="59a5-8847-fad5-2758" name="Ka&apos;Bandha, Daemon General of Signus" hidden="false" collective="false" targetId="3e2a-e0d1-0561-3872" type="selectionEntry">
+    <entryLink id="b7a3-4ed3-ee52-15ea" name="Daemon Lord" hidden="false" collective="false" import="true" targetId="92c6-2146-8ca7-bd35" type="selectionEntry"/>
+    <entryLink id="390e-66e4-54dd-2d48" name="Ruinstorm Greater Daemon" hidden="false" collective="false" import="true" targetId="b13b-5247-2078-4daf" type="selectionEntry"/>
+    <entryLink id="7e6c-e6d3-8cd8-4bab" name="Ruinstorm Daemon Chosen" hidden="false" collective="false" import="true" targetId="721a-409b-1ce8-0c50" type="selectionEntry"/>
+    <entryLink id="6abd-85be-2dde-6e52" name="Ruinstorm Daemon Brutes" hidden="false" collective="false" import="true" targetId="5eaf-49f3-f745-fd30" type="selectionEntry"/>
+    <entryLink id="21b0-f212-e2bd-cd24" name="Ruinstorm Daemon Beasts" hidden="false" collective="false" import="true" targetId="c877-3df6-7393-c32b" type="selectionEntry"/>
+    <entryLink id="39f3-6d6f-e05f-0c31" name="Ruinstorm Daemon Cavalry" hidden="false" collective="false" import="true" targetId="1137-8ddd-d812-1e70" type="selectionEntry"/>
+    <entryLink id="049d-b9de-3c25-91d5" name="Ruinstorm Daemon Shrike" hidden="false" collective="false" import="true" targetId="1f45-4da0-7891-e2cc" type="selectionEntry"/>
+    <entryLink id="2ec0-500d-4029-9f83" name="Ruinstorm Daemon Swarms" hidden="false" collective="false" import="true" targetId="ae3c-2429-b663-dcbc" type="selectionEntry"/>
+    <entryLink id="a67e-9984-e65c-a43a" name="Ruinstorm Arch-Daemon" hidden="false" collective="false" import="true" targetId="ea70-5e79-b1a0-3256" type="selectionEntry"/>
+    <entryLink id="2f27-5108-1a63-a58f" name="Ruinstorm Daemon Behemoth" hidden="false" collective="false" import="true" targetId="bf7e-0c26-b8b8-758a" type="selectionEntry"/>
+    <entryLink id="0dc1-e444-dfc2-52c6" name="Greater Ruinstorm Daemon Beast" hidden="false" collective="false" import="true" targetId="b7a8-a1e3-5f05-fc69" type="selectionEntry"/>
+    <entryLink id="b1f5-228b-2edc-93d5" name="Crimson Fury" hidden="false" collective="false" import="true" targetId="1c0c-a8bb-13c6-daea" type="selectionEntry"/>
+    <entryLink id="c40c-cbf9-905c-29e9" name="Creeping Scourge" hidden="false" collective="false" import="true" targetId="5a0b-2e45-8c90-360e" type="selectionEntry"/>
+    <entryLink id="f00e-f8ec-a67c-eb40" name="Lurid Onslaught" hidden="false" collective="false" import="true" targetId="0946-b1da-a2c7-12f9" type="selectionEntry"/>
+    <entryLink id="fdb5-4797-2bd0-efcd" name="Mirror of Hatred" hidden="false" collective="false" import="true" targetId="73dd-f79e-10cf-dc2f" type="selectionEntry"/>
+    <entryLink id="394c-38b0-fa5d-0598" name="Presplendend Terror" hidden="false" collective="false" import="true" targetId="dc24-bd44-bce4-a7f1" type="selectionEntry"/>
+    <entryLink id="59a5-8847-fad5-2758" name="Ka&apos;Bandha, Daemon General of Signus" hidden="false" collective="false" import="true" targetId="3e2a-e0d1-0561-3872" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="15ab-693a-dd31-d370" name="HQ" hidden="false" targetId="485123232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="6e88-de55-8f1a-c58f" name="Possessed Legionaries" hidden="false" collective="false" targetId="308e-c800-4fa9-efde" type="selectionEntry"/>
-    <entryLink id="ca1d-7026-8e22-46c8" name="Possessed Auxiliaries" hidden="false" collective="false" targetId="f3d7-3331-372c-a480" type="selectionEntry"/>
-    <entryLink id="f913-e33e-5360-df0f" name="Cor&apos;bax Utterblight Unbound, Daemon Lord Of The Ruinstorm" hidden="false" collective="false" targetId="5ddb-4a5d-5b2d-c540" type="selectionEntry">
+    <entryLink id="6e88-de55-8f1a-c58f" name="Possessed Legionaries" hidden="false" collective="false" import="true" targetId="308e-c800-4fa9-efde" type="selectionEntry"/>
+    <entryLink id="ca1d-7026-8e22-46c8" name="Possessed Auxiliaries" hidden="false" collective="false" import="true" targetId="f3d7-3331-372c-a480" type="selectionEntry"/>
+    <entryLink id="f913-e33e-5360-df0f" name="Cor&apos;bax Utterblight Unbound, Daemon Lord Of The Ruinstorm" hidden="false" collective="false" import="true" targetId="5ddb-4a5d-5b2d-c540" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="d499-276f-f4fe-5100" name="HQ" hidden="false" targetId="485123232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="d518-5909-d60f-79db" name="Samus Unbound, Daemon Lord of the Ruinstorm" hidden="false" collective="false" targetId="777d-7ee1-4f6d-9ca8" type="selectionEntry">
+    <entryLink id="d518-5909-d60f-79db" name="Samus Unbound, Daemon Lord of the Ruinstorm" hidden="false" collective="false" import="true" targetId="777d-7ee1-4f6d-9ca8" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="feb9-0a69-7838-340a" name="HQ" hidden="false" targetId="485123232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
   </entryLinks>
   <sharedSelectionEntries>
-    <selectionEntry id="092e-7d74-b86e-14a4" name="Lord of Sorcery" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="092e-7d74-b86e-14a4" name="Lord of Sorcery" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="c7e9-ff04-2095-0c9e" name="Lord of Sorcery" hidden="false" targetId="72b2-44f6-a487-9711" type="profile"/>
       </infoLinks>
@@ -213,7 +213,7 @@
         <cost name="pts" typeId="points" value="25.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="92c6-2146-8ca7-bd35" name="Ruinstorm Daemon Lord" hidden="false" collective="false" type="unit">
+    <selectionEntry id="92c6-2146-8ca7-bd35" name="Ruinstorm Daemon Lord" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="set" field="4571-257a-8d04-03c5" value="0.0">
           <conditionGroups>
@@ -234,7 +234,7 @@
         <categoryLink id="f02e-cc87-ce15-adf1" name="HQ" hidden="false" targetId="485123232344415441232323" primary="true"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="12ad-550e-4bd4-a82b" name="Ruinstorm Daemon Brutes" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="12ad-550e-4bd4-a82b" name="Ruinstorm Daemon Brutes" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
@@ -252,7 +252,7 @@
             <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="31c8-198d-7ede-1680" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="c3ea-cce7-8d35-0777" name="Ruinstorm Daemon Brutes" hidden="false" collective="false" type="model">
+            <selectionEntry id="c3ea-cce7-8d35-0777" name="Ruinstorm Daemon Brutes" hidden="false" collective="false" import="true" type="model">
               <constraints>
                 <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5598-fad0-9b4d-5b32" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="785e-5e21-3cb3-f50a" type="min"/>
@@ -271,7 +271,7 @@
             </selectionEntry>
           </selectionEntries>
           <entryLinks>
-            <entryLink id="ef14-1ec4-998b-436b" name="Emanations of Horror [1]" hidden="false" collective="false" targetId="377a-f74e-00b1-f5f5" type="selectionEntryGroup">
+            <entryLink id="ef14-1ec4-998b-436b" name="Emanations of Horror [1]" hidden="false" collective="false" import="true" targetId="377a-f74e-00b1-f5f5" type="selectionEntryGroup">
               <modifiers>
                 <modifier type="set" field="e7c1-3a77-ef39-0f98" value="2"/>
               </modifiers>
@@ -281,7 +281,7 @@
             <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="1aa6-e8a8-4288-3545" name="Ruinstorm Daemon Lord" hidden="false" collective="false" type="model">
+        <selectionEntry id="1aa6-e8a8-4288-3545" name="Ruinstorm Daemon Lord" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="77dd-9d50-20dc-2179" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b10f-ec48-11ab-db5e" type="min"/>
@@ -306,7 +306,7 @@
             <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="4a3e-a87e-7efc-0a7a" name="Flying Monstrous Creature (Character)" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="4a3e-a87e-7efc-0a7a" name="Flying Monstrous Creature (Character)" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
@@ -328,7 +328,7 @@
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink id="c70a-e7a0-d805-3f8c" name="Emanations of Horror [2]" hidden="false" collective="false" targetId="fbff-b318-fc9d-9b88" type="selectionEntryGroup">
+        <entryLink id="c70a-e7a0-d805-3f8c" name="Emanations of Horror [2]" hidden="false" collective="false" import="true" targetId="fbff-b318-fc9d-9b88" type="selectionEntryGroup">
           <modifiers>
             <modifier type="increment" field="6444-bd31-dc43-d332" value="3"/>
           </modifiers>
@@ -338,15 +338,15 @@
         <cost name="pts" typeId="points" value="200.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="5c39-d5e2-e0eb-3280" name="Maddening Swarms" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="5c39-d5e2-e0eb-3280" name="Maddening Swarms" hidden="false" collective="false" import="true" type="upgrade">
       <categoryLinks>
-        <categoryLink id="70c2-4087-319e-b655" name="Aetheric Dominion" hidden="false" targetId="5297-7e0f-fa0b-3537" primary="true"/>
+        <categoryLink id="1554-7c96-8a8e-ca23" name="New CategoryLink" hidden="false" targetId="2271-1b9a-5c30-9676" primary="true"/>
       </categoryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="7d02-f800-e124-ea50" name="Daemonic Wings" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="7d02-f800-e124-ea50" name="Daemonic Wings" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8a93-de89-13e4-acc9" type="max"/>
       </constraints>
@@ -357,9 +357,9 @@
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="9ad5-5b92-5f1f-e661" name="Ruinstorm Lesser Daemons" hidden="false" collective="false" type="unit">
+    <selectionEntry id="9ad5-5b92-5f1f-e661" name="Ruinstorm Lesser Daemons" hidden="false" collective="false" import="true" type="unit">
       <selectionEntries>
-        <selectionEntry id="23df-3d35-fc4d-f51a" name="Ruinstorm Lesser Daemons" hidden="false" collective="false" type="model">
+        <selectionEntry id="23df-3d35-fc4d-f51a" name="Ruinstorm Lesser Daemons" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="20.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2129-273d-758e-06fd" type="max"/>
             <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6400-e7ee-9f4c-0e6e" type="min"/>
@@ -376,7 +376,7 @@
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink id="8ee9-09bc-8039-bb3c" name="Emanations of Horror [1]" hidden="false" collective="false" targetId="377a-f74e-00b1-f5f5" type="selectionEntryGroup">
+        <entryLink id="8ee9-09bc-8039-bb3c" name="Emanations of Horror [1]" hidden="false" collective="false" import="true" targetId="377a-f74e-00b1-f5f5" type="selectionEntryGroup">
           <modifiers>
             <modifier type="increment" field="e7c1-3a77-ef39-0f98" value="3"/>
           </modifiers>
@@ -386,7 +386,7 @@
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="a4fc-26a9-cd55-3b4b" name="Crushing Claws" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="a4fc-26a9-cd55-3b4b" name="Crushing Claws" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ef9-4d4f-97dd-d462" type="max"/>
       </constraints>
@@ -398,7 +398,7 @@
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="e4ca-d240-cc12-1709" name="Flensing Talons" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="e4ca-d240-cc12-1709" name="Flensing Talons" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e694-13a8-d32e-bab5" type="max"/>
       </constraints>
@@ -410,7 +410,7 @@
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="84b2-d1d6-1872-c4ef" name="Corrosive Vomit" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="84b2-d1d6-1872-c4ef" name="Corrosive Vomit" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5f87-a57c-d34a-1de1" type="max"/>
       </constraints>
@@ -422,12 +422,12 @@
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="5eaf-49f3-f745-fd30" name="Ruinstorm Daemon Brutes" hidden="false" collective="false" type="unit">
+    <selectionEntry id="5eaf-49f3-f745-fd30" name="Ruinstorm Daemon Brutes" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
         <categoryLink id="5a79-01c8-c1c7-ef77" name="Elites" hidden="false" targetId="456c6974657323232344415441232323" primary="true"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="4224-c0ee-3840-381f" name="Ruinstorm Daemon Brutes" hidden="false" collective="false" type="model">
+        <selectionEntry id="4224-c0ee-3840-381f" name="Ruinstorm Daemon Brutes" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="253c-4177-cd13-6dda" type="max"/>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cb73-fe73-7556-9206" type="min"/>
@@ -464,7 +464,7 @@
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink id="08c5-d695-f9ec-e08b" name="Bracket One" hidden="false" collective="false" targetId="377a-f74e-00b1-f5f5" type="selectionEntryGroup">
+        <entryLink id="08c5-d695-f9ec-e08b" name="Bracket One" hidden="false" collective="false" import="true" targetId="377a-f74e-00b1-f5f5" type="selectionEntryGroup">
           <modifiers>
             <modifier type="increment" field="e7c1-3a77-ef39-0f98" value="2"/>
           </modifiers>
@@ -474,12 +474,12 @@
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="b13b-5247-2078-4daf" name="Ruinstorm Greater Daemon" hidden="false" collective="false" type="unit">
+    <selectionEntry id="b13b-5247-2078-4daf" name="Ruinstorm Greater Daemon" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
         <categoryLink id="de3d-2656-aeae-8bf0" name="HQ" hidden="false" targetId="485123232344415441232323" primary="true"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="53c0-0b7b-42e5-0eda" name="Ruinstorm Greater Daemon" hidden="false" collective="false" type="model">
+        <selectionEntry id="53c0-0b7b-42e5-0eda" name="Ruinstorm Greater Daemon" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fccf-db2f-d1a3-333f" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2342-0d11-6faa-3e91" type="min"/>
@@ -496,7 +496,7 @@
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink id="1355-24cb-c9df-e80c" name="Emanations of Horror [2]" hidden="false" collective="false" targetId="fbff-b318-fc9d-9b88" type="selectionEntryGroup">
+        <entryLink id="1355-24cb-c9df-e80c" name="Emanations of Horror [2]" hidden="false" collective="false" import="true" targetId="fbff-b318-fc9d-9b88" type="selectionEntryGroup">
           <modifiers>
             <modifier type="increment" field="6444-bd31-dc43-d332" value="3"/>
           </modifiers>
@@ -506,12 +506,12 @@
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="721a-409b-1ce8-0c50" name="Ruinstorm Daemon Chosen" hidden="false" collective="false" type="unit">
+    <selectionEntry id="721a-409b-1ce8-0c50" name="Ruinstorm Daemon Chosen" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
         <categoryLink id="b09a-30f0-39d0-6fb3" name="HQ" hidden="false" targetId="485123232344415441232323" primary="true"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="ce79-9255-4834-834b" name="Ruinstorm Daemon Chosen" hidden="false" collective="false" type="model">
+        <selectionEntry id="ce79-9255-4834-834b" name="Ruinstorm Daemon Chosen" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2ac5-fb24-17cb-d205" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5654-a827-1a05-9e93" type="max"/>
@@ -529,7 +529,7 @@
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink id="295b-5114-2089-b4dc" name="Emanations of Horror [2]" hidden="false" collective="false" targetId="fbff-b318-fc9d-9b88" type="selectionEntryGroup">
+        <entryLink id="295b-5114-2089-b4dc" name="Emanations of Horror [2]" hidden="false" collective="false" import="true" targetId="fbff-b318-fc9d-9b88" type="selectionEntryGroup">
           <modifiers>
             <modifier type="increment" field="6444-bd31-dc43-d332" value="3"/>
           </modifiers>
@@ -539,12 +539,12 @@
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="1137-8ddd-d812-1e70" name="Ruinstorm Daemon Cavalry" hidden="false" collective="false" type="unit">
+    <selectionEntry id="1137-8ddd-d812-1e70" name="Ruinstorm Daemon Cavalry" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
         <categoryLink id="5571-9b8f-6e12-06ee" name="Fast Attack" hidden="false" targetId="466173742041747461636b23232344415441232323" primary="true"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="85a4-e359-e057-894b" name="Ruinstorm Daemon Cavalry" hidden="false" collective="false" type="model">
+        <selectionEntry id="85a4-e359-e057-894b" name="Ruinstorm Daemon Cavalry" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ae68-67dd-b755-d089" type="max"/>
             <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2962-691d-d73b-76ef" type="min"/>
@@ -561,7 +561,7 @@
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink id="7409-a973-1a0f-c633" name="Bracket One" hidden="false" collective="false" targetId="377a-f74e-00b1-f5f5" type="selectionEntryGroup">
+        <entryLink id="7409-a973-1a0f-c633" name="Bracket One" hidden="false" collective="false" import="true" targetId="377a-f74e-00b1-f5f5" type="selectionEntryGroup">
           <modifiers>
             <modifier type="increment" field="e7c1-3a77-ef39-0f98" value="2"/>
           </modifiers>
@@ -571,12 +571,12 @@
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="c877-3df6-7393-c32b" name="Ruinstorm Daemon Beasts" hidden="false" collective="false" type="unit">
+    <selectionEntry id="c877-3df6-7393-c32b" name="Ruinstorm Daemon Beasts" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
         <categoryLink id="cf97-4f31-aa52-f7f5" name="Troops" hidden="false" targetId="54726f6f707323232344415441232323" primary="true"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="6bb2-6321-dfaf-0eda" name="Ruinstorm Daemon Beasts" hidden="false" collective="false" type="model">
+        <selectionEntry id="6bb2-6321-dfaf-0eda" name="Ruinstorm Daemon Beasts" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6104-fcf7-7181-6a8d" type="max"/>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c93d-e50f-1669-8f3c" type="min"/>
@@ -593,7 +593,7 @@
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink id="d13b-f3af-3a38-2dac" name="Bracket One" hidden="false" collective="false" targetId="377a-f74e-00b1-f5f5" type="selectionEntryGroup">
+        <entryLink id="d13b-f3af-3a38-2dac" name="Bracket One" hidden="false" collective="false" import="true" targetId="377a-f74e-00b1-f5f5" type="selectionEntryGroup">
           <modifiers>
             <modifier type="increment" field="e7c1-3a77-ef39-0f98" value="2"/>
           </modifiers>
@@ -603,12 +603,12 @@
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="ae3c-2429-b663-dcbc" name="Ruinstorm Daemon Swarms" hidden="false" collective="false" type="unit">
+    <selectionEntry id="ae3c-2429-b663-dcbc" name="Ruinstorm Daemon Swarms" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
         <categoryLink id="7f7f-257b-f4ee-5af8" name="Troops" hidden="false" targetId="54726f6f707323232344415441232323" primary="true"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="f757-a9dc-829d-0f07" name="Ruinstorm Daemon Swarms" hidden="false" collective="false" type="model">
+        <selectionEntry id="f757-a9dc-829d-0f07" name="Ruinstorm Daemon Swarms" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="86a6-8205-e620-15e3" type="max"/>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bc7f-6c95-1d6f-e290" type="min"/>
@@ -627,7 +627,7 @@
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink id="414e-2de8-4537-4b03" name="Emanations of Horror [1]" hidden="false" collective="false" targetId="377a-f74e-00b1-f5f5" type="selectionEntryGroup">
+        <entryLink id="414e-2de8-4537-4b03" name="Emanations of Horror [1]" hidden="false" collective="false" import="true" targetId="377a-f74e-00b1-f5f5" type="selectionEntryGroup">
           <modifiers>
             <modifier type="increment" field="e7c1-3a77-ef39-0f98" value="1"/>
           </modifiers>
@@ -637,12 +637,12 @@
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="1f45-4da0-7891-e2cc" name="Ruinstorm Daemon Shrike" hidden="false" collective="false" type="unit">
+    <selectionEntry id="1f45-4da0-7891-e2cc" name="Ruinstorm Daemon Shrike" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
         <categoryLink id="8ccd-e535-2882-af9e" name="Fast Attack" hidden="false" targetId="466173742041747461636b23232344415441232323" primary="true"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="382f-0d1e-6bff-a7a3" name="Ruinstorm Daemon Shrike" hidden="false" collective="false" type="model">
+        <selectionEntry id="382f-0d1e-6bff-a7a3" name="Ruinstorm Daemon Shrike" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="063d-6e2a-8b0d-611f" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c68e-83b9-8097-6d20" type="max"/>
@@ -659,7 +659,7 @@
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink id="8ae3-61ed-31c1-ce55" name="Emanations of Horror [2]" hidden="false" collective="false" targetId="fbff-b318-fc9d-9b88" type="selectionEntryGroup">
+        <entryLink id="8ae3-61ed-31c1-ce55" name="Emanations of Horror [2]" hidden="false" collective="false" import="true" targetId="fbff-b318-fc9d-9b88" type="selectionEntryGroup">
           <modifiers>
             <modifier type="increment" field="6444-bd31-dc43-d332" value="2"/>
           </modifiers>
@@ -669,12 +669,12 @@
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="bf7e-0c26-b8b8-758a" name="Ruinstorm Daemon Behemoth" hidden="false" collective="false" type="unit">
+    <selectionEntry id="bf7e-0c26-b8b8-758a" name="Ruinstorm Daemon Behemoth" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
         <categoryLink id="bba1-7f66-485f-9ec7" name="Heavy Support" hidden="false" targetId="486561767920537570706f727423232344415441232323" primary="true"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="87b5-6bc7-c8d2-68bf" name="Ruinstorm Daemon Behemoth" hidden="false" collective="false" type="model">
+        <selectionEntry id="87b5-6bc7-c8d2-68bf" name="Ruinstorm Daemon Behemoth" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e8c0-ada9-8bc2-6910" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="429d-5b16-7404-845b" type="min"/>
@@ -692,7 +692,7 @@
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink id="99e0-42d8-03bb-61c2" name="Emanations of Horror [3]" hidden="false" collective="false" targetId="7eba-bb63-a86c-5b07" type="selectionEntryGroup">
+        <entryLink id="99e0-42d8-03bb-61c2" name="Emanations of Horror [3]" hidden="false" collective="false" import="true" targetId="7eba-bb63-a86c-5b07" type="selectionEntryGroup">
           <modifiers>
             <modifier type="increment" field="44fc-ca72-33e4-b530" value="3"/>
           </modifiers>
@@ -702,12 +702,12 @@
         <cost name="pts" typeId="points" value="300.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="b7a8-a1e3-5f05-fc69" name="Ruinstorm Greater Daemon Beasts" hidden="false" collective="false" type="unit">
+    <selectionEntry id="b7a8-a1e3-5f05-fc69" name="Ruinstorm Greater Daemon Beasts" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
         <categoryLink id="3e95-5559-6cef-3f4c" name="Heavy Support" hidden="false" targetId="486561767920537570706f727423232344415441232323" primary="true"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="0ea3-dfe8-8919-5bf7" name="Greater Ruinstorm Daemon Beast" hidden="false" collective="false" type="model">
+        <selectionEntry id="0ea3-dfe8-8919-5bf7" name="Greater Ruinstorm Daemon Beast" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="94f7-aa65-7faa-c675" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9cc1-e8be-56e7-5abe" type="min"/>
@@ -727,7 +727,7 @@
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="d139-49ad-d066-bb05" name="Emanations of Horror [3]" hidden="false" collective="false">
+        <selectionEntryGroup id="d139-49ad-d066-bb05" name="Emanations of Horror [3]" hidden="false" collective="false" import="true">
           <modifiers>
             <modifier type="increment" field="1bd5-5962-2608-d4b4" value="1">
               <conditions>
@@ -739,7 +739,7 @@
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1bd5-5962-2608-d4b4" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="07fd-9d5f-ed3e-a352" name="Crushing Claws" hidden="false" collective="false" targetId="a4fc-26a9-cd55-3b4b" type="selectionEntry">
+            <entryLink id="07fd-9d5f-ed3e-a352" name="Crushing Claws" hidden="false" collective="false" import="true" targetId="a4fc-26a9-cd55-3b4b" type="selectionEntry">
               <modifiers>
                 <modifier type="increment" field="points" value="10">
                   <repeats>
@@ -748,7 +748,7 @@
                 </modifier>
               </modifiers>
             </entryLink>
-            <entryLink id="0c15-32ff-e28a-3736" name="Flensing Talons" hidden="false" collective="false" targetId="e4ca-d240-cc12-1709" type="selectionEntry">
+            <entryLink id="0c15-32ff-e28a-3736" name="Flensing Talons" hidden="false" collective="false" import="true" targetId="e4ca-d240-cc12-1709" type="selectionEntry">
               <modifiers>
                 <modifier type="increment" field="points" value="5">
                   <repeats>
@@ -757,7 +757,7 @@
                 </modifier>
               </modifiers>
             </entryLink>
-            <entryLink id="0925-0bc0-7e2b-e75f" name="Sundering Fangs" hidden="false" collective="false" targetId="6714-4a30-d5ab-f43b" type="selectionEntry">
+            <entryLink id="0925-0bc0-7e2b-e75f" name="Sundering Fangs" hidden="false" collective="false" import="true" targetId="6714-4a30-d5ab-f43b" type="selectionEntry">
               <modifiers>
                 <modifier type="increment" field="points" value="5">
                   <repeats>
@@ -766,7 +766,7 @@
                 </modifier>
               </modifiers>
             </entryLink>
-            <entryLink id="a834-7fa2-c737-a81f" name="Miasma of Rot" hidden="false" collective="false" targetId="1777-1007-cc23-1481" type="selectionEntry">
+            <entryLink id="a834-7fa2-c737-a81f" name="Miasma of Rot" hidden="false" collective="false" import="true" targetId="1777-1007-cc23-1481" type="selectionEntry">
               <modifiers>
                 <modifier type="increment" field="points" value="15">
                   <repeats>
@@ -775,7 +775,7 @@
                 </modifier>
               </modifiers>
             </entryLink>
-            <entryLink id="0f6f-37ac-8e24-5b8f" name="Brass Collars" hidden="false" collective="false" targetId="da14-1454-058f-f0cd" type="selectionEntry">
+            <entryLink id="0f6f-37ac-8e24-5b8f" name="Brass Collars" hidden="false" collective="false" import="true" targetId="da14-1454-058f-f0cd" type="selectionEntry">
               <modifiers>
                 <modifier type="increment" field="points" value="15">
                   <repeats>
@@ -784,7 +784,7 @@
                 </modifier>
               </modifiers>
             </entryLink>
-            <entryLink id="5053-cf74-afc0-631f" name="Stupefying Musk" hidden="false" collective="false" targetId="6c9f-9f45-11f1-1079" type="selectionEntry">
+            <entryLink id="5053-cf74-afc0-631f" name="Stupefying Musk" hidden="false" collective="false" import="true" targetId="6c9f-9f45-11f1-1079" type="selectionEntry">
               <modifiers>
                 <modifier type="increment" field="points" value="10">
                   <repeats>
@@ -793,7 +793,7 @@
                 </modifier>
               </modifiers>
             </entryLink>
-            <entryLink id="9794-1766-4fba-2938" name="Corrosive Vomit" hidden="false" collective="false" targetId="84b2-d1d6-1872-c4ef" type="selectionEntry">
+            <entryLink id="9794-1766-4fba-2938" name="Corrosive Vomit" hidden="false" collective="false" import="true" targetId="84b2-d1d6-1872-c4ef" type="selectionEntry">
               <modifiers>
                 <modifier type="increment" field="points" value="15">
                   <repeats>
@@ -802,7 +802,7 @@
                 </modifier>
               </modifiers>
             </entryLink>
-            <entryLink id="2802-b8bc-3f75-5fde" name="Rift Barb" hidden="false" collective="false" targetId="19f9-a3b4-ae4e-845e" type="selectionEntry">
+            <entryLink id="2802-b8bc-3f75-5fde" name="Rift Barb" hidden="false" collective="false" import="true" targetId="19f9-a3b4-ae4e-845e" type="selectionEntry">
               <modifiers>
                 <modifier type="increment" field="points" value="15">
                   <repeats>
@@ -811,7 +811,7 @@
                 </modifier>
               </modifiers>
             </entryLink>
-            <entryLink id="71bc-10c5-3bd0-c11e" name="Molten Blood" hidden="false" collective="false" targetId="e001-8e2e-f957-4bb7" type="selectionEntry">
+            <entryLink id="71bc-10c5-3bd0-c11e" name="Molten Blood" hidden="false" collective="false" import="true" targetId="e001-8e2e-f957-4bb7" type="selectionEntry">
               <modifiers>
                 <modifier type="increment" field="points" value="5">
                   <repeats>
@@ -820,7 +820,7 @@
                 </modifier>
               </modifiers>
             </entryLink>
-            <entryLink id="b893-30c9-ce82-9ead" name="Horned Crown" hidden="false" collective="false" targetId="3f3e-bbfb-732a-9fa8" type="selectionEntry">
+            <entryLink id="b893-30c9-ce82-9ead" name="Horned Crown" hidden="false" collective="false" import="true" targetId="3f3e-bbfb-732a-9fa8" type="selectionEntry">
               <modifiers>
                 <modifier type="increment" field="points" value="15">
                   <repeats>
@@ -829,7 +829,7 @@
                 </modifier>
               </modifiers>
             </entryLink>
-            <entryLink id="2e15-e363-6e39-1b2a" name="Warp-scaled Hide" hidden="false" collective="false" targetId="5759-049f-35eb-37c2" type="selectionEntry">
+            <entryLink id="2e15-e363-6e39-1b2a" name="Warp-scaled Hide" hidden="false" collective="false" import="true" targetId="5759-049f-35eb-37c2" type="selectionEntry">
               <modifiers>
                 <modifier type="increment" field="points" value="25">
                   <repeats>
@@ -838,7 +838,7 @@
                 </modifier>
               </modifiers>
             </entryLink>
-            <entryLink id="bf59-9547-b813-8fc2" name="Quicksilver Speed" hidden="false" collective="false" targetId="7e9f-dc4a-0fa8-732d" type="selectionEntry">
+            <entryLink id="bf59-9547-b813-8fc2" name="Quicksilver Speed" hidden="false" collective="false" import="true" targetId="7e9f-dc4a-0fa8-732d" type="selectionEntry">
               <modifiers>
                 <modifier type="increment" field="points" value="15">
                   <repeats>
@@ -847,7 +847,7 @@
                 </modifier>
               </modifiers>
             </entryLink>
-            <entryLink id="1ab6-c6e0-1547-27f6" name="Flaming Ichor" hidden="false" collective="false" targetId="e531-b96d-ec46-184a" type="selectionEntry">
+            <entryLink id="1ab6-c6e0-1547-27f6" name="Flaming Ichor" hidden="false" collective="false" import="true" targetId="e531-b96d-ec46-184a" type="selectionEntry">
               <modifiers>
                 <modifier type="increment" field="points" value="20">
                   <repeats>
@@ -856,7 +856,7 @@
                 </modifier>
               </modifiers>
             </entryLink>
-            <entryLink id="403c-d3a9-dd84-da78" name="Spine Volley" hidden="false" collective="false" targetId="6a35-94d3-e17d-37b0" type="selectionEntry">
+            <entryLink id="403c-d3a9-dd84-da78" name="Spine Volley" hidden="false" collective="false" import="true" targetId="6a35-94d3-e17d-37b0" type="selectionEntry">
               <modifiers>
                 <modifier type="increment" field="points" value="10">
                   <repeats>
@@ -865,7 +865,7 @@
                 </modifier>
               </modifiers>
             </entryLink>
-            <entryLink id="cf68-0c94-99a1-8427" name="Bone Shard Harpoons" hidden="false" collective="false" targetId="823e-a42d-9475-c2dd" type="selectionEntry">
+            <entryLink id="cf68-0c94-99a1-8427" name="Bone Shard Harpoons" hidden="false" collective="false" import="true" targetId="823e-a42d-9475-c2dd" type="selectionEntry">
               <modifiers>
                 <modifier type="increment" field="points" value="10">
                   <repeats>
@@ -874,7 +874,7 @@
                 </modifier>
               </modifiers>
             </entryLink>
-            <entryLink id="df3d-59a6-c720-68ed" name="Shroud of Darkness" hidden="false" collective="false" targetId="8600-a910-cd18-0f0a" type="selectionEntry">
+            <entryLink id="df3d-59a6-c720-68ed" name="Shroud of Darkness" hidden="false" collective="false" import="true" targetId="8600-a910-cd18-0f0a" type="selectionEntry">
               <modifiers>
                 <modifier type="increment" field="points" value="20">
                   <repeats>
@@ -890,7 +890,7 @@
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="ea70-5e79-b1a0-3256" name="Ruinstorm Arch-Daemon" hidden="false" collective="false" type="model">
+    <selectionEntry id="ea70-5e79-b1a0-3256" name="Ruinstorm Arch-Daemon" hidden="false" collective="false" import="true" type="model">
       <infoLinks>
         <infoLink id="17ab-6c0d-90e1-5146" name="Parting the Veil" hidden="false" targetId="c828-3e09-a384-735b" type="rule"/>
         <infoLink id="107e-5fd7-28c1-d676" name="Tide of Madness" hidden="false" targetId="a2dc-7a16-0067-a4db" type="rule"/>
@@ -914,7 +914,7 @@
         <categoryLink id="93e2-727d-d5f9-320b" name="Lords of War" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="8432-da5e-4922-f15d" name="Flying Gargantuan Creature (Character)" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="8432-da5e-4922-f15d" name="Flying Gargantuan Creature (Character)" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="98b8-350d-33a3-1513" type="max"/>
           </constraints>
@@ -924,12 +924,12 @@
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="1aff-adeb-3152-60b5" name="Arch-Daemon Emanations" publicationId="8700-b3bb-pubN65537" page="252" hidden="false" collective="false">
+        <selectionEntryGroup id="1aff-adeb-3152-60b5" name="Arch-Daemon Emanations" publicationId="8700-b3bb-pubN65537" page="252" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ae1-eac8-937c-b423" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="4240-2a3e-186a-b9d5" name="Lord of Chaos" publicationId="8700-b3bb-pubN65537" page="253" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="4240-2a3e-186a-b9d5" name="Lord of Chaos" publicationId="8700-b3bb-pubN65537" page="253" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="13eb-ed81-6dbf-c1c9" type="max"/>
               </constraints>
@@ -944,7 +944,7 @@
                 <cost name="pts" typeId="points" value="50.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="13a4-65f6-dcf0-9bcd" name="Warp-forged Plate" publicationId="8700-b3bb-pubN65537" page="253" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="13a4-65f6-dcf0-9bcd" name="Warp-forged Plate" publicationId="8700-b3bb-pubN65537" page="253" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7265-6ee9-fca1-9691" type="max"/>
               </constraints>
@@ -959,7 +959,7 @@
                 <cost name="pts" typeId="points" value="50.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="acf6-297c-97f1-b4e6" name="Rend Time and Space" publicationId="8700-b3bb-pubN65537" page="253" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="acf6-297c-97f1-b4e6" name="Rend Time and Space" publicationId="8700-b3bb-pubN65537" page="253" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="854d-1fdf-4428-61b6" type="max"/>
               </constraints>
@@ -974,7 +974,7 @@
                 <cost name="pts" typeId="points" value="50.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="eb07-2d1b-8baa-7fa8" name="Warp Blast" publicationId="8700-b3bb-pubN65537" page="253" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="eb07-2d1b-8baa-7fa8" name="Warp Blast" publicationId="8700-b3bb-pubN65537" page="253" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1cb5-9975-cb29-9308" type="max"/>
               </constraints>
@@ -992,7 +992,7 @@
                 <cost name="pts" typeId="points" value="35.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="bcee-006c-c92c-4fc5" name="Torrent of Unreality" publicationId="8700-b3bb-pubN65537" page="253" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="bcee-006c-c92c-4fc5" name="Torrent of Unreality" publicationId="8700-b3bb-pubN65537" page="253" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c3bf-aec9-e18b-ccc3" type="max"/>
               </constraints>
@@ -1010,7 +1010,7 @@
                 <cost name="pts" typeId="points" value="30.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="fa7e-1e6c-b4ac-7b97" name="Wound in Reality" publicationId="8700-b3bb-pubN65537" page="253" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="fa7e-1e6c-b4ac-7b97" name="Wound in Reality" publicationId="8700-b3bb-pubN65537" page="253" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="27c2-b56f-002d-5fc7" type="max"/>
               </constraints>
@@ -1025,7 +1025,7 @@
                 <cost name="pts" typeId="points" value="25.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="8dc5-9537-854e-1d0e" name="Font of the Warp" publicationId="8700-b3bb-pubN65537" page="253" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="8dc5-9537-854e-1d0e" name="Font of the Warp" publicationId="8700-b3bb-pubN65537" page="253" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="37fa-34f5-719f-2ed3" type="max"/>
               </constraints>
@@ -1043,7 +1043,7 @@
                 <cost name="pts" typeId="points" value="100.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="b373-3f27-6e31-fb8a" name="Reaper of Souls" publicationId="8700-b3bb-pubN65537" page="253" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="b373-3f27-6e31-fb8a" name="Reaper of Souls" publicationId="8700-b3bb-pubN65537" page="253" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf2d-4fda-0b74-25b9" type="max"/>
               </constraints>
@@ -1058,7 +1058,7 @@
                 <cost name="pts" typeId="points" value="25.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="326d-c026-c192-27d6" name="Breaker of Titans" publicationId="8700-b3bb-pubN65537" page="253" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="326d-c026-c192-27d6" name="Breaker of Titans" publicationId="8700-b3bb-pubN65537" page="253" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5507-ca82-b232-1ef5" type="max"/>
               </constraints>
@@ -1073,7 +1073,7 @@
                 <cost name="pts" typeId="points" value="35.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="a232-8fe1-4fe3-b274" name="Beyond Death" publicationId="8700-b3bb-pubN65537" page="253" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="a232-8fe1-4fe3-b274" name="Beyond Death" publicationId="8700-b3bb-pubN65537" page="253" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="35ec-2899-402f-14dc" type="max"/>
               </constraints>
@@ -1095,7 +1095,7 @@
         <cost name="pts" typeId="points" value="600.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="19f9-a3b4-ae4e-845e" name="Rift Barb" publicationId="8700-b3bb-pubN65537" page="235" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="19f9-a3b4-ae4e-845e" name="Rift Barb" publicationId="8700-b3bb-pubN65537" page="235" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="221e-623f-315e-1f2f" type="max"/>
       </constraints>
@@ -1108,7 +1108,7 @@
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="8600-a910-cd18-0f0a" name="Shroud of Darkness" publicationId="8700-b3bb-pubN65537" page="235" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="8600-a910-cd18-0f0a" name="Shroud of Darkness" publicationId="8700-b3bb-pubN65537" page="235" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="51b0-60bb-e704-601d" type="max"/>
       </constraints>
@@ -1119,7 +1119,7 @@
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="e001-8e2e-f957-4bb7" name="Molten Blood" publicationId="8700-b3bb-pubN65537" page="235" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="e001-8e2e-f957-4bb7" name="Molten Blood" publicationId="8700-b3bb-pubN65537" page="235" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f504-5a84-ff01-bce8" type="max"/>
       </constraints>
@@ -1130,7 +1130,7 @@
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="9488-98d4-9eeb-b790" name="Ephemeral Terror" publicationId="8700-b3bb-pubN65537" page="235" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="9488-98d4-9eeb-b790" name="Ephemeral Terror" publicationId="8700-b3bb-pubN65537" page="235" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ade7-2e46-66c3-d049" type="max"/>
       </constraints>
@@ -1141,7 +1141,7 @@
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="6a35-94d3-e17d-37b0" name="Spine Volley" publicationId="8700-b3bb-pubN65537" page="235" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="6a35-94d3-e17d-37b0" name="Spine Volley" publicationId="8700-b3bb-pubN65537" page="235" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ad8c-d207-16bf-2598" type="max"/>
       </constraints>
@@ -1153,7 +1153,7 @@
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="823e-a42d-9475-c2dd" name="Bone Shard Harpoons" publicationId="8700-b3bb-pubN65537" page="235" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="823e-a42d-9475-c2dd" name="Bone Shard Harpoons" publicationId="8700-b3bb-pubN65537" page="235" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="732f-7992-a692-0021" type="max"/>
       </constraints>
@@ -1166,7 +1166,7 @@
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="7e9f-dc4a-0fa8-732d" name="Quicksilver Speed" publicationId="8700-b3bb-pubN65537" page="235" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="7e9f-dc4a-0fa8-732d" name="Quicksilver Speed" publicationId="8700-b3bb-pubN65537" page="235" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cec4-4112-7eea-6a8e" type="max"/>
       </constraints>
@@ -1179,7 +1179,7 @@
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="5759-049f-35eb-37c2" name="Warp-scaled Hide" publicationId="8700-b3bb-pubN65537" page="235" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="5759-049f-35eb-37c2" name="Warp-scaled Hide" publicationId="8700-b3bb-pubN65537" page="235" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f972-f654-0d4d-faa6" type="max"/>
       </constraints>
@@ -1190,7 +1190,7 @@
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="3f3e-bbfb-732a-9fa8" name="Horned Crown" publicationId="8700-b3bb-pubN65537" page="235" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="3f3e-bbfb-732a-9fa8" name="Horned Crown" publicationId="8700-b3bb-pubN65537" page="235" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2275-143a-8519-dd33" type="max"/>
       </constraints>
@@ -1202,7 +1202,7 @@
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="8833-0efb-fa13-96fe" name="Warp Scions" publicationId="8700-b3bb-pubN65537" page="235" hidden="true" collective="false" type="upgrade">
+    <selectionEntry id="8833-0efb-fa13-96fe" name="Warp Scions" publicationId="8700-b3bb-pubN65537" page="235" hidden="true" collective="false" import="true" type="upgrade">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
@@ -1238,7 +1238,7 @@
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="6c9f-9f45-11f1-1079" name="Stupefying Musk" publicationId="8700-b3bb-pubN65537" page="235" hidden="true" collective="false" type="upgrade">
+    <selectionEntry id="6c9f-9f45-11f1-1079" name="Stupefying Musk" publicationId="8700-b3bb-pubN65537" page="235" hidden="true" collective="false" import="true" type="upgrade">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
@@ -1284,7 +1284,7 @@
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="da14-1454-058f-f0cd" name="Brass Collars" publicationId="8700-b3bb-pubN65537" page="235" hidden="true" collective="false" type="upgrade">
+    <selectionEntry id="da14-1454-058f-f0cd" name="Brass Collars" publicationId="8700-b3bb-pubN65537" page="235" hidden="true" collective="false" import="true" type="upgrade">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
@@ -1331,7 +1331,7 @@
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="1777-1007-cc23-1481" name="Miasma of Rot" publicationId="8700-b3bb-pubN65537" page="235" hidden="true" collective="false" type="upgrade">
+    <selectionEntry id="1777-1007-cc23-1481" name="Miasma of Rot" publicationId="8700-b3bb-pubN65537" page="235" hidden="true" collective="false" import="true" type="upgrade">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
@@ -1377,7 +1377,7 @@
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="6714-4a30-d5ab-f43b" name="Sundering Fangs" publicationId="8700-b3bb-pubN65537" page="235" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="6714-4a30-d5ab-f43b" name="Sundering Fangs" publicationId="8700-b3bb-pubN65537" page="235" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a886-28cd-c27b-ce73" type="max"/>
       </constraints>
@@ -1389,7 +1389,7 @@
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="e531-b96d-ec46-184a" name="Flaming Ichor" publicationId="8700-b3bb-pubN65537" page="235" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="e531-b96d-ec46-184a" name="Flaming Ichor" publicationId="8700-b3bb-pubN65537" page="235" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="807c-ba2a-a66d-3ba9" type="max"/>
       </constraints>
@@ -1403,7 +1403,7 @@
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="1c0c-a8bb-13c6-daea" name="Crimson Fury" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="1c0c-a8bb-13c6-daea" name="Crimson Fury" hidden="false" collective="false" import="true" type="upgrade">
       <modifiers>
         <modifier type="set" field="4632-6854-da60-0105" value="1">
           <conditions>
@@ -1415,21 +1415,21 @@
         <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4632-6854-da60-0105" type="min"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="91cb-adbc-d386-a574" name="Aetheric Dominion" hidden="false" targetId="5297-7e0f-fa0b-3537" primary="true"/>
+        <categoryLink id="fe62-3b4b-3186-1c59" name="New CategoryLink" hidden="false" targetId="2271-1b9a-5c30-9676" primary="true"/>
       </categoryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="0946-b1da-a2c7-12f9" name="Lurid Onslaught" publicationId="8700-b3bb-pubN65537" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="0946-b1da-a2c7-12f9" name="Lurid Onslaught" publicationId="8700-b3bb-pubN65537" hidden="false" collective="false" import="true" type="upgrade">
       <categoryLinks>
-        <categoryLink id="2d3f-0693-cea4-97c5" name="Aetheric Dominion" hidden="false" targetId="5297-7e0f-fa0b-3537" primary="true"/>
+        <categoryLink id="b572-bd07-cafa-980a" name="New CategoryLink" hidden="false" targetId="2271-1b9a-5c30-9676" primary="true"/>
       </categoryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="5a0b-2e45-8c90-360e" name="Creeping Scourge" publicationId="8700-b3bb-pubN65537" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="5a0b-2e45-8c90-360e" name="Creeping Scourge" publicationId="8700-b3bb-pubN65537" hidden="false" collective="false" import="true" type="upgrade">
       <modifiers>
         <modifier type="set" field="0715-b682-d447-5c10" value="1">
           <conditions>
@@ -1441,21 +1441,21 @@
         <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0715-b682-d447-5c10" type="min"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="4ac0-d3ef-0316-6008" name="Aetheric Dominion" hidden="false" targetId="5297-7e0f-fa0b-3537" primary="true"/>
+        <categoryLink id="e9c5-f0a4-4d49-b748" name="New CategoryLink" hidden="false" targetId="2271-1b9a-5c30-9676" primary="true"/>
       </categoryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="73dd-f79e-10cf-dc2f" name="Mirror of Hatred" publicationId="8700-b3bb-pubN65537" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="73dd-f79e-10cf-dc2f" name="Mirror of Hatred" publicationId="8700-b3bb-pubN65537" hidden="false" collective="false" import="true" type="upgrade">
       <categoryLinks>
-        <categoryLink id="897f-b60c-6fc7-59e2" name="Aetheric Dominion" hidden="false" targetId="5297-7e0f-fa0b-3537" primary="true"/>
+        <categoryLink id="110d-26a3-c9e8-944c" name="New CategoryLink" hidden="false" targetId="2271-1b9a-5c30-9676" primary="true"/>
       </categoryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="dc24-bd44-bce4-a7f1" name="Resplendent Terror" publicationId="8700-b3bb-pubN65537" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="dc24-bd44-bce4-a7f1" name="Resplendent Terror" publicationId="8700-b3bb-pubN65537" hidden="false" collective="false" import="true" type="upgrade">
       <modifiers>
         <modifier type="set" field="3d92-7ea6-6e8f-7684" value="1">
           <conditions>
@@ -1467,13 +1467,13 @@
         <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3d92-7ea6-6e8f-7684" type="min"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="383f-5901-c8a4-33f5" name="Aetheric Dominion" hidden="false" targetId="5297-7e0f-fa0b-3537" primary="true"/>
+        <categoryLink id="d846-6ed5-4f5f-2793" name="New CategoryLink" hidden="false" targetId="2271-1b9a-5c30-9676" primary="true"/>
       </categoryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="3e2a-e0d1-0561-3872" name="Ka&apos;Bandha, Daemon General of Signus" publicationId="8700-b3bb-pubN65537" hidden="false" collective="false" type="model">
+    <selectionEntry id="3e2a-e0d1-0561-3872" name="Ka&apos;Bandha, Daemon General of Signus" publicationId="8700-b3bb-pubN65537" hidden="false" collective="false" import="true" type="model">
       <modifiers>
         <modifier type="set" field="33f3-58b0-0dc9-4d8e" value="1">
           <conditionGroups>
@@ -1533,17 +1533,17 @@ Eternal Rivalry: If Sanguinius is removed as a casualty while it is fighting in 
         <infoLink id="ab16-e2ca-d661-eb58" name="Preferred Enemy" hidden="false" targetId="4dd2-fcb0-de6a-5b70" type="rule"/>
       </infoLinks>
       <entryLinks>
-        <entryLink id="5394-5b8e-7434-eba2" name="Molten Blood" hidden="false" collective="false" targetId="e001-8e2e-f957-4bb7" type="selectionEntry">
+        <entryLink id="5394-5b8e-7434-eba2" name="Molten Blood" hidden="false" collective="false" import="true" targetId="e001-8e2e-f957-4bb7" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fdb3-9e9d-d9a7-ee66" type="min"/>
           </constraints>
         </entryLink>
-        <entryLink id="85b1-cf13-ed21-09b9" name="Brass Collars" hidden="false" collective="false" targetId="da14-1454-058f-f0cd" type="selectionEntry">
+        <entryLink id="85b1-cf13-ed21-09b9" name="Brass Collars" hidden="false" collective="false" import="true" targetId="da14-1454-058f-f0cd" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5285-b87f-d33e-6b1d" type="min"/>
           </constraints>
         </entryLink>
-        <entryLink id="ac51-f053-a92c-eaa3" name="Horned Crown" hidden="false" collective="false" targetId="3f3e-bbfb-732a-9fa8" type="selectionEntry">
+        <entryLink id="ac51-f053-a92c-eaa3" name="Horned Crown" hidden="false" collective="false" import="true" targetId="3f3e-bbfb-732a-9fa8" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="22c6-bc74-50a5-6c7f" type="min"/>
           </constraints>
@@ -1553,7 +1553,7 @@ Eternal Rivalry: If Sanguinius is removed as a casualty while it is fighting in 
         <cost name="pts" typeId="points" value="460.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="308e-c800-4fa9-efde" name="Possessed Legionaries" publicationId="8700-b3bb-pubN65537" hidden="false" collective="false" type="unit">
+    <selectionEntry id="308e-c800-4fa9-efde" name="Possessed Legionaries" publicationId="8700-b3bb-pubN65537" hidden="false" collective="false" import="true" type="unit">
       <infoLinks>
         <infoLink id="6349-c3c3-6f07-5e59" name="Support Squad" hidden="false" targetId="2c16-3b25-a714-a656" type="rule"/>
         <infoLink id="cc8c-ad29-14b4-95cc" name="Slaves to Darkness" hidden="false" targetId="b407-fb29-f206-4ad3" type="rule"/>
@@ -1562,7 +1562,7 @@ Eternal Rivalry: If Sanguinius is removed as a casualty while it is fighting in 
         <categoryLink id="e68e-7fa4-829e-48bc" name="Troops" hidden="false" targetId="54726f6f707323232344415441232323" primary="true"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="c4a1-6f68-d186-1fb8" name="Possessed Legionaries" publicationId="8700-b3bb-pubN65537" hidden="false" collective="false" type="model">
+        <selectionEntry id="c4a1-6f68-d186-1fb8" name="Possessed Legionaries" publicationId="8700-b3bb-pubN65537" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7f5e-0c92-2620-c236" type="min"/>
             <constraint field="selections" scope="parent" value="20.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7dcb-21fd-89eb-c921" type="max"/>
@@ -1576,7 +1576,7 @@ Eternal Rivalry: If Sanguinius is removed as a casualty while it is fighting in 
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="568d-aff6-8c8c-cf99" name="Ranged options" publicationId="8700-b3bb-pubN65537" hidden="true" collective="false">
+        <selectionEntryGroup id="568d-aff6-8c8c-cf99" name="Ranged options" publicationId="8700-b3bb-pubN65537" hidden="true" collective="false" import="true">
           <modifiers>
             <modifier type="increment" field="e272-8d3d-9323-2db5" value="1">
               <repeats>
@@ -1596,18 +1596,18 @@ Eternal Rivalry: If Sanguinius is removed as a casualty while it is fighting in 
             <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e272-8d3d-9323-2db5" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="7fdc-0309-2fd0-e7eb" name="Flamer" hidden="false" collective="false" targetId="7867-8570-aa83-08ea" type="selectionEntry"/>
-            <entryLink id="392c-18c7-b172-a170" name="Melta Gun" hidden="false" collective="false" targetId="7bc1-bde8-2057-25dd" type="selectionEntry"/>
-            <entryLink id="48ae-fb52-e7d1-7d67" name="Plasma gun" hidden="false" collective="false" targetId="6732-7335-4e43-ab38" type="selectionEntry"/>
+            <entryLink id="7fdc-0309-2fd0-e7eb" name="Flamer" hidden="false" collective="false" import="true" targetId="7867-8570-aa83-08ea" type="selectionEntry"/>
+            <entryLink id="392c-18c7-b172-a170" name="Melta Gun" hidden="false" collective="false" import="true" targetId="7bc1-bde8-2057-25dd" type="selectionEntry"/>
+            <entryLink id="48ae-fb52-e7d1-7d67" name="Plasma gun" hidden="false" collective="false" import="true" targetId="6732-7335-4e43-ab38" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="26f0-4ab1-f620-23f5" name="Bolt weapons" hidden="false" collective="false" defaultSelectionEntryId="5ed7-d286-2724-2c47">
+        <selectionEntryGroup id="26f0-4ab1-f620-23f5" name="Bolt weapons" hidden="false" collective="false" import="true" defaultSelectionEntryId="5ed7-d286-2724-2c47">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e1f8-64db-d855-c81c" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9aa4-e8a4-bc29-a7d7" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="5ed7-d286-2724-2c47" name="Boltguns" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="5ed7-d286-2724-2c47" name="Boltguns" hidden="false" collective="false" import="true" type="upgrade">
               <profiles>
                 <profile id="121e-4ff1-f2c0-8696" name="Boltgun" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
                   <characteristics>
@@ -1622,7 +1622,7 @@ Eternal Rivalry: If Sanguinius is removed as a casualty while it is fighting in 
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="409b-38b8-04d9-c581" name="Bolt pistols" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="409b-38b8-04d9-c581" name="Bolt pistols" hidden="false" collective="false" import="true" type="upgrade">
               <profiles>
                 <profile id="d2c6-4d2d-13ac-dcb6" name="Bolt pistol" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
                   <characteristics>
@@ -1639,26 +1639,26 @@ Eternal Rivalry: If Sanguinius is removed as a casualty while it is fighting in 
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="a21b-bcbd-1253-5ba5" name="Melee option" hidden="false" collective="false">
+        <selectionEntryGroup id="a21b-bcbd-1253-5ba5" name="Melee option" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="df0e-3032-f20e-22fb" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="3cac-146c-a90b-4ebe" name="Lightning Claw" hidden="false" collective="false" targetId="06b7-61a6-377d-a656" type="selectionEntry"/>
-            <entryLink id="e9b4-ecef-2ebc-5d90" name="Power Weapon" hidden="false" collective="false" targetId="8662-73e2-61f5-5430" type="selectionEntryGroup"/>
-            <entryLink id="b7c0-a951-695d-5562" name="Thunder Hammer" hidden="false" collective="false" targetId="d72d-713f-9aaa-6e7e" type="selectionEntry"/>
-            <entryLink id="c0e5-74b0-43a0-2320" name="Power Fist" hidden="false" collective="false" targetId="87d8-0b67-7ead-0627" type="selectionEntry"/>
+            <entryLink id="3cac-146c-a90b-4ebe" name="Lightning Claw" hidden="false" collective="false" import="true" targetId="06b7-61a6-377d-a656" type="selectionEntry"/>
+            <entryLink id="e9b4-ecef-2ebc-5d90" name="Power Weapon" hidden="false" collective="false" import="true" targetId="8662-73e2-61f5-5430" type="selectionEntryGroup"/>
+            <entryLink id="b7c0-a951-695d-5562" name="Thunder Hammer" hidden="false" collective="false" import="true" targetId="d72d-713f-9aaa-6e7e" type="selectionEntry"/>
+            <entryLink id="c0e5-74b0-43a0-2320" name="Power Fist" hidden="false" collective="false" import="true" targetId="87d8-0b67-7ead-0627" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="1597-10e8-37b2-adec" name="Close Combat Weapons" hidden="false" collective="false" targetId="2b7e-7858-5d4c-2af7" type="selectionEntry"/>
+        <entryLink id="1597-10e8-37b2-adec" name="Close Combat Weapons" hidden="false" collective="false" import="true" targetId="2b7e-7858-5d4c-2af7" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="06b7-61a6-377d-a656" name="Lightning Claw" publicationId="8700-b3bb-pubN75780" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="06b7-61a6-377d-a656" name="Lightning Claw" publicationId="8700-b3bb-pubN75780" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1804-d94d-f1da-2541" type="max"/>
       </constraints>
@@ -1679,7 +1679,7 @@ Eternal Rivalry: If Sanguinius is removed as a casualty while it is fighting in 
         <cost name="pts" typeId="points" value="15.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="7ccb-406e-ff1e-7142" name="Power Sword" publicationId="8700-b3bb-pubN75780" page="181" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="7ccb-406e-ff1e-7142" name="Power Sword" publicationId="8700-b3bb-pubN75780" page="181" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="d079-21c3-81aa-60aa" name="Power Sword" publicationId="8700-b3bb-pubN75780" page="181" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
           <characteristics>
@@ -1694,7 +1694,7 @@ Eternal Rivalry: If Sanguinius is removed as a casualty while it is fighting in 
         <cost name="pts" typeId="points" value="10.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="d292-78eb-f8f4-315e" name="Power Maul" publicationId="8700-b3bb-pubN75780" page="181" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="d292-78eb-f8f4-315e" name="Power Maul" publicationId="8700-b3bb-pubN75780" page="181" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0727-c8e9-ad06-96c2" type="max"/>
       </constraints>
@@ -1715,7 +1715,7 @@ Eternal Rivalry: If Sanguinius is removed as a casualty while it is fighting in 
         <cost name="pts" typeId="points" value="10.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="71f1-4f38-4a0c-2a71" name="Power Axe" publicationId="8700-b3bb-pubN75780" page="181" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="71f1-4f38-4a0c-2a71" name="Power Axe" publicationId="8700-b3bb-pubN75780" page="181" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2c2c-d5a9-6b1e-f786" type="max"/>
       </constraints>
@@ -1736,7 +1736,7 @@ Eternal Rivalry: If Sanguinius is removed as a casualty while it is fighting in 
         <cost name="pts" typeId="points" value="10.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="5bd5-b988-5923-3347" name="Power Lance" publicationId="8700-b3bb-pubN75780" page="181" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="5bd5-b988-5923-3347" name="Power Lance" publicationId="8700-b3bb-pubN75780" page="181" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9905-8604-fe58-fc8e" type="max"/>
       </constraints>
@@ -1759,7 +1759,7 @@ Eternal Rivalry: If Sanguinius is removed as a casualty while it is fighting in 
         <cost name="pts" typeId="points" value="10.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="d72d-713f-9aaa-6e7e" name="Thunder Hammer" publicationId="8700-b3bb-pubN75780" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="d72d-713f-9aaa-6e7e" name="Thunder Hammer" publicationId="8700-b3bb-pubN75780" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6afd-bd2a-9628-959d" type="max"/>
       </constraints>
@@ -1781,7 +1781,7 @@ Eternal Rivalry: If Sanguinius is removed as a casualty while it is fighting in 
         <cost name="pts" typeId="points" value="20.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="87d8-0b67-7ead-0627" name="Power Fist" publicationId="8700-b3bb-pubN75780" page="181" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="87d8-0b67-7ead-0627" name="Power Fist" publicationId="8700-b3bb-pubN75780" page="181" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4c20-0692-4896-4c62" type="max"/>
       </constraints>
@@ -1803,7 +1803,7 @@ Eternal Rivalry: If Sanguinius is removed as a casualty while it is fighting in 
         <cost name="pts" typeId="points" value="15.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="aaa2-5fa0-5e9e-bc0d" name="Laspistol" publicationId="8700-b3bb-pubN75780" page="178" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="aaa2-5fa0-5e9e-bc0d" name="Laspistol" publicationId="8700-b3bb-pubN75780" page="178" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="4cce-a9ee-38c2-5d88" name="Laspistol" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
           <characteristics>
@@ -1818,7 +1818,7 @@ Eternal Rivalry: If Sanguinius is removed as a casualty while it is fighting in 
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="7bc1-bde8-2057-25dd" name="Melta Gun" publicationId="8700-b3bb-pubN75780" page="178" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="7bc1-bde8-2057-25dd" name="Melta Gun" publicationId="8700-b3bb-pubN75780" page="178" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="8a4e-7375-5a41-00c0" name="Melta Gun" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
           <characteristics>
@@ -1836,7 +1836,7 @@ Eternal Rivalry: If Sanguinius is removed as a casualty while it is fighting in 
         <cost name="pts" typeId="points" value="15.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="6732-7335-4e43-ab38" name="Plasma gun" publicationId="8700-b3bb-pubN75780" page="178" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="6732-7335-4e43-ab38" name="Plasma gun" publicationId="8700-b3bb-pubN75780" page="178" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="3147-1d75-1afc-8a0e" name="Plasma gun" publicationId="8700-b3bb-pubN75780" page="178" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
           <characteristics>
@@ -1854,7 +1854,7 @@ Eternal Rivalry: If Sanguinius is removed as a casualty while it is fighting in 
         <cost name="pts" typeId="points" value="15.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="7867-8570-aa83-08ea" name="Flamer" publicationId="8700-b3bb-pubN75780" page="177" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="7867-8570-aa83-08ea" name="Flamer" publicationId="8700-b3bb-pubN75780" page="177" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="5a59-705d-7088-30f0" name="Flamer" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
           <characteristics>
@@ -1869,7 +1869,7 @@ Eternal Rivalry: If Sanguinius is removed as a casualty while it is fighting in 
         <cost name="pts" typeId="points" value="10.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="bb27-c2f2-7d8d-4400" name="Heavy Stubber" publicationId="8700-b3bb-pubN75780" page="179" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="bb27-c2f2-7d8d-4400" name="Heavy Stubber" publicationId="8700-b3bb-pubN75780" page="179" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="c740-8a78-e3f0-739f" name="Heavy Stubber" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
           <characteristics>
@@ -1884,7 +1884,7 @@ Eternal Rivalry: If Sanguinius is removed as a casualty while it is fighting in 
         <cost name="pts" typeId="points" value="10.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="b865-f161-0f5a-afdd" name="Grenade Launcher" publicationId="8700-b3bb-pubN75780" page="177" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="b865-f161-0f5a-afdd" name="Grenade Launcher" publicationId="8700-b3bb-pubN75780" page="177" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="c9a9-0524-224b-bb4b" name="Grenade Launcher (Frag)" publicationId="8700-b3bb-pubN75780" page="177" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
           <characteristics>
@@ -1907,7 +1907,7 @@ Eternal Rivalry: If Sanguinius is removed as a casualty while it is fighting in 
         <cost name="pts" typeId="points" value="10.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="68ed-20b5-1aab-f3e4" name="Rotor Cannon" publicationId="8700-b3bb-pubN75780" page="177" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="68ed-20b5-1aab-f3e4" name="Rotor Cannon" publicationId="8700-b3bb-pubN75780" page="177" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
         <profile id="2ff9-234e-e445-e051" name="Rotor Cannon" publicationId="8700-b3bb-pubN75780" page="177" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
           <characteristics>
@@ -1922,7 +1922,7 @@ Eternal Rivalry: If Sanguinius is removed as a casualty while it is fighting in 
         <cost name="pts" typeId="points" value="10.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="2b7e-7858-5d4c-2af7" name="Close Combat Weapons" publicationId="8700-b3bb-pubN75780" page="42" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="2b7e-7858-5d4c-2af7" name="Close Combat Weapons" publicationId="8700-b3bb-pubN75780" page="42" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="11b5-36e0-fced-c692" type="max"/>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aa29-14b9-3a9d-09fc" type="min"/>
@@ -1941,7 +1941,7 @@ Eternal Rivalry: If Sanguinius is removed as a casualty while it is fighting in 
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="f3d7-3331-372c-a480" name="Possessed Auxiliaries" publicationId="8700-b3bb-pubN65537" hidden="false" collective="false" type="unit">
+    <selectionEntry id="f3d7-3331-372c-a480" name="Possessed Auxiliaries" publicationId="8700-b3bb-pubN65537" hidden="false" collective="false" import="true" type="unit">
       <infoLinks>
         <infoLink id="da2c-f2b1-e48d-385b" name="Support Squad" hidden="false" targetId="2c16-3b25-a714-a656" type="rule"/>
         <infoLink id="36c5-f6e5-d4de-e737" name="Slaves to Darkness" hidden="false" targetId="b407-fb29-f206-4ad3" type="rule"/>
@@ -1950,7 +1950,7 @@ Eternal Rivalry: If Sanguinius is removed as a casualty while it is fighting in 
         <categoryLink id="817f-7291-757f-0ff1" name="Troops" hidden="false" targetId="54726f6f707323232344415441232323" primary="true"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="6778-7a1d-24a3-3ac4" name="Possessed Auxiliaries" hidden="false" collective="false" type="model">
+        <selectionEntry id="6778-7a1d-24a3-3ac4" name="Possessed Auxiliaries" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="20.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4cae-1769-89ba-b5e5" type="max"/>
             <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="21b1-5cce-b10b-c03d" type="min"/>
@@ -1964,13 +1964,13 @@ Eternal Rivalry: If Sanguinius is removed as a casualty while it is fighting in 
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="bcfd-619a-c770-3fb0" name="Rifle options" publicationId="8700-b3bb-pubN65537" hidden="false" collective="false" defaultSelectionEntryId="9b53-664b-95ce-3a79">
+        <selectionEntryGroup id="bcfd-619a-c770-3fb0" name="Rifle options" publicationId="8700-b3bb-pubN65537" hidden="false" collective="false" import="true" defaultSelectionEntryId="9b53-664b-95ce-3a79">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="98a3-92b7-4ca3-b398" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0c87-4015-bdec-5efc" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="9b53-664b-95ce-3a79" name="Auxilia Rifles" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="9b53-664b-95ce-3a79" name="Auxilia Rifles" hidden="false" collective="false" import="true" type="upgrade">
               <profiles>
                 <profile id="5a2d-7130-8415-47f0" name="Auxilia Rifle" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
                   <characteristics>
@@ -1985,7 +1985,7 @@ Eternal Rivalry: If Sanguinius is removed as a casualty while it is fighting in 
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="c79b-7a8f-b4d3-c2b5" name="Laspistols" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="c79b-7a8f-b4d3-c2b5" name="Laspistols" hidden="false" collective="false" import="true" type="upgrade">
               <infoLinks>
                 <infoLink id="b70b-6cad-9a2d-2faa" name="Laspistol" page="" hidden="false" targetId="f2b7-768f-a270-de64" type="profile"/>
               </infoLinks>
@@ -1995,7 +1995,7 @@ Eternal Rivalry: If Sanguinius is removed as a casualty while it is fighting in 
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="eaed-2dc9-0395-14fb" name="Ranged options" publicationId="8700-b3bb-pubN65537" hidden="true" collective="false">
+        <selectionEntryGroup id="eaed-2dc9-0395-14fb" name="Ranged options" publicationId="8700-b3bb-pubN65537" hidden="true" collective="false" import="true">
           <modifiers>
             <modifier type="increment" field="8a35-8f25-6084-cf2f" value="1">
               <repeats>
@@ -2012,12 +2012,12 @@ Eternal Rivalry: If Sanguinius is removed as a casualty while it is fighting in 
             <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8a35-8f25-6084-cf2f" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="1a26-d078-edb8-8f9b" name="Heavy Stubber" hidden="false" collective="false" targetId="bb27-c2f2-7d8d-4400" type="selectionEntry"/>
-            <entryLink id="80b9-33c0-85e4-aa5f" name="Rotor Cannon" hidden="false" collective="false" targetId="68ed-20b5-1aab-f3e4" type="selectionEntry"/>
-            <entryLink id="f02f-5915-32f3-f01b" name="Flamer" hidden="false" collective="false" targetId="7867-8570-aa83-08ea" type="selectionEntry"/>
-            <entryLink id="8663-007e-8b54-2f70" name="Plasma gun" hidden="false" collective="false" targetId="6732-7335-4e43-ab38" type="selectionEntry"/>
-            <entryLink id="60b6-df89-51fe-32b3" name="Melta Gun" hidden="false" collective="false" targetId="7bc1-bde8-2057-25dd" type="selectionEntry"/>
-            <entryLink id="58c4-e875-956c-8394" name="Grenade Launcher" hidden="false" collective="false" targetId="b865-f161-0f5a-afdd" type="selectionEntry"/>
+            <entryLink id="1a26-d078-edb8-8f9b" name="Heavy Stubber" hidden="false" collective="false" import="true" targetId="bb27-c2f2-7d8d-4400" type="selectionEntry"/>
+            <entryLink id="80b9-33c0-85e4-aa5f" name="Rotor Cannon" hidden="false" collective="false" import="true" targetId="68ed-20b5-1aab-f3e4" type="selectionEntry"/>
+            <entryLink id="f02f-5915-32f3-f01b" name="Flamer" hidden="false" collective="false" import="true" targetId="7867-8570-aa83-08ea" type="selectionEntry"/>
+            <entryLink id="8663-007e-8b54-2f70" name="Plasma gun" hidden="false" collective="false" import="true" targetId="6732-7335-4e43-ab38" type="selectionEntry"/>
+            <entryLink id="60b6-df89-51fe-32b3" name="Melta Gun" hidden="false" collective="false" import="true" targetId="7bc1-bde8-2057-25dd" type="selectionEntry"/>
+            <entryLink id="58c4-e875-956c-8394" name="Grenade Launcher" hidden="false" collective="false" import="true" targetId="b865-f161-0f5a-afdd" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
@@ -2025,7 +2025,7 @@ Eternal Rivalry: If Sanguinius is removed as a casualty while it is fighting in 
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="5ddb-4a5d-5b2d-c540" name="Cor&apos;bax Utterblight Unbound, Daemon Lord Of The Ruinstorm" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="5ddb-4a5d-5b2d-c540" name="Cor&apos;bax Utterblight Unbound, Daemon Lord Of The Ruinstorm" hidden="false" collective="false" import="true" type="upgrade">
       <modifiers>
         <modifier type="set" field="ca6b-6f29-c512-6a3e" value="1">
           <conditionGroups>
@@ -2042,7 +2042,7 @@ Eternal Rivalry: If Sanguinius is removed as a casualty while it is fighting in 
         <constraint field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ca6b-6f29-c512-6a3e" type="max"/>
       </constraints>
       <profiles>
-        <profile id="7098-b32b-e073-843a" name="Cor&apos;bax Utterblight Unbound, Daemon Lord Of The Ruinstorm" publicationId="8700-b3bb-pubN77795" page="245" hidden="false" typeId="556e697423232344415441232323" typeName="">
+        <profile id="7098-b32b-e073-843a" name="Cor&apos;bax Utterblight Unbound, Daemon Lord Of The Ruinstorm" publicationId="8700-b3bb-pubN77795" page="245" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
           <characteristics>
             <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Monstrous Creature (Character)</characteristic>
             <characteristic name="WS" typeId="575323232344415441232323">6</characteristic>
@@ -2081,17 +2081,17 @@ Eternal Rivalry: If Sanguinius is removed as a casualty while it is fighting in 
         <infoLink id="d71a-00d1-7f68-2ff6" name="Eternal Warrior" hidden="false" targetId="3e0b-be9f-b7eb-8c5e" type="rule"/>
       </infoLinks>
       <entryLinks>
-        <entryLink id="4602-1266-d39b-cf44" name="Shroud of Darkness" hidden="false" collective="false" targetId="8600-a910-cd18-0f0a" type="selectionEntry">
+        <entryLink id="4602-1266-d39b-cf44" name="Shroud of Darkness" hidden="false" collective="false" import="true" targetId="8600-a910-cd18-0f0a" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8b23-2f90-3689-90d5" type="min"/>
           </constraints>
         </entryLink>
-        <entryLink id="b502-f2b5-042c-ecae" name="Miasma of Rot" hidden="false" collective="false" targetId="1777-1007-cc23-1481" type="selectionEntry">
+        <entryLink id="b502-f2b5-042c-ecae" name="Miasma of Rot" hidden="false" collective="false" import="true" targetId="1777-1007-cc23-1481" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5b08-3d6a-b71d-9c81" type="min"/>
           </constraints>
         </entryLink>
-        <entryLink id="22be-2ae9-df5c-6ed2" name="Crushing Claws" hidden="false" collective="false" targetId="a4fc-26a9-cd55-3b4b" type="selectionEntry">
+        <entryLink id="22be-2ae9-df5c-6ed2" name="Crushing Claws" hidden="false" collective="false" import="true" targetId="a4fc-26a9-cd55-3b4b" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5b85-c9a2-db3f-b37a" type="min"/>
           </constraints>
@@ -2101,7 +2101,7 @@ Eternal Rivalry: If Sanguinius is removed as a casualty while it is fighting in 
         <cost name="pts" typeId="points" value="425.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="777d-7ee1-4f6d-9ca8" name="Samus Unbound, Daemon Lord of the Ruinstorm" hidden="false" collective="false" type="model">
+    <selectionEntry id="777d-7ee1-4f6d-9ca8" name="Samus Unbound, Daemon Lord of the Ruinstorm" hidden="false" collective="false" import="true" type="model">
       <modifiers>
         <modifier type="set" field="47bb-db5c-c3f6-5d14" value="1">
           <conditionGroups>
@@ -2166,17 +2166,17 @@ Models in combat with Sam us Unbound, as well as those taking Fear tests in orde
         <infoLink id="7501-1e5f-b12f-8bff" name="Murderous Strike" hidden="false" targetId="b0c5-b980-95e5-b181" type="rule"/>
       </infoLinks>
       <entryLinks>
-        <entryLink id="52be-9af4-6d05-1496" name="Brass Collars" hidden="false" collective="false" targetId="da14-1454-058f-f0cd" type="selectionEntry">
+        <entryLink id="52be-9af4-6d05-1496" name="Brass Collars" hidden="false" collective="false" import="true" targetId="da14-1454-058f-f0cd" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3d51-3228-87c8-8665" type="min"/>
           </constraints>
         </entryLink>
-        <entryLink id="507c-9300-8dc1-d9bf" name="Quicksilver Speed" hidden="false" collective="false" targetId="7e9f-dc4a-0fa8-732d" type="selectionEntry">
+        <entryLink id="507c-9300-8dc1-d9bf" name="Quicksilver Speed" hidden="false" collective="false" import="true" targetId="7e9f-dc4a-0fa8-732d" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="28b0-9142-9736-9eef" type="min"/>
           </constraints>
         </entryLink>
-        <entryLink id="0c89-f195-9197-1c8c" name="Molten Blood" hidden="false" collective="false" targetId="e001-8e2e-f957-4bb7" type="selectionEntry">
+        <entryLink id="0c89-f195-9197-1c8c" name="Molten Blood" hidden="false" collective="false" import="true" targetId="e001-8e2e-f957-4bb7" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="51ba-cbca-b2a1-3adf" type="min"/>
           </constraints>
@@ -2188,7 +2188,7 @@ Models in combat with Sam us Unbound, as well as those taking Fear tests in orde
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
-    <selectionEntryGroup id="fbff-b318-fc9d-9b88" name="Emanations of Horror [2]" hidden="false" collective="false">
+    <selectionEntryGroup id="fbff-b318-fc9d-9b88" name="Emanations of Horror [2]" hidden="false" collective="false" import="true">
       <modifiers>
         <modifier type="increment" field="6444-bd31-dc43-d332" value="1">
           <conditions>
@@ -2211,7 +2211,7 @@ Models in combat with Sam us Unbound, as well as those taking Fear tests in orde
         <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6444-bd31-dc43-d332" type="max"/>
       </constraints>
       <entryLinks>
-        <entryLink id="3c8e-7c94-6079-aaa8" name="Lord of Sorcery" hidden="false" collective="false" targetId="092e-7d74-b86e-14a4" type="selectionEntry">
+        <entryLink id="3c8e-7c94-6079-aaa8" name="Lord of Sorcery" hidden="false" collective="false" import="true" targetId="092e-7d74-b86e-14a4" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="ed53-aaf4-ba7c-445a" value="-1">
               <conditions>
@@ -2233,7 +2233,7 @@ Models in combat with Sam us Unbound, as well as those taking Fear tests in orde
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed53-aaf4-ba7c-445a" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="5879-dc12-535b-12fc" name="Daemonic Wings" hidden="false" collective="false" targetId="7d02-f800-e124-ea50" type="selectionEntry">
+        <entryLink id="5879-dc12-535b-12fc" name="Daemonic Wings" hidden="false" collective="false" import="true" targetId="7d02-f800-e124-ea50" type="selectionEntry">
           <modifiers>
             <modifier type="increment" field="points" value="25">
               <repeats>
@@ -2245,7 +2245,7 @@ Models in combat with Sam us Unbound, as well as those taking Fear tests in orde
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cc64-3da5-5e22-940e" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="e144-a98a-da0f-b053" name="Corrosive Vomit" hidden="false" collective="false" targetId="84b2-d1d6-1872-c4ef" type="selectionEntry">
+        <entryLink id="e144-a98a-da0f-b053" name="Corrosive Vomit" hidden="false" collective="false" import="true" targetId="84b2-d1d6-1872-c4ef" type="selectionEntry">
           <modifiers>
             <modifier type="increment" field="points" value="10">
               <repeats>
@@ -2257,7 +2257,7 @@ Models in combat with Sam us Unbound, as well as those taking Fear tests in orde
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f782-6109-dcca-e2bc" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="cbde-e835-ee88-5021" name="Crushing Claws" hidden="false" collective="false" targetId="a4fc-26a9-cd55-3b4b" type="selectionEntry">
+        <entryLink id="cbde-e835-ee88-5021" name="Crushing Claws" hidden="false" collective="false" import="true" targetId="a4fc-26a9-cd55-3b4b" type="selectionEntry">
           <modifiers>
             <modifier type="increment" field="points" value="15">
               <repeats>
@@ -2269,7 +2269,7 @@ Models in combat with Sam us Unbound, as well as those taking Fear tests in orde
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c1ff-2e4c-546b-de99" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="bfd7-9c2d-a6e0-6d31" name="Flensing Talons" hidden="false" collective="false" targetId="e4ca-d240-cc12-1709" type="selectionEntry">
+        <entryLink id="bfd7-9c2d-a6e0-6d31" name="Flensing Talons" hidden="false" collective="false" import="true" targetId="e4ca-d240-cc12-1709" type="selectionEntry">
           <modifiers>
             <modifier type="increment" field="points" value="10">
               <repeats>
@@ -2281,7 +2281,7 @@ Models in combat with Sam us Unbound, as well as those taking Fear tests in orde
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b23e-a19d-41c2-1712" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="810e-97e8-7bbe-4658" name="Stupefying Musk" hidden="false" collective="false" targetId="6c9f-9f45-11f1-1079" type="selectionEntry">
+        <entryLink id="810e-97e8-7bbe-4658" name="Stupefying Musk" hidden="false" collective="false" import="true" targetId="6c9f-9f45-11f1-1079" type="selectionEntry">
           <modifiers>
             <modifier type="increment" field="points" value="10">
               <repeats>
@@ -2290,7 +2290,7 @@ Models in combat with Sam us Unbound, as well as those taking Fear tests in orde
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="ffae-6387-c3e9-0f12" name="Sundering Fangs" hidden="false" collective="false" targetId="6714-4a30-d5ab-f43b" type="selectionEntry">
+        <entryLink id="ffae-6387-c3e9-0f12" name="Sundering Fangs" hidden="false" collective="false" import="true" targetId="6714-4a30-d5ab-f43b" type="selectionEntry">
           <modifiers>
             <modifier type="increment" field="points" value="15">
               <repeats>
@@ -2299,7 +2299,7 @@ Models in combat with Sam us Unbound, as well as those taking Fear tests in orde
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="84d4-035a-1a40-c320" name="Miasma of Rot" hidden="false" collective="false" targetId="1777-1007-cc23-1481" type="selectionEntry">
+        <entryLink id="84d4-035a-1a40-c320" name="Miasma of Rot" hidden="false" collective="false" import="true" targetId="1777-1007-cc23-1481" type="selectionEntry">
           <modifiers>
             <modifier type="increment" field="points" value="10">
               <repeats>
@@ -2308,7 +2308,7 @@ Models in combat with Sam us Unbound, as well as those taking Fear tests in orde
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="93b2-f8fe-0f88-e91c" name="Brass Collars" hidden="false" collective="false" targetId="da14-1454-058f-f0cd" type="selectionEntry">
+        <entryLink id="93b2-f8fe-0f88-e91c" name="Brass Collars" hidden="false" collective="false" import="true" targetId="da14-1454-058f-f0cd" type="selectionEntry">
           <modifiers>
             <modifier type="increment" field="points" value="10">
               <repeats>
@@ -2317,12 +2317,12 @@ Models in combat with Sam us Unbound, as well as those taking Fear tests in orde
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="d775-2d6a-5675-f199" name="Rift Barb" hidden="false" collective="false" targetId="19f9-a3b4-ae4e-845e" type="selectionEntry">
+        <entryLink id="d775-2d6a-5675-f199" name="Rift Barb" hidden="false" collective="false" import="true" targetId="19f9-a3b4-ae4e-845e" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="points" value="10"/>
           </modifiers>
         </entryLink>
-        <entryLink id="c74d-55bd-ec70-2139" name="Flaming Ichor" hidden="false" collective="false" targetId="e531-b96d-ec46-184a" type="selectionEntry">
+        <entryLink id="c74d-55bd-ec70-2139" name="Flaming Ichor" hidden="false" collective="false" import="true" targetId="e531-b96d-ec46-184a" type="selectionEntry">
           <modifiers>
             <modifier type="increment" field="points" value="15">
               <repeats>
@@ -2331,7 +2331,7 @@ Models in combat with Sam us Unbound, as well as those taking Fear tests in orde
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="88b0-ca5d-8964-f663" name="Molten Blood" hidden="false" collective="false" targetId="e001-8e2e-f957-4bb7" type="selectionEntry">
+        <entryLink id="88b0-ca5d-8964-f663" name="Molten Blood" hidden="false" collective="false" import="true" targetId="e001-8e2e-f957-4bb7" type="selectionEntry">
           <modifiers>
             <modifier type="increment" field="points" value="5">
               <repeats>
@@ -2340,7 +2340,7 @@ Models in combat with Sam us Unbound, as well as those taking Fear tests in orde
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="3e6d-e4cc-9bb4-aac5" name="Quicksilver Speed" hidden="false" collective="false" targetId="7e9f-dc4a-0fa8-732d" type="selectionEntry">
+        <entryLink id="3e6d-e4cc-9bb4-aac5" name="Quicksilver Speed" hidden="false" collective="false" import="true" targetId="7e9f-dc4a-0fa8-732d" type="selectionEntry">
           <modifiers>
             <modifier type="increment" field="points" value="10">
               <repeats>
@@ -2349,7 +2349,7 @@ Models in combat with Sam us Unbound, as well as those taking Fear tests in orde
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="8d91-f9ad-d676-a21e" name="Warp-scaled Hide" hidden="false" collective="false" targetId="5759-049f-35eb-37c2" type="selectionEntry">
+        <entryLink id="8d91-f9ad-d676-a21e" name="Warp-scaled Hide" hidden="false" collective="false" import="true" targetId="5759-049f-35eb-37c2" type="selectionEntry">
           <modifiers>
             <modifier type="increment" field="points" value="15">
               <repeats>
@@ -2358,7 +2358,7 @@ Models in combat with Sam us Unbound, as well as those taking Fear tests in orde
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="20c7-3b6b-4972-7238" name="Horned Crown" hidden="false" collective="false" targetId="3f3e-bbfb-732a-9fa8" type="selectionEntry">
+        <entryLink id="20c7-3b6b-4972-7238" name="Horned Crown" hidden="false" collective="false" import="true" targetId="3f3e-bbfb-732a-9fa8" type="selectionEntry">
           <modifiers>
             <modifier type="increment" field="points" value="10">
               <repeats>
@@ -2367,7 +2367,7 @@ Models in combat with Sam us Unbound, as well as those taking Fear tests in orde
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="e7ea-2a39-c739-b0e4" name="Ephemeral Terror" hidden="false" collective="false" targetId="9488-98d4-9eeb-b790" type="selectionEntry">
+        <entryLink id="e7ea-2a39-c739-b0e4" name="Ephemeral Terror" hidden="false" collective="false" import="true" targetId="9488-98d4-9eeb-b790" type="selectionEntry">
           <modifiers>
             <modifier type="increment" field="points" value="5">
               <repeats>
@@ -2376,7 +2376,7 @@ Models in combat with Sam us Unbound, as well as those taking Fear tests in orde
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="106e-0ed7-13ba-6d17" name="Shroud of Darkness" hidden="false" collective="false" targetId="8600-a910-cd18-0f0a" type="selectionEntry">
+        <entryLink id="106e-0ed7-13ba-6d17" name="Shroud of Darkness" hidden="false" collective="false" import="true" targetId="8600-a910-cd18-0f0a" type="selectionEntry">
           <modifiers>
             <modifier type="increment" field="points" value="15">
               <repeats>
@@ -2385,7 +2385,7 @@ Models in combat with Sam us Unbound, as well as those taking Fear tests in orde
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="9427-69de-a785-8d83" name="Bone Shard Harpoons" hidden="false" collective="false" targetId="823e-a42d-9475-c2dd" type="selectionEntry">
+        <entryLink id="9427-69de-a785-8d83" name="Bone Shard Harpoons" hidden="false" collective="false" import="true" targetId="823e-a42d-9475-c2dd" type="selectionEntry">
           <modifiers>
             <modifier type="increment" field="points" value="5">
               <repeats>
@@ -2394,7 +2394,7 @@ Models in combat with Sam us Unbound, as well as those taking Fear tests in orde
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="5b2d-48bb-578e-ba49" name="Spine Volley" hidden="false" collective="false" targetId="6a35-94d3-e17d-37b0" type="selectionEntry">
+        <entryLink id="5b2d-48bb-578e-ba49" name="Spine Volley" hidden="false" collective="false" import="true" targetId="6a35-94d3-e17d-37b0" type="selectionEntry">
           <modifiers>
             <modifier type="increment" field="points" value="5">
               <repeats>
@@ -2405,7 +2405,7 @@ Models in combat with Sam us Unbound, as well as those taking Fear tests in orde
         </entryLink>
       </entryLinks>
     </selectionEntryGroup>
-    <selectionEntryGroup id="377a-f74e-00b1-f5f5" name="Emanations of Horror [1]" hidden="false" collective="false">
+    <selectionEntryGroup id="377a-f74e-00b1-f5f5" name="Emanations of Horror [1]" hidden="false" collective="false" import="true">
       <modifiers>
         <modifier type="increment" field="e7c1-3a77-ef39-0f98" value="1">
           <conditions>
@@ -2418,7 +2418,7 @@ Models in combat with Sam us Unbound, as well as those taking Fear tests in orde
         <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e7c1-3a77-ef39-0f98" type="max"/>
       </constraints>
       <entryLinks>
-        <entryLink id="2662-c1ce-b34e-3c1a" name="Daemonic Wings" hidden="false" collective="false" targetId="7d02-f800-e124-ea50" type="selectionEntry">
+        <entryLink id="2662-c1ce-b34e-3c1a" name="Daemonic Wings" hidden="false" collective="false" import="true" targetId="7d02-f800-e124-ea50" type="selectionEntry">
           <modifiers>
             <modifier type="increment" field="points" value="5">
               <repeats>
@@ -2427,7 +2427,7 @@ Models in combat with Sam us Unbound, as well as those taking Fear tests in orde
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="820d-44b7-8a2f-2543" name="Crushing Claws" hidden="false" collective="false" targetId="a4fc-26a9-cd55-3b4b" type="selectionEntry">
+        <entryLink id="820d-44b7-8a2f-2543" name="Crushing Claws" hidden="false" collective="false" import="true" targetId="a4fc-26a9-cd55-3b4b" type="selectionEntry">
           <modifiers>
             <modifier type="increment" field="points" value="5">
               <repeats>
@@ -2436,7 +2436,7 @@ Models in combat with Sam us Unbound, as well as those taking Fear tests in orde
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="3682-1644-e4d7-7451" name="Flensing Talons" hidden="false" collective="false" targetId="e4ca-d240-cc12-1709" type="selectionEntry">
+        <entryLink id="3682-1644-e4d7-7451" name="Flensing Talons" hidden="false" collective="false" import="true" targetId="e4ca-d240-cc12-1709" type="selectionEntry">
           <modifiers>
             <modifier type="increment" field="points" value="3">
               <repeats>
@@ -2445,7 +2445,7 @@ Models in combat with Sam us Unbound, as well as those taking Fear tests in orde
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="3420-d6c0-fb7f-b613" name="Corrosive Vomit" hidden="false" collective="false" targetId="84b2-d1d6-1872-c4ef" type="selectionEntry">
+        <entryLink id="3420-d6c0-fb7f-b613" name="Corrosive Vomit" hidden="false" collective="false" import="true" targetId="84b2-d1d6-1872-c4ef" type="selectionEntry">
           <modifiers>
             <modifier type="increment" field="points" value="3">
               <repeats>
@@ -2454,7 +2454,7 @@ Models in combat with Sam us Unbound, as well as those taking Fear tests in orde
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="ddd5-47ed-0c62-0663" name="Miasma of Rot" hidden="false" collective="false" targetId="1777-1007-cc23-1481" type="selectionEntry">
+        <entryLink id="ddd5-47ed-0c62-0663" name="Miasma of Rot" hidden="false" collective="false" import="true" targetId="1777-1007-cc23-1481" type="selectionEntry">
           <modifiers>
             <modifier type="increment" field="points" value="3">
               <repeats>
@@ -2463,7 +2463,7 @@ Models in combat with Sam us Unbound, as well as those taking Fear tests in orde
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="ba14-1ed5-1711-15bb" name="Brass Collars" hidden="false" collective="false" targetId="da14-1454-058f-f0cd" type="selectionEntry">
+        <entryLink id="ba14-1ed5-1711-15bb" name="Brass Collars" hidden="false" collective="false" import="true" targetId="da14-1454-058f-f0cd" type="selectionEntry">
           <modifiers>
             <modifier type="increment" field="points" value="5">
               <repeats>
@@ -2472,7 +2472,7 @@ Models in combat with Sam us Unbound, as well as those taking Fear tests in orde
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="dc9a-ae5f-bc8e-c614" name="Warp Scions" hidden="false" collective="false" targetId="8833-0efb-fa13-96fe" type="selectionEntry">
+        <entryLink id="dc9a-ae5f-bc8e-c614" name="Warp Scions" hidden="false" collective="false" import="true" targetId="8833-0efb-fa13-96fe" type="selectionEntry">
           <modifiers>
             <modifier type="increment" field="points" value="3">
               <repeats>
@@ -2481,12 +2481,12 @@ Models in combat with Sam us Unbound, as well as those taking Fear tests in orde
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="9394-c25d-fce9-131d" name="Rift Barb" hidden="false" collective="false" targetId="19f9-a3b4-ae4e-845e" type="selectionEntry">
+        <entryLink id="9394-c25d-fce9-131d" name="Rift Barb" hidden="false" collective="false" import="true" targetId="19f9-a3b4-ae4e-845e" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="points" value="3"/>
           </modifiers>
         </entryLink>
-        <entryLink id="d09b-8db3-a6c5-2413" name="Molten Blood" hidden="false" collective="false" targetId="e001-8e2e-f957-4bb7" type="selectionEntry">
+        <entryLink id="d09b-8db3-a6c5-2413" name="Molten Blood" hidden="false" collective="false" import="true" targetId="e001-8e2e-f957-4bb7" type="selectionEntry">
           <modifiers>
             <modifier type="increment" field="points" value="3">
               <repeats>
@@ -2495,7 +2495,7 @@ Models in combat with Sam us Unbound, as well as those taking Fear tests in orde
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="fadd-f16d-0d18-861f" name="Horned Crown" hidden="false" collective="false" targetId="3f3e-bbfb-732a-9fa8" type="selectionEntry">
+        <entryLink id="fadd-f16d-0d18-861f" name="Horned Crown" hidden="false" collective="false" import="true" targetId="3f3e-bbfb-732a-9fa8" type="selectionEntry">
           <modifiers>
             <modifier type="increment" field="points" value="3">
               <repeats>
@@ -2504,7 +2504,7 @@ Models in combat with Sam us Unbound, as well as those taking Fear tests in orde
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="750c-58b3-a8b2-e154" name="Warp-scaled Hide" hidden="false" collective="false" targetId="5759-049f-35eb-37c2" type="selectionEntry">
+        <entryLink id="750c-58b3-a8b2-e154" name="Warp-scaled Hide" hidden="false" collective="false" import="true" targetId="5759-049f-35eb-37c2" type="selectionEntry">
           <modifiers>
             <modifier type="increment" field="points" value="5">
               <repeats>
@@ -2513,7 +2513,7 @@ Models in combat with Sam us Unbound, as well as those taking Fear tests in orde
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="dc4b-9c78-a4a4-4f62" name="Shroud of Darkness" hidden="false" collective="false" targetId="8600-a910-cd18-0f0a" type="selectionEntry">
+        <entryLink id="dc4b-9c78-a4a4-4f62" name="Shroud of Darkness" hidden="false" collective="false" import="true" targetId="8600-a910-cd18-0f0a" type="selectionEntry">
           <modifiers>
             <modifier type="increment" field="points" value="5">
               <repeats>
@@ -2522,7 +2522,7 @@ Models in combat with Sam us Unbound, as well as those taking Fear tests in orde
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="da86-4d34-ec83-d288" name="Bone Shard Harpoons" hidden="false" collective="false" targetId="823e-a42d-9475-c2dd" type="selectionEntry">
+        <entryLink id="da86-4d34-ec83-d288" name="Bone Shard Harpoons" hidden="false" collective="false" import="true" targetId="823e-a42d-9475-c2dd" type="selectionEntry">
           <modifiers>
             <modifier type="increment" field="points" value="3">
               <repeats>
@@ -2531,7 +2531,7 @@ Models in combat with Sam us Unbound, as well as those taking Fear tests in orde
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="c740-794c-99a0-0d89" name="Spine Volley" hidden="false" collective="false" targetId="6a35-94d3-e17d-37b0" type="selectionEntry">
+        <entryLink id="c740-794c-99a0-0d89" name="Spine Volley" hidden="false" collective="false" import="true" targetId="6a35-94d3-e17d-37b0" type="selectionEntry">
           <modifiers>
             <modifier type="increment" field="points" value="3">
               <repeats>
@@ -2540,7 +2540,7 @@ Models in combat with Sam us Unbound, as well as those taking Fear tests in orde
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="d49a-04dc-b124-85f8" name="Flaming Ichor" hidden="false" collective="false" targetId="e531-b96d-ec46-184a" type="selectionEntry">
+        <entryLink id="d49a-04dc-b124-85f8" name="Flaming Ichor" hidden="false" collective="false" import="true" targetId="e531-b96d-ec46-184a" type="selectionEntry">
           <modifiers>
             <modifier type="increment" field="points" value="3">
               <repeats>
@@ -2549,7 +2549,7 @@ Models in combat with Sam us Unbound, as well as those taking Fear tests in orde
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="be88-01a6-ec08-d594" name="Quicksilver Speed" hidden="false" collective="false" targetId="7e9f-dc4a-0fa8-732d" type="selectionEntry">
+        <entryLink id="be88-01a6-ec08-d594" name="Quicksilver Speed" hidden="false" collective="false" import="true" targetId="7e9f-dc4a-0fa8-732d" type="selectionEntry">
           <modifiers>
             <modifier type="increment" field="points" value="3">
               <repeats>
@@ -2558,7 +2558,7 @@ Models in combat with Sam us Unbound, as well as those taking Fear tests in orde
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="127c-1e84-8c15-d084" name="Ephemeral Terror" hidden="false" collective="false" targetId="9488-98d4-9eeb-b790" type="selectionEntry">
+        <entryLink id="127c-1e84-8c15-d084" name="Ephemeral Terror" hidden="false" collective="false" import="true" targetId="9488-98d4-9eeb-b790" type="selectionEntry">
           <modifiers>
             <modifier type="increment" field="points" value="1">
               <repeats>
@@ -2567,7 +2567,7 @@ Models in combat with Sam us Unbound, as well as those taking Fear tests in orde
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="37d6-0719-b2be-dda2" name="Sundering Fangs" hidden="false" collective="false" targetId="6714-4a30-d5ab-f43b" type="selectionEntry">
+        <entryLink id="37d6-0719-b2be-dda2" name="Sundering Fangs" hidden="false" collective="false" import="true" targetId="6714-4a30-d5ab-f43b" type="selectionEntry">
           <modifiers>
             <modifier type="increment" field="points" value="5">
               <repeats>
@@ -2576,7 +2576,7 @@ Models in combat with Sam us Unbound, as well as those taking Fear tests in orde
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="8e58-b0dc-73dd-69a9" name="Stupefying Musk" hidden="false" collective="false" targetId="6c9f-9f45-11f1-1079" type="selectionEntry">
+        <entryLink id="8e58-b0dc-73dd-69a9" name="Stupefying Musk" hidden="false" collective="false" import="true" targetId="6c9f-9f45-11f1-1079" type="selectionEntry">
           <modifiers>
             <modifier type="increment" field="points" value="3">
               <repeats>
@@ -2587,18 +2587,18 @@ Models in combat with Sam us Unbound, as well as those taking Fear tests in orde
         </entryLink>
       </entryLinks>
     </selectionEntryGroup>
-    <selectionEntryGroup id="8662-73e2-61f5-5430" name="Power Weapon" publicationId="8700-b3bb-pubN75780" hidden="false" collective="false">
+    <selectionEntryGroup id="8662-73e2-61f5-5430" name="Power Weapon" publicationId="8700-b3bb-pubN75780" hidden="false" collective="false" import="true">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="95b4-828d-a7f7-c3ce" type="max"/>
       </constraints>
       <entryLinks>
-        <entryLink id="d067-a2cc-cde0-d1db" name="Power Sword" hidden="false" collective="false" targetId="7ccb-406e-ff1e-7142" type="selectionEntry"/>
-        <entryLink id="064c-b1f3-4642-7353" name="Power Axe" hidden="false" collective="false" targetId="71f1-4f38-4a0c-2a71" type="selectionEntry"/>
-        <entryLink id="2960-437e-d7f2-a721" name="Power Maul" hidden="false" collective="false" targetId="d292-78eb-f8f4-315e" type="selectionEntry"/>
-        <entryLink id="72c3-28d0-9d44-754b" name="Power Lance" hidden="false" collective="false" targetId="5bd5-b988-5923-3347" type="selectionEntry"/>
+        <entryLink id="d067-a2cc-cde0-d1db" name="Power Sword" hidden="false" collective="false" import="true" targetId="7ccb-406e-ff1e-7142" type="selectionEntry"/>
+        <entryLink id="064c-b1f3-4642-7353" name="Power Axe" hidden="false" collective="false" import="true" targetId="71f1-4f38-4a0c-2a71" type="selectionEntry"/>
+        <entryLink id="2960-437e-d7f2-a721" name="Power Maul" hidden="false" collective="false" import="true" targetId="d292-78eb-f8f4-315e" type="selectionEntry"/>
+        <entryLink id="72c3-28d0-9d44-754b" name="Power Lance" hidden="false" collective="false" import="true" targetId="5bd5-b988-5923-3347" type="selectionEntry"/>
       </entryLinks>
     </selectionEntryGroup>
-    <selectionEntryGroup id="7eba-bb63-a86c-5b07" name="Emanations of Horror [3]" hidden="false" collective="false">
+    <selectionEntryGroup id="7eba-bb63-a86c-5b07" name="Emanations of Horror [3]" hidden="false" collective="false" import="true">
       <modifiers>
         <modifier type="increment" field="44fc-ca72-33e4-b530" value="1">
           <conditions>
@@ -2611,7 +2611,7 @@ Models in combat with Sam us Unbound, as well as those taking Fear tests in orde
         <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="44fc-ca72-33e4-b530" type="max"/>
       </constraints>
       <entryLinks>
-        <entryLink id="b0f6-6657-7864-dc45" name="Flensing Talons" hidden="false" collective="false" targetId="e4ca-d240-cc12-1709" type="selectionEntry">
+        <entryLink id="b0f6-6657-7864-dc45" name="Flensing Talons" hidden="false" collective="false" import="true" targetId="e4ca-d240-cc12-1709" type="selectionEntry">
           <modifiers>
             <modifier type="increment" field="points" value="5">
               <repeats>
@@ -2620,7 +2620,7 @@ Models in combat with Sam us Unbound, as well as those taking Fear tests in orde
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="e94d-597f-479b-e5a5" name="Sundering Fangs" hidden="false" collective="false" targetId="6714-4a30-d5ab-f43b" type="selectionEntry">
+        <entryLink id="e94d-597f-479b-e5a5" name="Sundering Fangs" hidden="false" collective="false" import="true" targetId="6714-4a30-d5ab-f43b" type="selectionEntry">
           <modifiers>
             <modifier type="increment" field="points" value="5">
               <repeats>
@@ -2629,7 +2629,7 @@ Models in combat with Sam us Unbound, as well as those taking Fear tests in orde
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="2983-7403-7753-e433" name="Miasma of Rot" hidden="false" collective="false" targetId="1777-1007-cc23-1481" type="selectionEntry">
+        <entryLink id="2983-7403-7753-e433" name="Miasma of Rot" hidden="false" collective="false" import="true" targetId="1777-1007-cc23-1481" type="selectionEntry">
           <modifiers>
             <modifier type="increment" field="points" value="15">
               <repeats>
@@ -2638,7 +2638,7 @@ Models in combat with Sam us Unbound, as well as those taking Fear tests in orde
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="c761-2ffa-4496-bd0b" name="Brass Collars" hidden="false" collective="false" targetId="da14-1454-058f-f0cd" type="selectionEntry">
+        <entryLink id="c761-2ffa-4496-bd0b" name="Brass Collars" hidden="false" collective="false" import="true" targetId="da14-1454-058f-f0cd" type="selectionEntry">
           <modifiers>
             <modifier type="increment" field="points" value="15">
               <repeats>
@@ -2647,7 +2647,7 @@ Models in combat with Sam us Unbound, as well as those taking Fear tests in orde
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="4328-913d-ff08-45ef" name="Stupefying Musk" hidden="false" collective="false" targetId="6c9f-9f45-11f1-1079" type="selectionEntry">
+        <entryLink id="4328-913d-ff08-45ef" name="Stupefying Musk" hidden="false" collective="false" import="true" targetId="6c9f-9f45-11f1-1079" type="selectionEntry">
           <modifiers>
             <modifier type="increment" field="points" value="10">
               <repeats>
@@ -2656,7 +2656,7 @@ Models in combat with Sam us Unbound, as well as those taking Fear tests in orde
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="c51b-f798-ddfc-c615" name="Corrosive Vomit" hidden="false" collective="false" targetId="84b2-d1d6-1872-c4ef" type="selectionEntry">
+        <entryLink id="c51b-f798-ddfc-c615" name="Corrosive Vomit" hidden="false" collective="false" import="true" targetId="84b2-d1d6-1872-c4ef" type="selectionEntry">
           <modifiers>
             <modifier type="increment" field="points" value="15">
               <repeats>
@@ -2665,12 +2665,12 @@ Models in combat with Sam us Unbound, as well as those taking Fear tests in orde
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="18ff-0280-9697-2850" name="Rift Barb" hidden="false" collective="false" targetId="19f9-a3b4-ae4e-845e" type="selectionEntry">
+        <entryLink id="18ff-0280-9697-2850" name="Rift Barb" hidden="false" collective="false" import="true" targetId="19f9-a3b4-ae4e-845e" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="points" value="15"/>
           </modifiers>
         </entryLink>
-        <entryLink id="a424-c1ae-0b63-ae78" name="Molten Blood" hidden="false" collective="false" targetId="e001-8e2e-f957-4bb7" type="selectionEntry">
+        <entryLink id="a424-c1ae-0b63-ae78" name="Molten Blood" hidden="false" collective="false" import="true" targetId="e001-8e2e-f957-4bb7" type="selectionEntry">
           <modifiers>
             <modifier type="increment" field="points" value="5">
               <repeats>
@@ -2679,7 +2679,7 @@ Models in combat with Sam us Unbound, as well as those taking Fear tests in orde
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="2bf8-dcb9-1b6b-29e7" name="Horned Crown" hidden="false" collective="false" targetId="3f3e-bbfb-732a-9fa8" type="selectionEntry">
+        <entryLink id="2bf8-dcb9-1b6b-29e7" name="Horned Crown" hidden="false" collective="false" import="true" targetId="3f3e-bbfb-732a-9fa8" type="selectionEntry">
           <modifiers>
             <modifier type="increment" field="points" value="15">
               <repeats>
@@ -2688,7 +2688,7 @@ Models in combat with Sam us Unbound, as well as those taking Fear tests in orde
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="6d80-5f13-e680-5024" name="Warp-scaled Hide" hidden="false" collective="false" targetId="5759-049f-35eb-37c2" type="selectionEntry">
+        <entryLink id="6d80-5f13-e680-5024" name="Warp-scaled Hide" hidden="false" collective="false" import="true" targetId="5759-049f-35eb-37c2" type="selectionEntry">
           <modifiers>
             <modifier type="increment" field="points" value="25">
               <repeats>
@@ -2697,7 +2697,7 @@ Models in combat with Sam us Unbound, as well as those taking Fear tests in orde
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="5815-9405-96e1-e5a5" name="Quicksilver Speed" hidden="false" collective="false" targetId="7e9f-dc4a-0fa8-732d" type="selectionEntry">
+        <entryLink id="5815-9405-96e1-e5a5" name="Quicksilver Speed" hidden="false" collective="false" import="true" targetId="7e9f-dc4a-0fa8-732d" type="selectionEntry">
           <modifiers>
             <modifier type="increment" field="points" value="15">
               <repeats>
@@ -2706,7 +2706,7 @@ Models in combat with Sam us Unbound, as well as those taking Fear tests in orde
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="4332-219d-036a-1ee2" name="Flaming Ichor" hidden="false" collective="false" targetId="e531-b96d-ec46-184a" type="selectionEntry">
+        <entryLink id="4332-219d-036a-1ee2" name="Flaming Ichor" hidden="false" collective="false" import="true" targetId="e531-b96d-ec46-184a" type="selectionEntry">
           <modifiers>
             <modifier type="increment" field="points" value="20">
               <repeats>
@@ -2715,7 +2715,7 @@ Models in combat with Sam us Unbound, as well as those taking Fear tests in orde
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="2ee9-0844-f9eb-bac9" name="Spine Volley" hidden="false" collective="false" targetId="6a35-94d3-e17d-37b0" type="selectionEntry">
+        <entryLink id="2ee9-0844-f9eb-bac9" name="Spine Volley" hidden="false" collective="false" import="true" targetId="6a35-94d3-e17d-37b0" type="selectionEntry">
           <modifiers>
             <modifier type="increment" field="points" value="10">
               <repeats>
@@ -2724,7 +2724,7 @@ Models in combat with Sam us Unbound, as well as those taking Fear tests in orde
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="3c1c-a91a-3cb4-341c" name="Bone Shard Harpoons" hidden="false" collective="false" targetId="823e-a42d-9475-c2dd" type="selectionEntry">
+        <entryLink id="3c1c-a91a-3cb4-341c" name="Bone Shard Harpoons" hidden="false" collective="false" import="true" targetId="823e-a42d-9475-c2dd" type="selectionEntry">
           <modifiers>
             <modifier type="increment" field="points" value="10">
               <repeats>
@@ -2733,7 +2733,7 @@ Models in combat with Sam us Unbound, as well as those taking Fear tests in orde
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="340c-ad66-d1a0-bada" name="Shroud of Darkness" hidden="false" collective="false" targetId="8600-a910-cd18-0f0a" type="selectionEntry">
+        <entryLink id="340c-ad66-d1a0-bada" name="Shroud of Darkness" hidden="false" collective="false" import="true" targetId="8600-a910-cd18-0f0a" type="selectionEntry">
           <modifiers>
             <modifier type="increment" field="points" value="20">
               <repeats>
@@ -2742,7 +2742,7 @@ Models in combat with Sam us Unbound, as well as those taking Fear tests in orde
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="897b-f7ee-19dd-f6b1" name="Crushing Claws" hidden="false" collective="false" targetId="a4fc-26a9-cd55-3b4b" type="selectionEntry">
+        <entryLink id="897b-f7ee-19dd-f6b1" name="Crushing Claws" hidden="false" collective="false" import="true" targetId="a4fc-26a9-cd55-3b4b" type="selectionEntry">
           <modifiers>
             <modifier type="increment" field="points" value="10">
               <repeats>

--- a/(HH) Mechanicum - Taghmata Army List.cat
+++ b/(HH) Mechanicum - Taghmata Army List.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="cf03-f607-41dc-7545" name="Mechanicum: Taghmata Army List" revision="87" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="85" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="cf03-f607-41dc-7545" name="Mechanicum: Taghmata Army List" revision="88" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="85" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="cf03-f607-pubN65537" name="Horus Heresy: Taghmata Army List"/>
     <publication id="cf03-f607-pubN65563" name="AoDRB"/>
@@ -2479,27 +2479,6 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <cost name="pts" typeId="points" value="15.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="c92a3180-03bc-a10e-e3ef-0583fb1b7ae1" name="Frag and Krak Grenades" page="0" hidden="false" collective="false" import="true" type="upgrade">
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="14a7fda8-1896-921f-f636-722dbe5f39dd" name="Frag, Krak, and Rad Grenades" page="0" hidden="false" collective="false" import="true" type="upgrade">
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <infoLinks>
-        <infoLink id="bf0f177a-136b-f7e0-7758-a4fb9d65210c" hidden="false" targetId="64f9440e-6178-f5ae-f529-4d23a91f0bf9" type="rule"/>
-      </infoLinks>
-      <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
     <selectionEntry id="4e6055a9-83c9-d85b-e657-0cb85f3f1fcc" name="Graviton Gun" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
@@ -3320,7 +3299,7 @@ Reduces transport capacity to 8.</description>
               </selectionEntries>
               <entryLinks>
                 <entryLink id="8692-e3c3-e8e4-9e57" name="New EntryLink" hidden="false" collective="false" import="true" targetId="2645-2048-de94-299c" type="selectionEntry"/>
-                <entryLink id="ca7e-939a-3b3e-9f46" name="New EntryLink" hidden="false" collective="false" import="true" targetId="acf4-096f-2127-80a3" type="selectionEntry"/>
+                <entryLink id="ca7e-939a-3b3e-9f46" name="Melta Bombs" hidden="false" collective="false" import="true" targetId="4c62-8983-4a1b-d1c6" type="selectionEntry"/>
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="357d-b90a-64c5-172f" name="Techno-Arcana" hidden="false" collective="false" import="true">
@@ -4280,7 +4259,7 @@ Reduces transport capacity to 8.</description>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="81f0-cd7e-d2fe-e7a0" name="Karacnos mortar battery" publicationId="cf03-f607-pubN92488" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="81f0-cd7e-d2fe-e7a0" name="Karacnos Mortar Battery" publicationId="cf03-f607-pubN92488" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="46ef-e4f2-2515-490c" type="max"/>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="bcef-29aa-f05e-cc54" type="min"/>
@@ -4664,17 +4643,6 @@ Buildings and Fortifications D</description>
       </infoLinks>
       <costs>
         <cost name="pts" typeId="points" value="10.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="acf4-096f-2127-80a3" name="Melta Bombs" page="0" hidden="false" collective="false" import="true" type="upgrade">
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8069-22b1-88de-45c8" type="max"/>
-      </constraints>
-      <infoLinks>
-        <infoLink id="0093-d502-9efb-e4d0" name="New InfoLink" hidden="false" targetId="a1d8-f9f3-865a-9faf" type="profile"/>
-      </infoLinks>
-      <costs>
-        <cost name="pts" typeId="points" value="5.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="bd94-0269-4234-4a81" name="Secutarii Axiarch" publicationId="cf03-f607-pubN92488" hidden="false" collective="false" import="true" type="unit">
@@ -7539,7 +7507,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
           </selectionEntries>
           <entryLinks>
             <entryLink id="237b-614f-9aa0-179b" name="New EntryLink" hidden="false" collective="false" import="true" targetId="2645-2048-de94-299c" type="selectionEntry"/>
-            <entryLink id="5ff9-7462-fecc-00a2" name="New EntryLink" hidden="false" collective="false" import="true" targetId="acf4-096f-2127-80a3" type="selectionEntry"/>
+            <entryLink id="5ff9-7462-fecc-00a2" name="Melta Bombs" hidden="false" collective="false" import="true" targetId="4c62-8983-4a1b-d1c6" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="a3d9-dc72-fba3-af4f" name="Exchange Volkite Serpenta for" hidden="false" collective="false" import="true">
@@ -8315,7 +8283,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
           </selectionEntries>
           <entryLinks>
             <entryLink id="956b-25cb-9eac-8971" name="New EntryLink" hidden="false" collective="false" import="true" targetId="2645-2048-de94-299c" type="selectionEntry"/>
-            <entryLink id="562c-e0fc-1558-210a" name="New EntryLink" hidden="false" collective="false" import="true" targetId="acf4-096f-2127-80a3" type="selectionEntry"/>
+            <entryLink id="562c-e0fc-1558-210a" name="Melta Bombs" hidden="false" collective="false" import="true" targetId="4c62-8983-4a1b-d1c6" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="1fc3-6b29-d5c9-e39a" name="Ranged Weapon:" hidden="false" collective="false" import="true" defaultSelectionEntryId="9215-e924-50c1-c56a">
@@ -8702,7 +8670,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
           </selectionEntries>
           <entryLinks>
             <entryLink id="9986-60cb-f9bd-7af4" name="New EntryLink" hidden="false" collective="false" import="true" targetId="2645-2048-de94-299c" type="selectionEntry"/>
-            <entryLink id="0528-9016-03a1-e977" name="New EntryLink" hidden="false" collective="false" import="true" targetId="acf4-096f-2127-80a3" type="selectionEntry"/>
+            <entryLink id="0528-9016-03a1-e977" name="Melta Bombs" hidden="false" collective="false" import="true" targetId="4c62-8983-4a1b-d1c6" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="d2fe-5252-15d0-a938" name="May take one of the following additional weapons:" hidden="false" collective="false" import="true">
@@ -9306,7 +9274,7 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
           </selectionEntries>
           <entryLinks>
             <entryLink id="4ac3-cda7-73fd-173d" name="New EntryLink" hidden="false" collective="false" import="true" targetId="2645-2048-de94-299c" type="selectionEntry"/>
-            <entryLink id="b5aa-728c-0688-9e50" name="New EntryLink" hidden="false" collective="false" import="true" targetId="acf4-096f-2127-80a3" type="selectionEntry"/>
+            <entryLink id="b5aa-728c-0688-9e50" name="Melta Bombs" hidden="false" collective="false" import="true" targetId="4c62-8983-4a1b-d1c6" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="e3c1-c1dc-a079-b4c5" name="The Magos Reductor may also take one of the following options:" hidden="false" collective="false" import="true">
@@ -9730,7 +9698,7 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b864-b797-09b4-0624" type="min"/>
               </constraints>
             </entryLink>
-            <entryLink id="424d-b6d2-ed34-5d22" name="Frag and Krak grenades" hidden="false" collective="false" import="true" targetId="e8ea-b5c1-7636-cbb3" type="selectionEntry"/>
+            <entryLink id="424d-b6d2-ed34-5d22" name="Frag and Krak Grenades" hidden="false" collective="false" import="true" targetId="0a53-b471-df87-7b83" type="selectionEntry"/>
             <entryLink id="c43e-be6c-653d-079d" name="Infravisor" hidden="false" collective="false" import="true" targetId="f921-3533-183e-c741" type="selectionEntry"/>
             <entryLink id="f860-0cb3-3969-924d" name="Refractor Field" hidden="false" collective="false" import="true" targetId="40e37f6e-a984-4232-4dc4-807ed9028f62" type="selectionEntry">
               <modifiers>
@@ -9806,7 +9774,7 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7da9-85c9-5058-56fc" type="min"/>
               </constraints>
             </entryLink>
-            <entryLink id="f660-075b-3bb3-32cd" name="Frag and Krak grenades" hidden="false" collective="false" import="true" targetId="e8ea-b5c1-7636-cbb3" type="selectionEntry"/>
+            <entryLink id="f660-075b-3bb3-32cd" name="Frag and Krak Grenades" hidden="false" collective="false" import="true" targetId="0a53-b471-df87-7b83" type="selectionEntry"/>
             <entryLink id="7f32-722a-1c86-8998" name="Infravisor" hidden="false" collective="false" import="true" targetId="f921-3533-183e-c741" type="selectionEntry"/>
             <entryLink id="9d94-a35c-eb02-d896" name="Refractor Field" hidden="false" collective="false" import="true" targetId="40e37f6e-a984-4232-4dc4-807ed9028f62" type="selectionEntry">
               <modifiers>
@@ -9907,7 +9875,7 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
             </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks>
-            <entryLink id="909e-07ac-38f8-8149" name="Frag and Krak grenades" hidden="false" collective="false" import="true" targetId="e8ea-b5c1-7636-cbb3" type="selectionEntry"/>
+            <entryLink id="909e-07ac-38f8-8149" name="Frag and Krak Grenades" hidden="false" collective="false" import="true" targetId="0a53-b471-df87-7b83" type="selectionEntry"/>
             <entryLink id="b832-043d-777a-1276" name="Infravisor" hidden="false" collective="false" import="true" targetId="f921-3533-183e-c741" type="selectionEntry"/>
             <entryLink id="835b-30bc-6902-efa3" name="Refractor Field" hidden="false" collective="false" import="true" targetId="40e37f6e-a984-4232-4dc4-807ed9028f62" type="selectionEntry">
               <modifiers>
@@ -9991,7 +9959,7 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
             </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks>
-            <entryLink id="7f1e-fb0d-94d3-08a4" name="Frag and Krak grenades" hidden="false" collective="false" import="true" targetId="e8ea-b5c1-7636-cbb3" type="selectionEntry"/>
+            <entryLink id="7f1e-fb0d-94d3-08a4" name="Frag and Krak Grenades" hidden="false" collective="false" import="true" targetId="0a53-b471-df87-7b83" type="selectionEntry"/>
             <entryLink id="00aa-4d63-68af-f44f" name="Infravisor" hidden="false" collective="false" import="true" targetId="f921-3533-183e-c741" type="selectionEntry"/>
             <entryLink id="c7eb-7961-691c-0cd0" name="Refractor Field" hidden="false" collective="false" import="true" targetId="40e37f6e-a984-4232-4dc4-807ed9028f62" type="selectionEntry">
               <modifiers>
@@ -10704,9 +10672,6 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
           </characteristics>
         </profile>
       </profiles>
-      <infoLinks>
-        <infoLink id="395f-c0ea-e4ab-8c3e" name="Vulcan Mega-bolter" hidden="false" targetId="3b45-b564-4fce-e3d8" type="profile"/>
-      </infoLinks>
       <categoryLinks>
         <categoryLink id="8df9-950a-10d8-bcfd" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
         <categoryLink id="e656-eb28-181a-2eee" name="New CategoryLink" hidden="false" targetId="53bd-99e7-aba0-e79f" primary="false"/>
@@ -10736,6 +10701,15 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
           <costs>
             <cost name="pts" typeId="points" value="0.0"/>
           </costs>
+        </selectionEntry>
+        <selectionEntry id="fb8a-66b1-f049-f859" name="Vulcan Mega-bolter" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e399-3b8f-0e8c-477a" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="55a1-f8c7-ee84-4928" type="min"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="f736-87bb-36bf-082f" name="Vulcan Mega-bolter" hidden="false" targetId="3b45-b564-4fce-e3d8" type="profile"/>
+          </infoLinks>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -10860,19 +10834,29 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
             <characteristic name="Type" typeId="5479706523232344415441232323">Super-heavy Vehicle</characteristic>
           </characteristics>
         </profile>
-        <profile id="e70a-7533-edfa-dbd4" name="Stormsword Siege Cannon" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
-          <characteristics>
-            <characteristic name="Range" typeId="52616e676523232344415441232323">36&quot;</characteristic>
-            <characteristic name="Strength" typeId="537472656e67746823232344415441232323">10</characteristic>
-            <characteristic name="AP" typeId="415023232344415441232323">1</characteristic>
-            <characteristic name="Type" typeId="5479706523232344415441232323">Primary Weapon 1, Apocalyptic Blast (10&quot;), Ignores Cover</characteristic>
-          </characteristics>
-        </profile>
       </profiles>
       <categoryLinks>
         <categoryLink id="41f2-631a-325a-473d" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
         <categoryLink id="34b1-f962-ad42-a3b7" name="New CategoryLink" hidden="false" targetId="53bd-99e7-aba0-e79f" primary="false"/>
       </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="5d89-d22f-758a-fc11" name="Stormsword Siege Cannon" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="74db-a5d3-bc3c-f1e3" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="22f5-65c2-f46d-9f2d" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="59ad-bc9d-f158-f9d7" name="Stormsword Siege Cannon" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="52616e676523232344415441232323">36&quot;</characteristic>
+                <characteristic name="Strength" typeId="537472656e67746823232344415441232323">10</characteristic>
+                <characteristic name="AP" typeId="415023232344415441232323">1</characteristic>
+                <characteristic name="Type" typeId="5479706523232344415441232323">Primary Weapon 1, Apocalyptic Blast (10&quot;), Ignores Cover</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+        </selectionEntry>
+      </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="d2fa-c119-4cca-5263" name="May take any of the following:" hidden="false" collective="false" import="true">
           <constraints>
@@ -10928,19 +10912,29 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
             <characteristic name="Type" typeId="5479706523232344415441232323">Super-Heavy</characteristic>
           </characteristics>
         </profile>
-        <profile id="e699-a5d4-0db7-a77b" name="Baneblade Cannon" publicationId="cf03-f607-pubN99227" page="284" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
-          <characteristics>
-            <characteristic name="Range" typeId="52616e676523232344415441232323">72&quot;</characteristic>
-            <characteristic name="Strength" typeId="537472656e67746823232344415441232323">9</characteristic>
-            <characteristic name="AP" typeId="415023232344415441232323">2</characteristic>
-            <characteristic name="Type" typeId="5479706523232344415441232323">Primary Weapon 1, Apocalyptic Blast</characteristic>
-          </characteristics>
-        </profile>
       </profiles>
       <categoryLinks>
         <categoryLink id="f7a0-1f54-beff-42d3" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
         <categoryLink id="f212-3585-5d60-4b1b" name="New CategoryLink" hidden="false" targetId="53bd-99e7-aba0-e79f" primary="false"/>
       </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="814f-54a8-c846-1880" name="Baneblade Cannon" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b68f-d258-fc93-c692" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a7d5-3756-57f9-2c6f" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="9622-085f-5d47-c323" name="Baneblade Cannon" publicationId="cf03-f607-pubN99227" page="284" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="52616e676523232344415441232323">72&quot;</characteristic>
+                <characteristic name="Strength" typeId="537472656e67746823232344415441232323">9</characteristic>
+                <characteristic name="AP" typeId="415023232344415441232323">2</characteristic>
+                <characteristic name="Type" typeId="5479706523232344415441232323">Primary Weapon 1, Apocalyptic Blast</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+        </selectionEntry>
+      </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="c51f-2073-5531-2fae" name="May take any of the following:" hidden="false" collective="false" import="true">
           <constraints>
@@ -11001,6 +10995,29 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
         <categoryLink id="8341-f35c-7d0f-011d" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
         <categoryLink id="ba97-b4c1-ffb1-9730" name="New CategoryLink" hidden="false" targetId="53bd-99e7-aba0-e79f" primary="false"/>
       </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="10b6-4e9a-31e2-c12d" name="Tremor Cannon" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8e47-966f-dcaa-294f" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9bc6-b259-beeb-b295" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="a6c4-e6f8-b928-73e6" name="Tremor Cannon" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="52616e676523232344415441232323">60&quot;</characteristic>
+                <characteristic name="Strength" typeId="537472656e67746823232344415441232323">8</characteristic>
+                <characteristic name="AP" typeId="415023232344415441232323">3</characteristic>
+                <characteristic name="Type" typeId="5479706523232344415441232323">Primary Weapon 1, Earthshock, Massive Blast</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="0086-7051-7c99-73f6" name="Earthshock" hidden="false">
+              <description>All models under the tremor cannon’s massive blast marker that were not removed from play as a result of that shooting attack must take a Dangerous Terrain test once the hit has been resolved.</description>
+            </rule>
+          </rules>
+        </selectionEntry>
+      </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="2c35-cd8e-bd11-fa46" name="May take any of the following:" hidden="false" collective="false" import="true">
           <constraints>
@@ -11061,6 +11078,24 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
         <categoryLink id="bf18-c268-d568-fd36" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
         <categoryLink id="2684-1b30-347e-bd73" name="New CategoryLink" hidden="false" targetId="53bd-99e7-aba0-e79f" primary="false"/>
       </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="a6e2-207b-e769-b39f" name="Magma cannon" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="30a9-c486-62a6-6c74" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b3bf-38f4-18fa-2109" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="f256-a166-82ed-0284" name="Magma cannon" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="52616e676523232344415441232323">60&quot;</characteristic>
+                <characteristic name="Strength" typeId="537472656e67746823232344415441232323">10</characteristic>
+                <characteristic name="AP" typeId="415023232344415441232323">1</characteristic>
+                <characteristic name="Type" typeId="5479706523232344415441232323">Primary Weapon 1, Large Blast</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+        </selectionEntry>
+      </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="1041-2c19-1195-ca77" name="May take any of the following:" hidden="false" collective="false" import="true">
           <constraints>
@@ -11251,19 +11286,6 @@ In addition to its weapon attacks, units assaulting a model or unit with a gravi
       </infoLinks>
       <costs>
         <cost name="pts" typeId="points" value="35.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="e8ea-b5c1-7636-cbb3" name="Frag and Krak grenades" hidden="false" collective="false" import="true" type="upgrade">
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9c4a-71c7-68fa-e7b9" type="max"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a4b0-9aa0-0305-568f" type="min"/>
-      </constraints>
-      <infoLinks>
-        <infoLink id="03f4-2f82-8a70-1f19" name="New InfoLink" hidden="false" targetId="d890-1b84-bbd9-12d3" type="profile"/>
-        <infoLink id="d52b-271a-5ac2-cc50" name="New InfoLink" hidden="false" targetId="d9f7-775b-1047-f335" type="profile"/>
-      </infoLinks>
-      <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="f921-3533-183e-c741" name="Infravisor" hidden="false" collective="false" import="true" type="upgrade">
@@ -12827,9 +12849,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
     </rule>
     <rule id="bc3aeb96-92f2-e6f1-662f-f6632f61a360" name="Frag and Krak Grenades" page="0" hidden="false"/>
     <rule id="64f9440e-6178-f5ae-f529-4d23a91f0bf9" name="Frag, Krak, and Rad Grenades" page="0" hidden="false">
-      <description>During a turn in which a unit equipped with Rad Grenades assaults or is assaulted, the enemy
-                unit(s) suffer a -1 penalty to the Toughness until the end of the Assault Phase. This does affect the
-                victim&apos;s Instant Death thresholds.</description>
+      <description>During a turn in which a unit equipped with Rad Grenades assaults or is assaulted, the enemy unit(s) suffer a -1 penalty to the Toughness until the end of the Assault Phase. This does affect the victim&apos;s Instant Death thresholds.</description>
     </rule>
     <rule id="8e53a9a8-1408-23bf-5be8-4601caec5d10" name="Fusillade Attack" publicationId="cf03-f607-pubN76979" page="220" hidden="false">
       <description>May fire two ranged weapons in the shooting phase as long as they are at the same target</description>


### PR DESCRIPTION
Taghmata various Fixes again

Taghmata
Baneblade - Baneblade Cannon now selection entry (helps in desktop version for checking items)
Banehammer - Tremor Cannon added as was missing in entry
Fixed issue of Frag and Krak grenades entry was replicated, and not using GST file. The previously used entries, also did not have the assault profile for Frag Grenades, or Assault Grenades rules
Doomhammer - Magna Cannon added as was missing in entry
Frag, Krak and Rad Grenades entry - removed as it wasn't being used by anything. In future could be readded by GST file entries anyway.
Melta Bombs entry removed and the entries in 5 places replaced by the GST one.
Stormlord - Vulcan Mega-bolter now selection entry (helps in desktop version for checking items) #1581 #1582
Stormsword - Stormsword Siege Cannon now selection entry (helps in desktop version for checking items)

LA Various fixes and space savers

Removed Frag and Krak entry that was being used mainly on characters, and replaced link to GST file entry.
Same for Frag, Krak and Rad grenades entry.
 #1586 stuff below
Arlatax Arc scourge now corrected to 10pts cost.
Triaros Sicaran issue and flareshield resolved