### PR TITLE
Mechanicum Profile Fixes

### DIFF
--- a/(HH) Craftworld Eldar - Asuryani Army List.cat
+++ b/(HH) Craftworld Eldar - Asuryani Army List.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="0798-288f-4f71-eab9" name="Asuryani Army List (Fanmade)" revision="4" battleScribeVersion="2.03" authorName="Dono Author / Maye Gelt the Battlescribbler" authorContact="Dono (for Content) / Maye Gelt (for Battlescibbling)" authorUrl="http://www.facebook.com/AUS30K" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="106" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="0798-288f-4f71-eab9" name="Asuryani Army List (Fanmade)" revision="5" battleScribeVersion="2.03" authorName="Dono Author / Maye Gelt the Battlescribbler" authorContact="Dono (for Content) / Maye Gelt (for Battlescibbling)" authorUrl="http://www.facebook.com/AUS30K" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="106" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="5c4c-bef9-9681-e0fc" name="30K Craftworld Aeldari - Asuryani Army List"/>
   </publications>
@@ -85,6 +85,12 @@
         <categoryLink id="f779-d832-3f92-1939" name="Fortification" hidden="false" targetId="857e-59aa-0b44-f48d" primary="false">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3f1b-b768-79e5-5132" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="435f-297c-35c0-d25a" name="Aliens and Daemons" hidden="false" targetId="cd09-c1c6-237a-798e" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1de5-293b-d988-e9ad" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="91cc-9aa1-1a06-dc3b" type="min"/>
           </constraints>
         </categoryLink>
       </categoryLinks>
@@ -399,6 +405,15 @@
     <entryLink id="19e9-3aea-e7eb-38dd" name="Craftworld Doctrines" hidden="false" collective="false" import="true" targetId="4f6b-f05a-b801-e0de" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="c203-c212-9e28-386e" name="New CategoryLink" hidden="false" targetId="07c2-ac27-e893-9f99" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="c9a7-0827-eda3-ee6d" name="Aliens and Daemons" hidden="false" collective="false" import="true" targetId="8221-a45d-16b8-2dcf" type="selectionEntry">
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e99-d95a-5926-572c" type="max"/>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cc30-a4d3-f6d9-1bcc" type="min"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="ef1f-7bab-5216-33ce" name="New CategoryLink" hidden="false" targetId="cd09-c1c6-237a-798e" primary="true"/>
       </categoryLinks>
     </entryLink>
   </entryLinks>

--- a/(HH) Daemons of the Ruinstorm Army List.cat
+++ b/(HH) Daemons of the Ruinstorm Army List.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="8700-b3bb-a471-a0ad" name="Daemons of the Ruinstorm" revision="11" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="85" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="8700-b3bb-a471-a0ad" name="Daemons of the Ruinstorm" revision="12" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="85" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="8700-b3bb-pubN65537" name="HH8: Malevolence"/>
     <publication id="8700-b3bb-pubN75780" name="BRB"/>
@@ -105,6 +105,12 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="bd05-995d-e028-ad9f" type="max"/>
           </constraints>
         </categoryLink>
+        <categoryLink id="862b-ca67-81a0-5d08" name="Aliens and Daemons" hidden="false" targetId="cd09-c1c6-237a-798e" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5e04-3c4a-cd59-824c" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1eea-709b-98c5-af0f" type="min"/>
+          </constraints>
+        </categoryLink>
       </categoryLinks>
     </forceEntry>
   </forceEntries>
@@ -201,6 +207,15 @@
     <entryLink id="d518-5909-d60f-79db" name="Samus Unbound, Daemon Lord of the Ruinstorm" hidden="false" collective="false" import="true" targetId="777d-7ee1-4f6d-9ca8" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="feb9-0a69-7838-340a" name="HQ" hidden="false" targetId="485123232344415441232323" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="5b60-f0c4-abb1-e1f4" name="Aliens and Daemons" hidden="false" collective="false" import="true" targetId="8221-a45d-16b8-2dcf" type="selectionEntry">
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1a38-1eed-c7e8-699a" type="max"/>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="10c9-a2d1-5e84-9a82" type="min"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="f556-e8fe-57c3-e682" name="New CategoryLink" hidden="false" targetId="cd09-c1c6-237a-798e" primary="true"/>
       </categoryLinks>
     </entryLink>
   </entryLinks>

--- a/(HH) Mechanicum - Questoris Knight.cat
+++ b/(HH) Mechanicum - Questoris Knight.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="32d1ddc6-3187-cf6f-3bf8-9891e527a002" name="Questoris Knight Crusade Army" revision="48" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="85" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="32d1ddc6-3187-cf6f-3bf8-9891e527a002" name="Questoris Knight Crusade Army" revision="49" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="85" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="32d1ddc6--pubN65537" name="Age of Darkness Crusade Army List"/>
     <publication id="32d1ddc6--pubN66650" name="HH4: Conquest"/>
@@ -1681,6 +1681,20 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
           </modifiers>
         </entryLink>
         <entryLink id="38ae-7cc3-463a-a8de" name="Questoris Knight Dominus" hidden="false" collective="false" import="true" targetId="3902-a5e5-c69e-7a01" type="selectionEntry"/>
+        <entryLink id="4e1e-f097-8024-9c0e" name="Acastus Knight Asterius" hidden="false" collective="false" import="true" targetId="72ad-abe8-94d8-5926" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2f44-17e9-3707-22f2" type="instanceOf"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ff61-cf0e-681b-82bb" type="instanceOf"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+        </entryLink>
       </entryLinks>
     </selectionEntryGroup>
     <selectionEntryGroup id="365d-5bf0-6a3b-6253" name="Allegiance" hidden="false" collective="false" import="true">

--- a/(HH) Mechanicum - Taghmata Army List.cat
+++ b/(HH) Mechanicum - Taghmata Army List.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="cf03-f607-41dc-7545" name="Mechanicum: Taghmata Army List" revision="89" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="85" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="cf03-f607-41dc-7545" name="Mechanicum: Taghmata Army List" revision="90" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="85" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="cf03-f607-pubN65537" name="Horus Heresy: Taghmata Army List"/>
     <publication id="cf03-f607-pubN65563" name="AoDRB"/>
@@ -1776,6 +1776,11 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
       </costs>
     </selectionEntry>
     <selectionEntry id="48db-84ca-2bad-520f" name="Castellax Class Battle-Automata Maniple" page="" hidden="false" collective="false" import="true" type="unit">
+      <rules>
+        <rule id="fff0-5baf-2869-4e6a" name="Atomantic Shielding" publicationId="ca571888--pubN82424" page="26" hidden="false">
+          <description>A model with Atomantic shielding has a 5+ invulnerable save against shooting attacks and explosions, and a 6+ invulnerable save against attacks suffered in close combat. In adition, if the battle automata suffers a reactor blast explosion, add +1 to the radius the blast causes.</description>
+        </rule>
+      </rules>
       <infoLinks>
         <infoLink id="7678-ae60-16f2-e948" name="" hidden="false" targetId="988c-d4d0-9418-1165" type="rule"/>
         <infoLink id="a7f0-6bc1-ed4a-34dc" name="New InfoLink" hidden="false" targetId="d5cf-bd98-2854-13cf" type="rule"/>
@@ -7428,14 +7433,6 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
             <cost name="pts" typeId="points" value="5.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="e714-7e43-a6e5-04b4" name="Power Weapon" publicationId="cf03-f607-pubN76780" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7ec3-da59-1d69-df29" type="max"/>
-          </constraints>
-          <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
         <selectionEntry id="954d-f1c5-971f-eba5" name="Relics of the Dark Age of Technology" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="135f-ed77-3978-0385" type="max"/>
@@ -7651,6 +7648,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
       </selectionEntryGroups>
       <entryLinks>
         <entryLink id="47a3-6141-b585-da3e" name="May be mounted on:" hidden="false" collective="false" import="true" targetId="df18-c724-2a3d-a6e5" type="selectionEntryGroup"/>
+        <entryLink id="5483-614b-65da-0140" name="Power Weapon" hidden="false" collective="false" import="true" targetId="9d3d-aef5-6635-b0c6" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="155.0"/>
@@ -8363,6 +8361,16 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e21c-8e84-f87f-c0c8" type="max"/>
               </constraints>
+              <profiles>
+                <profile id="39f0-cf31-7bf7-bec9" name="Meltagun" publicationId="ca571888--pubN106502" page="178" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="52616e676523232344415441232323">12&quot;</characteristic>
+                    <characteristic name="Strength" typeId="537472656e67746823232344415441232323">8</characteristic>
+                    <characteristic name="AP" typeId="415023232344415441232323">1</characteristic>
+                    <characteristic name="Type" typeId="5479706523232344415441232323">Assault 1, Melta</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
               </costs>
@@ -8703,6 +8711,16 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7da0-e4e8-1bf6-0dc2" type="max"/>
               </constraints>
+              <profiles>
+                <profile id="f074-e239-a3f1-0e25" name="Meltagun" publicationId="ca571888--pubN106502" page="178" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="52616e676523232344415441232323">12&quot;</characteristic>
+                    <characteristic name="Strength" typeId="537472656e67746823232344415441232323">8</characteristic>
+                    <characteristic name="AP" typeId="415023232344415441232323">1</characteristic>
+                    <characteristic name="Type" typeId="5479706523232344415441232323">Assault 1, Melta</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
               </costs>

--- a/(HH) Mechanicum - Taghmata Army List.cat
+++ b/(HH) Mechanicum - Taghmata Army List.cat
@@ -4210,6 +4210,7 @@ Reduces transport capacity to 8.</description>
           </modifiers>
         </infoLink>
         <infoLink id="f08e-5bfd-bc98-fabd" name="New InfoLink" hidden="false" targetId="6e59-4afd-8668-f066" type="rule"/>
+        <infoLink id="b89b-ab5f-63e9-11d0" name="Hazardous Munitions" hidden="false" targetId="dc06-a6df-61f8-d030" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="6a1d-d4d0-0b1d-7d1f" name="New CategoryLink" hidden="false" targetId="53bd-99e7-aba0-e79f" primary="false"/>
@@ -4254,23 +4255,6 @@ Reduces transport capacity to 8.</description>
         <infoLink id="eece-b51d-21eb-7fb3" name="New InfoLink" hidden="false" targetId="8269-2cd6-9236-16e7" type="rule"/>
         <infoLink id="187b-9c0d-a255-47a5" name="New InfoLink" hidden="false" targetId="89da-0cb5-bee4-8ec2" type="rule"/>
         <infoLink id="34f2-d4c2-6479-ae57" name="New InfoLink" hidden="false" targetId="e571-5701-104d-9e3d" type="profile"/>
-      </infoLinks>
-      <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="81f0-cd7e-d2fe-e7a0" name="Karacnos Mortar Battery" publicationId="cf03-f607-pubN92488" hidden="false" collective="false" import="true" type="upgrade">
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="46ef-e4f2-2515-490c" type="max"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="bcef-29aa-f05e-cc54" type="min"/>
-      </constraints>
-      <infoLinks>
-        <infoLink id="87da-cec7-d35e-d856" name="New InfoLink" hidden="false" targetId="dc06-a6df-61f8-d030" type="rule"/>
-        <infoLink id="d4fa-f51d-b933-45ae" name="Karacnos motar battery" hidden="false" targetId="0345-be6c-3862-1bf7" type="profile"/>
-        <infoLink id="8f21-00b9-4039-131d" name="New InfoLink" hidden="false" targetId="f624-f475-e5ec-0dfa" type="rule"/>
-        <infoLink id="fe4a-57ec-ac3e-c862" name="New InfoLink" hidden="false" targetId="4575-0a0a-caaf-e4bf" type="rule"/>
-        <infoLink id="c798-cbca-09c4-3f65" name="New InfoLink" hidden="false" targetId="acf2-681d-4188-94d7" type="rule"/>
-        <infoLink id="72b7-04cb-4e70-7262" name="New InfoLink" hidden="false" targetId="eefe-09e4-17aa-deb2" type="rule"/>
       </infoLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
@@ -4668,7 +4652,7 @@ Buildings and Fortifications D</description>
             <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="cd54-fdde-91fe-9b2e" name="Exchange Power Maul and Radium Pistol for:" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="cd54-fdde-91fe-9b2e" name="Exchange Arc Maul and Radium Pistol for:" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fa44-2971-943b-ab5f" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a24e-896f-31ea-e73d" type="min"/>
@@ -10607,6 +10591,7 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
             <entryLink id="9291-22af-b60c-8f0b" name="Questoris Knight Warden" hidden="false" collective="false" import="true" targetId="f4f1-dad6-0596-ca5a" type="selectionEntry"/>
             <entryLink id="f73d-6c6a-8a8a-9dd9" name="Cerastus Knight-Lancer" hidden="false" collective="false" import="true" targetId="ca45ca55-eae1-1a81-8afc-1330611055a6" type="selectionEntry"/>
             <entryLink id="593f-5de1-07e1-a4cb" name="Acastus Knight Porphyrion" hidden="false" collective="false" import="true" targetId="4ded-9de3-f964-33a7" type="selectionEntry"/>
+            <entryLink id="d060-75e7-6ceb-e4ce" name="Acastus Knight Asterius" hidden="false" collective="false" import="true" targetId="72ad-abe8-94d8-5926" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
@@ -12971,8 +12956,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
       <description>Must re-roll all failed Dangerous Terrain tests</description>
     </rule>
     <rule id="dc06-a6df-61f8-d030" name="Hazardous Munitions" publicationId="cf03-f607-pubN92488" hidden="false">
-      <description>If the Karacnos explodes due to damage, it has a D6+2 Blast radius and inflicts Str 5, AP 4
-                hits.</description>
+      <description>If the Karacnos explodes due to damage, it has a D6+2 Blast radius and inflicts Str 5, AP 4 hits.</description>
     </rule>
     <rule id="5c81-31f3-2fcb-596d" name="Hardened Armour" hidden="false"/>
     <rule id="9cc7-f83e-f251-4e5c" name="Titanshard Armour" publicationId="cf03-f607-pubN96051" hidden="false">

--- a/(HH) Necron Army List.cat
+++ b/(HH) Necron Army List.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="b50f-0671-3aea-cf90" name="Necron Army List (Fanmade)" revision="2" battleScribeVersion="2.03" authorName="Dono Author / Maye Gelt the Battlescribbler" authorContact="Dono (for Content) / Maye Gelt (for Battlescibbling)" authorUrl="http://www.facebook.com/AUS30K" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="108" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="b50f-0671-3aea-cf90" name="Necron Army List (Fanmade)" revision="3" battleScribeVersion="2.03" authorName="Dono Author / Maye Gelt the Battlescribbler" authorContact="Dono (for Content) / Maye Gelt (for Battlescibbling)" authorUrl="http://www.facebook.com/AUS30K" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="108" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="6fc6-dd7c-7a39-b0c8" name="30K Necron Army List (Fanmade)"/>
   </publications>
@@ -237,6 +237,12 @@
           </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="-1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4f27-e2e7-3207-6ffe" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="2b1a-d16e-e778-d90b" name="Aliens and Daemons" hidden="false" targetId="cd09-c1c6-237a-798e" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7c3f-6fc6-c9d7-8db7" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="603f-9859-f789-40a4" type="min"/>
           </constraints>
         </categoryLink>
       </categoryLinks>
@@ -800,6 +806,15 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="e19f-bddc-5ac1-283d" name="New CategoryLink" hidden="false" targetId="564d-9137-b8e7-1818" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="6587-c35e-d1be-af5c" name="Aliens and Daemons" hidden="false" collective="false" import="true" targetId="8221-a45d-16b8-2dcf" type="selectionEntry">
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9a09-3f48-9b9d-4dc4" type="max"/>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9f59-17fd-a40e-7329" type="min"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="fabf-a3a2-2963-3a61" name="New CategoryLink" hidden="false" targetId="cd09-c1c6-237a-798e" primary="true"/>
       </categoryLinks>
     </entryLink>
   </entryLinks>

--- a/(HH) Solar Auxilia - Crusade Army List.cat
+++ b/(HH) Solar Auxilia - Crusade Army List.cat
@@ -1137,6 +1137,11 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
       </costs>
     </selectionEntry>
     <selectionEntry id="48db-84ca-2bad-520f" name="Castellax Class Battle-Automata Maniple" page="" hidden="false" collective="false" import="true" type="unit">
+      <rules>
+        <rule id="d791-033f-9cf0-43a6" name="Atomantic Shielding" publicationId="ca571888--pubN82424" page="26" hidden="false">
+          <description>A model with Atomantic shielding has a 5+ invulnerable save against shooting attacks and explosions, and a 6+ invulnerable save against attacks suffered in close combat. In adition, if the battle automata suffers a reactor blast explosion, add +1 to the radius the blast causes.</description>
+        </rule>
+      </rules>
       <infoLinks>
         <infoLink id="7678-ae60-16f2-e948" name="" hidden="false" targetId="988c-d4d0-9418-1165" type="rule"/>
         <infoLink id="a7f0-6bc1-ed4a-34dc" name="New InfoLink" hidden="false" targetId="d5cf-bd98-2854-13cf" type="rule"/>
@@ -1439,16 +1444,6 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
-              <profiles>
-                <profile id="a87f-f6ed-2055-4789" name="Autocannon" publicationId="ca571888--pubN106502" page="176" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
-                  <characteristics>
-                    <characteristic name="Range" typeId="52616e676523232344415441232323">48&quot;</characteristic>
-                    <characteristic name="Strength" typeId="537472656e67746823232344415441232323">7</characteristic>
-                    <characteristic name="AP" typeId="415023232344415441232323">4</characteristic>
-                    <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 2</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
               </costs>
@@ -1457,16 +1452,6 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
-              <profiles>
-                <profile id="1d62-533d-fbdb-8246" name="Lascannon" publicationId="ca571888--pubN106502" page="178" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
-                  <characteristics>
-                    <characteristic name="Range" typeId="52616e676523232344415441232323">48&quot;</characteristic>
-                    <characteristic name="Strength" typeId="537472656e67746823232344415441232323">9</characteristic>
-                    <characteristic name="AP" typeId="415023232344415441232323">2</characteristic>
-                    <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 1</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
               </costs>
@@ -1486,16 +1471,6 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
-              <profiles>
-                <profile id="8ea2-91e7-683f-c591" name="Lascannon" publicationId="ca571888--pubN106502" page="178" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
-                  <characteristics>
-                    <characteristic name="Range" typeId="52616e676523232344415441232323">48&quot;</characteristic>
-                    <characteristic name="Strength" typeId="537472656e67746823232344415441232323">9</characteristic>
-                    <characteristic name="AP" typeId="415023232344415441232323">2</characteristic>
-                    <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 1</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
               </costs>
@@ -1504,16 +1479,6 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
-              <profiles>
-                <profile id="b4a0-d11a-59ea-0b19" name="Autocannon" publicationId="ca571888--pubN106502" page="176" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
-                  <characteristics>
-                    <characteristic name="Range" typeId="52616e676523232344415441232323">48&quot;</characteristic>
-                    <characteristic name="Strength" typeId="537472656e67746823232344415441232323">7</characteristic>
-                    <characteristic name="AP" typeId="415023232344415441232323">4</characteristic>
-                    <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 2</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
               </costs>
@@ -3499,16 +3464,9 @@ but the tank loses the Fast special rule.</description>
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a41d-3123-be90-81f3" type="max"/>
                   </constraints>
-                  <profiles>
-                    <profile id="1df7-c0ca-474f-e99d" name="Quad Multi-laser" publicationId="7f243fc5--pubN74753" page="247" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
-                      <characteristics>
-                        <characteristic name="Range" typeId="52616e676523232344415441232323">36&quot;</characteristic>
-                        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">6</characteristic>
-                        <characteristic name="AP" typeId="415023232344415441232323">6</characteristic>
-                        <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 6, Twin-linked</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
+                  <infoLinks>
+                    <infoLink id="629b-5b79-4c6a-f740" name="Multi-laser" hidden="false" targetId="92be-1bfc-f355-f214" type="profile"/>
+                  </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="0.0"/>
                   </costs>
@@ -5988,16 +5946,6 @@ Precision Shots</description>
               <constraints>
                 <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="588c-a65f-25cc-f85c" type="max"/>
               </constraints>
-              <profiles>
-                <profile id="a523-cef1-17bd-d865" name="Heavy Flamer" publicationId="ca571888--pubN106502" page="177" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
-                  <characteristics>
-                    <characteristic name="Range" typeId="52616e676523232344415441232323">Template</characteristic>
-                    <characteristic name="Strength" typeId="537472656e67746823232344415441232323">5</characteristic>
-                    <characteristic name="AP" typeId="415023232344415441232323">4</characteristic>
-                    <characteristic name="Type" typeId="5479706523232344415441232323">Assault 1</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
@@ -6017,16 +5965,6 @@ Precision Shots</description>
               <constraints>
                 <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e2d3-f0cb-b741-1069" type="max"/>
               </constraints>
-              <profiles>
-                <profile id="6ee7-f565-b1a7-95b5" name="Lascannon" publicationId="ca571888--pubN106502" page="178" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
-                  <characteristics>
-                    <characteristic name="Range" typeId="52616e676523232344415441232323">48&quot;</characteristic>
-                    <characteristic name="Strength" typeId="537472656e67746823232344415441232323">9</characteristic>
-                    <characteristic name="AP" typeId="415023232344415441232323">2</characteristic>
-                    <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 1</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
               </costs>
@@ -6035,16 +5973,6 @@ Precision Shots</description>
               <constraints>
                 <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d070-a58a-6748-0bee" type="max"/>
               </constraints>
-              <profiles>
-                <profile id="9b69-bfb3-cb51-7781" name="Multi-Melta" publicationId="ca571888--pubN106502" page="178" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
-                  <characteristics>
-                    <characteristic name="Range" typeId="52616e676523232344415441232323">24&quot;</characteristic>
-                    <characteristic name="Strength" typeId="537472656e67746823232344415441232323">8</characteristic>
-                    <characteristic name="AP" typeId="415023232344415441232323">1</characteristic>
-                    <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 1, Melta</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
               </costs>

--- a/The Horus Heresy.gst
+++ b/The Horus Heresy.gst
@@ -187,6 +187,7 @@
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="01d2-0dda-55c9-4e01" type="min"/>
       </constraints>
     </categoryEntry>
+    <categoryEntry id="cd09-c1c6-237a-798e" name="Aliens and Daemons" hidden="false"/>
   </categoryEntries>
   <forceEntries>
     <forceEntry id="61f7-09c7-326c-8c49" name="New ForceEntry" hidden="true">
@@ -197,46 +198,109 @@
   </forceEntries>
   <entryLinks>
     <entryLink id="eda5-87ee-05e1-fd98" name="Acastus Knight Porphyrion" hidden="false" collective="false" import="true" targetId="4ded-9de3-f964-33a7" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8221-a45d-16b8-2dcf" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="087e-6cb9-3b34-bd8d" name="New CategoryLink" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="f5c0-2dc9-a454-3265" name="Questoris Knight Crusader" hidden="false" collective="false" import="true" targetId="09ee-4370-1462-2cb5" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8221-a45d-16b8-2dcf" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="40b7-30a8-e66b-6e88" name="New CategoryLink" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="2691-7e0f-9139-5503" name="Questoris Knight Errant" hidden="false" collective="false" import="true" targetId="4b70feb1-a2e7-2f93-8320-1d6775bf5a59" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8221-a45d-16b8-2dcf" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="1583-91a3-00e9-176a" name="New CategoryLink" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="f1ac-cd3f-39fa-a73c" name="Questoris Knight Gallant" hidden="false" collective="false" import="true" targetId="74b8-f485-4b58-0071" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8221-a45d-16b8-2dcf" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="c989-d886-5fd8-f6d5" name="New CategoryLink" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="f724-e283-e301-075c" name="Questoris Knight Magaera" hidden="false" collective="false" import="true" targetId="fb7cd031-7573-eb28-4446-d709eb5acdbc" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8221-a45d-16b8-2dcf" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="c01c-cc1c-2d9c-0fdc" name="New CategoryLink" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="62a5-7380-1456-3c95" name="Questoris Knight Paladin" hidden="false" collective="false" import="true" targetId="02eb28bb-1883-8603-0af7-b8bf2b7b69c8" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8221-a45d-16b8-2dcf" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="3956-ea6c-808c-767a" name="New CategoryLink" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="e357-a8cf-d30f-00af" name="Questoris Knight Styrix" hidden="false" collective="false" import="true" targetId="a5b350ff-895e-4557-70a6-d24a936919c2" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8221-a45d-16b8-2dcf" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="05ad-5252-2d84-c8eb" name="New CategoryLink" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="a204-0a13-cf14-18d3" name="Questoris Knight Warden" hidden="false" collective="false" import="true" targetId="f4f1-dad6-0596-ca5a" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8221-a45d-16b8-2dcf" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="95f6-22fe-84cf-30bb" name="New CategoryLink" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="78a9-6f20-6fe6-a0e2" name="Questoris Knight Dominus" hidden="false" collective="false" import="true" targetId="6eec-767d-0b14-95ab" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8221-a45d-16b8-2dcf" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="1daa-66b3-bbef-8da8" name="New CategoryLink" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
       </categoryLinks>
@@ -247,6 +311,13 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="c35d-3ad4-5d6e-6d1c" name="Acastus Knight Asterius" hidden="false" collective="false" import="true" targetId="72ad-abe8-94d8-5926" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8221-a45d-16b8-2dcf" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="b6de-ab6a-c3b2-8e78" name="New CategoryLink" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
       </categoryLinks>
@@ -5941,6 +6012,9 @@ or Gargantuan Creatures. </description>
             <infoLink id="85f3-19bf-d67d-6794" name="Volkite Culverin" hidden="false" targetId="34d1-b4db-3e75-ccce" type="profile"/>
             <infoLink id="8e3f-63f6-e39a-7d4e" name="Deflagrate" hidden="false" targetId="b46a-a3ec-91a5-5001" type="rule"/>
           </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -5989,6 +6063,11 @@ or Gargantuan Creatures. </description>
         <infoLink id="0415-8fc8-4097-3195" name="Sunder" hidden="false" targetId="841f-9119-9f9d-5058" type="rule"/>
         <infoLink id="7a81-5dee-82df-f0e0" name="Wrecker" hidden="false" targetId="fe2f-3220-3fef-b177" type="rule"/>
       </infoLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="8221-a45d-16b8-2dcf" name="Aliens and Daemons" hidden="false" collective="false" import="true" type="upgrade">
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>

--- a/The Horus Heresy.gst
+++ b/The Horus Heresy.gst
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<gameSystem id="ca571888-56a9-c58e-ddaf-54f4713538bc" name="Warhammer 30,000 - The Horus Heresy" revision="111" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
+<gameSystem id="ca571888-56a9-c58e-ddaf-54f4713538bc" name="Warhammer 30,000 - The Horus Heresy" revision="112" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
   <publications>
     <publication id="ca571888--pubN65537" name="Forgeworld Horus Heresy Series"/>
     <publication id="ca571888--pubN66489" name="HH:MT"/>
@@ -244,6 +244,11 @@
     <entryLink id="7d9f-d54b-09db-e954" name="Use Playtest Rules" hidden="false" collective="false" import="true" targetId="5a90-c53e-42ca-b4ca" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="d2d6-3f07-f393-0be4" name="New CategoryLink" hidden="false" targetId="fdf4-0683-3e84-5a4b" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="c35d-3ad4-5d6e-6d1c" name="Acastus Knight Asterius" hidden="false" collective="false" import="true" targetId="72ad-abe8-94d8-5926" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="b6de-ab6a-c3b2-8e78" name="New CategoryLink" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
       </categoryLinks>
     </entryLink>
   </entryLinks>
@@ -4665,9 +4670,6 @@ The Bunkers of the Castellum Stronghold have a 5+ invulnerable save against shoo
       </costs>
     </selectionEntry>
     <selectionEntry id="4ded-9de3-f964-33a7" name="Acastus Knight Porphyrion" hidden="false" collective="false" import="true" type="upgrade">
-      <constraints>
-        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4f38-2f45-a1a8-1aab" type="max"/>
-      </constraints>
       <profiles>
         <profile id="208e-17a3-a067-6ea1" name="Acastus Knight Porphyrion" hidden="false" typeId="57616c6b657223232344415441232323" typeName="Walker">
           <characteristics>
@@ -5862,6 +5864,133 @@ or Gargantuan Creatures. </description>
       </infoLinks>
       <costs>
         <cost name="pts" typeId="points" value="25.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="81f0-cd7e-d2fe-e7a0" name="Karacnos Mortar Battery" publicationId="ca571888--pubN92115" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b78f-2be8-e349-3847" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9349-cd95-9b4d-dee9" type="min"/>
+      </constraints>
+      <profiles>
+        <profile id="510a-98be-3d81-65a9" name="Karacnos motar battery" publicationId="ca571888--pubN92115" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="52616e676523232344415441232323">60&quot;</characteristic>
+            <characteristic name="Strength" typeId="537472656e67746823232344415441232323">5</characteristic>
+            <characteristic name="AP" typeId="415023232344415441232323">4</characteristic>
+            <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 3, Barrage, Blast (3&quot;), Fleshbane, Rad-Phage, Ignores Cover, Pinning</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="f202-38e1-7dcd-8076" name="New InfoLink" hidden="false" targetId="f624-f475-e5ec-0dfa" type="rule"/>
+        <infoLink id="3807-a9c0-1309-5203" name="New InfoLink" hidden="false" targetId="4575-0a0a-caaf-e4bf" type="rule"/>
+        <infoLink id="51b3-01fb-f89c-f60f" name="New InfoLink" hidden="false" targetId="acf2-681d-4188-94d7" type="rule"/>
+        <infoLink id="0685-7fdf-1831-6c0e" name="New InfoLink" hidden="false" targetId="eefe-09e4-17aa-deb2" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="72ad-abe8-94d8-5926" name="Acastus Knight Asterius" publicationId="ca571888--pubN106705" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="d0ee-8407-6d22-b0d3" name="Acastus Knight Asterius" hidden="false" typeId="57616c6b657223232344415441232323" typeName="Walker">
+          <characteristics>
+            <characteristic name="WS" typeId="575323232344415441232323">4</characteristic>
+            <characteristic name="BS" typeId="425323232344415441232323">5</characteristic>
+            <characteristic name="S" typeId="5323232344415441232323">10</characteristic>
+            <characteristic name="Front" typeId="46726f6e7423232344415441232323">14</characteristic>
+            <characteristic name="Side" typeId="5369646523232344415441232323">13</characteristic>
+            <characteristic name="Rear" typeId="5265617223232344415441232323">12</characteristic>
+            <characteristic name="I" typeId="4923232344415441232323">3</characteristic>
+            <characteristic name="A" typeId="4123232344415441232323">3</characteristic>
+            <characteristic name="HP" typeId="485023232344415441232323">8</characteristic>
+            <characteristic name="Type" typeId="5479706523232344415441232323">Super-heavy Walker</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="bed1-b54d-9881-2978" name="" hidden="false" targetId="342d5e83-9f9b-42c0-cecb-e6c9c197ab9d" type="profile"/>
+      </infoLinks>
+      <selectionEntries>
+        <selectionEntry id="567b-162a-f3e6-3076" name="Two Twin linked Conversion Beam Cannon" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6940-8927-51d4-0164" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="832d-36fa-23e1-b81f" type="min"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="15b1-830d-e996-944d" name="New InfoLink" hidden="false" targetId="10a8-8d89-0bec-3e21" type="rule"/>
+          </infoLinks>
+          <entryLinks>
+            <entryLink id="c25a-7a06-e16d-c0c9" name="Conversion Beam Cannon" hidden="false" collective="false" import="true" targetId="1292-7672-b955-42da" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="22e5-aa3a-373a-de57" type="max"/>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9709-4fde-12c4-7e41" type="min"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="fbc0-cca8-2aba-9596" name="Vulkite Culverin" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c683-c05d-48ab-936b" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c11e-b833-a38f-a94b" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="85f3-19bf-d67d-6794" name="Volkite Culverin" hidden="false" targetId="34d1-b4db-3e75-ccce" type="profile"/>
+            <infoLink id="8e3f-63f6-e39a-7d4e" name="Deflagrate" hidden="false" targetId="b46a-a3ec-91a5-5001" type="rule"/>
+          </infoLinks>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="cdcc-ff0c-c151-4cfa" name="May be upgraded with:" hidden="false" collective="false" import="true">
+          <entryLinks>
+            <entryLink id="be86-c093-5371-34ae" name="New EntryLink" hidden="false" collective="false" import="true" targetId="348b-40f4-c774-1f9a" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="46e4-af77-01ab-dc86" name="Household Rank" hidden="false" collective="false" import="true" targetId="2f28-c5f0-6110-c614" type="selectionEntry"/>
+        <entryLink id="c71f-68e1-66f2-a643" name="Karacnos Mortar Battery" hidden="false" collective="false" import="true" targetId="81f0-cd7e-d2fe-e7a0" type="selectionEntry"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="540.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1292-7672-b955-42da" name="Conversion Beam Cannon" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="f4bb-8747-e6b9-6566" name="Conversion Beam Cannon (3)" publicationId="ca571888--pubN67636" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="52616e676523232344415441232323">42&quot; - 72&quot;</characteristic>
+            <characteristic name="Strength" typeId="537472656e67746823232344415441232323">10</characteristic>
+            <characteristic name="AP" typeId="415023232344415441232323">3</characteristic>
+            <characteristic name="Type" typeId="5479706523232344415441232323">Ordnance 1, Massive Blast (7&quot;), Wrecker, Sunder</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="9af1-3185-a3de-5781" name="Conversion Beam Cannon (2)" publicationId="ca571888--pubN67636" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="52616e676523232344415441232323">18&quot; - 42&quot;</characteristic>
+            <characteristic name="Strength" typeId="537472656e67746823232344415441232323">10</characteristic>
+            <characteristic name="AP" typeId="415023232344415441232323">2</characteristic>
+            <characteristic name="Type" typeId="5479706523232344415441232323">Ordnance 1, Large Blast (5&quot;), Wrecker</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="ea62-d627-ee8e-9c5f" name="Conversion Beam Cannon (1)" publicationId="ca571888--pubN67636" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="52616e676523232344415441232323">Up to 18&quot;</characteristic>
+            <characteristic name="Strength" typeId="537472656e67746823232344415441232323">10</characteristic>
+            <characteristic name="AP" typeId="415023232344415441232323">3</characteristic>
+            <characteristic name="Type" typeId="5479706523232344415441232323">Ordnance 1, Blast (3&quot;)</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="0415-8fc8-4097-3195" name="Sunder" hidden="false" targetId="841f-9119-9f9d-5058" type="rule"/>
+        <infoLink id="7a81-5dee-82df-f0e0" name="Wrecker" hidden="false" targetId="fe2f-3220-3fef-b177" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>


### PR DESCRIPTION
> ⚠️  NOTE: use notes like this to emphasize something about the PR. This could
> include other PRs this PR is built on top of; reasons for why the PR is on hold; 
or anything else you would like > to draw attention to

## Description
* First issue: Magos prime, if you give him a melta gun, the weapon profile doesn't show up.
* the same goes for the magos dominus, so i think something's wonky with melta gun in particular
* the archmagos dominus still can't choose a specific power weapon. just "power weapon"
* the hardened armour on the abeyant is missing its description
apparently the rules for hardened armour can be found under the "breachers" entry in the legions book
* Ursarax are missing their lightning claws 
* Castellax don't have the atomantic shielding listed properly
