### PR TITLE
1617, 1618, 1619 1622 1624 1625

### DIFF
--- a/(HH) Daemons of the Ruinstorm Army List.cat
+++ b/(HH) Daemons of the Ruinstorm Army List.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="8700-b3bb-a471-a0ad" name="Daemons of the Ruinstorm" revision="10" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="85" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="8700-b3bb-a471-a0ad" name="Daemons of the Ruinstorm" revision="11" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="85" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="8700-b3bb-pubN65537" name="HH8: Malevolence"/>
     <publication id="8700-b3bb-pubN75780" name="BRB"/>
@@ -1475,19 +1475,19 @@
     </selectionEntry>
     <selectionEntry id="3e2a-e0d1-0561-3872" name="Ka&apos;Bandha, Daemon General of Signus" publicationId="8700-b3bb-pubN65537" hidden="false" collective="false" import="true" type="model">
       <modifiers>
-        <modifier type="set" field="33f3-58b0-0dc9-4d8e" value="1">
+        <modifier type="set" field="33f3-58b0-0dc9-4d8e" value="1.0">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b1f5-228b-2edc-93d5" type="equalTo"/>
                 <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="92c6-2146-8ca7-bd35" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1c0c-a8bb-13c6-daea" type="equalTo"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="33f3-58b0-0dc9-4d8e" type="max"/>
+        <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="33f3-58b0-0dc9-4d8e" type="max"/>
       </constraints>
       <profiles>
         <profile id="eb4a-79e6-b1eb-fc66" name="Ka&apos;Bandha, Daemon General of Signus" publicationId="8700-b3bb-pubN65537" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
@@ -2031,7 +2031,7 @@ Eternal Rivalry: If Sanguinius is removed as a casualty while it is fighting in 
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c40c-cbf9-905c-29e9" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5a0b-2e45-8c90-360e" type="equalTo"/>
                 <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="92c6-2146-8ca7-bd35" type="equalTo"/>
               </conditions>
             </conditionGroup>
@@ -2103,11 +2103,11 @@ Eternal Rivalry: If Sanguinius is removed as a casualty while it is fighting in 
     </selectionEntry>
     <selectionEntry id="777d-7ee1-4f6d-9ca8" name="Samus Unbound, Daemon Lord of the Ruinstorm" hidden="false" collective="false" import="true" type="model">
       <modifiers>
-        <modifier type="set" field="47bb-db5c-c3f6-5d14" value="1">
+        <modifier type="set" field="47bb-db5c-c3f6-5d14" value="1.0">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="394c-38b0-fa5d-0598" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dc24-bd44-bce4-a7f1" type="equalTo"/>
                 <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="92c6-2146-8ca7-bd35" type="equalTo"/>
               </conditions>
             </conditionGroup>
@@ -2115,7 +2115,7 @@ Eternal Rivalry: If Sanguinius is removed as a casualty while it is fighting in 
         </modifier>
       </modifiers>
       <constraints>
-        <constraint field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="47bb-db5c-c3f6-5d14" type="max"/>
+        <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="47bb-db5c-c3f6-5d14" type="max"/>
       </constraints>
       <profiles>
         <profile id="f25e-e9dc-2abe-cfa0" name="Samus, Daemon Prince of the Ruinstorm" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">


### PR DESCRIPTION
#1617  Head of the Gorgon Fix

#1618  Sky Slayer Squad chainswords now default option, and sergeant fixed to have their bolt pistol and chainsword as default selection..
Exodus given his melta bombs
Alpharius given special rules that were missing.
Shamshir fixed for Praetors and Centurions to increase the toughness and armour saves as they should.
Edit: Tsolmon Khan toughness on bike also fixed

#1619 Fixed Termy weapon options showing when they shouldn't have.

#1623 Fix for Cor'bax, Ka'Bandha & Samus

#1624 Fix for Polux to have his master crafted power fist.

#1625 Fix for world eaters getting errors when selecting chain axes.