### PR TITLE
DotRS Maddening Swarms + LA Vets fix

### DIFF
--- a/(HH) Daemons of the Ruinstorm Army List.cat
+++ b/(HH) Daemons of the Ruinstorm Army List.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="8700-b3bb-a471-a0ad" name="Daemons of the Ruinstorm" revision="13" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="85" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="8700-b3bb-a471-a0ad" name="Daemons of the Ruinstorm" revision="14" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="85" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="8700-b3bb-pubN65537" name="HH8: Malevolence"/>
     <publication id="8700-b3bb-pubN75780" name="BRB"/>
@@ -413,7 +413,7 @@
       <entryLinks>
         <entryLink id="8ee9-09bc-8039-bb3c" name="Emanations of Horror [1]" hidden="false" collective="false" import="true" targetId="377a-f74e-00b1-f5f5" type="selectionEntryGroup">
           <modifiers>
-            <modifier type="increment" field="e7c1-3a77-ef39-0f98" value="3"/>
+            <modifier type="increment" field="e7c1-3a77-ef39-0f98" value="3.0"/>
           </modifiers>
         </entryLink>
       </entryLinks>
@@ -765,9 +765,9 @@
       <selectionEntryGroups>
         <selectionEntryGroup id="d139-49ad-d066-bb05" name="Emanations of Horror [3]" hidden="false" collective="false" import="true">
           <modifiers>
-            <modifier type="increment" field="1bd5-5962-2608-d4b4" value="1">
+            <modifier type="increment" field="1bd5-5962-2608-d4b4" value="1.0">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9463-14b2-5a43-17b0" type="atLeast"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5c39-d5e2-e0eb-3280" type="atLeast"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -2228,7 +2228,7 @@ Models in combat with Sam us Unbound, as well as those taking Fear tests in orde
       <modifiers>
         <modifier type="increment" field="6444-bd31-dc43-d332" value="1">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9463-14b2-5a43-17b0" type="atLeast"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5c39-d5e2-e0eb-3280" type="atLeast"/>
           </conditions>
         </modifier>
         <modifier type="increment" field="6444-bd31-dc43-d332" value="1">
@@ -2443,9 +2443,9 @@ Models in combat with Sam us Unbound, as well as those taking Fear tests in orde
     </selectionEntryGroup>
     <selectionEntryGroup id="377a-f74e-00b1-f5f5" name="Emanations of Horror [1]" hidden="false" collective="false" import="true">
       <modifiers>
-        <modifier type="increment" field="e7c1-3a77-ef39-0f98" value="1">
+        <modifier type="increment" field="e7c1-3a77-ef39-0f98" value="1.0">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9463-14b2-5a43-17b0" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5c39-d5e2-e0eb-3280" type="equalTo"/>
           </conditions>
         </modifier>
         <modifier type="set" field="name" value="Emanations of Horror"/>
@@ -2636,9 +2636,9 @@ Models in combat with Sam us Unbound, as well as those taking Fear tests in orde
     </selectionEntryGroup>
     <selectionEntryGroup id="7eba-bb63-a86c-5b07" name="Emanations of Horror [3]" hidden="false" collective="false" import="true">
       <modifiers>
-        <modifier type="increment" field="44fc-ca72-33e4-b530" value="1">
+        <modifier type="increment" field="44fc-ca72-33e4-b530" value="1.0">
           <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9463-14b2-5a43-17b0" type="atLeast"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5c39-d5e2-e0eb-3280" type="atLeast"/>
           </conditions>
         </modifier>
         <modifier type="set" field="name" value="Emanations of Horror"/>


### PR DESCRIPTION
Sorry @capitaladot still not sure what you wanted me to do differently. So another quick pull here to fix 2 issues.

Maddening Swarm fix for Daemons. Relinked it to fix an issue where they weren't getting their additional emanation. (Though still can't get the mandatory ones to be mandatory 

#1656 also fixed. Was an issue for some reason the Veteran marines had been clicked to be a collective, no idea why or when this happened.
Also found that it wasn't enforcing the min level of bolt pistol or exchanges for them, due to ticked "and all child forces" on the min requirement.