### PR TITLE
Load of Fixes

### DIFF
--- a/(HH) Imperialis Militia and Cults Army List.cat
+++ b/(HH) Imperialis Militia and Cults Army List.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="90aa-c2c8-ffb0-496e" name="Imperialis Militia and Cults Army List" revision="97" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="85" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="90aa-c2c8-ffb0-496e" name="Imperialis Militia and Cults Army List" revision="98" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="85" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="90aa-c2c8-pubN65537" name="Crusade Imperialis"/>
     <publication id="90aa-c2c8-pubN65563" name="AoDRB"/>
@@ -5956,7 +5956,7 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7a8c-585d-b61e-6cfa" type="max"/>
                   </constraints>
                   <infoLinks>
-                    <infoLink id="fddf-ac32-9681-f3e4" name="Multi-Melta" hidden="false" targetId="4fc7-8b16-afe4-dad3" type="profile"/>
+                    <infoLink id="fddf-ac32-9681-f3e4" name="Multi-laser" hidden="false" targetId="92be-1bfc-f355-f214" type="profile"/>
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="0.0"/>

--- a/(HH) Mechanicum - Taghmata Army List.cat
+++ b/(HH) Mechanicum - Taghmata Army List.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="cf03-f607-41dc-7545" name="Mechanicum: Taghmata Army List" revision="90" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="85" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="cf03-f607-41dc-7545" name="Mechanicum: Taghmata Army List" revision="92" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="85" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="cf03-f607-pubN65537" name="Horus Heresy: Taghmata Army List"/>
     <publication id="cf03-f607-pubN65563" name="AoDRB"/>
@@ -45,6 +45,7 @@
     <publication id="cf03-f607-pubN145694" name="HH7"/>
     <publication id="cf03-f607-pubN146636" name="Imperial Armour Vol 1, 2nd Editio"/>
     <publication id="ece2-a265-6237-7efa" name="HH Mechanicum Knight Moirax Talon Download"/>
+    <publication id="2369-0496-8060-eda3" name="Imperial Armour Apocalypse 2013"/>
   </publications>
   <categoryEntries>
     <categoryEntry id="ce39-b313-7b57-ee8e" name="Artillery" publicationId="cf03-f607-pubN65563" page="65" hidden="false">
@@ -935,18 +936,18 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
     <entryLink id="a6da-fabe-6b98-c46e" name="Secutarii Peltast Phalanx" hidden="false" collective="false" import="true" targetId="8190-e779-2c49-c564" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5f7c-939a-f2de-413a" type="greaterThan"/>
-          </conditions>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5f7c-939a-f2de-413a" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d266-0416-a5a6-881e" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
         </modifier>
-        <modifier type="set" field="8ca6-c4ee-0f61-effa" value="-1">
+        <modifier type="set" field="8ca6-c4ee-0f61-effa" value="-1.0">
           <conditions>
             <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5f7c-939a-f2de-413a" type="equalTo"/>
-          </conditions>
-        </modifier>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d266-0416-a5a6-881e" type="greaterThan"/>
           </conditions>
         </modifier>
       </modifiers>
@@ -957,18 +958,18 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
     <entryLink id="4fe0-ed8d-a28a-d78d" name="Secutarii Hoplite Phalanx" hidden="false" collective="false" import="true" targetId="4ff6-b526-4208-0d33" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5f7c-939a-f2de-413a" type="greaterThan"/>
-          </conditions>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5f7c-939a-f2de-413a" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d266-0416-a5a6-881e" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
         </modifier>
-        <modifier type="set" field="6fb1-d527-17a7-2ba0" value="-1">
+        <modifier type="set" field="6fb1-d527-17a7-2ba0" value="-1.0">
           <conditions>
             <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5f7c-939a-f2de-413a" type="equalTo"/>
-          </conditions>
-        </modifier>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5f7c-939a-f2de-413a" type="greaterThan"/>
           </conditions>
         </modifier>
       </modifiers>
@@ -1038,9 +1039,14 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
           </conditions>
         </modifier>
         <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5f7c-939a-f2de-413a" type="greaterThan"/>
-          </conditions>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5f7c-939a-f2de-413a" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d266-0416-a5a6-881e" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
@@ -1417,18 +1423,18 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
     <entryLink id="92bf-c517-a343-1e64" name="Secutarii Hoplite Phalanx" hidden="true" collective="false" import="true" targetId="4ff6-b526-4208-0d33" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5f7c-939a-f2de-413a" type="greaterThan"/>
-          </conditions>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5f7c-939a-f2de-413a" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d266-0416-a5a6-881e" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
         </modifier>
         <modifier type="set" field="6fb1-d527-17a7-2ba0" value="-1">
           <conditions>
             <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5f7c-939a-f2de-413a" type="greaterThan"/>
-          </conditions>
-        </modifier>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d266-0416-a5a6-881e" type="greaterThan"/>
           </conditions>
         </modifier>
       </modifiers>
@@ -1445,14 +1451,14 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
           </conditions>
         </modifier>
         <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5f7c-939a-f2de-413a" type="greaterThan"/>
-          </conditions>
-        </modifier>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5f7c-939a-f2de-413a" type="greaterThan"/>
-          </conditions>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5f7c-939a-f2de-413a" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d266-0416-a5a6-881e" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
@@ -1462,15 +1468,20 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
     </entryLink>
     <entryLink id="a4c3-b327-2fbf-5621" name="Secutarii Axiarch" hidden="true" collective="false" import="true" targetId="bd94-0269-4234-4a81" type="selectionEntry">
       <modifiers>
-        <modifier type="set" field="hidden" value="false">
+        <modifier type="set" field="f855-004d-6a48-f343" value="-1.0">
           <conditions>
             <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5f7c-939a-f2de-413a" type="greaterThan"/>
           </conditions>
         </modifier>
-        <modifier type="set" field="f855-004d-6a48-f343" value="-1">
-          <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5f7c-939a-f2de-413a" type="greaterThan"/>
-          </conditions>
+        <modifier type="set" field="hidden" value="false">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5f7c-939a-f2de-413a" type="greaterThan"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d266-0416-a5a6-881e" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
@@ -1822,6 +1833,20 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
               </characteristics>
             </profile>
           </profiles>
+          <selectionEntries>
+            <selectionEntry id="0d5f-1c68-d2cc-52cf" name="Automantic Shielding" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="54c0-0759-0622-9d62" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5bc3-5606-70d8-cf5f" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="ff61-a84d-78e7-c4c0" hidden="false" targetId="6eb5b812-8b8b-9e7c-279e-c9e9c93fefe9" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
           <selectionEntryGroups>
             <selectionEntryGroup id="6564-7afd-3cef-078a" name="May exchange its Mauler bolt cannon for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="11ea-37df-c659-bc84">
               <constraints>
@@ -2349,6 +2374,9 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
             <infoLink id="516b-3599-158b-fde7" hidden="false" targetId="2c169963-d356-aa63-60bd-eee2ee1afcc0" type="profile"/>
             <infoLink id="847e-2611-c8c5-5628" name="Gets Hot" hidden="false" targetId="f4fd-d519-4769-5510" type="rule"/>
           </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -2399,6 +2427,9 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
                   </characteristics>
                 </profile>
               </profiles>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
@@ -4877,7 +4908,7 @@ Buildings and Fortifications D</description>
           <selectionEntries>
             <selectionEntry id="b706-2690-0d23-a459" name="Multi-laser" hidden="false" collective="false" import="true" type="upgrade">
               <infoLinks>
-                <infoLink id="4af4-18f5-946b-0625" name="Multi-laser" hidden="false" targetId="c812-a8fe-2b49-75a5" type="profile"/>
+                <infoLink id="4af4-18f5-946b-0625" name="Multi-laser" hidden="false" targetId="92be-1bfc-f355-f214" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
@@ -4893,7 +4924,7 @@ Buildings and Fortifications D</description>
             </selectionEntry>
             <selectionEntry id="f835-7925-5e93-fd6e" name="Twin-linked Multi-laser" hidden="false" collective="false" import="true" type="upgrade">
               <infoLinks>
-                <infoLink id="ca3a-db81-b97f-f9a4" name="Multi-laser" hidden="false" targetId="c812-a8fe-2b49-75a5" type="profile">
+                <infoLink id="ca3a-db81-b97f-f9a4" name="Multi-laser" hidden="false" targetId="92be-1bfc-f355-f214" type="profile">
                   <modifiers>
                     <modifier type="append" field="5479706523232344415441232323" value="Twin-Linked"/>
                   </modifiers>
@@ -5117,7 +5148,7 @@ Buildings and Fortifications D</description>
                 <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a54c-2bd9-f1a5-8519" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="162d-9285-11e0-9548" name="Multi-laser" hidden="false" targetId="c812-a8fe-2b49-75a5" type="profile">
+                <infoLink id="162d-9285-11e0-9548" name="Multi-laser" hidden="false" targetId="92be-1bfc-f355-f214" type="profile">
                   <modifiers>
                     <modifier type="append" field="5479706523232344415441232323" value="Twin-Linked"/>
                   </modifiers>
@@ -5486,7 +5517,7 @@ Buildings and Fortifications D</description>
                 <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="73f2-bae4-8f9e-bcb9" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="271a-4c38-f990-c118" hidden="false" targetId="c812-a8fe-2b49-75a5" type="profile"/>
+                <infoLink id="271a-4c38-f990-c118" name="Multi-laser" hidden="false" targetId="92be-1bfc-f355-f214" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
@@ -6116,6 +6147,11 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
             <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Instant Death, Prisoned</characteristic>
           </characteristics>
         </profile>
+        <profile id="19f5-f425-8098-26d3" name="Lorica Thallax (Ursarax)" publicationId="cf03-f607-pubN123006" page="240" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
+          <characteristics>
+            <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Provides 4+ Armour and FNP 5+ but may not make Sweeping Advances</characteristic>
+          </characteristics>
+        </profile>
       </profiles>
       <rules>
         <rule id="4c49-0057-b261-0b66" name="Prisoned" publicationId="cf03-f607-pubN76979" page="225" hidden="false">
@@ -6123,7 +6159,6 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="6597-4778-af85-276b" hidden="false" targetId="405d3ced-c3a6-9f99-2018-9ab90162b6b1" type="profile"/>
         <infoLink id="ddf9-f1a0-2338-56ad" name="New InfoLink" hidden="false" targetId="38d5-b6eb-bda8-2497" type="rule"/>
         <infoLink id="a338-e667-e28c-222a" name="New InfoLink" hidden="false" targetId="9bdd-5ec7-8dd6-63c0" type="rule"/>
         <infoLink id="c9b4-d21b-e862-cae0" name="New InfoLink" hidden="false" targetId="7be5-30af-1a02-0a89" type="rule"/>
@@ -6141,10 +6176,26 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="80b7-5204-19ac-9fbe" name="May exchange Lightning Claws for:" hidden="false" collective="false" import="true">
+          <modifiers>
+            <modifier type="increment" field="a61f-706f-fe77-5fac" value="1.0">
+              <repeats>
+                <repeat field="selections" scope="2f28-034a-ca2c-5b9e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4957-7ef8-5245-25b3" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+            <modifier type="increment" field="d5c5-d9f3-94ba-102f" value="1.0">
+              <repeats>
+                <repeat field="selections" scope="2f28-034a-ca2c-5b9e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4957-7ef8-5245-25b3" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d5c5-d9f3-94ba-102f" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a61f-706f-fe77-5fac" type="min"/>
+          </constraints>
           <selectionEntries>
             <selectionEntry id="5267-8b4e-938c-aabc" name="Power Fist" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
-                <modifier type="increment" field="6d2f-7ad8-dffd-ef59" value="1">
+                <modifier type="increment" field="6d2f-7ad8-dffd-ef59" value="1.0">
                   <repeats>
                     <repeat field="selections" scope="2f28-034a-ca2c-5b9e" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4957-7ef8-5245-25b3" repeats="1" roundUp="false"/>
                   </repeats>
@@ -6158,6 +6209,24 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="6d45-350f-7bfa-5e49" name="Lightning Claws" hidden="false" collective="false" import="true" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="d0b3-0615-51c8-f4e4" value="1.0">
+                  <repeats>
+                    <repeat field="selections" scope="2f28-034a-ca2c-5b9e" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4957-7ef8-5245-25b3" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d0b3-0615-51c8-f4e4" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="883a-1c0d-4b5a-e86a" name="Lightning Claw" hidden="false" targetId="3cec-4483-3f2e-fbc2" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -7492,6 +7561,9 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7ec3-da59-1d69-df29" type="max"/>
           </constraints>
+          <entryLinks>
+            <entryLink id="df8f-ae1d-9c6b-21df" name="Power Weapon" hidden="false" collective="false" import="true" targetId="9d3d-aef5-6635-b0c6" type="selectionEntryGroup"/>
+          </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0.0"/>
           </costs>
@@ -7604,6 +7676,10 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0864-d7ea-3a5a-8d93" type="max"/>
               </constraints>
+              <infoLinks>
+                <infoLink id="31db-bbe0-adef-d4dd" name="Plasma Pistol" hidden="false" targetId="f9fd-36be-dc19-401f" type="profile"/>
+                <infoLink id="0d1f-2c8f-7ec7-f8bc" name="Gets Hot" hidden="false" targetId="f4fd-d519-4769-5510" type="rule"/>
+              </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
               </costs>
@@ -7644,6 +7720,10 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6dfd-351d-dc1e-334c" type="max"/>
               </constraints>
+              <infoLinks>
+                <infoLink id="8602-560d-15af-1d53" name="Meltagun" hidden="false" targetId="8ae4-74e5-7700-3804" type="profile"/>
+                <infoLink id="3a3a-6669-8883-a23c" name="Melta" hidden="false" targetId="21c0-62ff-3ed2-17a7" type="rule"/>
+              </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
               </costs>
@@ -7666,6 +7746,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
               </constraints>
               <infoLinks>
                 <infoLink id="f349-e824-32bc-2aee" hidden="false" targetId="43648289-5a0f-99d3-1cfc-55b689750afa" type="profile"/>
+                <infoLink id="6a6c-8fb2-a772-3c5b" name="Gets Hot" hidden="false" targetId="f4fd-d519-4769-5510" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="30.0"/>
@@ -7800,6 +7881,9 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
               </characteristics>
             </profile>
           </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="7ce7-0f51-08e6-b8fe" name="Graviton Ram" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
@@ -7836,6 +7920,9 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
             <infoLink id="4681-9f65-85ff-ee2d" name="Haywire" hidden="false" targetId="6970-1bf3-b33e-5dce" type="rule"/>
             <infoLink id="e0f1-3126-ee62-1900" name="Concussive" hidden="false" targetId="9d85-46f7-f5e6-a5f7" type="rule"/>
           </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -7970,6 +8057,9 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 <infoLink id="f835-b577-c875-f273" name="New InfoLink" hidden="false" targetId="78af-b5dc-76fa-8d9d" type="rule"/>
                 <infoLink id="7577-da36-8b6b-7684" name="Gets Hot" hidden="false" targetId="f4fd-d519-4769-5510" type="rule"/>
               </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
             </selectionEntry>
           </selectionEntries>
           <costs>
@@ -8103,6 +8193,9 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
             <infoLink id="e324-7a48-092a-d6be" hidden="false" targetId="2c169963-d356-aa63-60bd-eee2ee1afcc0" type="profile"/>
             <infoLink id="6b7d-bf18-5d79-4623" name="Gets Hot" hidden="false" targetId="f4fd-d519-4769-5510" type="rule"/>
           </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -8153,6 +8246,9 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                   </characteristics>
                 </profile>
               </profiles>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
@@ -8507,6 +8603,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
             <selectionEntry id="e121-c521-afa8-5c64" name="Plasma Pistol" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <infoLinks>
                 <infoLink id="da0f-57a1-6256-9a0a" name="Plasma Pistol" hidden="false" targetId="f4a1-b459-ba82-3789" type="profile"/>
+                <infoLink id="901a-8fcb-1b69-abaa" name="Gets Hot" hidden="false" targetId="f4fd-d519-4769-5510" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
@@ -8562,6 +8659,10 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e21c-8e84-f87f-c0c8" type="max"/>
               </constraints>
+              <infoLinks>
+                <infoLink id="3217-f6f5-2de6-9397" name="Meltagun" hidden="false" targetId="8ae4-74e5-7700-3804" type="profile"/>
+                <infoLink id="4d9e-7a03-fa1b-8560" name="Melta" hidden="false" targetId="21c0-62ff-3ed2-17a7" type="rule"/>
+              </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
               </costs>
@@ -8606,6 +8707,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
               </constraints>
               <infoLinks>
                 <infoLink id="1f4b-7df8-1957-c40b" hidden="false" targetId="43648289-5a0f-99d3-1cfc-55b689750afa" type="profile"/>
+                <infoLink id="6454-e329-02d8-3e64" name="Gets Hot" hidden="false" targetId="f4fd-d519-4769-5510" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="30.0"/>
@@ -8902,6 +9004,10 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7da0-e4e8-1bf6-0dc2" type="max"/>
               </constraints>
+              <infoLinks>
+                <infoLink id="8a8d-dc3d-5597-eb1d" name="Meltagun" hidden="false" targetId="8ae4-74e5-7700-3804" type="profile"/>
+                <infoLink id="0da1-6d72-dc3a-6194" name="Melta" hidden="false" targetId="21c0-62ff-3ed2-17a7" type="rule"/>
+              </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
               </costs>
@@ -8957,6 +9063,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
               </constraints>
               <infoLinks>
                 <infoLink id="d4fa-6ced-5c23-b81e" name="Photon Thruster" hidden="false" targetId="43648289-5a0f-99d3-1cfc-55b689750afa" type="profile"/>
+                <infoLink id="49e8-952c-6e70-e7a6" name="Gets Hot" hidden="false" targetId="f4fd-d519-4769-5510" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="30.0"/>
@@ -10838,6 +10945,7 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
         <entryLink id="e497-8836-3c5b-fdfb" name="Macharius" hidden="false" collective="false" import="true" targetId="48cf-f73d-a3c0-e911" type="selectionEntry"/>
         <entryLink id="d746-1e2e-8c7d-8bf3" name="Macharius Vulcan" publicationId="cf03-f607-pubN130172" page="230" hidden="false" collective="false" import="true" targetId="0be5-7f1a-2281-5671" type="selectionEntry"/>
         <entryLink id="356f-8bd2-3fd7-e983" name="Macharius Vanquisher" hidden="false" collective="false" import="true" targetId="07a7-a3a5-d46e-b873" type="selectionEntry"/>
+        <entryLink id="8f57-6e0a-3189-cb17" name="Macharius Omega" hidden="false" collective="false" import="true" targetId="fe5b-01ec-07b2-48ba" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
@@ -11815,9 +11923,9 @@ Assault rules unless otherwise noted.</description>
         <infoLink id="cd6e-3511-9e2c-2cc0" name="Vulcan Mega-bolter" hidden="false" targetId="0725d9e4-9558-7135-8059-379ac7a62e19" type="profile"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="7fe6-c6cc-15d5-8c12" name="New CategoryLink" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
-        <categoryLink id="a13e-2dc1-e4e1-8079" name="New CategoryLink" hidden="false" targetId="8d56-b8fc-9b94-9cc9" primary="false"/>
-        <categoryLink id="8da7-3a1b-9877-1f82" name="New CategoryLink" hidden="false" targetId="53bd-99e7-aba0-e79f" primary="false"/>
+        <categoryLink id="f1d7-0989-fdc1-43ba" name="New CategoryLink" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
+        <categoryLink id="dab2-4f2d-cd75-754a" name="Super Heavy Tank" hidden="false" targetId="8d56-b8fc-9b94-9cc9" primary="false"/>
+        <categoryLink id="1411-ff78-d2f4-17c2" name="Vehicle" hidden="false" targetId="53bd-99e7-aba0-e79f" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="42d1-c0d7-c941-1875" name="Sponsons" hidden="false" collective="false" import="true" defaultSelectionEntryId="7c79-ce78-c993-284f">
@@ -12109,7 +12217,7 @@ Any abilities that allow the vehicle to fire multiple shots will use the same sh
                 <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a2d1-2d62-35fb-ba48" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="59d7-7fa2-1989-c144" hidden="false" targetId="c812-a8fe-2b49-75a5" type="profile"/>
+                <infoLink id="59d7-7fa2-1989-c144" name="Multi-laser" hidden="false" targetId="92be-1bfc-f355-f214" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
@@ -12553,6 +12661,113 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="150.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="fe5b-01ec-07b2-48ba" name="Macharius Omega" publicationId="2369-0496-8060-eda3" page="35" hidden="false" collective="false" import="true" type="unit">
+      <profiles>
+        <profile id="2088-be7e-84ab-0097" name="Macharius Omega" hidden="false" typeId="56656869636c6523232344415441232323" typeName="Vehicle">
+          <characteristics>
+            <characteristic name="BS" typeId="425323232344415441232323">3</characteristic>
+            <characteristic name="Front" typeId="46726f6e7423232344415441232323">14</characteristic>
+            <characteristic name="Side" typeId="5369646523232344415441232323">13</characteristic>
+            <characteristic name="Rear" typeId="5265617223232344415441232323">12</characteristic>
+            <characteristic name="HP" typeId="485023232344415441232323">6</characteristic>
+            <characteristic name="Type" typeId="5479706523232344415441232323">Super-heavy Vehicle</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <categoryLinks>
+        <categoryLink id="217b-9534-dc28-0a7e" name="Vehicle" hidden="false" targetId="53bd-99e7-aba0-e79f" primary="false"/>
+        <categoryLink id="e677-1352-153a-e030" name="Super Heavy Tank" hidden="false" targetId="8d56-b8fc-9b94-9cc9" primary="false"/>
+        <categoryLink id="c16d-a6d7-aeef-555e" name="New CategoryLink" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="b8c4-869f-dcfa-bc6a" name="Omega Pattern Plasma Blastgun" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c3a8-ec97-b841-d955" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="91f7-3bde-fe7c-5279" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="925d-a089-b207-4755" name="Omega Pattern Plasma Blastgun (Maximal)" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="52616e676523232344415441232323">72&quot;</characteristic>
+                <characteristic name="Strength" typeId="537472656e67746823232344415441232323">9</characteristic>
+                <characteristic name="AP" typeId="415023232344415441232323">2</characteristic>
+                <characteristic name="Type" typeId="5479706523232344415441232323">Primary Weapon 1, Massive Blast (7&quot;), Meltdown</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="199e-5fa3-75e5-8f7f" name="Omega Pattern Plasma Blastgun (Pulsed Bolts)" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="52616e676523232344415441232323">60&quot;</characteristic>
+                <characteristic name="Strength" typeId="537472656e67746823232344415441232323">7</characteristic>
+                <characteristic name="AP" typeId="415023232344415441232323">2</characteristic>
+                <characteristic name="Type" typeId="5479706523232344415441232323">Primary Weapon 3, Large Blast</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="46e8-4758-f822-2b41" name="Meltdown" publicationId="2369-0496-8060-eda3" page="135" hidden="false">
+              <description>Roll 1D6 for each shot fired by the weapon with the meltdown rule. on the roll of a 1, the vehicle suffers D3 glancing hits. If the vehicle is permitted to reroll, only a subsequent result of a 1 will cause this damage.</description>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="ad0f-0cbd-23b7-65dc" name="Primary Weapon" hidden="false" targetId="e64b-54b8-34df-2f13" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="cd90-33e8-9153-6fbb" name="May take any of the following:" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1813-2081-24bd-3029" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="96a9-ad18-8c53-ee52" name="Hunter-killer Missile" page="0" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d4d5-cede-9480-b9b4" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="db54-45bc-097e-91c0" name="Sponson-mounted Weapons" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="554d-96ea-815e-bce1" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="7ae6-c5c4-9e3c-774a" name="2x Heavy Bolters" page="0" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="21d5-a47d-9869-b35d" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="1c3c-a85b-910b-8730" name="2x Heavy Flamers" page="0" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b1b3-ebab-ea77-ae3e" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="ab67-36ed-bc2a-3a74" name="2x Autocannon" page="0" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e3c0-5339-2f14-ce74" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="20.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="points" value="355.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>

--- a/(HH) Mechanicum - Taghmata Army List.cat
+++ b/(HH) Mechanicum - Taghmata Army List.cat
@@ -1651,7 +1651,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
           <profiles>
             <profile id="1d9f-74bd-40b6-8d34" name="Thanatar Class Siege-automata" publicationId="cf03-f607-pubN76270" page="51" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
               <modifiers>
-                <modifier type="increment" field="4923232344415441232323" value="1">
+                <modifier type="set" field="4923232344415441232323" value="3*">
                   <conditions>
                     <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="d266-0416-a5a6-881e" type="equalTo"/>
                   </conditions>
@@ -1813,7 +1813,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
           <profiles>
             <profile id="659d-11d2-faad-4259" name="Castellax" publicationId="cf03-f607-pubN76270" page="41" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
               <modifiers>
-                <modifier type="increment" field="4923232344415441232323" value="1">
+                <modifier type="set" field="4923232344415441232323" value="4*">
                   <conditions>
                     <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="d266-0416-a5a6-881e" type="equalTo"/>
                   </conditions>
@@ -2081,7 +2081,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
           <profiles>
             <profile id="712d-49a5-7c53-fbc4" name="Vorax" publicationId="cf03-f607-pubN76270" page="46" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
               <modifiers>
-                <modifier type="increment" field="4923232344415441232323" value="1">
+                <modifier type="set" field="4923232344415441232323" value="5*">
                   <conditions>
                     <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="d266-0416-a5a6-881e" type="equalTo"/>
                   </conditions>
@@ -2322,7 +2322,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
       <profiles>
         <profile id="6541-820d-ace7-de64" name="Arlatax" publicationId="cf03-f607-pubN80487" page="274" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
           <modifiers>
-            <modifier type="increment" field="4923232344415441232323" value="1">
+            <modifier type="set" field="4923232344415441232323" value="5*">
               <conditions>
                 <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="d266-0416-a5a6-881e" type="equalTo"/>
               </conditions>
@@ -2683,7 +2683,8 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <rule id="a41a-3473-ef5f-7a99" name="Machinator Array" publicationId="cf03-f607-pubN82540" page="112" hidden="false">
           <description>A machinator array adds +1 to its user’s Toughness value and provides the Night Vision special rule. It also incorporates a flamer and an inferno pistol, and the user can either opt to fire both of these weapons in the Shooting phase, or one of them and another ranged weapon the model is carrying.
 A model with the Battlesmith special rule may add +2 to their Repair roll result if they are also equipped with a machinator array.
-A model equipped with a machinator array may make two additional attacks per turn in close combat as well as any they would normally be eligible to make. This is done using the profile shown below:</description>
+A model equipped with a machinator array may make two additional attacks per turn in close combat as well as any they would normally be eligible to make. This is done using the profile shown below:
+*Included in Battlescribe Profiles when taken</description>
         </rule>
       </rules>
       <infoLinks>
@@ -4515,7 +4516,7 @@ Buildings and Fortifications D</description>
           <profiles>
             <profile id="dff2-ef91-c9fb-bcb3" name="Vultarax Stratos-automata" publicationId="cf03-f607-pubN76270" page="46" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
               <modifiers>
-                <modifier type="increment" field="4923232344415441232323" value="1">
+                <modifier type="set" field="4923232344415441232323" value="4*">
                   <conditions>
                     <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="d266-0416-a5a6-881e" type="equalTo"/>
                   </conditions>
@@ -5368,7 +5369,8 @@ Buildings and Fortifications D</description>
     <selectionEntry id="d266-0416-a5a6-881e" name="Legio Cybernetica" hidden="false" collective="false" import="true" type="upgrade">
       <rules>
         <rule id="63b4-5638-3ee9-3f50" name="Enhanced Cyber Control" publicationId="cf03-f607-pubN93687" page="74" hidden="false">
-          <description>When chosen as a part of a Legio Cybernetica Battle Cohort detachment, all models with a Cybernetica Cortex gain +1 to their Initiative characteristic.</description>
+          <description>When chosen as a part of a Legio Cybernetica Battle Cohort detachment, all models with a Cybernetica Cortex gain +1 to their Initiative characteristic.
+*Iincluded in profiles on Battlescribe</description>
         </rule>
         <rule id="f400-2aae-e7a1-8dd1" name="Rule of the Dominus" publicationId="cf03-f607-pubN93687" page="74" hidden="false">
           <description>If chosen as a Primary Detachment, then if no models with the Cortex Controller wargear survive from the detachment in play at the end of the game, the opposing side gains +D3 additional Victory Points in missions where this is relevant.</description>
@@ -5835,7 +5837,8 @@ Buildings and Fortifications D</description>
       </constraints>
       <rules>
         <rule id="59e8-556e-c520-2259" name="Mech-assassin" publicationId="cf03-f607-pubN76979" page="215" hidden="false">
-          <description>WS and Attacks are increased by +1</description>
+          <description>WS and Attacks are increased by +1
+*Included in profiles on Battlescribe</description>
         </rule>
         <rule id="a682-30d3-5a50-65cb" name="Preferred Enemy (Characters)" page="0" hidden="false"/>
       </rules>
@@ -5908,14 +5911,14 @@ Buildings and Fortifications D</description>
       <profiles>
         <profile id="0a16-d44e-d1c5-294f" name="Anacharis Scoria" publicationId="cf03-f607-pubN80487" page="272" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
           <modifiers>
-            <modifier type="set" field="5723232344415441232323" value="5">
+            <modifier type="set" field="5723232344415441232323" value="5*">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7036-e2e2-8907-a43e" type="greaterThan"/>
+                <condition field="selections" scope="83ef-4568-5093-61d5" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7036-e2e2-8907-a43e" type="equalTo"/>
               </conditions>
             </modifier>
-            <modifier type="set" field="4123232344415441232323" value="4">
+            <modifier type="set" field="4123232344415441232323" value="4*">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7036-e2e2-8907-a43e" type="equalTo"/>
+                <condition field="selections" scope="83ef-4568-5093-61d5" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7036-e2e2-8907-a43e" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -5924,7 +5927,7 @@ Buildings and Fortifications D</description>
             <characteristic name="WS" typeId="575323232344415441232323">5</characteristic>
             <characteristic name="BS" typeId="425323232344415441232323">5</characteristic>
             <characteristic name="S" typeId="5323232344415441232323">5</characteristic>
-            <characteristic name="T" typeId="5423232344415441232323">5</characteristic>
+            <characteristic name="T" typeId="5423232344415441232323">6*</characteristic>
             <characteristic name="W" typeId="5723232344415441232323">4</characteristic>
             <characteristic name="I" typeId="4923232344415441232323">5</characteristic>
             <characteristic name="A" typeId="4123232344415441232323">3</characteristic>
@@ -5998,7 +6001,8 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
               <profiles>
                 <profile id="b4c8-e5ff-4fe8-1de3" name="Xanathite Abeyant" publicationId="cf03-f607-pubN80487" page="273" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
                   <characteristics>
-                    <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Confers +1 Wound, +1 Attack, Move Through Cover, Very Bulky, Hardened Armour, It Will Not Die, and a Photon Thruster which can be fired in addition to his usual shooting attacks.  </characteristic>
+                    <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Confers +1 Wound, +1 Attack, Move Through Cover, Very Bulky, Hardened Armour, It Will Not Die, and a Photon Thruster which can be fired in addition to his usual shooting attacks.
+*Included in Battlescribe profile if taken</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -6016,6 +6020,16 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="1a88-b612-b46f-0ad5" name="Machinator Array" hidden="false" collective="false" import="true" targetId="9d9f-63d3-f635-7fd5" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="points" value="0.0"/>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c9c3-346c-8026-1baf" type="min"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="275.0"/>
       </costs>
@@ -6239,6 +6253,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
     <selectionEntry id="8352-9d62-82af-9642" name="Legio" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="a31c-5898-b718-da0c" type="max"/>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="d840-836e-ac79-65a6" type="min"/>
       </constraints>
       <categoryLinks>
         <categoryLink id="a702-5a7f-6560-9221" name="New CategoryLink" hidden="false" targetId="5297-7e0f-fa0b-3537" primary="true"/>
@@ -6472,7 +6487,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
           <profiles>
             <profile id="bfb5-ae03-0ddd-18d3" name="Domitar Class Battle-automata" publicationId="cf03-f607-pubN80965" page="227" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
               <modifiers>
-                <modifier type="increment" field="4923232344415441232323" value="1">
+                <modifier type="set" field="4923232344415441232323" value="4*">
                   <conditions>
                     <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="d266-0416-a5a6-881e" type="equalTo"/>
                   </conditions>
@@ -7498,15 +7513,15 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
       <profiles>
         <profile id="51d0-31e2-8fa6-8581" name="Archmagos Dominus" publicationId="cf03-f607-pubN76780" page="75" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
           <modifiers>
-            <modifier type="increment" field="5723232344415441232323" value="1">
-              <repeats>
-                <repeat field="selections" scope="e35b-b300-7fb2-e063" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="df18-c724-2a3d-a6e5" repeats="1" roundUp="false"/>
-              </repeats>
+            <modifier type="set" field="5723232344415441232323" value="4*">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="df18-c724-2a3d-a6e5" type="equalTo"/>
+              </conditions>
             </modifier>
-            <modifier type="increment" field="5423232344415441232323" value="1">
-              <repeats>
-                <repeat field="selections" scope="e35b-b300-7fb2-e063" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b12a-8c7a-29c8-6b85" repeats="1" roundUp="false"/>
-              </repeats>
+            <modifier type="set" field="5423232344415441232323" value="6*">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9d9f-63d3-f635-7fd5" type="equalTo"/>
+              </conditions>
             </modifier>
           </modifiers>
           <characteristics>
@@ -7801,7 +7816,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
       <profiles>
         <profile id="ca31-e06c-7410-8919" name="Thanatar-Calix Class Siege-Automata" publicationId="cf03-f607-pubN76270" page="52" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
           <modifiers>
-            <modifier type="increment" field="4923232344415441232323" value="1">
+            <modifier type="set" field="4923232344415441232323" value="3*">
               <conditions>
                 <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="d266-0416-a5a6-881e" type="equalTo"/>
               </conditions>
@@ -7981,7 +7996,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
           <profiles>
             <profile id="1943-9446-88bf-f4ed" name="Thanatar-Cynis Class Siege-Automata" publicationId="cf03-f607-pubN76270" page="54" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
               <modifiers>
-                <modifier type="increment" field="4923232344415441232323" value="1">
+                <modifier type="set" field="4923232344415441232323" value="3*">
                   <conditions>
                     <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="d266-0416-a5a6-881e" type="equalTo"/>
                   </conditions>
@@ -8135,7 +8150,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
       <profiles>
         <profile id="3a6d-c2a2-4a35-88e9" name="Homonculex" publicationId="cf03-f607-pubN80487" page="274" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
           <modifiers>
-            <modifier type="increment" field="4923232344415441232323" value="1">
+            <modifier type="set" field="4923232344415441232323" value="5*">
               <conditions>
                 <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="d266-0416-a5a6-881e" type="equalTo"/>
               </conditions>
@@ -8264,12 +8279,19 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
       </constraints>
       <profiles>
         <profile id="271a-bd31-7c7b-dbff" name="Archmagos Draykavac" publicationId="cf03-f607-pubN99227" page="300" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+          <modifiers>
+            <modifier type="set" field="5723232344415441232323" value="4*">
+              <conditions>
+                <condition field="selections" scope="2ff2-0526-3cea-acb2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b64f-0f26-64a5-8298" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
           <characteristics>
             <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry (Character)</characteristic>
             <characteristic name="WS" typeId="575323232344415441232323">4</characteristic>
             <characteristic name="BS" typeId="425323232344415441232323">5</characteristic>
             <characteristic name="S" typeId="5323232344415441232323">4</characteristic>
-            <characteristic name="T" typeId="5423232344415441232323">6</characteristic>
+            <characteristic name="T" typeId="5423232344415441232323">6*</characteristic>
             <characteristic name="W" typeId="5723232344415441232323">3</characteristic>
             <characteristic name="I" typeId="4923232344415441232323">4</characteristic>
             <characteristic name="A" typeId="4123232344415441232323">2</characteristic>
@@ -8298,7 +8320,6 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="db0f-e9d8-6b2e-5b89" hidden="false" targetId="3ffc1f76-719b-bc95-a3c9-15614a8c94bc" type="profile"/>
         <infoLink id="4e97-83b5-18a8-fbb5" hidden="false" targetId="ec8086ee-40ef-30cb-d8ed-2138991ab56b" type="profile"/>
         <infoLink id="0418-9e63-463b-8b4e" name="Cortex Controller" hidden="false" targetId="e135-8b23-7190-9f2c" type="profile">
           <modifiers>
@@ -8347,6 +8368,14 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
       <entryLinks>
         <entryLink id="e9ff-c808-888a-3bd8" hidden="false" collective="false" import="true" targetId="df18-c724-2a3d-a6e5" type="selectionEntryGroup"/>
         <entryLink id="bf87-03a2-476e-4512" name="Archmagos" hidden="false" collective="false" import="true" targetId="00cf-20ab-1b17-aad1" type="selectionEntry"/>
+        <entryLink id="178e-d55f-b46f-db6d" name="Machinator Array" hidden="false" collective="false" import="true" targetId="9d9f-63d3-f635-7fd5" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="points" value="0.0"/>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f2ac-5602-cd1e-0955" type="min"/>
+          </constraints>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="240.0"/>
@@ -8450,12 +8479,12 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
       <profiles>
         <profile id="594a-289b-a120-b0fe" name="Magos Dominus" publicationId="cf03-f607-pubN76979" page="218" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
           <modifiers>
-            <modifier type="increment" field="5423232344415441232323" value="1">
+            <modifier type="set" field="5423232344415441232323" value="5*">
               <conditions>
                 <condition field="selections" scope="f891-cee8-321e-f159" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fd25-794a-04f3-54e0" type="equalTo"/>
               </conditions>
             </modifier>
-            <modifier type="increment" field="5723232344415441232323" value="1">
+            <modifier type="set" field="5723232344415441232323" value="3*">
               <conditions>
                 <condition field="selections" scope="f891-cee8-321e-f159" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab7e-c741-1e8e-0b4f" type="equalTo"/>
               </conditions>
@@ -8745,22 +8774,22 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 <condition field="selections" scope="aa74-77f4-7266-36b6" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="076b-2276-b456-9d6f" type="greaterThan"/>
               </conditions>
             </modifier>
-            <modifier type="increment" field="5423232344415441232323" value="1">
+            <modifier type="set" field="5423232344415441232323" value="5*">
               <conditions>
                 <condition field="selections" scope="aa74-77f4-7266-36b6" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c0d7-ca99-c60d-789b" type="equalTo"/>
               </conditions>
             </modifier>
-            <modifier type="increment" field="5723232344415441232323" value="1">
+            <modifier type="set" field="5723232344415441232323" value="3*">
               <conditions>
                 <condition field="selections" scope="aa74-77f4-7266-36b6" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1ad6-9042-a001-972b" type="equalTo"/>
               </conditions>
             </modifier>
-            <modifier type="increment" field="575323232344415441232323" value="1">
+            <modifier type="set" field="575323232344415441232323" value="4*">
               <conditions>
                 <condition field="selections" scope="aa74-77f4-7266-36b6" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c615-024f-f3f7-78e6" type="equalTo"/>
               </conditions>
             </modifier>
-            <modifier type="increment" field="4123232344415441232323" value="1">
+            <modifier type="set" field="4123232344415441232323" value="3*">
               <conditions>
                 <condition field="selections" scope="aa74-77f4-7266-36b6" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c615-024f-f3f7-78e6" type="equalTo"/>
               </conditions>
@@ -8798,22 +8827,22 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
           <profiles>
             <profile id="fa6c-41f2-66df-2115" name="Archmagos Prime" publicationId="cf03-f607-pubN76979" page="214" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
               <modifiers>
-                <modifier type="increment" field="5423232344415441232323" value="1">
+                <modifier type="set" field="5423232344415441232323" value="6*">
                   <conditions>
                     <condition field="selections" scope="aa74-77f4-7266-36b6" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c0d7-ca99-c60d-789b" type="equalTo"/>
                   </conditions>
                 </modifier>
-                <modifier type="increment" field="5723232344415441232323" value="1">
+                <modifier type="set" field="5723232344415441232323" value="4*">
                   <conditions>
                     <condition field="selections" scope="aa74-77f4-7266-36b6" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1ad6-9042-a001-972b" type="equalTo"/>
                   </conditions>
                 </modifier>
-                <modifier type="increment" field="575323232344415441232323" value="1">
+                <modifier type="set" field="575323232344415441232323" value="5*">
                   <conditions>
                     <condition field="selections" scope="aa74-77f4-7266-36b6" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c615-024f-f3f7-78e6" type="equalTo"/>
                   </conditions>
                 </modifier>
-                <modifier type="increment" field="4123232344415441232323" value="1">
+                <modifier type="set" field="4123232344415441232323" value="3*">
                   <conditions>
                     <condition field="selections" scope="aa74-77f4-7266-36b6" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c615-024f-f3f7-78e6" type="equalTo"/>
                   </conditions>
@@ -9282,12 +9311,12 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 <condition field="selections" scope="04e8-11de-2eb4-67e0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8952-ed12-5b98-7de7" type="equalTo"/>
               </conditions>
             </modifier>
-            <modifier type="increment" field="5423232344415441232323" value="1">
+            <modifier type="set" field="5423232344415441232323" value="5*">
               <conditions>
                 <condition field="selections" scope="04e8-11de-2eb4-67e0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="919a-ac57-084f-a5c5" type="equalTo"/>
               </conditions>
             </modifier>
-            <modifier type="increment" field="5723232344415441232323" value="1">
+            <modifier type="set" field="5723232344415441232323" value="3*">
               <conditions>
                 <condition field="selections" scope="04e8-11de-2eb4-67e0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="85b6-d34f-8949-cb91" type="equalTo"/>
               </conditions>
@@ -9313,12 +9342,12 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 <condition field="selections" scope="04e8-11de-2eb4-67e0" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8952-ed12-5b98-7de7" type="equalTo"/>
               </conditions>
             </modifier>
-            <modifier type="increment" field="5423232344415441232323" value="1">
+            <modifier type="set" field="5423232344415441232323" value="6*">
               <conditions>
                 <condition field="selections" scope="04e8-11de-2eb4-67e0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="919a-ac57-084f-a5c5" type="equalTo"/>
               </conditions>
             </modifier>
-            <modifier type="increment" field="5723232344415441232323" value="1">
+            <modifier type="set" field="5723232344415441232323" value="4*">
               <conditions>
                 <condition field="selections" scope="04e8-11de-2eb4-67e0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="85b6-d34f-8949-cb91" type="equalTo"/>
               </conditions>
@@ -9794,7 +9823,7 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
             <characteristic name="WS" typeId="575323232344415441232323">3</characteristic>
             <characteristic name="BS" typeId="425323232344415441232323">4</characteristic>
             <characteristic name="S" typeId="5323232344415441232323">5</characteristic>
-            <characteristic name="T" typeId="5423232344415441232323">5</characteristic>
+            <characteristic name="T" typeId="5423232344415441232323">5*</characteristic>
             <characteristic name="W" typeId="5723232344415441232323">3</characteristic>
             <characteristic name="I" typeId="4923232344415441232323">4</characteristic>
             <characteristic name="A" typeId="4123232344415441232323">2</characteristic>
@@ -9928,6 +9957,14 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
       <entryLinks>
         <entryLink id="fc9b-b619-b8cd-bf76" name="Cyber-familiar" hidden="false" collective="false" import="true" targetId="dd09a633-0c59-7ea7-d62e-e978aefb3cff" type="selectionEntry"/>
         <entryLink id="c692-95ee-a268-68e5" hidden="false" collective="false" import="true" targetId="0de5-5b51-907d-e5e2" type="selectionEntry"/>
+        <entryLink id="e253-f716-a506-e14e" name="Machinator Array" hidden="false" collective="false" import="true" targetId="9d9f-63d3-f635-7fd5" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="points" value="0.0"/>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="133c-a2bf-6bf4-dac2" type="min"/>
+          </constraints>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="175.0"/>

--- a/(HH) Mechanicum - Taghmata Army List.cat
+++ b/(HH) Mechanicum - Taghmata Army List.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="cf03-f607-41dc-7545" name="Mechanicum: Taghmata Army List" revision="92" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="85" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="cf03-f607-41dc-7545" name="Mechanicum: Taghmata Army List" revision="91" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="85" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="cf03-f607-pubN65537" name="Horus Heresy: Taghmata Army List"/>
     <publication id="cf03-f607-pubN65563" name="AoDRB"/>

--- a/(HH) Necron Army List.cat
+++ b/(HH) Necron Army List.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="b50f-0671-3aea-cf90" name="Necron Army List (Fanmade)" revision="3" battleScribeVersion="2.03" authorName="Dono Author / Maye Gelt the Battlescribbler" authorContact="Dono (for Content) / Maye Gelt (for Battlescibbling)" authorUrl="http://www.facebook.com/AUS30K" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="108" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="b50f-0671-3aea-cf90" name="Necron Army List (Fanmade)" revision="4" battleScribeVersion="2.03" authorName="Dono Author / Maye Gelt the Battlescribbler" authorContact="Dono (for Content) / Maye Gelt (for Battlescibbling)" authorUrl="http://www.facebook.com/AUS30K" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="108" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="6fc6-dd7c-7a39-b0c8" name="30K Necron Army List (Fanmade)"/>
   </publications>
@@ -59,6 +59,15 @@
                 <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e77c-6929-efc9-2983" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
+            <modifier type="decrement" field="d329-3658-29da-4d2a" value="1.0">
+              <repeats>
+                <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="d48a-abe8-0b89-51fd" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="38b1-9536-4af6-f327" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="69bf-f8d0-0dea-3708" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="b04e-14f3-f749-2279" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="086d-4581-2fd4-0c62" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
           </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d329-3658-29da-4d2a" type="min"/>
@@ -97,9 +106,9 @@
         </categoryLink>
         <categoryLink id="e184-7801-3112-33b1" name="Fast Attack" hidden="false" targetId="a673-7d7e-4e32-171a" primary="false">
           <modifiers>
-            <modifier type="increment" field="79f8-9afe-621b-9c87" value="3.0">
+            <modifier type="increment" field="79f8-9afe-621b-9c87" value="1.0">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab10-ea27-64d3-4246" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e77c-6929-efc9-2983" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -831,6 +840,15 @@
             <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e77c-6929-efc9-2983" repeats="1" roundUp="false"/>
           </repeats>
         </modifier>
+        <modifier type="decrement" field="a120-9494-6ad0-07b8" value="1.0">
+          <repeats>
+            <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="69bf-f8d0-0dea-3708" repeats="1" roundUp="false"/>
+            <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="086d-4581-2fd4-0c62" repeats="1" roundUp="false"/>
+            <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="b04e-14f3-f749-2279" repeats="1" roundUp="false"/>
+            <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="38b1-9536-4af6-f327" repeats="1" roundUp="false"/>
+            <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="d48a-abe8-0b89-51fd" repeats="1" roundUp="false"/>
+          </repeats>
+        </modifier>
       </modifiers>
       <constraints>
         <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a120-9494-6ad0-07b8" type="min"/>
@@ -1106,22 +1124,20 @@
       <constraints>
         <constraint field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2ba8-8b9f-b6fb-161a" type="max"/>
       </constraints>
+      <rules>
+        <rule id="08d6-cc63-f773-1952" name="Royal Court" hidden="false">
+          <description>The members of the Conclave may be distributed and attached amongst the armies Dynastic Legion units, except for Tomb Blades, and the armies Lords, Nemesor and/or Overlord. In addition each Cryptek Lord may count as a Bronze Lord for the purposes of the Force Organisational Chart, but may not be Warlord.</description>
+        </rule>
+        <rule id="7c02-e184-03cb-00ba" name="Technomancer" hidden="false">
+          <description>If this model and the unit it is attached to is destroyed, the Technomancer may attempt its Reanimation Protocol first and, if successful, allows for the rest of the unit to also attempt its Reanimation Protocol.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="7c97-88a3-294d-1a0b" name="Reanimation Protocols" hidden="false" targetId="d0e0-b3d2-1273-9e33" type="rule"/>
+      </infoLinks>
       <selectionEntries>
         <selectionEntry id="e95a-f4cd-995e-9234" name="Cryptek" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
-            <modifier type="set" field="points" value="65.0">
-              <conditionGroups>
-                <conditionGroup type="or">
-                  <conditions>
-                    <condition field="selections" scope="9a39-bed4-a90f-ded4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1e28-5e09-e179-e876" type="equalTo"/>
-                    <condition field="selections" scope="9a39-bed4-a90f-ded4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5e51-818f-a343-dcf2" type="equalTo"/>
-                    <condition field="selections" scope="9a39-bed4-a90f-ded4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b632-c2db-9a76-2997" type="equalTo"/>
-                    <condition field="selections" scope="9a39-bed4-a90f-ded4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="36ea-c1a8-11a0-b47f" type="equalTo"/>
-                    <condition field="selections" scope="9a39-bed4-a90f-ded4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="18a3-a2f0-a7e3-6fa1" type="equalTo"/>
-                  </conditions>
-                </conditionGroup>
-              </conditionGroups>
-            </modifier>
             <modifier type="append" field="name" value="Harbinger of Despair">
               <conditions>
                 <condition field="selections" scope="9a39-bed4-a90f-ded4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1e28-5e09-e179-e876" type="equalTo"/>
@@ -1147,6 +1163,28 @@
                 <condition field="selections" scope="9a39-bed4-a90f-ded4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="18a3-a2f0-a7e3-6fa1" type="equalTo"/>
               </conditions>
             </modifier>
+            <modifier type="set" field="e736-669d-a5d1-f3f3" value="0.0">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="9a39-bed4-a90f-ded4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="69bf-f8d0-0dea-3708" type="equalTo"/>
+                    <condition field="selections" scope="9a39-bed4-a90f-ded4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="38b1-9536-4af6-f327" type="equalTo"/>
+                    <condition field="selections" scope="9a39-bed4-a90f-ded4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b04e-14f3-f749-2279" type="equalTo"/>
+                    <condition field="selections" scope="9a39-bed4-a90f-ded4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="086d-4581-2fd4-0c62" type="equalTo"/>
+                    <condition field="selections" scope="9a39-bed4-a90f-ded4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d48a-abe8-0b89-51fd" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="decrement" field="c647-7ba7-b656-1c98" value="1.0">
+              <repeats>
+                <repeat field="selections" scope="9a39-bed4-a90f-ded4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="38b1-9536-4af6-f327" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="9a39-bed4-a90f-ded4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="086d-4581-2fd4-0c62" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="9a39-bed4-a90f-ded4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="69bf-f8d0-0dea-3708" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="9a39-bed4-a90f-ded4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d48a-abe8-0b89-51fd" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="9a39-bed4-a90f-ded4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b04e-14f3-f749-2279" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
           </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c647-7ba7-b656-1c98" type="max"/>
@@ -1168,14 +1206,6 @@
               </characteristics>
             </profile>
           </profiles>
-          <rules>
-            <rule id="48c8-9239-ffd8-ab5f" name="Royal Court" hidden="false">
-              <description>The members of the Conclave may be distributed and attached amongst the armies Dynastic Legion units, except for Tomb Blades. In addition they may be attached to the armies Lords, Nemesor and/or Overlord.</description>
-            </rule>
-            <rule id="3726-cda0-9e9a-426b" name="Technomancer" hidden="false">
-              <description>If this model and the unit it is attached to is destroyed, the Technomancer may attempt its Reanimation Protocol first and, if successful, allows for the rest of the unit to also attempt its Reanimation Protocol.</description>
-            </rule>
-          </rules>
           <infoLinks>
             <infoLink id="69bb-3844-8e78-7c67" name="Reanimation Protocols" hidden="false" targetId="d0e0-b3d2-1273-9e33" type="rule"/>
           </infoLinks>
@@ -1238,7 +1268,7 @@
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
-            <selectionEntryGroup id="e860-cffc-d3cd-a883" name="Disciples may take 1 of these if they have no Canoptek Khepri Drones &amp; have upgraded to their disciples weapon. (Only 1 of each per army)" hidden="false" collective="false" import="true">
+            <selectionEntryGroup id="e860-cffc-d3cd-a883" name="Disciples may take 1 of these &amp; have upgraded to their disciples weapon. (Only 1 of each per army)" hidden="false" collective="false" import="true">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4473-b010-7ebb-4ada" type="max"/>
               </constraints>
@@ -1250,7 +1280,6 @@
                         <conditionGroup type="and">
                           <conditions>
                             <condition field="selections" scope="9a39-bed4-a90f-ded4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="36ea-c1a8-11a0-b47f" type="equalTo"/>
-                            <condition field="selections" scope="e95a-f4cd-995e-9234" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4774-127a-6f12-3b15" type="equalTo"/>
                             <condition field="selections" scope="e95a-f4cd-995e-9234" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bd19-a0a1-d9b7-b21e" type="equalTo"/>
                           </conditions>
                         </conditionGroup>
@@ -1265,7 +1294,6 @@
                         <conditionGroup type="and">
                           <conditions>
                             <condition field="selections" scope="9a39-bed4-a90f-ded4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="36ea-c1a8-11a0-b47f" type="equalTo"/>
-                            <condition field="selections" scope="e95a-f4cd-995e-9234" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4774-127a-6f12-3b15" type="equalTo"/>
                             <condition field="selections" scope="e95a-f4cd-995e-9234" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bd19-a0a1-d9b7-b21e" type="equalTo"/>
                           </conditions>
                         </conditionGroup>
@@ -1280,7 +1308,6 @@
                         <conditionGroup type="and">
                           <conditions>
                             <condition field="selections" scope="e95a-f4cd-995e-9234" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dd1c-6375-b144-6f1d" type="equalTo"/>
-                            <condition field="selections" scope="e95a-f4cd-995e-9234" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4774-127a-6f12-3b15" type="equalTo"/>
                             <condition field="selections" scope="9a39-bed4-a90f-ded4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1e28-5e09-e179-e876" type="equalTo"/>
                           </conditions>
                         </conditionGroup>
@@ -1295,7 +1322,6 @@
                         <conditionGroup type="and">
                           <conditions>
                             <condition field="selections" scope="9a39-bed4-a90f-ded4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1e28-5e09-e179-e876" type="equalTo"/>
-                            <condition field="selections" scope="e95a-f4cd-995e-9234" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4774-127a-6f12-3b15" type="equalTo"/>
                             <condition field="selections" scope="e95a-f4cd-995e-9234" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dd1c-6375-b144-6f1d" type="equalTo"/>
                           </conditions>
                         </conditionGroup>
@@ -1310,7 +1336,6 @@
                         <conditionGroup type="and">
                           <conditions>
                             <condition field="selections" scope="e95a-f4cd-995e-9234" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="32c0-c740-8cc9-c98c" type="equalTo"/>
-                            <condition field="selections" scope="e95a-f4cd-995e-9234" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4774-127a-6f12-3b15" type="equalTo"/>
                             <condition field="selections" scope="9a39-bed4-a90f-ded4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="18a3-a2f0-a7e3-6fa1" type="equalTo"/>
                           </conditions>
                         </conditionGroup>
@@ -1325,7 +1350,6 @@
                         <conditionGroup type="and">
                           <conditions>
                             <condition field="selections" scope="e95a-f4cd-995e-9234" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="32c0-c740-8cc9-c98c" type="equalTo"/>
-                            <condition field="selections" scope="e95a-f4cd-995e-9234" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4774-127a-6f12-3b15" type="equalTo"/>
                             <condition field="selections" scope="9a39-bed4-a90f-ded4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="18a3-a2f0-a7e3-6fa1" type="equalTo"/>
                           </conditions>
                         </conditionGroup>
@@ -1340,7 +1364,6 @@
                         <conditionGroup type="and">
                           <conditions>
                             <condition field="selections" scope="e95a-f4cd-995e-9234" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4dc4-42f8-0e21-86ac" type="equalTo"/>
-                            <condition field="selections" scope="e95a-f4cd-995e-9234" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4774-127a-6f12-3b15" type="equalTo"/>
                             <condition field="selections" scope="9a39-bed4-a90f-ded4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b632-c2db-9a76-2997" type="equalTo"/>
                           </conditions>
                         </conditionGroup>
@@ -1355,7 +1378,6 @@
                         <conditionGroup type="and">
                           <conditions>
                             <condition field="selections" scope="e95a-f4cd-995e-9234" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4dc4-42f8-0e21-86ac" type="equalTo"/>
-                            <condition field="selections" scope="e95a-f4cd-995e-9234" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4774-127a-6f12-3b15" type="equalTo"/>
                             <condition field="selections" scope="9a39-bed4-a90f-ded4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b632-c2db-9a76-2997" type="equalTo"/>
                           </conditions>
                         </conditionGroup>
@@ -1370,7 +1392,6 @@
                         <conditionGroup type="and">
                           <conditions>
                             <condition field="selections" scope="e95a-f4cd-995e-9234" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8855-e8b7-ccb4-895f" type="equalTo"/>
-                            <condition field="selections" scope="e95a-f4cd-995e-9234" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4774-127a-6f12-3b15" type="equalTo"/>
                             <condition field="selections" scope="9a39-bed4-a90f-ded4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5e51-818f-a343-dcf2" type="equalTo"/>
                           </conditions>
                         </conditionGroup>
@@ -1385,7 +1406,6 @@
                         <conditionGroup type="and">
                           <conditions>
                             <condition field="selections" scope="e95a-f4cd-995e-9234" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8855-e8b7-ccb4-895f" type="equalTo"/>
-                            <condition field="selections" scope="e95a-f4cd-995e-9234" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4774-127a-6f12-3b15" type="equalTo"/>
                             <condition field="selections" scope="9a39-bed4-a90f-ded4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5e51-818f-a343-dcf2" type="equalTo"/>
                           </conditions>
                         </conditionGroup>
@@ -1419,14 +1439,339 @@
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="45.0"/>
+            <cost name="pts" typeId="points" value="55.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="38b1-9536-4af6-f327" name="Cryptek Lord of Transmogrification" hidden="true" collective="false" import="true" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="9a39-bed4-a90f-ded4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="36ea-c1a8-11a0-b47f" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="9a39-bed4-a90f-ded4" value="2.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="4562-5082-9ba8-78fc" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="f626-f806-e739-cdd5" name="Cryptek Lord of Transmogrification" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+              <characteristics>
+                <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry (Character)</characteristic>
+                <characteristic name="WS" typeId="575323232344415441232323">4</characteristic>
+                <characteristic name="BS" typeId="425323232344415441232323">4</characteristic>
+                <characteristic name="S" typeId="5323232344415441232323">5</characteristic>
+                <characteristic name="T" typeId="5423232344415441232323">5</characteristic>
+                <characteristic name="W" typeId="5723232344415441232323">2</characteristic>
+                <characteristic name="I" typeId="4923232344415441232323">2</characteristic>
+                <characteristic name="A" typeId="4123232344415441232323">1</characteristic>
+                <characteristic name="LD" typeId="4c4423232344415441232323">10</characteristic>
+                <characteristic name="Save" typeId="5361766523232344415441232323">3+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="a63b-028d-b6f9-a697" name="Lords may take 1 of these upgrades (Only 1 of each per army)" hidden="false" collective="false" import="true">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ae63-bedf-de26-a501" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="cc15-0ee5-5070-cf90" name="Harp of Dissonance" hidden="false" collective="false" import="true" targetId="bbd9-1bf5-5c4e-6b09" type="selectionEntry"/>
+                <entryLink id="b90f-fbff-4208-4d8a" name="Seismic Crucible" hidden="false" collective="false" import="true" targetId="1f81-f6bf-42b0-0b0b" type="selectionEntry"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="9748-3b52-a49c-63c9" name="Tremorstave" hidden="false" collective="false" import="true" targetId="94d8-845b-95d1-1421" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2bda-dfe7-d633-e2fe" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fd7c-04be-53f9-fe50" type="min"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="126f-6ce9-a6f1-a2c5" name="Mindshackle Scarabs" hidden="false" collective="false" import="true" targetId="6fd7-2cda-4ba8-ee79" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="f32b-7fd8-45aa-70f7" name="Phylactery" hidden="false" collective="false" import="true" targetId="31ff-2c1b-4442-94e9" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="points" value="15.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="a29c-9c11-8050-789d" name="Canoptek Khepri Drones" hidden="false" collective="false" import="true" targetId="851d-8247-1e7c-482a" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e70d-e591-879e-9262" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="75.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="d48a-abe8-0b89-51fd" name="Cryptek Lord of Storm" hidden="true" collective="false" import="true" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="9a39-bed4-a90f-ded4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5e51-818f-a343-dcf2" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="9a39-bed4-a90f-ded4" value="2.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="8432-80af-5c26-66ed" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="b86a-23e0-fa3d-7a4f" name="Cryptek Lord of Storm" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+              <characteristics>
+                <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry (Character)</characteristic>
+                <characteristic name="WS" typeId="575323232344415441232323">4</characteristic>
+                <characteristic name="BS" typeId="425323232344415441232323">4</characteristic>
+                <characteristic name="S" typeId="5323232344415441232323">5</characteristic>
+                <characteristic name="T" typeId="5423232344415441232323">5</characteristic>
+                <characteristic name="W" typeId="5723232344415441232323">2</characteristic>
+                <characteristic name="I" typeId="4923232344415441232323">2</characteristic>
+                <characteristic name="A" typeId="4123232344415441232323">1</characteristic>
+                <characteristic name="LD" typeId="4c4423232344415441232323">10</characteristic>
+                <characteristic name="Save" typeId="5361766523232344415441232323">3+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="3d26-0340-4537-2713" name="Lords may take 1 of these upgrades (Only 1 of each per army)" hidden="false" collective="false" import="true">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fa42-0072-36a1-27af" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="d79f-3084-db1f-48c8" name="Lightning Field" hidden="false" collective="false" import="true" targetId="faae-1911-e3b2-6797" type="selectionEntry"/>
+                <entryLink id="349a-914f-aa94-fbf8" name="Ether Crystals" hidden="false" collective="false" import="true" targetId="f6a7-23cd-b3cc-3a74" type="selectionEntry"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="f2ba-997b-be33-2405" name="Voltaic Staff" hidden="false" collective="false" import="true" targetId="f76d-5cdc-7152-6a44" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf60-c986-493d-2407" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5c3a-0309-5772-164c" type="min"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="482b-936d-3da7-4103" name="Mindshackle Scarabs" hidden="false" collective="false" import="true" targetId="6fd7-2cda-4ba8-ee79" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="247d-0c3a-0a5f-7e7d" name="Phylactery" hidden="false" collective="false" import="true" targetId="31ff-2c1b-4442-94e9" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="points" value="15.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="3584-af5a-1c46-e8b1" name="Canoptek Khepri Drones" hidden="false" collective="false" import="true" targetId="851d-8247-1e7c-482a" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af01-2305-8965-d41c" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="75.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="b04e-14f3-f749-2279" name="Cryptek Lord of Eternity" hidden="true" collective="false" import="true" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="9a39-bed4-a90f-ded4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b632-c2db-9a76-2997" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="9a39-bed4-a90f-ded4" value="2.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="1e69-b0cc-5a07-fbc8" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="16d2-f720-2dfe-b557" name="Cryptek Lord of Eternity" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+              <characteristics>
+                <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry (Character)</characteristic>
+                <characteristic name="WS" typeId="575323232344415441232323">4</characteristic>
+                <characteristic name="BS" typeId="425323232344415441232323">4</characteristic>
+                <characteristic name="S" typeId="5323232344415441232323">5</characteristic>
+                <characteristic name="T" typeId="5423232344415441232323">5</characteristic>
+                <characteristic name="W" typeId="5723232344415441232323">2</characteristic>
+                <characteristic name="I" typeId="4923232344415441232323">2</characteristic>
+                <characteristic name="A" typeId="4123232344415441232323">1</characteristic>
+                <characteristic name="LD" typeId="4c4423232344415441232323">10</characteristic>
+                <characteristic name="Save" typeId="5361766523232344415441232323">3+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="ce12-2385-69a4-1238" name="Lords may take 1 of these upgrades (Only 1 of each per army)" hidden="false" collective="false" import="true">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cb16-7ade-9b60-0ff2" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="5bfc-252e-8a7c-f45c" name="Chronometron" hidden="false" collective="false" import="true" targetId="8a08-307a-6dab-2286" type="selectionEntry"/>
+                <entryLink id="f0ed-d82d-da8d-f8ef" name="Timesplinter Cloak" hidden="false" collective="false" import="true" targetId="78cf-a0ac-1c61-4da3" type="selectionEntry"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="3421-8683-338f-b154" name="Aeonstave" hidden="false" collective="false" import="true" targetId="1596-a1ae-f623-fdb0" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1b7e-c6a9-4ab6-979b" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d50-48a7-a513-0664" type="min"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="b63b-7334-9075-68ec" name="Mindshackle Scarabs" hidden="false" collective="false" import="true" targetId="6fd7-2cda-4ba8-ee79" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="792a-8007-7c16-811f" name="Phylactery" hidden="false" collective="false" import="true" targetId="31ff-2c1b-4442-94e9" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="points" value="15.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="9758-21a1-edbc-4ade" name="Canoptek Khepri Drones" hidden="false" collective="false" import="true" targetId="851d-8247-1e7c-482a" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c164-d9dc-3e0e-e0ae" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="75.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="086d-4581-2fd4-0c62" name="Cryptek Lord of Destruction" hidden="true" collective="false" import="true" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="9a39-bed4-a90f-ded4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="18a3-a2f0-a7e3-6fa1" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="9a39-bed4-a90f-ded4" value="2.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="ef27-c0b5-01d3-c7cc" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="c3e6-e8da-cd16-6c08" name="Cryptek Lord of Destruction" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+              <characteristics>
+                <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry (Character)</characteristic>
+                <characteristic name="WS" typeId="575323232344415441232323">4</characteristic>
+                <characteristic name="BS" typeId="425323232344415441232323">4</characteristic>
+                <characteristic name="S" typeId="5323232344415441232323">5</characteristic>
+                <characteristic name="T" typeId="5423232344415441232323">5</characteristic>
+                <characteristic name="W" typeId="5723232344415441232323">2</characteristic>
+                <characteristic name="I" typeId="4923232344415441232323">2</characteristic>
+                <characteristic name="A" typeId="4123232344415441232323">1</characteristic>
+                <characteristic name="LD" typeId="4c4423232344415441232323">10</characteristic>
+                <characteristic name="Save" typeId="5361766523232344415441232323">3+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="34c8-01e1-62e4-2c53" name="Lords may take 1 of these upgrades (Only 1 of each per army)" hidden="false" collective="false" import="true">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9ed6-582b-2c01-6f27" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="33df-d811-08e4-5c14" name="Gaze of Flame" hidden="false" collective="false" import="true" targetId="117b-8f22-fbc5-3ea8" type="selectionEntry"/>
+                <entryLink id="ec8b-ae68-1b52-f4fa" name="Solar Pulse" hidden="false" collective="false" import="true" targetId="ba0e-aee1-d36b-8972" type="selectionEntry"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="a6a9-0f8b-e748-0b29" name="Eldritch Lance" hidden="false" collective="false" import="true" targetId="232c-d79d-4400-1374" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e774-ac79-7060-bf08" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5821-b638-abf0-11b0" type="min"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="010c-87a1-3a35-831b" name="Mindshackle Scarabs" hidden="false" collective="false" import="true" targetId="6fd7-2cda-4ba8-ee79" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="d08d-3002-7a2b-aefe" name="Phylactery" hidden="false" collective="false" import="true" targetId="31ff-2c1b-4442-94e9" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="points" value="15.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="10a6-6ed9-fabe-0bed" name="Canoptek Khepri Drones" hidden="false" collective="false" import="true" targetId="851d-8247-1e7c-482a" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf44-d3bb-9967-7b98" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="75.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="69bf-f8d0-0dea-3708" name="Cryptek Lord of Despair" hidden="true" collective="false" import="true" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="9a39-bed4-a90f-ded4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1e28-5e09-e179-e876" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="9a39-bed4-a90f-ded4" value="2.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="d0d5-a28a-084c-4a38" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="fca7-79bd-0d19-c216" name="Cryptek Lord of Despair" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+              <characteristics>
+                <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry (Character)</characteristic>
+                <characteristic name="WS" typeId="575323232344415441232323">4</characteristic>
+                <characteristic name="BS" typeId="425323232344415441232323">4</characteristic>
+                <characteristic name="S" typeId="5323232344415441232323">5</characteristic>
+                <characteristic name="T" typeId="5423232344415441232323">5</characteristic>
+                <characteristic name="W" typeId="5723232344415441232323">2</characteristic>
+                <characteristic name="I" typeId="4923232344415441232323">2</characteristic>
+                <characteristic name="A" typeId="4123232344415441232323">1</characteristic>
+                <characteristic name="LD" typeId="4c4423232344415441232323">10</characteristic>
+                <characteristic name="Save" typeId="5361766523232344415441232323">3+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="f9ef-4524-c54a-8d2a" name="Lords may take 1 of these upgrades (Only 1 of each per army)" hidden="false" collective="false" import="true">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6ff9-88b9-7953-a04c" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="03df-aaf8-35ed-e641" name="Nightmare Shroud" hidden="false" collective="false" import="true" targetId="08b6-0917-3799-0b28" type="selectionEntry"/>
+                <entryLink id="e9b2-3466-dc31-5620" name="Veil of Darkness" publicationId="ca571888--pubN89821" hidden="false" collective="false" import="true" targetId="2b5e-2a8d-108c-5587" type="selectionEntry"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="ef75-c220-9d75-ce1a" name="Abyssal Staff" hidden="false" collective="false" import="true" targetId="e80a-7f29-3f2b-ce77" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f54a-4701-6821-d426" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5125-9d27-a8d2-e7aa" type="min"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="bed9-e8c4-caaf-5a3c" name="Mindshackle Scarabs" hidden="false" collective="false" import="true" targetId="6fd7-2cda-4ba8-ee79" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="057e-89f7-b1a8-70ae" name="Phylactery" hidden="false" collective="false" import="true" targetId="31ff-2c1b-4442-94e9" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="points" value="15.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="eabd-605d-4542-da61" name="Canoptek Khepri Drones" hidden="false" collective="false" import="true" targetId="851d-8247-1e7c-482a" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5f81-5044-5e41-86b5" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="75.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="f730-4ede-4f34-b819" name="Any unit of Cyptek may choose to follow one discipline at 20pts per Cryptek:" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="f730-4ede-4f34-b819" name="Any unit of Cyptek may choose to follow one discipline:" hidden="false" collective="false" import="true" defaultSelectionEntryId="8a3c-af0e-27d2-fb16">
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="973c-3238-3488-f6b7" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="973c-3238-3488-f6b7" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="28bc-f0a3-cd7f-61bd" type="max"/>
           </constraints>
           <rules>
@@ -1474,6 +1819,11 @@
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
+            </selectionEntry>
+            <selectionEntry id="8a3c-af0e-27d2-fb16" name="Unaligned Conclave" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed3f-34c9-9734-f5bf" type="max"/>
+              </constraints>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
@@ -1778,8 +2128,7 @@ If there are three or more models all projecting Nightshrouds between them, they
           <profiles>
             <profile id="038f-9274-3342-e8dd" name="Veil of Darkness" publicationId="6fc6-dd7c-7a39-b0c8" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
               <characteristics>
-                <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">A Cryptek with a Veil of Darkness can use it in the Movement phase instead of moving normally. The Cryptek and its unit are removed from the tabletop and immediately Deep Strike back onto the
-battlefield. The Veil of Darkness cannot be used if the Cryptek is locked in combat.</characteristic>
+                <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">A Cryptek with a Veil of Darkness can use it in the Movement phase instead of moving normally. The Cryptek and its unit are removed from the tabletop and immediately Deep Strike back onto the battlefield. The Veil of Darkness cannot be used if the Cryptek is locked in combat.</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -3954,7 +4303,7 @@ In addition, the controlling may sacrifice any number of drones in their shootin
         <infoLink id="0de2-1783-d5f0-b081" name="Exile Ray" hidden="false" targetId="5787-7bfb-ea91-2792" type="rule"/>
       </infoLinks>
       <costs>
-        <cost name="pts" typeId="points" value="15.0"/>
+        <cost name="pts" typeId="points" value="10.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="e701-5eee-4c8d-00e6" name="C&apos;tan Shard" publicationId="6fc6-dd7c-7a39-b0c8" hidden="false" collective="false" import="true" type="upgrade">

--- a/The Horus Heresy.gst
+++ b/The Horus Heresy.gst
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<gameSystem id="ca571888-56a9-c58e-ddaf-54f4713538bc" name="Warhammer 30,000 - The Horus Heresy" revision="115" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
+<gameSystem id="ca571888-56a9-c58e-ddaf-54f4713538bc" name="Warhammer 30,000 - The Horus Heresy" revision="114" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
   <publications>
     <publication id="ca571888--pubN65537" name="Forgeworld Horus Heresy Series"/>
     <publication id="ca571888--pubN66489" name="HH:MT"/>

--- a/The Horus Heresy.gst
+++ b/The Horus Heresy.gst
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<gameSystem id="ca571888-56a9-c58e-ddaf-54f4713538bc" name="Warhammer 30,000 - The Horus Heresy" revision="113" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
+<gameSystem id="ca571888-56a9-c58e-ddaf-54f4713538bc" name="Warhammer 30,000 - The Horus Heresy" revision="115" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
   <publications>
     <publication id="ca571888--pubN65537" name="Forgeworld Horus Heresy Series"/>
     <publication id="ca571888--pubN66489" name="HH:MT"/>
@@ -418,7 +418,7 @@
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="527e-483e-7b4a-4cc8" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="808f-3d7c-5e48-b696" name="Multi-laser" hidden="false" targetId="c812-a8fe-2b49-75a5" type="profile"/>
+                <infoLink id="808f-3d7c-5e48-b696" name="Multi-laser" hidden="false" targetId="92be-1bfc-f355-f214" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
@@ -8357,16 +8357,11 @@ Some can also Hover – see page 81. Zooming allows the Flyer to move at extreme
     <rule id="6f38-4691-2eda-8e1b" name="Psy-Lash" publicationId="ca571888--pubN103311" page="301" hidden="false">
       <description>When attacking a unit with the Daemon, Psyker, Brotherhood of Psykers/Sorcerers, Psychic Pilot special rule then one randomlyed selected model in the unit with that special rule suffers Perils of the Warp in addition to any other damage.</description>
     </rule>
+    <rule id="7439f6fd-4c50-f88a-eb41-81d9b9c9eed8" name="Hardened Armour" publicationId="ca571888--pubN82424" page="32" hidden="false">
+      <description>Hardened Armour counts as being Void Hardened (Cold Void mission special rules from Betrayal)..  Failed armour saves against template and blast weapons may be re-rolled.  Reduces distance rolled for charges, sweeping advances, and run moves by 1&quot;</description>
+    </rule>
   </sharedRules>
   <sharedProfiles>
-    <profile id="c812-a8fe-2b49-75a5" name="Multi-laser" publicationId="ca571888--pubN84158" page="247" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
-      <characteristics>
-        <characteristic name="Range" typeId="52616e676523232344415441232323">36&quot;</characteristic>
-        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">6</characteristic>
-        <characteristic name="AP" typeId="415023232344415441232323">6</characteristic>
-        <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 3</characteristic>
-      </characteristics>
-    </profile>
     <profile id="74effb54-87f7-8481-9e5f-86d9e3ed37c2" name="Battle Servitor Control" publicationId="ca571888--pubN67227" page="43" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
       <characteristics>
         <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Provides Tank Hunters special rule.  </characteristic>
@@ -9377,7 +9372,7 @@ Jetbikes can move over all other models and terrain freely. However, if a moving
     </profile>
     <profile id="92be-1bfc-f355-f214" name="Multi-laser" publicationId="ca571888--pubN106502" page="178" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
-        <characteristic name="Range" typeId="52616e676523232344415441232323">36</characteristic>
+        <characteristic name="Range" typeId="52616e676523232344415441232323">36&quot;</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">6</characteristic>
         <characteristic name="AP" typeId="415023232344415441232323">6</characteristic>
         <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 3</characteristic>


### PR DESCRIPTION
HH Gst v114
Militia v98
Mech now v91
Legion Astartes V556

#1627 seemed to be in a pull a while ago, but then didn't make it. Fixed.
Also noticed the GST had 2 versions of Multilaser. So corrected this at the same time, relinking all linked ones that were linked to the second one (Mainly Mech needed it)

#1645 Fixed Searchlight issue not having a linked profile in Entries for LA things (mainly javs and such).

Various fixes to Legion rules to make clearer the affect of limitations from Shattered Legions.
Fixed Whitescar Shattered Legions having the Laugh in the Face of Death restiction placed on them, when it shouldn't have.
Added additional option to Alpha Legion Mutable Tactics, to have a selection that is only visible when using Shattered Legions to be clickable for if your Shattered Legion does not have an Alpha Legionnaire as its Warlord.

Praetor Weapons for Termy Armour were linked incorrectly. So relinked them so that it works. Seems like someone just made entries for them. Without linking them to the items. So no profiles were viable.

#1651 Maccy Omega added to Tagmata List

#1652 Fix for Golden Keshig Power Lance cost. Also fixed Sergeant Power Weapon not having a max.

Also added various other Mech and some Solar fixes from the #1640 pull request.
Magos prime, if you give him a melta gun, the weapon profile doesn't show up. FIXED
the same goes for the magos dominus, so i think something's wonky with melta gun in particular FIXED
the archmagos dominus still can't choose a specific power weapon. just "power weapon" FIXED
the hardened armour on the abeyant is missing its description apparently the rules for hardened armour can be found under the "breachers" entry in the legions book FIXED
Ursarax are missing their lightning claws FIXED
Castellax don't have the atomantic shielding listed properly FIXED
Had a look at it, and found a few extra missing bits, like the photon thrusters not having "Gets Hot" and plasma pistol option having no profiles at all. FIXED
Also played with Hardened Armour (moving it to GST and then relinking in Mech and LA, but think i need to change it from a rule to a wargear, as it will then show on units a bit more obviously. FIXED
Ursarax also have a 5+++ fnp not a 6+++ like the lorica thallax gives. FIXED

#1653 fix as well added