### PR TITLE
Bunch of fixes and the start of Mournival

### DIFF
--- a/(HH) Craftworld Eldar - Asuryani Army List.cat
+++ b/(HH) Craftworld Eldar - Asuryani Army List.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="0798-288f-4f71-eab9" name="Asuryani Army List (Fanmade)" revision="5" battleScribeVersion="2.03" authorName="Dono Author / Maye Gelt the Battlescribbler" authorContact="Dono (for Content) / Maye Gelt (for Battlescibbling)" authorUrl="http://www.facebook.com/AUS30K" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="106" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="0798-288f-4f71-eab9" name="Asuryani Army List (Fanmade)" revision="6" battleScribeVersion="2.03" authorName="Dono Author / Maye Gelt the Battlescribbler" authorContact="Dono (for Content) / Maye Gelt (for Battlescibbling)" authorUrl="http://www.facebook.com/AUS30K" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="5" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="5c4c-bef9-9681-e0fc" name="30K Craftworld Aeldari - Asuryani Army List"/>
   </publications>
@@ -132,6 +132,12 @@
           </modifiers>
           <constraints>
             <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7b17-14e3-06d0-b4e5" type="min"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="9a9e-2506-87df-9e8b" name="Aliens and Daemons" hidden="false" targetId="cd09-c1c6-237a-798e" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ca3f-8481-537f-9e51" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3860-8976-dc6a-71f1" type="min"/>
           </constraints>
         </categoryLink>
       </categoryLinks>

--- a/(HH) Daemons of the Ruinstorm Army List.cat
+++ b/(HH) Daemons of the Ruinstorm Army List.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="8700-b3bb-a471-a0ad" name="Daemons of the Ruinstorm" revision="14" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="85" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="8700-b3bb-a471-a0ad" name="Daemons of the Ruinstorm" revision="14" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="14" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="8700-b3bb-pubN65537" name="HH8: Malevolence"/>
     <publication id="8700-b3bb-pubN75780" name="BRB"/>
@@ -65,10 +65,20 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="25ba-08c7-f871-f88c" type="max"/>
           </constraints>
         </categoryLink>
-        <categoryLink id="7a11-130d-e08e-65be" name="Aetheric Dominion" hidden="false" targetId="2271-1b9a-5c30-9676" primary="false"/>
+        <categoryLink id="7a11-130d-e08e-65be" name="Aetheric Dominion" hidden="false" targetId="2271-1b9a-5c30-9676" primary="false">
+          <constraints>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7bd9-4ea2-c150-12a5" type="max"/>
+          </constraints>
+        </categoryLink>
         <categoryLink id="63e0-0102-d8af-800e" name="Compulsory Troops" hidden="false" targetId="0547-e031-0d25-4c6c" primary="false">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7daa-ff7f-f82a-4841" type="min"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="019f-692f-ccea-cb9d" name="Aliens and Daemons" hidden="false" targetId="cd09-c1c6-237a-798e" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6ef4-e2d8-333f-abda" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f9e5-f5d6-b58b-311e" type="min"/>
           </constraints>
         </categoryLink>
       </categoryLinks>

--- a/(HH) Daemons of the Ruinstorm Army List.cat
+++ b/(HH) Daemons of the Ruinstorm Army List.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="8700-b3bb-a471-a0ad" name="Daemons of the Ruinstorm" revision="14" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="14" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="8700-b3bb-a471-a0ad" name="Daemons of the Ruinstorm" revision="15" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="14" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="8700-b3bb-pubN65537" name="HH8: Malevolence"/>
     <publication id="8700-b3bb-pubN75780" name="BRB"/>

--- a/(HH) Mechanicum - Questoris Knight.cat
+++ b/(HH) Mechanicum - Questoris Knight.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="32d1ddc6-3187-cf6f-3bf8-9891e527a002" name="Questoris Knight Crusade Army" revision="51" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="50" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="32d1ddc6-3187-cf6f-3bf8-9891e527a002" name="Questoris Knight Crusade Army" revision="52" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="51" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="32d1ddc6--pubN65537" name="Age of Darkness Crusade Army List"/>
     <publication id="32d1ddc6--pubN66650" name="HH4: Conquest"/>
@@ -132,6 +132,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="ac7f-e6e4-68f0-b12e" type="max"/>
           </constraints>
         </categoryLink>
+        <categoryLink id="9e58-4f4e-5579-cb58" name="Allegiance" hidden="false" targetId="5297-7e0f-fa0b-3537" primary="false"/>
       </categoryLinks>
     </forceEntry>
   </forceEntries>

--- a/(HH) Mornival Units.cat
+++ b/(HH) Mornival Units.cat
@@ -1,0 +1,12711 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<catalogue id="9f87-b468-2001-5e3b" name="Mornival Units (Fanmade)" revision="2" battleScribeVersion="2.03" authorName="Aus30K / Mourival Events" authorContact="" authorUrl="https://www.facebook.com/groups/190699548351507/" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="2" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+  <publications>
+    <publication id="0e6e-8c19-c436-39c4" name="Mournival Events 3.0 Digital Version"/>
+    <publication id="cf75-540e-e446-ecd5" name="Mournival Events FAQ and Experimental Errata v3.1"/>
+  </publications>
+  <categoryEntries>
+    <categoryEntry id="4479-8d19-40d7-a1f9" name="Allegiance" hidden="false">
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5908-9f82-91c8-a9c3" type="min"/>
+      </constraints>
+    </categoryEntry>
+    <categoryEntry id="93ab-5925-3957-7ae1" name="Dedicated Transport" hidden="false"/>
+    <categoryEntry id="685b-1231-2899-7552" name="Deep Strike" hidden="false"/>
+    <categoryEntry id="377a-0893-fb71-3682" name="Elites" hidden="false"/>
+    <categoryEntry id="cb67-ac31-6c00-e520" name="Drop Pod" hidden="false"/>
+    <categoryEntry id="f01c-3731-7dbd-62f4" name="Fast Attack" hidden="false"/>
+    <categoryEntry id="8b51-3627-bcfb-b4c3" name="Heavy Support" hidden="false"/>
+    <categoryEntry id="afc6-80bb-888b-d1cf" name="HQ" hidden="false"/>
+    <categoryEntry id="1d9c-cc5a-0f91-2590" name="Independent Character" hidden="false">
+      <infoLinks>
+        <infoLink id="47f9-eb68-611e-d367" name="Independent Character" hidden="false" targetId="3ad4-1c37-d60b-1a4e" type="rule"/>
+      </infoLinks>
+    </categoryEntry>
+    <categoryEntry id="1ab3-f1ac-f724-8544" name="Infantry" hidden="false"/>
+    <categoryEntry id="d45f-b4ad-cc22-c7be" name="Jetbike" hidden="false">
+      <infoLinks>
+        <infoLink id="e978-d250-e079-f915" name="Relentless" hidden="false" targetId="3c7d-a1fa-c68b-caad" type="rule"/>
+        <infoLink id="70d8-a940-b64a-6d1b" name="Hammer of Wrath" hidden="false" targetId="6f66-b417-6004-0916" type="rule"/>
+        <infoLink id="5c52-f57d-f2b6-6643" name="Jink" hidden="false" targetId="d3e5-b43d-a89c-3bd8" type="rule"/>
+        <infoLink id="95c5-3830-83be-d65c" name="Very Bulky" hidden="false" targetId="abc9-8566-bb61-4b7c" type="rule"/>
+      </infoLinks>
+    </categoryEntry>
+    <categoryEntry id="d4cd-caa3-e499-6439" name="Jetpack Infantry" hidden="false">
+      <infoLinks>
+        <infoLink id="c135-f2dc-c0b6-7168" name="Deep Strike" hidden="false" targetId="d219-2314-4834-c054" type="rule"/>
+        <infoLink id="25da-8102-6985-4f23" name="Relentless" hidden="false" targetId="3c7d-a1fa-c68b-caad" type="rule"/>
+        <infoLink id="6cf7-e32a-2559-7767" name="Bulky" hidden="false" targetId="38d5-b6eb-bda8-2497" type="rule"/>
+        <infoLink id="f30e-e844-5559-2256" name="Trust Move" hidden="false" targetId="97c4-1c1c-3727-757f" type="rule"/>
+        <infoLink id="26be-a802-d58e-4a85" name="Skybourne" hidden="false" targetId="5c8a-63f9-5cdc-b17b" type="rule"/>
+      </infoLinks>
+    </categoryEntry>
+    <categoryEntry id="a787-4801-eb77-f2cf" name="Jump Units" hidden="false">
+      <infoLinks>
+        <infoLink id="f48b-b744-68bc-b7a0" name="Bulky" hidden="false" targetId="38d5-b6eb-bda8-2497" type="rule"/>
+        <infoLink id="e43f-53f7-1faf-bb3a" name="Deep Strike" hidden="false" targetId="d219-2314-4834-c054" type="rule"/>
+        <infoLink id="4837-a4d5-618b-49df" name="Jump Unit" hidden="false" targetId="8cb0-ff25-22a2-d480" type="rule"/>
+      </infoLinks>
+    </categoryEntry>
+    <categoryEntry id="5962-83d3-6a2c-06d0" name="Legion" hidden="false"/>
+    <categoryEntry id="f321-f2d7-7d68-8f93" name="Legiones Astartes" hidden="false">
+      <rules>
+        <rule id="b72b-80ab-a19c-66b4" name="A Talent for Murder" hidden="false">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2732-8ccb-cc97-ee5d" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <description>If any units with the Legiones Astartes (Night Lords) special rule outnumber one or more enemy infantry units during any Initiative step in which they fight in assault, they gain +1 To Hit and To Wound (to a maximum of a 2+). Bulky models count as two models and Very Bulky models as three models on both sides for the purposes of working out when Night Lords outnumber their victims.</description>
+        </rule>
+        <rule id="2b44-9ad7-9bc9-e548" name="Bitter Pride" hidden="false">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="550e-dd7c-23b2-c37b" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <description>Units with this special rule cannot benefit from the Warlord Trait of an allied character or an allied Independent Character’s Leadership score.</description>
+        </rule>
+        <rule id="fc63-1fb0-1437-6bf9" name="Blood and Honour" hidden="false">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb3-6eea-535f-86a5" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <description>Models with this rule may not choose to fail Morale checks. In addition, Imperial Fists characters must issue a Challenge in combat if they are able (their controlling player choosing which character makes the Challenge where more than one character is involved). When fighting in Challenges, models with the Legiones Astartes (Imperial Fists) special rule must re-roll failed To Hit rolls of 1..</description>
+        </rule>
+        <rule id="192f-29a5-3999-a3bf" name="Bloodlust" hidden="false">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3d14-4976-b582-a736" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <description>After winning an assault, models with this special rule must always consolidate towards the nearest enemy unit they have the ability to harm. Should a unit with this special rule fail a Morale check after being defeated in combat, before rolling for Fall Back, roll a D6. On a roll of 4 they do not flee (and count as passing their Morale check instead), but now become subject to the Rage special rule for the rest of the battle. Place a counter by the unit or otherwise mark that this is the case.</description>
+        </rule>
+        <rule id="2fd1-c888-70ab-183e" name="Born in the Saddle (Skilled Rider)" publicationId="ca571888--pubN103311" hidden="false">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="391e-b071-6cbc-c41a" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0c41-9db4-3ae3-67ce" type="notInstanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d45f-b4ad-cc22-c7be" type="notInstanceOf"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+          <description>Born in the Saddle: All models with the Legiones Astartes (White Scars) special rule and the Bike or Jetbike unit type have the Skilled Rider special rule.</description>
+        </rule>
+        <rule id="30a1-aea7-d10b-d760" name="Certainty and Resolve" hidden="false">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c52d-5459-0d1f-8a9e" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <description>Any model with the Legiones Astartes (Ultramarines) special rule takes Fear and Regrouping tests on an unmodified Leadership value of 10.</description>
+        </rule>
+        <rule id="017b-3d99-e3cd-2b9a" name="Counter-attack (Space Wolves)" publicationId="ca571888--pubN89821" hidden="false">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a1c-44d8-4d14-c203" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <description>If a unit contains at least one model with this special rule, and that unit is charged, every model with the Counter-attack special rule in the unit gets 1 Attack until the end of the phase.
+If, when charged, the unit was already locked in combat, the Counter-attack special rule has no effect.</description>
+        </rule>
+        <rule id="6e8b-c462-5a38-7f88" name="Cut Them Down" hidden="false">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4997-fb0a-fb78-aca8" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <description>All units with the Legiones Astartes (Word Bearers) special rule must always make Sweeping Advances when possible, and must re-roll Sweeping Advance roll results of a ‘1 ’.</description>
+        </rule>
+        <rule id="0ba9-aa86-34c8-b078" name="Death Dealer" hidden="false">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="550e-dd7c-23b2-c37b" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <description>Models with this special rule gain 1 BS when shooting with Pistol, Assault and Rapid Fire weapons at targets 12&quot; or less away (this special rule does not apply when making Snap Shots, Chain Fire or Fury of the Legion attacks).</description>
+        </rule>
+        <rule id="4338-d720-c00b-a1e7" name="Disciplined Fire" hidden="false">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb3-6eea-535f-86a5" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <description>Units with this special rule may add 1 to their BS when using boltguns, bolt pistols, heavy bolters and quad heavy bolters, and when firing the bolter component of a combi-weapon. Heavy Support squads with this special rule also gain the Tank Hunters special rule.</description>
+        </rule>
+        <rule id="8ebe-6569-22aa-ed69" name="Encarmine Fury" hidden="false">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="59f6-638d-8c1d-75dd" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <description>When fighting in an assault and using a Melee type weapon, any model with the Legiones Astartes (Blood Angels) special rule requires one lower result To Wound than they would normally, to a minimum of 2+. This effect applies regardless of the weapon they are using (for example, if using a Str 4 Melee weapon and attacking a target with a Toughness of 4, the Blood Angel will require a 3 To Wound rather than the usual 4+).</description>
+        </rule>
+        <rule id="00d7-4284-b666-6c39" name="Fleet (By Wing and Talon)" publicationId="ca571888--pubN67459" hidden="false">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1ab3-f1ac-f724-8544" type="notInstanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0eb0-2501-9397-1104" type="instanceOf"/>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b8d-2642-cc86-8114" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+          <description>A unit composed entirely of models with this special rule can re-roll one or more of the dice when determining Run moves and charge ranges (such as a single D6 from a charge range roll, for example).</description>
+        </rule>
+        <rule id="3962-9022-90bc-e0b9" name="From the Shadows" hidden="false">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2732-8ccb-cc97-ee5d" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <description>All models with this special rule have a cover save of 5 on the first game turn, even in open ground. This rule can be combined with the effects of Stealth, etc, as normal, but other forms of cover the model might be in which provide a higher save supersede it.</description>
+        </rule>
+        <rule id="52c9-1ddd-001d-b9f9" name="Furious Assault (By Wing and Talon)" publicationId="ca571888--pubN67459" hidden="false">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b8d-2642-cc86-8114" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d45f-b4ad-cc22-c7be" type="notInstanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0eb0-2501-9397-1104" type="notInstanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a787-4801-eb77-f2cf" type="notInstanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0c41-9db4-3ae3-67ce" type="notInstanceOf"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+          <description>In a turn in which a model with this special rule charges into combat, it adds 1 to its Strength characteristic until the end of the Assault phase. A model that has made a disordered charge that turn receives no benefit from Furious Charge.</description>
+        </rule>
+        <rule id="b379-4d63-23e4-4131" name="Incarnate Violence" hidden="false">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3d14-4976-b582-a736" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <description>Models with the Legiones Astartes (World Eaters) rule may re-roll To Wound rolls of a 1 on any turn in which they charge into combat, unless they are making a Disordered charge. Character models with this rule also gain 1 WS when fighting in a challenge.</description>
+        </rule>
+        <rule id="383f-ac96-7837-241d" name="Infiltrate (By Wing and Talon)" publicationId="ca571888--pubN67459" hidden="false">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0eb0-2501-9397-1104" type="instanceOf"/>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b8d-2642-cc86-8114" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d4cd-caa3-e499-6439" type="notInstanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1ab3-f1ac-f724-8544" type="notInstanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a787-4801-eb77-f2cf" type="notInstanceOf"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+          <description>Units that contain at least one model with this special rule are deployed last, after all other units (friend and foe) have been deployed. If both sides have Infiltrators, the players roll-off and the winner decides who goes first, then alternate deploying these units.
+
+Infiltrators can be set up anywhere on the table that is more than 12&quot; from any enemy unit, as long as no deployed enemy unit can draw line of sight to them. This includes in a building, as long as the building is more than 12&quot; from any enemy unit. Alternatively, they can be set up anywhere on the table more than 18&quot; from any enemy unit, even in plain sight.
+
+If a unit with Infiltrate deploys inside a Dedicated Transport, they may Infiltrate along with their Transport.
+
+A unit that deploys using these rules cannot charge in their first turn. Having Infiltrate also confers the Outflank special rule to units of Infiltrators that are kept as Reserves.
+
+If a unit has both the Infiltrate and Scout special rule, that unit can deploy as per the Infiltrate special rule and then redeploy as per the Scout special rule.</description>
+        </rule>
+        <rule id="4c71-3a90-477d-5e6f" name="Interlocking Tactics" hidden="false">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c52d-5459-0d1f-8a9e" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <description>The Ultramarines pride themselves above all things on their unity of purpose and their seamless tactical integration in battle. For many years they have been accorded as being the most numerous of the Space Marine Legions and, under their Primarch, they have forged a significant range of tactical doctrines which hone their unity and strength in numbers to lethal advantage.
+• Whenever a unit with the Legiones Astartes (Ultramarines) special rule makes a shooting attack against a target which has already been successfully hit in the same Shooting phase by another Ultramarines unit*, they may re-roll rolls of 1 to wound or penetrate the target’s armour. This does not affect Snap Shots or Blast weapons.
+• Whenever a unit with the Legiones Astartes (Ultramarines) special rule charges a unit which is already engaged in an assault by another Ultramarines unit and fails to reach the target owing to a failed Charge Range roll, this roll must be re-rolled.
+*For the purposes of this special rule, an Ultramarines unit is defined as any unit in the same detachment drawn from the Space Marine Legion Crusade Army list except Super-heavy vehicles, Flyers, Servo-automata and Battle-automata of any kind.</description>
+        </rule>
+        <rule id="0ae0-f965-89e9-d3ee" name="Intractable" hidden="false">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0f9b-69d0-8106-dc52" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <description>When making Sweeping Advance tests, models with this special rule reduce the score they roll by -1.</description>
+        </rule>
+        <rule id="b07f-9c0b-e32f-8d68" name="Inviolate Armour" hidden="false">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b7d6-8217-4fe9-45d4" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <description>All models with the Legiones Astartes (Iron Hands) special rule reduce the strength of all shooting attacks against them by -1.</description>
+        </rule>
+        <rule id="3524-0ac2-1612-c8d3" name="Mastery of the Blade" hidden="false">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1445-c8d0-6c21-9c6a" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <description>When fighting in an assault with one of the following weapons: combat blade, chainsword, heavy chainsword, power sword, Terranic greatsword, Calibanite war blade and paragon blades modelled as swords, and when fighting a model with an equal WS, a model with this special rule strikes on a 3.</description>
+        </rule>
+        <rule id="2451-bb69-8ce0-a2d2" name="Merciless Fighters" hidden="false">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="550e-dd7c-23b2-c37b" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <description>If the number of Sons of Horus infantry models* in a particular close combat is greater than that of the enemy during Initiative step 1 of the Fight sub-phase, then each model with this rule that has already fought may make a single additional attack.
+*Count Bulky models on both sides as two models each, and very Bulky models as three models each for the purpose of working this out.</description>
+        </rule>
+        <rule id="b0e3-21ad-8ce7-3e7f" name="Mutable Tactics" hidden="false">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="eac6-9b93-9a5a-a30b" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <description>An Alpha Legion army must pick one of the following special rules at the point where Warlord Traits have been selected for the game. This rule then applies to all of the units in the detachment with the Legiones Astartes (Alpha Legion) special rule for the duration of this game:
+- Scout
+- Infiltrate
+- Tank Hunters
+- Counter-attack
+- Move Through Cover
+- Adamantium Will</description>
+        </rule>
+        <rule id="a8ee-a76d-b32b-fc1d" name="Night Vision" hidden="false">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2732-8ccb-cc97-ee5d" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <description>All models in a Night Lords primary detachment (not just those with the Legiones Astartes (Night Lords) special rule) have the Night Vision special rule.</description>
+        </rule>
+        <rule id="8b4a-bbf6-ae20-fac5" name="Nocturne Born" hidden="false">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e2d7-e297-5b99-cbac" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <description>All units with the Legiones Astartes (Salamanders) special rule do not add their Initiative score to their Sweeping Advance rolls and reduce their randomly rolled Run and Charge distances by -1&quot; to a minimum of 1&quot;.</description>
+        </rule>
+        <rule id="b614-6669-4f82-ab09" name="Nostraman Blood" hidden="false">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2732-8ccb-cc97-ee5d" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <description>All models with this special rule fall back 1&quot; further than normal. If they fail a Pinning test, they may, if the controlling player wishes, fall back instead of becoming pinned - just as if they had failed a Morale check for taking casualties in the Shooting phase.</description>
+        </rule>
+        <rule id="fb82-a7ea-1f89-3001" name="Promethean Gift" hidden="false">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e2d7-e297-5b99-cbac" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <description>All hand flamers, flamers and heavy flamers used by models with this special rule gain 1 Strength to their listed profile. This special rule also extends to all vehicles used by a detachment containing units with this rule. In addition, all enemy flamer-type attacks are at -x Strength when used against models with this rule.</description>
+        </rule>
+        <rule id="a30c-fdf7-19b5-03a3" name="Remorseless" hidden="false">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0f9b-69d0-8106-dc52" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <description>The Death Guard are immune to Fear and automatically pass any Pinning tests they are called on to make.</description>
+        </rule>
+        <rule id="b7de-2eea-7c2c-f712" name="Sons of Barbarus" hidden="false">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0f9b-69d0-8106-dc52" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <description>Veterans of the most hellish battlefields of the Great Crusade, Death Guard models with this special rule may re-roll failed Dangerous Terrain tests. Models with this rule also gain a Feel No Pain (4) against any wounds inflicted against them by attacks that have the Poison or Fleshbane type ability. This ability cannot be combined with Feel no Pain from other sources.</description>
+        </rule>
+        <rule id="1377-972f-89c5-86c6" name="Stand and Fight" hidden="false">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b7d6-8217-4fe9-45d4" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <description>All models with the Legiones Astartes (Iron Hands) special rule must pass a Leadership test in order to make Sweeping Advances after winning an assault or to make a Run move in the Shooting phase. In addition, models with this rule may not voluntarily Go to Ground.</description>
+        </rule>
+        <rule id="9fb2-2ded-5695-a866" name="Strength of Will" hidden="false">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e2d7-e297-5b99-cbac" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <description>All units with this special rule automatically pass any Fear test they are called on to make and must re-roll a single D6 when Morale checks and Pinning tests are failed.</description>
+        </rule>
+        <rule id="5d2f-390a-5501-fe7e" name="Swift Action" hidden="false">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="391e-b071-6cbc-c41a" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <description>Swift Action: On any turn in which a unit with this special rule ends the Movement phase at least 6&quot; (or 12&quot; if the unit is of the Bike or Jetbike type) from the point where it began the phase, it may, until the beginning of its controlling player&apos;s next turn, re-roll failed To Wound rolls of a 1 with all attacks.</description>
+        </rule>
+        <rule id="20d2-642c-a2ea-3b93" name="The Edge of the Spear" hidden="false">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="550e-dd7c-23b2-c37b" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <description>Units with this rule who are held in Reserve (and any transport vehicles they are being carried in) may, if their controlling player wishes, re-roll results of a 1 when making Reserve rolls.</description>
+        </rule>
+        <rule id="fa2c-d83a-3125-2686" name="True Believers" hidden="false">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4997-fb0a-fb78-aca8" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <description>All units with the Legiones Astartes (Word Bearers) special rule roll 3D6 for all Morale checks and must pick the two lowest dice.</description>
+        </rule>
+        <rule id="b55c-c755-7c0d-c3a5" name="Unshakeable Defense" hidden="false">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb3-6eea-535f-86a5" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <description>Unshakable Defence: Models with the Legiones Astartes (Imperial Fists) special rule are immune to pinning when claiming cover/fighting from fortifications and barricades.</description>
+        </rule>
+        <rule id="fe85-015b-9cd3-e695" name="Without Remorse, Without Relent" hidden="false">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="59f6-638d-8c1d-75dd" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <description>Models with the Legiones Astartes (Blood Angels) special rule must always make Sweeping Advances if they are able to, and may not voluntarily Go To Ground.</description>
+        </rule>
+        <rule id="3b09-f877-37b8-dd6b" name="Wrack and Ruin" hidden="false">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1660-f879-3beb-0c0b" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <description>Models with the Legiones Astartes (Iron Warriors) special rule do not suffer Morale checks from shooting attacks and may re-roll failed Pinning tests.
+All grenade and melta bomb attacks by models with the Legiones Astartes (Iron Warriors) special rule have the Wrecker special rule in addition to any other rules for the weapon type being used.</description>
+        </rule>
+        <rule id="062d-a2dd-5389-379e" name="Wrack and Ruin (Wrecker)" publicationId="ca571888--pubN82424" page="87" hidden="false">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1660-f879-3beb-0c0b" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <description>All grenade and melta bomb attack by models with the Legiones Astartes (Iron Warriors) special rule have the Wrecker special rule in addition to any other rules for hte weapon type being used.
+Attacks with this special rule may re-roll failed armour penetration rolls against fortifications and immobile structures and add 1 to any result rolled on the Building Damage chart.  If this attack damages a bulkhead or wall section of terrain and destroys it, remove that section of terrain from play if possible.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="6172-acad-7bbe-e7ad" name="Legiones Astartes" hidden="false" targetId="23a4-a37f-e8e8-c756" type="rule"/>
+      </infoLinks>
+    </categoryEntry>
+    <categoryEntry id="89bc-c78e-ab13-304b" name="Master of the Legion" hidden="false">
+      <rules>
+        <rule id="3efd-178c-b499-735c" name="Master of the Legion" publicationId="ca571888--pubN82424" page="15" hidden="false">
+          <description>A Legion army may only take one Model with the Master of the Legion rule for every 1000 points.  A model with this rule may also take a Command Squad.  If serving as the Army&apos;s Warlord, they may also roll twice on the Warlord Trait table and select one of the results.</description>
+        </rule>
+      </rules>
+    </categoryEntry>
+    <categoryEntry id="06d2-c97a-786c-a1d8" name="Monstrous Creature" hidden="false">
+      <infoLinks>
+        <infoLink id="201a-2386-6e9f-324c" name="Fear" hidden="false" targetId="52ff-4074-570b-4ea1" type="rule"/>
+        <infoLink id="fb42-6122-1c63-991f" name="Hammer of Wrath" hidden="false" targetId="6f66-b417-6004-0916" type="rule"/>
+        <infoLink id="3a55-8a8c-79c6-e2e0" name="Move Through Cover" hidden="false" targetId="6d06-5ea0-9a17-ca97" type="rule"/>
+        <infoLink id="f0dc-d9f2-0cdf-bcaa" name="Relentless" hidden="false" targetId="3c7d-a1fa-c68b-caad" type="rule"/>
+        <infoLink id="6152-2e93-bc00-f1ee" name="Smash" hidden="false" targetId="4284-18a1-9844-a0bd" type="rule"/>
+      </infoLinks>
+    </categoryEntry>
+    <categoryEntry id="3c78-d89e-b99b-5ccf" name="Rite of War" hidden="false"/>
+    <categoryEntry id="1302-97fa-834e-edc6" name="Skimmer" hidden="false"/>
+    <categoryEntry id="99b5-70da-2179-12fe" name="Tank" hidden="false"/>
+    <categoryEntry id="0eb0-2501-9397-1104" name="Terminators" hidden="false"/>
+    <categoryEntry id="0be9-0976-aa16-eea7" name="Transport" hidden="false">
+      <rules>
+        <rule id="9ab4-9a06-1bfe-048d" name="Unshakeable Nerve" publicationId="ca571888--pubN106502" page="77" hidden="false">
+          <description>Units embarked upon transports have the Fearless special rule while they are embarked.</description>
+        </rule>
+      </rules>
+    </categoryEntry>
+    <categoryEntry id="db5f-8f10-8525-28d4" name="Troops" hidden="false"/>
+    <categoryEntry id="8c70-1182-84f5-c93a" name="Vehicle" hidden="false"/>
+    <categoryEntry id="dd38-7d09-0bc8-df0d" name="Walker" hidden="false"/>
+    <categoryEntry id="1fb0-1499-5637-4715" name="Additional Ammunition, Weapons, Psychic Disciplines" hidden="false"/>
+    <categoryEntry id="0c41-9db4-3ae3-67ce" name="Bike" hidden="false">
+      <constraints>
+        <constraint field="selections" scope="parent" value="-1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a6d9-5629-8f68-c4a8" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="c2a2-a2b7-5e17-5af5" name="Relentless" hidden="false" targetId="3c7d-a1fa-c68b-caad" type="rule"/>
+        <infoLink id="5331-160c-bd6c-e794" name="Hammer of Wrath" hidden="false" targetId="6f66-b417-6004-0916" type="rule"/>
+        <infoLink id="e8b6-0e92-5a65-3f89" name="Jink" hidden="false" targetId="d3e5-b43d-a89c-3bd8" type="rule"/>
+        <infoLink id="1b5d-8fe8-4c3b-befd" name="Very Bulky" hidden="false" targetId="abc9-8566-bb61-4b7c" type="rule"/>
+      </infoLinks>
+    </categoryEntry>
+    <categoryEntry id="ae54-92c7-3e66-59f7" name="Character" hidden="false"/>
+  </categoryEntries>
+  <forceEntries>
+    <forceEntry id="fcb7-146d-eb7c-a81f" name="Supplementary Options" hidden="false">
+      <categoryLinks>
+        <categoryLink id="32b3-59dc-487f-aad5" name="Elites" hidden="false" targetId="377a-0893-fb71-3682" primary="false"/>
+        <categoryLink id="a760-98a0-9e4d-7e40" name="Fast Attack" hidden="false" targetId="f01c-3731-7dbd-62f4" primary="false"/>
+        <categoryLink id="95d6-b28a-d744-dd85" name="Heavy Support" hidden="false" targetId="8b51-3627-bcfb-b4c3" primary="false"/>
+        <categoryLink id="16d5-c5fc-e21e-31c7" name="Troops" hidden="false" targetId="db5f-8f10-8525-28d4" primary="false"/>
+        <categoryLink id="f768-9da1-dbb1-65fd" name="Lords of War" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="false"/>
+        <categoryLink id="41bd-9ed4-0579-7206" name="HQ" hidden="false" targetId="afc6-80bb-888b-d1cf" primary="false"/>
+        <categoryLink id="eed9-ff66-fdeb-c90d" name="Allegiance" hidden="false" targetId="4479-8d19-40d7-a1f9" primary="false"/>
+        <categoryLink id="d9ec-7397-14b2-2000" name="Additional Ammunition Types" hidden="false" targetId="1fb0-1499-5637-4715" primary="false"/>
+        <categoryLink id="8d00-5fcc-fe0a-e4b0" name="Legion" hidden="false" targetId="5962-83d3-6a2c-06d0" primary="false"/>
+        <categoryLink id="5b20-6a17-fc93-223c" name="Use Playtest Rules" hidden="false" targetId="fdf4-0683-3e84-5a4b" primary="false"/>
+        <categoryLink id="61f8-6e60-819b-b5b5" name="Rite of War" hidden="false" targetId="3c78-d89e-b99b-5ccf" primary="false"/>
+      </categoryLinks>
+    </forceEntry>
+  </forceEntries>
+  <entryLinks>
+    <entryLink id="7bf8-736a-cdfd-7e86" name="Allegiance" hidden="false" collective="false" import="true" targetId="f422-4b7c-29dc-7293" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="1e07-9e99-28b1-fed4" name="New CategoryLink" hidden="false" targetId="4479-8d19-40d7-a1f9" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="01b1-7fc9-d818-31de" name="Additional Psychic Disciplines" hidden="false" collective="false" import="true" targetId="f5eb-f2a0-c980-a02a" type="selectionEntry"/>
+    <entryLink id="0038-ab0d-d844-70ca" name="Exodus Assassin" hidden="false" collective="false" import="true" targetId="7d6c-b456-0c37-1f96" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="6208-4365-70d5-3d37" name="HQ" hidden="false" targetId="afc6-80bb-888b-d1cf" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="9227-c6fe-674e-33bf" name="Additional Ammunition Types" hidden="false" collective="false" import="true" targetId="984d-5135-e1be-f8e8" type="selectionEntry"/>
+    <entryLink id="abd2-40eb-4ef6-358a" name="Exotic Melee Weapns" hidden="false" collective="false" import="true" targetId="d273-e12a-a287-d944" type="selectionEntry"/>
+    <entryLink id="b403-00fc-857d-0131" name="Vanus Assassin" hidden="false" collective="false" import="true" targetId="6277-fb4b-0461-2f0e" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="ff79-2915-77b2-2002" name="New CategoryLink" hidden="false" targetId="377a-0893-fb71-3682" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="f6cd-e40a-1338-4aef" name="Venenum Assassin" hidden="false" collective="false" import="true" targetId="ceb1-cf74-814f-f02a" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="5e50-2c55-f435-6f49" name="New CategoryLink" hidden="false" targetId="377a-0893-fb71-3682" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="3304-fdfe-b8d2-7a1e" name="Rogue Psyker" hidden="false" collective="false" import="true" targetId="6f91-2969-795c-509b" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="5547-f822-bfb7-4352" name="New CategoryLink" hidden="false" targetId="afc6-80bb-888b-d1cf" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="7146-20cc-69d4-0407" name="Sisters of Silence Oblivion Knight-Centura" hidden="false" collective="false" import="true" targetId="693c-5450-e295-ce1f" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="5eea-0348-9aef-eac0" name="HQ" hidden="false" targetId="afc6-80bb-888b-d1cf" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="474d-3124-e905-0857" name="VIth Legion Watch Pack" hidden="false" collective="false" import="true" targetId="f171-3359-26b3-ea3e" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="29b6-c357-1190-f824" name="New CategoryLink" hidden="false" targetId="377a-0893-fb71-3682" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="6c4f-279c-c0ec-7ffd" name="Alpha Legion Sleeper Cell" hidden="false" collective="false" import="true" targetId="5a81-880e-e9ff-b913" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="71dc-a6a7-fa50-8ebd" name="New CategoryLink" hidden="false" targetId="377a-0893-fb71-3682" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="a713-ead7-46d5-1e92" name="Legion Gunnery Centurion" hidden="false" collective="false" import="true" targetId="a38d-bc4d-7016-cf8d" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="a21d-c568-3192-11d5" name="New CategoryLink" hidden="false" targetId="afc6-80bb-888b-d1cf" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="94d4-5774-b74e-cf36" name="Contemptor-Cortus Class Dreadnought Talon" hidden="false" collective="false" import="true" targetId="1524-ecd3-80b0-453c" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="695a-9bc0-456b-5f3a" name="New CategoryLink" hidden="false" targetId="377a-0893-fb71-3682" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="1408-6131-1677-6d8d" name="Legion Possessed Astartes Squad" hidden="false" collective="false" import="true" targetId="491a-9bf1-e9bd-b2f8" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="9b57-4de8-6c2c-2738" name="New CategoryLink" hidden="false" targetId="377a-0893-fb71-3682" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="16c3-33ba-d1f5-de9a" name="Legion Independent Techmarines" hidden="false" collective="false" import="true" targetId="7d04-bb7c-cffb-f005" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="6879-a969-b790-7022" name="Elites" hidden="false" targetId="377a-0893-fb71-3682" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="3da3-bf37-f82d-1440" name="Ulfhednar Pack" hidden="false" collective="false" import="true" targetId="ff4e-9474-9ad9-8975" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="8706-504b-65d6-d977" name="New CategoryLink" hidden="false" targetId="377a-0893-fb71-3682" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="4274-9cd2-c164-6acc" name="Assault Support Squad, Legion" hidden="false" collective="false" import="true" targetId="eefe-b2cd-3f41-7c84" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="6e04-cf89-1728-21fe" name="New CategoryLink" hidden="false" targetId="db5f-8f10-8525-28d4" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="255a-eab3-dda2-c696" name="Veteran Reconnaisance Squad, Legion" hidden="false" collective="false" import="true" targetId="5aa7-c454-3656-3a3f" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="360e-457b-30d3-369a" name="New CategoryLink" hidden="false" targetId="db5f-8f10-8525-28d4" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="1e6d-43a5-24e4-ae4f" name="Breacher Support Squad, Legion" hidden="false" collective="false" import="true" targetId="c5ba-7647-23ba-c728" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="9025-475b-dcab-87ab" name="New CategoryLink" hidden="false" targetId="db5f-8f10-8525-28d4" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="dfb5-47e0-23e9-e6b3" name="XIIth Legion Triarii Breacher Squad" hidden="false" collective="false" import="true" targetId="34da-0cfb-85e5-1573" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4adf-bcb8-7df3-fcae" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="331f-78d2-7045-9a6d" name="New CategoryLink" hidden="false" targetId="f01c-3731-7dbd-62f4" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="234a-c191-a0a3-7284" name="Sky Stalker Jetbike Squad on Bullock Jetcycles, Legion" hidden="false" collective="false" import="true" targetId="0183-7594-8997-5b90" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="5985-0b34-05ad-3019" name="New CategoryLink" hidden="false" targetId="f01c-3731-7dbd-62f4" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="9823-3c7e-729c-c7ea" name="Sky Stalker Jetbike Squad on Corvex Jetbikes, Legion" hidden="false" collective="false" import="true" targetId="fd86-a3a0-adcc-63b5" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="37e7-7136-84b1-84f9" name="New CategoryLink" hidden="false" targetId="8b51-3627-bcfb-b4c3" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="1417-d775-1316-57c2" name="Mars Pattern Land Speeder" hidden="false" collective="false" import="true" targetId="2b92-e606-8fb0-3117" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="21b7-780a-6912-1509" name="New CategoryLink" hidden="false" targetId="f01c-3731-7dbd-62f4" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="14e6-5020-b59a-53ec" name="Mars Cutter Pattern Land Speeder" hidden="false" collective="false" import="true" targetId="79c3-8891-b0e9-622a" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="8152-c5a8-ce73-707d" name="New CategoryLink" hidden="false" targetId="f01c-3731-7dbd-62f4" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="b591-881d-a58d-49eb" name="Mars Pattern Javelin Attack Speeder" hidden="false" collective="false" import="true" targetId="829f-26e6-6908-aa1f" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="ffef-554c-c4aa-5697" name="New CategoryLink" hidden="false" targetId="f01c-3731-7dbd-62f4" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="956b-9ebb-db83-2f6f" name="Sky Stalker Jetbike Squad on Bullock Jetcycles, Legion" hidden="false" collective="false" import="true" targetId="0183-7594-8997-5b90" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="418d-9dbf-183c-75cc" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="049e-4c33-667d-1780" name="New CategoryLink" hidden="false" targetId="db5f-8f10-8525-28d4" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="d7f0-c54d-aaae-4ad8" name="XIIth Legion Triarii Breacher Squad" hidden="false" collective="false" import="true" targetId="34da-0cfb-85e5-1573" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4adf-bcb8-7df3-fcae" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="f62a-2cc4-d6f9-b16a" name="New CategoryLink" hidden="false" targetId="db5f-8f10-8525-28d4" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="55c2-75ac-ce80-ddcb" name="Salamanders Infernus Destroyer Squad" hidden="false" collective="false" import="true" targetId="c74b-38cc-7b44-348c" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="d33f-ba33-8039-8399" name="New CategoryLink" hidden="false" targetId="377a-0893-fb71-3682" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="834d-9c15-11e5-40e4" name="Salamanders Infernus Destroyer Squad" hidden="false" collective="false" import="true" targetId="c74b-38cc-7b44-348c" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="4793-41be-40e8-7932" name="New CategoryLink" hidden="false" targetId="8b51-3627-bcfb-b4c3" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="2887-ab1e-b19a-c597" name="Salamanders Infernus Destroyer Squad" hidden="false" collective="false" import="true" targetId="c74b-38cc-7b44-348c" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6e6d-6838-22e6-e3a5" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="efd6-c161-db9c-d837" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="c5b2-93b6-7748-fbc3" name="New CategoryLink" hidden="false" targetId="8b51-3627-bcfb-b4c3" primary="false"/>
+        <categoryLink id="7b34-8a3c-235e-b984" name="New CategoryLink" hidden="false" targetId="db5f-8f10-8525-28d4" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="d903-8d2e-c723-80fb" name="Heavy Destroyer Squad, Legion" hidden="false" collective="false" import="true" targetId="402b-5f71-93f2-d28f" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="e25b-2288-31bb-20c5" name="New CategoryLink" hidden="false" targetId="8b51-3627-bcfb-b4c3" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+  </entryLinks>
+  <sharedSelectionEntries>
+    <selectionEntry id="6f91-2969-795c-509b" name="Rogue Psyker" publicationId="0e6e-8c19-c436-39c4" hidden="true" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e348-5834-5741-186f" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <profiles>
+        <profile id="9bd5-2b6b-5056-5494" name="Rogue Psyker" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="6f91-2969-795c-509b" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f252-9774-70ef-59b8" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry (Character)</characteristic>
+            <characteristic name="WS" typeId="575323232344415441232323">2</characteristic>
+            <characteristic name="BS" typeId="425323232344415441232323">2</characteristic>
+            <characteristic name="S" typeId="5323232344415441232323">3</characteristic>
+            <characteristic name="T" typeId="5423232344415441232323">3</characteristic>
+            <characteristic name="W" typeId="5723232344415441232323">2</characteristic>
+            <characteristic name="I" typeId="4923232344415441232323">3</characteristic>
+            <characteristic name="A" typeId="4123232344415441232323">1</characteristic>
+            <characteristic name="LD" typeId="4c4423232344415441232323">8</characteristic>
+            <characteristic name="Save" typeId="5361766523232344415441232323">-</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="230f-1bfc-afbc-5b89" name="Possessed" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+          <characteristics>
+            <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry (Character)</characteristic>
+            <characteristic name="WS" typeId="575323232344415441232323">5</characteristic>
+            <characteristic name="BS" typeId="425323232344415441232323">1</characteristic>
+            <characteristic name="S" typeId="5323232344415441232323">5</characteristic>
+            <characteristic name="T" typeId="5423232344415441232323">4</characteristic>
+            <characteristic name="W" typeId="5723232344415441232323">3</characteristic>
+            <characteristic name="I" typeId="4923232344415441232323">4</characteristic>
+            <characteristic name="A" typeId="4123232344415441232323"/>
+            <characteristic name="LD" typeId="4c4423232344415441232323">10</characteristic>
+            <characteristic name="Save" typeId="5361766523232344415441232323">-</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="5889-c4d4-d798-b530" name="Possession" hidden="false">
+          <description>If the Rogue Psyker is killed either by losing wounds or as the result of suffering a Perils of the Warp attack, roll a D6. On a result of a 5+ normally or a 2+ in the case of Perils of the Warp, the model becomes Possessed with the profile given above. The model gains the Daemon and Rending special rules but loses the Psyker special rule.
+If a Rogue Psyker who is the army’s Warlord becomes possessed, they are still counted as destroyed for the purpose of any victory conditions of the mission being played.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="0fb4-ddf7-7f75-e0bc" name="Fear" hidden="false" targetId="52ff-4074-570b-4ea1" type="rule"/>
+        <infoLink id="387a-d027-8a08-5094" name="Independent Character" hidden="false" targetId="3ad4-1c37-d60b-1a4e" type="rule"/>
+        <infoLink id="0ebb-2082-61ac-9fdf" name="Feel No Pain (5+)" hidden="false" targetId="dbf6-2f12-bb4a-517c" type="rule"/>
+        <infoLink id="ad8e-ea0a-216e-8c32" name="Psyker" hidden="false" targetId="0122-421f-88f2-9c68" type="rule"/>
+        <infoLink id="b01e-8815-9427-8993" name="Rending" hidden="false" targetId="8269-2cd6-9236-16e7" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="3e33-cc46-3dd8-6730" name="Independent Character" hidden="false" targetId="1d9c-cc5a-0f91-2590" primary="false"/>
+        <categoryLink id="d9bb-325f-86ed-9ee2" name="Infantry" hidden="false" targetId="1ab3-f1ac-f724-8544" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="ec60-2d01-c8c3-8b2c" name="Must Purchase 1-3 Psychic Mastery:" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7cb6-ea5c-52f0-d221" type="min"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b23e-e7a3-f7a4-f8c5" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="points" value="20.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="f252-9774-70ef-59b8" name="May upgrade from Rogue Psyker to Rogue Alpha" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cdcd-08f4-4b55-6dd3" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="0b35-35fd-060e-e0a8" name="Rogue Alpha" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+              <characteristics>
+                <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry (Character)</characteristic>
+                <characteristic name="WS" typeId="575323232344415441232323">2</characteristic>
+                <characteristic name="BS" typeId="425323232344415441232323">2</characteristic>
+                <characteristic name="S" typeId="5323232344415441232323">3</characteristic>
+                <characteristic name="T" typeId="5423232344415441232323">3</characteristic>
+                <characteristic name="W" typeId="5723232344415441232323">2</characteristic>
+                <characteristic name="I" typeId="4923232344415441232323">3</characteristic>
+                <characteristic name="A" typeId="4123232344415441232323">1</characteristic>
+                <characteristic name="LD" typeId="4c4423232344415441232323">8</characteristic>
+                <characteristic name="Save" typeId="5361766523232344415441232323">-</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="4a83-23c6-4c31-d5a5" name="May swap Close Combat weapon for Tainted Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="f2d6-71eb-c150-7568">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9167-59ac-2c89-9f05" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c3db-0b1a-aa39-728b" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="ac99-0f48-4e97-9694" name="Tainted Weapon" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f49b-3df7-41f1-daa5" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="183a-99f0-42ba-6e1d" name="Tainted Weapon" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="52616e676523232344415441232323">Melee</characteristic>
+                    <characteristic name="Strength" typeId="537472656e67746823232344415441232323">User</characteristic>
+                    <characteristic name="AP" typeId="415023232344415441232323">-</characteristic>
+                    <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Specialist Weapon, Instant Death</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink id="af48-e306-5012-644e" name="Instant Death" hidden="false" targetId="fbf1-6913-ff9f-5a4f" type="rule"/>
+                <infoLink id="155c-62db-23f0-6546" name="Specialist Weapon" hidden="false" targetId="7ee3-d437-bc44-3630" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <entryLinks>
+            <entryLink id="f2d6-71eb-c150-7568" name="Chainsword/Combat Blade" hidden="false" collective="false" import="true" targetId="4b1e-680b-1d39-e4f1" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="0fbc-8042-3ac1-fc9f" name="May be equiped with either of the following" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6d4c-e5ab-e1d9-4674" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="d740-6622-d29f-2265" name="Enhanced Refractor Field" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4bad-2ae1-7943-309d" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="2704-12af-414d-ad9e" name="Enhanced Refractor Field" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
+                  <characteristics>
+                    <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">4+ Invulnerable Save</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="points" value="15.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="7731-5de2-08f2-41f0" name="Refractor Field" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aaaa-05f4-6f1e-9af1" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="bc8f-edb4-c2a0-4e12" name="Refractor Field" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
+                  <characteristics>
+                    <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">5+ Invulnerable Save</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="points" value="15.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f171-3359-26b3-ea3e" name="VIth Legion Watch Pack" publicationId="0e6e-8c19-c436-39c4" hidden="true" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="a82a-f8d9-d454-b227" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <rules>
+        <rule id="f2c3-6562-5031-cebb" name="Lone Wolves" hidden="false">
+          <description>The Pack may not be joined by any other model.</description>
+        </rule>
+        <rule id="fd0b-8035-534c-6039" name="Pin and Bleed" hidden="false">
+          <description>Any turn in which a lone Monstrous Creature or lone Primarch fights a lone Watch Pack, at the start of the assault phase compare the number of Watch Pack models against their enemy’s current number of wounds. If the Watch Pack has an equal number, the enemy suffers -1 Initiative. If the Watch Pack has a higher number, the enemy model suffers -2 Initiative. In either case, the enemy model must re-roll successful It Will Not Die rolls while engaged in this manner</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="c2dc-76b3-6b32-38ff" name="Chosen Warriors" hidden="false" targetId="fdf7-02a8-bf82-6c11" type="rule"/>
+        <infoLink id="0d23-9446-c15f-9dcf" name="Stubborn" hidden="false" targetId="7be5-30af-1a02-0a89" type="rule"/>
+        <infoLink id="d190-dae1-fa38-37f3" name="Relentless" hidden="false" targetId="3c7d-a1fa-c68b-caad" type="rule"/>
+        <infoLink id="c789-6c53-6659-bde5" name="Sniper" hidden="false" targetId="3919-29f5-0c68-3ecb" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="eae8-2b3a-0e0a-c18e" name="Infantry" hidden="false" targetId="1ab3-f1ac-f724-8544" primary="false"/>
+        <categoryLink id="e533-afa5-4a77-a53b" name="Legiones Astartes" hidden="false" targetId="f321-f2d7-7d68-8f93" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="1405-5e6a-5915-e86f" name="Watchers" page="" hidden="false" collective="false" import="true" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d111-3117-8f17-5a51" type="min"/>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9e1d-7d75-2c5e-9ab2" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="866b-f29f-c92b-1c37" name="Watchers" page="" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+              <characteristics>
+                <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry</characteristic>
+                <characteristic name="WS" typeId="575323232344415441232323">5</characteristic>
+                <characteristic name="BS" typeId="425323232344415441232323">4</characteristic>
+                <characteristic name="S" typeId="5323232344415441232323">4</characteristic>
+                <characteristic name="T" typeId="5423232344415441232323">4</characteristic>
+                <characteristic name="W" typeId="5723232344415441232323">2</characteristic>
+                <characteristic name="I" typeId="4923232344415441232323">4</characteristic>
+                <characteristic name="A" typeId="4123232344415441232323">2</characteristic>
+                <characteristic name="LD" typeId="4c4423232344415441232323">9</characteristic>
+                <characteristic name="Save" typeId="5361766523232344415441232323">3+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="35.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="4cf2-59b3-ce49-6888" name="Huscarl" page="" hidden="false" collective="false" import="true" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d4d0-c5ce-e03d-b807" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ff5e-3bf7-9435-f621" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="eeaf-f6d3-a9f7-3164" name="Watch Leader" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+              <characteristics>
+                <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry</characteristic>
+                <characteristic name="WS" typeId="575323232344415441232323">6</characteristic>
+                <characteristic name="BS" typeId="425323232344415441232323">4</characteristic>
+                <characteristic name="S" typeId="5323232344415441232323">4</characteristic>
+                <characteristic name="T" typeId="5423232344415441232323">4</characteristic>
+                <characteristic name="W" typeId="5723232344415441232323">2</characteristic>
+                <characteristic name="I" typeId="4923232344415441232323">5</characteristic>
+                <characteristic name="A" typeId="4123232344415441232323">3</characteristic>
+                <characteristic name="LD" typeId="4c4423232344415441232323">10</characteristic>
+                <characteristic name="Save" typeId="5361766523232344415441232323">2+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <categoryLinks>
+            <categoryLink id="ff92-72ef-1ea3-1306" name="Character" hidden="false" targetId="ae54-92c7-3e66-59f7" primary="false"/>
+          </categoryLinks>
+          <entryLinks>
+            <entryLink id="279d-f102-2ba9-77e5" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="c6b8-8b0b-8a31-6aa3" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4fc4-4675-3a6c-90e8" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="52dd-baf7-e6a3-2070" type="min"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="fed2-616d-f8fb-1bc5" name="Dedicated Transport" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="57c9-2b68-5fce-d849" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="cd9f-416f-f625-24b4" name="Rhino Armoured Carrier, Legion" hidden="false" collective="false" import="true" targetId="00ee-3a61-8872-d01e" type="selectionEntry"/>
+            <entryLink id="cbdb-62e7-021d-fb5b" name="Drop Pod" hidden="false" collective="false" import="true" targetId="2dcf-da0f-297d-fccf" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="948d-71e8-6673-6add" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="399f-3dda-0dfb-ba6a" name="For every 3 models in the squad, one model may either:" hidden="false" collective="false" import="true">
+          <modifiers>
+            <modifier type="increment" field="ff66-98f8-4ffb-ac68" value="1.0">
+              <repeats>
+                <repeat field="selections" scope="f171-3359-26b3-ea3e" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ff66-98f8-4ffb-ac68" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="f137-9146-769d-2bc3" name="Bolt Gun for:" hidden="false" collective="false" import="true">
+              <entryLinks>
+                <entryLink id="2f12-7d6e-94b6-c66d" name="Plasma gun" hidden="false" collective="false" import="true" targetId="0f13-bded-1c10-bc38" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="5f3e-444b-2315-5e66" value="3.0"/>
+                  </modifiers>
+                </entryLink>
+                <entryLink id="ee83-5826-3b14-8e26" name="Combi-weapon" hidden="false" collective="false" import="true" targetId="f07b-6978-8f48-6c0f" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="0770-0dac-1c23-cffe" value="3.0"/>
+                  </modifiers>
+                </entryLink>
+                <entryLink id="b846-a584-7e34-baac" name="Meltagun" hidden="false" collective="false" import="true" targetId="a22d-ceac-5063-54e1" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="c23b-b876-e683-4f04" value="3.0"/>
+                  </modifiers>
+                </entryLink>
+                <entryLink id="8454-9ceb-e7bd-7f8d" name="Flamer" hidden="false" collective="false" import="true" targetId="4cc6-e521-dc9a-c117" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="370c-bef4-57de-012c" value="3.0"/>
+                  </modifiers>
+                </entryLink>
+                <entryLink id="9487-a85d-4457-09d5" name="Volkite Charger" hidden="false" collective="false" import="true" targetId="f0c0-384d-440f-c03b" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="1823-e312-2e06-58c9" value="3.0"/>
+                  </modifiers>
+                </entryLink>
+                <entryLink id="464a-cb72-4f14-4184" name="Frost Claw" hidden="false" collective="false" import="true" targetId="0e82-ee75-815e-bb42" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="af12-b178-f023-ead5" value="3.0"/>
+                  </modifiers>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="51c6-8978-4a5b-51ba" name="Frost Weapon for:" hidden="false" collective="false" import="true">
+              <entryLinks>
+                <entryLink id="3812-fba7-3eda-9065" name="Power Fist" hidden="false" collective="false" import="true" targetId="fcef-f5ac-16a3-9401" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="6cf0-88b0-fff6-961c" value="3.0"/>
+                  </modifiers>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="6bf4-0af9-861c-e476" name="Thunder Hammer" hidden="false" collective="false" import="true" targetId="925c-50d4-0101-e0e7" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="b12c-09c9-fd19-2a1d" value="3.0"/>
+                  </modifiers>
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="6585-a5a8-6880-dc5d" name="Great Frost Blade" hidden="false" collective="false" import="true" targetId="20d9-aac6-cf49-54c7" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="95d5-1020-05c4-1f85" value="3.0"/>
+                  </modifiers>
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="e2af-bc46-d607-621b" name="Any Model my exhange their Bolt Gun for:" hidden="false" collective="false" import="true">
+          <entryLinks>
+            <entryLink id="87ad-fde5-dbed-e2cc" name="Combat Shield" hidden="false" collective="false" import="true" targetId="ee70-f3a2-17f8-f39e" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c759-a1b7-104a-826b" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="ed5f-472a-031f-6bac" name="Watch Leader may take Melta Bombs" hidden="false" collective="false" import="true">
+          <entryLinks>
+            <entryLink id="7d6c-28a1-58cf-5456" name="Melta Bombs" hidden="false" collective="false" import="true" targetId="4c62-8983-4a1b-d1c6" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="e42c-ad6b-0f7b-d46c" name="New EntryLink" hidden="false" collective="false" import="true" targetId="0a53-b471-df87-7b83" type="selectionEntry"/>
+        <entryLink id="05ba-6bd1-315a-6c84" name="New EntryLink" hidden="false" collective="false" import="true" targetId="0a96-04b6-7340-91a4" type="selectionEntry"/>
+        <entryLink id="23a9-0f81-32b1-a3d7" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="8e2a-0525-9100-3264" type="selectionEntry"/>
+        <entryLink id="ab5e-7ab0-0343-baa5" name="Bolters" hidden="false" collective="false" import="true" targetId="ac90-ce47-65c6-f5f3" type="selectionEntry"/>
+        <entryLink id="cbe4-c7eb-237a-189b" name="   VI: Space Wolves" hidden="false" collective="false" import="true" targetId="0a1c-44d8-4d14-c203" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a4a0-155c-a0b9-49e7" type="min"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="85.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5a81-880e-e9ff-b913" name="Alpha Legion Sleeper Cell" publicationId="0e6e-8c19-c436-39c4" hidden="true" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e348-5834-5741-186f" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <rules>
+        <rule id="c58a-92f8-08bf-02a4" name="The Alpha Legion (Sleeper Cell)" publicationId="ca571888--pubN67459" page="" hidden="false">
+          <description>If the Army is Alpha Legion then this unit may use Mutable Tactics and Martial Hubris as per the normal rules for the Alpha Legion.
+• Mutable Tactics: An Alpha Legion army must pick one of the following special rules at the point where Warlord Traits have been selected for the game. This rule then applies to all of the units in the detachment with the Legiones Astartes (Alpha Legion) special rule for the duration of this game:
+- Scout
+- Infiltrate
+- Tank Hunters
+- Counter-attack
+- Move Through Cover
+- Adamantium Will
+• Martial Hubris: In any mission where secondary objectives are being used, and an Alpha Legion army is your army’s primary detachment, if the Alpha Legion army has suffered more units destroyed than their enemy at the end of the game, then their enemy gains 1 Victory point.
+(In the case of Shattered Legions. The army only gains both of these benifits if the Warlord is Alpha Legion)</description>
+        </rule>
+        <rule id="b866-f3d5-81de-7df4" name="Deep Infiltration" hidden="false">
+          <description>At the start of any turn, the Cell is placed on the board and may act as normal for the remainder of the turn, e.g. moving, shooting and assaulting. Enemy units can use Interceptor to attack the Cell in the turn that they are placed on the board.</description>
+        </rule>
+        <rule id="07fc-64e0-c28c-19ae" name="Sleepers" hidden="false">
+          <description>On the turn the Cell is revealed, it gains Stealth.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="c5e5-a83c-1d6a-7573" name="Precision Shots" hidden="false" targetId="4771-b711-0e74-3aee" type="rule"/>
+        <infoLink id="1f02-0a52-a40d-706e" name="Legiones Astartes" hidden="false" targetId="23a4-a37f-e8e8-c756" type="rule"/>
+        <infoLink id="e33d-2f57-3862-2ba2" name="Stealth" hidden="false" targetId="0d66-14c9-d2f4-708b" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="f0a7-e433-ff04-fead" name="Infantry" hidden="false" targetId="1ab3-f1ac-f724-8544" primary="false"/>
+        <categoryLink id="1ed1-a1ac-2fa1-e041" name="Legiones Astartes" hidden="false" targetId="f321-f2d7-7d68-8f93" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="0d60-109e-1676-c048" name="Cell Operative" hidden="false" collective="false" import="true" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2249-1903-0c65-a38c" type="min"/>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c156-0d48-1189-f95a" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="7e77-5cb4-22b5-b741" name="Cell Operative" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+              <characteristics>
+                <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry</characteristic>
+                <characteristic name="WS" typeId="575323232344415441232323">4</characteristic>
+                <characteristic name="BS" typeId="425323232344415441232323">4</characteristic>
+                <characteristic name="S" typeId="5323232344415441232323">4</characteristic>
+                <characteristic name="T" typeId="5423232344415441232323">4</characteristic>
+                <characteristic name="W" typeId="5723232344415441232323">1</characteristic>
+                <characteristic name="I" typeId="4923232344415441232323">4</characteristic>
+                <characteristic name="A" typeId="4123232344415441232323">1</characteristic>
+                <characteristic name="LD" typeId="4c4423232344415441232323">8</characteristic>
+                <characteristic name="Save" typeId="5361766523232344415441232323">3+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="20.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="7018-e528-3115-7227" name="Cell Alpha" hidden="false" collective="false" import="true" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="12f2-abed-07af-8c02" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b4d7-5e43-750d-3958" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="c8ab-127a-6bf2-46b4" name="Cell Alpha" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+              <modifiers>
+                <modifier type="set" field="5361766523232344415441232323" value="2+">
+                  <conditions>
+                    <condition field="selections" scope="5a81-880e-e9ff-b913" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fea4-41e8-d811-35b1" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <characteristics>
+                <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry (Character)</characteristic>
+                <characteristic name="WS" typeId="575323232344415441232323">4</characteristic>
+                <characteristic name="BS" typeId="425323232344415441232323">4</characteristic>
+                <characteristic name="S" typeId="5323232344415441232323">4</characteristic>
+                <characteristic name="T" typeId="5423232344415441232323">4</characteristic>
+                <characteristic name="W" typeId="5723232344415441232323">1</characteristic>
+                <characteristic name="I" typeId="4923232344415441232323">4</characteristic>
+                <characteristic name="A" typeId="4123232344415441232323">2</characteristic>
+                <characteristic name="LD" typeId="4c4423232344415441232323">9</characteristic>
+                <characteristic name="Save" typeId="5361766523232344415441232323">3+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <categoryLinks>
+            <categoryLink id="159c-95b9-9de8-4203" name="Character" hidden="false" targetId="ae54-92c7-3e66-59f7" primary="false"/>
+          </categoryLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="ce74-2faa-b7d5-3f0e" name="Cell Alpha may select the following" hidden="false" collective="false" import="true">
+          <selectionEntries>
+            <selectionEntry id="2351-90c9-8fd6-f5ae" name="May Exchange Bolt Pistol for Plasma Pistol" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="aa92-4151-761f-f7d1" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="11f3-daf3-2287-20cc" name="New InfoLink" hidden="false" targetId="f9fd-36be-dc19-401f" type="profile"/>
+                <infoLink id="3873-5b63-6acc-f6af" name="New InfoLink" hidden="false" targetId="f4fd-d519-4769-5510" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="c892-870a-9990-4b82" name="May Exchange Combat Blade for Power Fist" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7da1-5746-a611-dec5" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="a403-11c1-47a0-68f7" name="New InfoLink" hidden="false" targetId="4ddd-399c-d71c-4ac1" type="profile"/>
+                <infoLink id="6647-077c-3d31-42c4" name="New InfoLink" hidden="false" targetId="7ee3-d437-bc44-3630" type="rule"/>
+                <infoLink id="2638-f573-7cbf-a7d7" name="New InfoLink" hidden="false" targetId="5eea-958c-d623-c3c9" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <entryLinks>
+            <entryLink id="fea4-41e8-d811-35b1" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="c6b8-8b0b-8a31-6aa3" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="90f4-8c32-7ca4-44d0" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="7172-450d-38a0-03f1" name="Melta Bombs" hidden="false" collective="false" import="true" targetId="4c62-8983-4a1b-d1c6" type="selectionEntry"/>
+            <entryLink id="f7b7-6f85-eca4-a4d6" name="Power Dagger" hidden="false" collective="false" import="true" targetId="5348-8a7f-e945-3bd8" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false"/>
+              </modifiers>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="1dee-bb99-5bfd-4437" name="For every 5 models in the squad, one can exchange their Bolt Gun:" hidden="false" collective="false" import="true">
+          <modifiers>
+            <modifier type="increment" field="5859-7e83-c590-745e" value="1.0">
+              <repeats>
+                <repeat field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af65-a094-f1b7-10d0" type="min"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5859-7e83-c590-745e" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="8765-b805-7100-534c" name="Heavy Bolter and Suspensor Web + Banestrike Ammo" page="0" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b7d5-168c-a105-1fd5" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="7f11-1b93-d47c-ce17" name="Heavy Bolter with Banestrike Ammo" publicationId="ca571888--pubN106502" page="" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="52616e676523232344415441232323">36&quot;</characteristic>
+                    <characteristic name="Strength" typeId="537472656e67746823232344415441232323">5</characteristic>
+                    <characteristic name="AP" typeId="415023232344415441232323">4</characteristic>
+                    <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 3, Banestrike</characteristic>
+                  </characteristics>
+                </profile>
+                <profile id="8be6-d5f1-ff6b-5a5c" name="Heavy Bolter with Banestrike (Suspensor)" publicationId="ca571888--pubN106502" page="" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="52616e676523232344415441232323">18&quot;</characteristic>
+                    <characteristic name="Strength" typeId="537472656e67746823232344415441232323">5</characteristic>
+                    <characteristic name="AP" typeId="415023232344415441232323">4</characteristic>
+                    <characteristic name="Type" typeId="5479706523232344415441232323">Assault 3, Banestrike</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink id="d469-5a87-48a6-3a6b" name="Suspensor Web" hidden="false" targetId="3d78-f901-8afc-00ff" type="rule"/>
+                <infoLink id="32da-38e9-fe23-8d48" name="Banestrike" hidden="false" targetId="8578-50de-d1fb-da80" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="15.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <entryLinks>
+            <entryLink id="1612-5e71-f387-95eb" name="Flamer" hidden="false" collective="false" import="true" targetId="4cc6-e521-dc9a-c117" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="370c-bef4-57de-012c" value="2.0"/>
+              </modifiers>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="1b1b-d8ac-1508-42a0" name="Lightning Claw" hidden="false" collective="false" import="true" targetId="26db-484d-3757-03c8" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="b2ab-5b47-b382-d02f" value="2.0"/>
+              </modifiers>
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="6560-d3c9-1229-16c3" name="Meltagun" hidden="false" collective="false" import="true" targetId="a22d-ceac-5063-54e1" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="c23b-b876-e683-4f04" value="2.0"/>
+              </modifiers>
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="2eb2-5666-9704-855c" name="Plasma gun" hidden="false" collective="false" import="true" targetId="0f13-bded-1c10-bc38" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="5f3e-444b-2315-5e66" value="2.0"/>
+              </modifiers>
+              <costs>
+                <cost name="pts" typeId="points" value="15.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="38e3-6aa7-c35e-931c" name="Power Weapon (Squad)" hidden="false" collective="false" import="true" targetId="8db1-05f7-f5dd-8b9c" type="selectionEntryGroup">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="35cf-1640-459e-6b9f" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="75ff-3eb6-30f6-ce62" name="New EntryLink" hidden="false" collective="false" import="true" targetId="0a96-04b6-7340-91a4" type="selectionEntry"/>
+        <entryLink id="8d98-bf6e-b590-f615" name="New EntryLink" hidden="false" collective="false" import="true" targetId="0a53-b471-df87-7b83" type="selectionEntry"/>
+        <entryLink id="a6f1-f89b-dbcf-c119" name="Bolter with Banestrike Rounds" hidden="false" collective="false" import="true" targetId="f0e7-972c-32ed-82de" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c5ea-3078-0bb4-bb99" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5217-5724-c509-8aaa" type="min"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="2c55-a6f3-d8bd-53ec" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="8e2a-0525-9100-3264" type="selectionEntry"/>
+        <entryLink id="5b8e-b8a5-5669-0099" name="Chainswords/Combat Blades" hidden="false" collective="false" import="true" targetId="1087-66c1-c342-9cdc" type="selectionEntry"/>
+        <entryLink id="58e8-3c8f-2e23-b8d5" name="Venom Spheres" hidden="false" collective="false" import="true" targetId="0b5b-7b9a-5afc-382b" type="selectionEntry">
+          <modifiers>
+            <modifier type="increment" field="points" value="2.0">
+              <repeats>
+                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0d60-109e-1676-c048" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7018-e528-3115-7227" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="45.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a38d-bc4d-7016-cf8d" name="Gunnery Centurion" publicationId="0e6e-8c19-c436-39c4" hidden="false" collective="false" import="true" type="unit">
+      <profiles>
+        <profile id="5c8b-9bfc-5ec0-aca1" name="Legion Gunnery Centurion" publicationId="0e6e-8c19-c436-39c4" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+          <modifiers>
+            <modifier type="set" field="5361766523232344415441232323" value="2+">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7626-70d3-905c-b378" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">5</characteristic>
+            <characteristic name="WS" typeId="575323232344415441232323">5</characteristic>
+            <characteristic name="BS" typeId="425323232344415441232323">4</characteristic>
+            <characteristic name="S" typeId="5323232344415441232323">4</characteristic>
+            <characteristic name="T" typeId="5423232344415441232323">4</characteristic>
+            <characteristic name="W" typeId="5723232344415441232323">2</characteristic>
+            <characteristic name="I" typeId="4923232344415441232323">5</characteristic>
+            <characteristic name="A" typeId="4123232344415441232323">3</characteristic>
+            <characteristic name="LD" typeId="4c4423232344415441232323">9</characteristic>
+            <characteristic name="Save" typeId="5361766523232344415441232323">3+</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="10fe-d4b7-a5d9-d92c" name="Coordinating Fire" hidden="false">
+          <description>The Centurion may Split Fire from any unit he joins. If he chooses to forego shooting, he instead grants Shred and Sunder to the unit’s attacks. This bonus does not apply to Blast and Template attacks.</description>
+        </rule>
+        <rule id="35f1-eb5e-4eb7-deee" name="Legion Gunnery Centurion" hidden="false">
+          <description>May only join Veteran Tactical, Tactical, Tactical Support and Heavy Support Squads and Rapier Batteries</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="23c4-d783-01fb-1e49" name="Support Officer" hidden="false" targetId="f546-a57f-5c5e-aed8" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="a4cd-8d98-aa73-047b" name="Independent Character" hidden="false" targetId="1d9c-cc5a-0f91-2590" primary="false"/>
+        <categoryLink id="11a5-8d39-84f5-c716" name="Infantry" hidden="false" targetId="1ab3-f1ac-f724-8544" primary="false"/>
+        <categoryLink id="2db6-6b01-21a3-7b0a" name="Legiones Astartes" hidden="false" targetId="f321-f2d7-7d68-8f93" primary="false"/>
+        <categoryLink id="3d25-e191-6f69-3177" name="Character" hidden="false" targetId="ae54-92c7-3e66-59f7" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="e6b1-1bc7-9baa-8dcb" name="Munitions (Any unit equiped with weapons listed may take upgrade at 2 points per model)" hidden="false" collective="false" import="true" type="upgrade">
+          <profiles>
+            <profile id="535d-8dbb-62e3-5bd8" name="Heavy Bolter: Splinter" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="52616e676523232344415441232323">35&quot;</characteristic>
+                <characteristic name="Strength" typeId="537472656e67746823232344415441232323">2</characteristic>
+                <characteristic name="AP" typeId="415023232344415441232323">4</characteristic>
+                <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 3, Rending</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="3786-8c46-f032-b393" name="Missile Launcher: Sabot" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="52616e676523232344415441232323">36&quot;</characteristic>
+                <characteristic name="Strength" typeId="537472656e67746823232344415441232323"/>
+                <characteristic name="AP" typeId="415023232344415441232323">2</characteristic>
+                <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 1, Sunder</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="f1d8-b221-8722-1536" name="Munitions" hidden="false">
+              <description>Any units in the same detachment may be equipped, for +2 pts per model, with:
+Autocannon: Sabot: 36” S8 AP2 Heavy 1 Sunder
+Missile Launcher: Sabot: 36” S8 AP2 Heavy 1 Sunder
+Heavy Bolter: Splinter: 36” S2 AP4 Heavy 3 Rending</description>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="c045-e082-5986-1b28" name="Rending" hidden="false" targetId="8269-2cd6-9236-16e7" type="rule"/>
+            <infoLink id="32ca-0a5c-4a94-229a" name="Sunder" hidden="false" targetId="841f-9119-9f9d-5058" type="rule"/>
+            <infoLink id="8fa9-9f7c-3295-bb5b" name="Autocannon: Sabot" hidden="false" targetId="d706-b010-f97a-ff5e" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="2.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="586c-2b17-ffdc-41fd" name="May Exchange his Master-Crafted Bolt Gun for a Master-Crafted:" hidden="false" collective="false" import="true" defaultSelectionEntryId="e5b6-1360-ef4f-8bb3">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9f0e-5e46-5032-3f77" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cefb-65b3-f92e-0dcc" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="fb6f-7485-8ebb-4307" name="Master-Crafted Volkite Charger" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7cf5-4cd0-0468-c231" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="34d7-dad9-b6ed-57a7" name="Master-crafted" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule"/>
+                <infoLink id="2834-3750-41da-e4a4" name="Volkite Charger" hidden="false" targetId="c440-1f53-4d20-5cab" type="profile"/>
+                <infoLink id="44b6-b311-27f8-46f2" name="Deflagrate" hidden="false" targetId="b46a-a3ec-91a5-5001" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="03a9-0786-8326-b2d8" name="Master-Crafted Volkite Caliver" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c9cc-e22e-999b-3a1e" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="0f00-5d13-06b2-a487" name="Master-crafted" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule"/>
+                <infoLink id="2eba-743c-57ff-b5c2" name="Volkite Caliver" hidden="false" targetId="626c-d79c-9bb7-3407" type="profile"/>
+                <infoLink id="da2a-30a9-3202-7538" name="Deflagrate" hidden="false" targetId="b46a-a3ec-91a5-5001" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="b4af-5593-5868-ddbb" name="Master-Crafted Melta Gun" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ca39-932a-e2e0-5e1f" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="3d68-77cc-2502-9706" name="Master-crafted" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule"/>
+                <infoLink id="2ced-f2ce-eb1f-cd42" name="Meltagun" hidden="false" targetId="8ae4-74e5-7700-3804" type="profile"/>
+                <infoLink id="20f2-8de1-282f-d1c7" name="New InfoLink" hidden="false" targetId="21c0-62ff-3ed2-17a7" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="94fb-be55-7bf4-0fc9" name="Master-Crafted Plasma Gun" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="accb-6f4a-8ff7-37b0" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="46f2-e061-8bc5-f606" name="Master-crafted" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule"/>
+                <infoLink id="5121-2d3b-6827-40f5" name="Plasma Gun" hidden="false" targetId="87c7-bd37-70f7-1933" type="profile"/>
+                <infoLink id="0282-945f-27f9-704c" name="New InfoLink" hidden="false" targetId="f4fd-d519-4769-5510" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="15.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="3d78-57bd-0404-a136" name="Master-Crafted Heavy Flamer" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c5f6-f10f-d5d8-9623" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="ebea-7026-f3a0-0212" name="Master-crafted" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule"/>
+                <infoLink id="fcef-65a8-7951-223f" name="Heavy Flamer" hidden="false" targetId="c554-a05e-607c-5831" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="2828-29a7-3dc2-9f1b" name="Master-Crafted Autocannon" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d62-a4b5-d73d-806d" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="d35b-8e97-1c80-b081" name="Master-crafted" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule"/>
+                <infoLink id="d279-c5e8-66f2-33b5" name="Autocannon" hidden="false" targetId="d55f-eed0-800f-5789" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="7dc6-1e1d-cb43-580c" name="Master-Crafted Missile Launcher" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dcae-8eab-16a5-d46f" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="a604-aa64-f9b1-590d" name="Master-crafted" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule"/>
+                <infoLink id="eb4c-e535-207a-2ec8" name="Krak Missile" hidden="false" targetId="e2f7-5bdf-479c-8107" type="profile"/>
+                <infoLink id="d5f0-30c4-cb2b-7300" name="Frag Missile" hidden="false" targetId="40e6-c95c-7c8d-cf02" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="e500-1db0-6682-8b4a" name="Master-Crafted Multi-Melta" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5a19-29e0-6202-8b96" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="e92d-e000-3f41-60d4" name="Master-crafted" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule"/>
+                <infoLink id="2f73-246b-41be-dcca" name="Multi-Melta" hidden="false" targetId="4fc7-8b16-afe4-dad3" type="profile"/>
+                <infoLink id="9317-c811-482d-260f" name="New InfoLink" hidden="false" targetId="21c0-62ff-3ed2-17a7" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="4f28-6fdd-19d1-33bf" name="Master-Crafted Plasma Cannon" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cd1f-1e8f-bdeb-2673" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="38d9-50aa-7dbb-0c07" name="Master-crafted" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule"/>
+                <infoLink id="ba13-3489-7da6-5820" name="Plasma Cannon" hidden="false" targetId="13df-d6b0-3f33-bf9b" type="profile"/>
+                <infoLink id="f04d-217f-1a3f-4f05" name="New InfoLink" hidden="false" targetId="f4fd-d519-4769-5510" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="15.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="9f6e-df6c-a152-2a2a" name="Master-Crafted Heavy Bolter" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="168b-6ba2-9c88-6c4e" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="3605-5927-d086-c5d1" name="Master-crafted" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule"/>
+                <infoLink id="4b06-192d-69f5-7de6" name="Heavy Bolter" hidden="false" targetId="271e-6286-86cc-06dd" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="d305-533a-b47d-240d" name="Master-Crafted Vulkite Culverin" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cd19-25f4-73e9-934c" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="9af4-cb99-a272-dc2d" name="Master-crafted" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule"/>
+                <infoLink id="d3a4-79b8-9af1-30da" name="Volkite Culverin" hidden="false" targetId="34d1-b4db-3e75-ccce" type="profile"/>
+                <infoLink id="91d6-fca7-1fd6-f027" name="Deflagrate" hidden="false" targetId="b46a-a3ec-91a5-5001" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="15.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="01c7-83e8-29c6-e74d" name="Master-Crafted Lascannon" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f5b8-bc8c-72b7-d672" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="6cc2-8c1e-3338-e3bb" name="Master-crafted" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule"/>
+                <infoLink id="ed69-c3f8-28e9-b160" name="Lascannon" hidden="false" targetId="1cce-972c-022a-2590" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="20.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <entryLinks>
+            <entryLink id="e5b6-1360-ef4f-8bb3" name="Master-Crafted Bolter" hidden="false" collective="false" import="true" targetId="baaf-8622-e173-2b64" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="8f37-b0f2-31e4-f52b" name="May select the following" hidden="false" collective="false" import="true">
+          <selectionEntries>
+            <selectionEntry id="51a6-2096-7285-16c9" name="Suspensor Web" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d1a-9623-cf61-c8ef" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="5981-b788-ec3b-2a41" name="Suspensor Web" hidden="false" targetId="3d78-f901-8afc-00ff" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="11d8-0d7d-2bd3-aad5" name="Hardened Armour" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9588-0d0b-e4e8-62ec" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="8bca-ad13-dea9-6d2d" name="Hardened Armour" hidden="false" targetId="7439f6fd-4c50-f88a-eb41-81d9b9c9eed8" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <entryLinks>
+            <entryLink id="7626-70d3-905c-b378" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="c6b8-8b0b-8a31-6aa3" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="771a-5923-04bc-f6a1" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="6c48-fdbf-ee33-38d1" name="Melta Bombs" hidden="false" collective="false" import="true" targetId="4c62-8983-4a1b-d1c6" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="e233-2b74-1a09-baed" name="May select one of the following:" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="863b-2529-0e10-b5d2" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="7598-a839-5829-1cf4" name="Chainsword/Combat Blade" hidden="false" collective="false" import="true" targetId="4b1e-680b-1d39-e4f1" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="points" value="2.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="a229-29c5-693b-d3d5" name="Power Weapon" hidden="false" collective="false" import="true" targetId="e890-52eb-3444-c6c7" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="67d1-fdfa-c672-123a" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="15.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="82ba-0771-ac86-5615" name="Chainaxe" hidden="false" collective="false" import="true" targetId="4a8a-4994-c863-7723" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f0f0-5a34-e0dd-535e" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="2.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="5ad5-a575-8fad-b688" name="Caedere Weapons" hidden="false" collective="false" import="true" targetId="1114-bee3-f372-1b0a" type="selectionEntryGroup"/>
+            <entryLink id="4c4b-5c30-8068-bddf" name="Nostraman Chainglaive" hidden="false" collective="false" import="true" targetId="b6e5-70ca-8084-765d" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="points" value="15.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="2f0d-0301-6c0c-41dc" name="Frost Axe" hidden="false" collective="false" import="true" targetId="9435-b3aa-6ea4-f998" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="points" value="20.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="a130-10f9-6e26-070b" name="Frost Blade" hidden="false" collective="false" import="true" targetId="4dba-8812-cdc6-6172" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="points" value="20.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="567f-80ad-7cd6-9b43" name="Frost Claw" hidden="false" collective="false" import="true" targetId="0e82-ee75-815e-bb42" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="points" value="20.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="ddd0-ad02-568f-9600" name="Great Frost Blade" hidden="false" collective="false" import="true" targetId="20d9-aac6-cf49-54c7" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="points" value="25.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="0a3e-c80a-618c-7c0c" name="May exchange Bolt Pistol for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="1878-ead4-5155-50eb">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c6a7-e5d3-9e46-5ed6" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="01b1-6a2d-5a9c-4d0e" type="min"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="1878-ead4-5155-50eb" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="8e2a-0525-9100-3264" type="selectionEntry"/>
+            <entryLink id="fc2b-020c-9bf7-93c1" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="f832-f4b2-6aaf-ad83" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="b26c-6acd-6ff7-a69b" name="Volkite Serpenta" hidden="false" collective="false" import="true" targetId="ae27-c659-fffd-1561" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="points" value="2.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="db5a-929e-c3e0-19aa" name="Inferno Pistol " hidden="false" collective="false" import="true" targetId="13f8-6607-3525-4298" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="59f6-638d-8c1d-75dd" type="equalTo"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e2d7-e297-5b99-cbac" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="68e1-d505-9fd7-022a" name="Hand Flamer" hidden="false" collective="false" import="true" targetId="8a98-53c5-6fab-b3a7" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="a778-35aa-8492-6eb4" name="New EntryLink" hidden="false" collective="false" import="true" targetId="0a96-04b6-7340-91a4" type="selectionEntry"/>
+        <entryLink id="4d6b-ea44-c079-dae4" name="New EntryLink" hidden="false" collective="false" import="true" targetId="0a53-b471-df87-7b83" type="selectionEntry"/>
+        <entryLink id="bb14-1fc4-4cfc-13ac" name="Nuncio-vox" hidden="false" collective="false" import="true" targetId="3b07-bf87-1e36-9181" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="points" value="0.0"/>
+          </modifiers>
+        </entryLink>
+        <entryLink id="66f9-b732-83dc-aca8" name="Legion-specific upgrade:" hidden="false" collective="false" import="true" targetId="efe5-effa-a371-ae4e" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="95.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="491a-9bf1-e9bd-b2f8" name="Possessed Astartes Squad, Legion" publicationId="0e6e-8c19-c436-39c4" hidden="true" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e348-5834-5741-186f" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <rules>
+        <rule id="52b7-271f-5f47-2f90" name="Damned" hidden="false">
+          <description>The unit never counts as Scoring</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="b423-71e5-6d19-8feb" name="Daemon" hidden="false" targetId="3eda-669d-bd54-e3c0" type="rule"/>
+        <infoLink id="c945-6808-2308-e135" name="Stubborn" hidden="false" targetId="7be5-30af-1a02-0a89" type="rule"/>
+        <infoLink id="c71d-55c0-59da-1ccb" name="Rending" hidden="false" targetId="8269-2cd6-9236-16e7" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Rending (Melee Only)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="ca3c-9986-ae91-6d75" name="Bulky" hidden="false" targetId="38d5-b6eb-bda8-2497" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="4ef7-d01a-79cd-67e7" name="Infantry" hidden="false" targetId="1ab3-f1ac-f724-8544" primary="false"/>
+        <categoryLink id="da0f-7846-87cb-cec8" name="Legiones Astartes" hidden="false" targetId="f321-f2d7-7d68-8f93" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="52f2-8d32-5d9e-e91f" name="Possessed Marine" hidden="false" collective="false" import="true" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="96ea-38c5-1409-ea30" type="min"/>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5586-5e8f-10e9-2cfb" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="3db5-074f-223c-5e92" name="Possessed Marine" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+              <modifiers>
+                <modifier type="increment" field="5423232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="491a-9bf1-e9bd-b2f8" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8cbb-74e5-2667-a519" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="4923232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="491a-9bf1-e9bd-b2f8" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="af0c-5985-bfa6-e99c" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="575323232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="491a-9bf1-e9bd-b2f8" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="af0c-5985-bfa6-e99c" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="5323232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="491a-9bf1-e9bd-b2f8" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7bef-bae1-dc26-e66c" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <characteristics>
+                <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry</characteristic>
+                <characteristic name="WS" typeId="575323232344415441232323">4</characteristic>
+                <characteristic name="BS" typeId="425323232344415441232323">4</characteristic>
+                <characteristic name="S" typeId="5323232344415441232323">4</characteristic>
+                <characteristic name="T" typeId="5423232344415441232323">4</characteristic>
+                <characteristic name="W" typeId="5723232344415441232323">2</characteristic>
+                <characteristic name="I" typeId="4923232344415441232323">4</characteristic>
+                <characteristic name="A" typeId="4123232344415441232323">2</characteristic>
+                <characteristic name="LD" typeId="4c4423232344415441232323">8</characteristic>
+                <characteristic name="Save" typeId="5361766523232344415441232323">3+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="25.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="363d-2beb-ff36-828a" name="Possessed Sergeant" hidden="false" collective="false" import="true" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2436-8726-ae72-a935" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="10aa-ccf0-fc4f-cfa5" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="57ac-6c2f-1cfc-13ab" name="Possessed Sergeant" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+              <modifiers>
+                <modifier type="set" field="5361766523232344415441232323" value="2+">
+                  <conditions>
+                    <condition field="selections" scope="491a-9bf1-e9bd-b2f8" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3162-da54-aed7-8537" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="5323232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="491a-9bf1-e9bd-b2f8" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7bef-bae1-dc26-e66c" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="5423232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="491a-9bf1-e9bd-b2f8" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8cbb-74e5-2667-a519" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="575323232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="491a-9bf1-e9bd-b2f8" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="af0c-5985-bfa6-e99c" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="4923232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="491a-9bf1-e9bd-b2f8" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="af0c-5985-bfa6-e99c" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <characteristics>
+                <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry (Character)</characteristic>
+                <characteristic name="WS" typeId="575323232344415441232323">4</characteristic>
+                <characteristic name="BS" typeId="425323232344415441232323">4</characteristic>
+                <characteristic name="S" typeId="5323232344415441232323">4</characteristic>
+                <characteristic name="T" typeId="5423232344415441232323">4</characteristic>
+                <characteristic name="W" typeId="5723232344415441232323">3</characteristic>
+                <characteristic name="I" typeId="4923232344415441232323">4</characteristic>
+                <characteristic name="A" typeId="4123232344415441232323">3</characteristic>
+                <characteristic name="LD" typeId="4c4423232344415441232323">9</characteristic>
+                <characteristic name="Save" typeId="5361766523232344415441232323">3+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <categoryLinks>
+            <categoryLink id="a45b-3ce9-b5fa-dcd5" name="Character" hidden="false" targetId="ae54-92c7-3e66-59f7" primary="false"/>
+          </categoryLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="39a9-c587-3076-b5d0" name="Dedicated Transport" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b470-1baf-1716-401b" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="4f77-36a5-e925-887c" name="Rhino Armoured Carrier, Legion" hidden="false" collective="false" import="true" targetId="00ee-3a61-8872-d01e" type="selectionEntry"/>
+            <entryLink id="dcda-1692-f99d-6b75" name="Drop Pod" hidden="false" collective="false" import="true" targetId="2dcf-da0f-297d-fccf" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="948d-71e8-6673-6add" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="df49-e13b-3031-71de" name="For every 5 models in the squad, one model may echange their Bolter for:" hidden="false" collective="false" import="true">
+          <modifiers>
+            <modifier type="increment" field="1fc0-8f97-1ed9-646b" value="1.0">
+              <repeats>
+                <repeat field="selections" scope="491a-9bf1-e9bd-b2f8" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1fc0-8f97-1ed9-646b" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="44cb-eeee-f6fe-99ee" name="Flamer" hidden="false" collective="false" import="true" targetId="4cc6-e521-dc9a-c117" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="370c-bef4-57de-012c" value="2.0"/>
+                <modifier type="set" field="points" value="5.0"/>
+              </modifiers>
+            </entryLink>
+            <entryLink id="1986-98ce-5a5d-5853" name="Meltagun" hidden="false" collective="false" import="true" targetId="a22d-ceac-5063-54e1" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="c23b-b876-e683-4f04" value="2.0"/>
+                <modifier type="set" field="points" value="10.0"/>
+              </modifiers>
+            </entryLink>
+            <entryLink id="13ad-772d-80c4-f3dc" name="Plasma gun" hidden="false" collective="false" import="true" targetId="0f13-bded-1c10-bc38" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="5f3e-444b-2315-5e66" value="2.0"/>
+              </modifiers>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="87d0-8bb6-b04f-9526" name="Possessed Sergeant may select the following" hidden="false" collective="false" import="true">
+          <entryLinks>
+            <entryLink id="3162-da54-aed7-8537" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="c6b8-8b0b-8a31-6aa3" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3599-02f6-da9b-b58d" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="3053-d51a-d9be-329a" name="Melta Bombs" hidden="false" collective="false" import="true" targetId="4c62-8983-4a1b-d1c6" type="selectionEntry"/>
+            <entryLink id="6d3b-f713-9ec6-1b73" name="Legion-specific upgrade:" hidden="false" collective="false" import="true" targetId="efe5-effa-a371-ae4e" type="selectionEntryGroup"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="95cf-fe00-7d11-d26a" name="Any model may exhange their Chainsword for" hidden="false" collective="false" import="true">
+          <modifiers>
+            <modifier type="increment" field="0e01-dccf-bc8c-156b" value="1.0">
+              <repeats>
+                <repeat field="selections" scope="491a-9bf1-e9bd-b2f8" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="52f2-8d32-5d9e-e91f" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+            <modifier type="increment" field="1409-408b-d6ec-3661" value="1.0">
+              <repeats>
+                <repeat field="selections" scope="491a-9bf1-e9bd-b2f8" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="52f2-8d32-5d9e-e91f" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0e01-dccf-bc8c-156b" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1409-408b-d6ec-3661" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="9d8e-5a2b-14b5-cb8d" name="Chainsword" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f8b1-e49f-aeb0-780a" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="a3e0-a6e7-c08a-565d" name="New InfoLink" hidden="false" targetId="730c-b70b-1e8f-f2e9" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <entryLinks>
+            <entryLink id="7096-c29e-a8ec-d6da" name="Chainaxe" hidden="true" collective="false" import="true" targetId="a3a3-3a90-0c2a-cd81" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3d14-4976-b582-a736" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="475f-95c0-81a4-64ba" value="9.0"/>
+              </modifiers>
+            </entryLink>
+            <entryLink id="a8b2-8899-3bdb-e502" name="Power Weapon (Squad)" hidden="false" collective="false" import="true" targetId="8db1-05f7-f5dd-8b9c" type="selectionEntryGroup"/>
+            <entryLink id="ab35-e652-add0-9c92" name="Pair of Lightning Claws" hidden="false" collective="false" import="true" targetId="67d0-a3f7-8e19-693b" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="0957-2766-a673-37ba" value="9.0"/>
+              </modifiers>
+              <costs>
+                <cost name="pts" typeId="points" value="15.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="1f41-215d-3d08-8243" name="Lightning Claw" hidden="false" collective="false" import="true" targetId="26db-484d-3757-03c8" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="b2ab-5b47-b382-d02f" value="9.0"/>
+              </modifiers>
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="76ce-9877-2785-2c0c" name="Raven&apos;s Talons" hidden="false" collective="false" import="true" targetId="d491-f3be-c649-cc6b" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="50ed-2ebb-cfe1-eda6" value="9.0"/>
+              </modifiers>
+              <costs>
+                <cost name="pts" typeId="points" value="20.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="cab0-50e4-64ec-705f" name="Pair of Raven&apos;s Talons" hidden="false" collective="false" import="true" targetId="a8e8-37e5-3b8e-ccef" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="8d7f-b6d0-74ed-93a7" value="9.0"/>
+              </modifiers>
+              <costs>
+                <cost name="pts" typeId="points" value="25.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="bfab-baa9-2658-86a0" name="Select one option for the unit" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ea4d-d70a-38d7-f301" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e9f3-7b78-3f22-b711" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="8cbb-74e5-2667-a519" name="Feel No Pain and T5" hidden="false" collective="false" import="true" type="upgrade">
+              <infoLinks>
+                <infoLink id="2ed5-ff0f-4acb-79ba" name="Feel No Pain (5+)" hidden="false" targetId="dbf6-2f12-bb4a-517c" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="af0c-5985-bfa6-e99c" name="Fleet, Crusader, I5 and WS5" hidden="false" collective="false" import="true" type="upgrade">
+              <infoLinks>
+                <infoLink id="47c5-27a8-2be4-cd87" name="Crusader" hidden="false" targetId="2b06-29a6-641a-b22e" type="rule"/>
+                <infoLink id="a445-ac2b-7a6e-26a8" name="Fleet" hidden="false" targetId="69e5-fc02-1f9d-63c2" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="454d-b51c-fac6-12d3" name="Brotherhood of Psykers (Level 1, increased to Level 2 whilst ever the squad numbers 6+ models)" hidden="false" collective="false" import="true" type="upgrade">
+              <infoLinks>
+                <infoLink id="51a7-f9f9-3b36-93b2" name="Brotherhood of Psykers/Sorcerers" hidden="false" targetId="8e59-1172-280d-75e8" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="7bef-bae1-dc26-e66c" name="Rage, Furious Charge and S5" hidden="false" collective="false" import="true" type="upgrade">
+              <infoLinks>
+                <infoLink id="2fad-d932-c4d4-08b6" name="Furious Charge" hidden="false" targetId="3aa7-9a8f-1e0d-921d" type="rule"/>
+                <infoLink id="57b4-f8d6-1be0-48f4" name="Rage" hidden="false" targetId="988c-d4d0-9418-1165" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="9853-9aca-a682-46a5" name="Legion-specific upgrade:" hidden="false" collective="false" import="true">
+          <categoryLinks>
+            <categoryLink id="ad65-697f-7fa8-e4db" name="Infantry" hidden="false" targetId="1ab3-f1ac-f724-8544" primary="false"/>
+            <categoryLink id="237f-3f15-9d5e-2317" name="Jump Units" hidden="false" targetId="a787-4801-eb77-f2cf" primary="false"/>
+            <categoryLink id="0a2b-00d4-d9f3-19fa" name="Legiones Astartes" hidden="false" targetId="f321-f2d7-7d68-8f93" primary="false"/>
+          </categoryLinks>
+          <entryLinks>
+            <entryLink id="3e74-66ca-bec7-8f12" name="Sonic Shriekers" hidden="false" collective="false" import="true" targetId="45cd-edae-7a23-95c6" type="selectionEntry">
+              <modifiers>
+                <modifier type="increment" field="points" value="2.0">
+                  <repeats>
+                    <repeat field="selections" scope="491a-9bf1-e9bd-b2f8" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e691-ca90-8d84-e998" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </entryLink>
+            <entryLink id="e976-5ce4-31a9-2e27" name="Cult Arcana" hidden="false" collective="false" import="true" targetId="52df-ddc4-325b-ec5a" type="selectionEntryGroup"/>
+            <entryLink id="3394-6063-b7d7-0f68" name="Chem-munitions" hidden="false" collective="false" import="true" targetId="b432-5750-528f-98f3" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="e1b9-6d3d-d55f-5470" name="Possessed Sergeant may replace his Chainsword with:" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5a94-a06c-a918-5ebf" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="175f-ad1e-c956-9f3e" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="a329-f384-3adf-9217" name="Chainsword" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1a79-5656-3d8b-eff6" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="3921-7fb4-0ea6-1b12" name="New InfoLink" hidden="false" targetId="730c-b70b-1e8f-f2e9" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <entryLinks>
+            <entryLink id="e5d6-7cb6-18e2-e199" name="Chainaxe" hidden="true" collective="false" import="true" targetId="a3a3-3a90-0c2a-cd81" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3d14-4976-b582-a736" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </entryLink>
+            <entryLink id="c322-486b-5e7d-c4e0" name="Pair of Lightning Claws" hidden="false" collective="false" import="true" targetId="67d0-a3f7-8e19-693b" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="points" value="15.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="45ca-43f4-ed7a-85a9" name="Lightning Claw" hidden="false" collective="false" import="true" targetId="26db-484d-3757-03c8" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="077b-eb43-b25d-4146" name="Power Fist" hidden="false" collective="false" import="true" targetId="fcef-f5ac-16a3-9401" type="selectionEntry"/>
+            <entryLink id="4ed3-661d-b12d-dfa8" name="Raven&apos;s Talons" hidden="false" collective="false" import="true" targetId="d491-f3be-c649-cc6b" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="points" value="20.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="1618-6c67-676b-2fb4" name="Pair of Raven&apos;s Talons" hidden="false" collective="false" import="true" targetId="a8e8-37e5-3b8e-ccef" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="points" value="25.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="7daf-b921-20a1-2380" name="Nostraman Chainglaive" hidden="false" collective="false" import="true" targetId="b6e5-70ca-8084-765d" type="selectionEntry"/>
+            <entryLink id="993d-af5b-e2ce-efc6" name="Power Glaive" hidden="false" collective="false" import="true" targetId="fd9c-9193-2c50-e929" type="selectionEntry"/>
+            <entryLink id="25ad-77ab-6b03-c743" name="Power Scythe" hidden="false" collective="false" import="true" targetId="3410-908e-d98d-593d" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="points" value="15.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="eefc-3f22-0f7b-d6f2" name="Calibanite War Blade" hidden="false" collective="false" import="true" targetId="5bc2-ceb4-2e34-7004" type="selectionEntry"/>
+            <entryLink id="c9e4-ee32-422c-00e1" name="Phoenix Spear" hidden="false" collective="false" import="true" targetId="bca4-ae83-c058-2822" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="points" value="15.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="f8b7-5e7b-9546-6b12" name="Albian Power Gladius" hidden="false" collective="false" import="true" targetId="1b80-5b44-0e03-b9e4" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="points" value="15.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="0d49-a83a-24ce-6f6e" name="Cthonian Culling Blade" hidden="false" collective="false" import="true" targetId="270a-0bb6-b354-6b75" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="points" value="15.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="a4cd-7f48-5408-8f7c" name="Power Axe" hidden="false" collective="false" import="true" targetId="7b92-ab87-86a1-ab2e" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f5ea-47ef-ce4f-5b84" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="feaa-a6f9-6ff2-2688" name="Power Lance" hidden="false" collective="false" import="true" targetId="233d-238b-6940-2740" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="23a4-bd28-b052-8763" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="40af-e3fe-4654-fb74" name="Power Maul" hidden="false" collective="false" import="true" targetId="e8a2-42e8-82a7-8dd9" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d37a-8fe5-0278-c93b" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="8ec3-05a1-13a0-cab5" name="Power Sword" hidden="false" collective="false" import="true" targetId="3e90-5ca1-8abe-0275" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e18e-36d6-8c76-61ec" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="a8be-fd0e-394a-642d" name="Tainted Weapon" hidden="false" collective="false" import="true" targetId="104d-2c15-b4b8-c299" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="d79e-909a-d489-64d2" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="8e2a-0525-9100-3264" type="selectionEntry"/>
+        <entryLink id="bb93-95b1-fb14-94e5" name="Bolters" hidden="false" collective="false" import="true" targetId="ac90-ce47-65c6-f5f3" type="selectionEntry"/>
+        <entryLink id="ddb2-635b-1b9d-d240" name="New EntryLink" hidden="false" collective="false" import="true" targetId="0a53-b471-df87-7b83" type="selectionEntry"/>
+        <entryLink id="5116-f123-6bdc-3aa2" name="New EntryLink" hidden="false" collective="false" import="true" targetId="0a96-04b6-7340-91a4" type="selectionEntry"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="50.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f5e9-9621-b2c8-ea31" name="Solar Auxilia Life Ward Retinue" publicationId="0e6e-8c19-c436-39c4" hidden="false" collective="false" import="true" type="unit">
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="8e3d-2ecf-63b7-d031" name="Eidis Engeineer Section" publicationId="0e6e-8c19-c436-39c4" hidden="false" collective="false" import="true" type="unit">
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b0a1-1da4-9b58-ef9f" name="Hades Breaching Drill" publicationId="0e6e-8c19-c436-39c4" hidden="false" collective="false" import="true" type="unit">
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b5a6-39bb-c647-ff8b" name="Armoured Sentinel Squadron" publicationId="0e6e-8c19-c436-39c4" hidden="false" collective="false" import="true" type="unit">
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="32a3-4c17-a969-d451" name="Lykis Maelstrom Section" publicationId="0e6e-8c19-c436-39c4" hidden="false" collective="false" import="true" type="unit">
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="bd24-af2a-dff1-0b3a" name="Achmiris Recon Section" publicationId="0e6e-8c19-c436-39c4" hidden="false" collective="false" import="true" type="unit">
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9aa7-a560-daad-a483" name="Vothid Salvage Suit" publicationId="0e6e-8c19-c436-39c4" hidden="false" collective="false" import="true" type="unit">
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="72ae-7bfc-596e-b3ce" name="Eposremis Thunder Section" publicationId="0e6e-8c19-c436-39c4" hidden="false" collective="false" import="true" type="unit">
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="de8e-b01a-4038-b174" name="Mechanicum Triaros Guardian" publicationId="0e6e-8c19-c436-39c4" hidden="false" collective="false" import="true" type="unit">
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="be8b-413e-7caf-3d17" name="Myrmidon Reductor" publicationId="0e6e-8c19-c436-39c4" hidden="false" collective="false" import="true" type="unit">
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="eaab-ed4b-01d4-f0aa" name="Militia Mounted Squadron" publicationId="0e6e-8c19-c436-39c4" hidden="false" collective="false" import="true" type="unit">
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ce2d-cdd3-8beb-2bb8" name="Legio Custodes Talon Master" publicationId="0e6e-8c19-c436-39c4" hidden="false" collective="false" import="true" type="unit">
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="d465-6e98-4ef0-ed90" name="Militia Land Speeder" publicationId="0e6e-8c19-c436-39c4" hidden="false" collective="false" import="true" type="unit">
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f422-4b7c-29dc-7293" name="Allegiance" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="45fb-f26a-cb44-3e03" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0e38-a1c5-4451-eec3" type="min"/>
+      </constraints>
+      <entryLinks>
+        <entryLink id="3292-8eba-b3ea-2145" name="Allegiance" hidden="false" collective="false" import="true" targetId="1230-9588-bb07-b67f" type="selectionEntryGroup"/>
+        <entryLink id="3231-dba7-b5cd-ef8b" name="Legions" hidden="false" collective="false" import="true" targetId="9cc1-123b-848a-d8d6" type="selectionEntryGroup"/>
+        <entryLink id="80cf-3346-a3e7-5d98" name="Rites of War" hidden="false" collective="false" import="true" targetId="8001-53aa-f47f-9939" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7d6c-b456-0c37-1f96" name="Exodus Assassin" publicationId="0e6e-8c19-c436-39c4" page="18" hidden="true" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e348-5834-5741-186f" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <rules>
+        <rule id="e2f1-65a1-21f2-69b6" name="Deadshot" hidden="false">
+          <description>All successful hits, excluding Snap Shots, gain the Precision Shot rule.</description>
+        </rule>
+        <rule id="5c5d-257a-5b36-509c" name="Execute the Mandate" hidden="false">
+          <description>Gain +1VP at the end of the game if the enemy’s Warlord was removed as a casualty as a result of a Wound inflicted by a model with this rule.</description>
+        </rule>
+        <rule id="51b2-29cc-3372-ed35" name="Lone Killer" hidden="false">
+          <description>An Exodus Assassin can never join or be joined by other models. May not be selected as a compulsory HQ or be the Warlord of an army.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="9873-b113-b59c-f408" name="Power Armour" hidden="false" targetId="16b1-5d9f-cc76-f19d" type="profile"/>
+        <infoLink id="46dd-1e07-a70a-d8c2" name="Independent Character" hidden="false" targetId="3ad4-1c37-d60b-1a4e" type="rule"/>
+        <infoLink id="3e95-834f-daa6-ec90" name="Acute Senses" hidden="false" targetId="e15d-1437-cfb2-b8dd" type="rule"/>
+        <infoLink id="be87-1280-ef3a-e519" name="Cameleoline" hidden="false" targetId="0999-730e-6f17-dcc7" type="profile"/>
+        <infoLink id="5d7d-7780-9eff-36cd" name="Infiltrate" hidden="false" targetId="34c7-8b61-a5b8-a301" type="rule"/>
+        <infoLink id="5b57-1aaa-6bab-0e68" name="Move Through Cover" hidden="false" targetId="6d06-5ea0-9a17-ca97" type="rule"/>
+        <infoLink id="f0c1-62fa-ddf0-36a8" name="Scout" hidden="false" targetId="9b30-1da3-eb8d-ce7a" type="rule"/>
+        <infoLink id="d441-1438-db66-1940" name="Agent of the Warmaster" hidden="false" targetId="438f-70e3-53e6-46fe" type="rule"/>
+        <infoLink id="6aa7-a623-2f06-506d" name="Stealth" hidden="false" targetId="0d66-14c9-d2f4-708b" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="6369-1631-3fe3-2bd3" name="Independent Character" hidden="false" targetId="1d9c-cc5a-0f91-2590" primary="false"/>
+        <categoryLink id="e9e6-0aa8-4c71-b803" name="Infantry" hidden="false" targetId="1ab3-f1ac-f724-8544" primary="false"/>
+        <categoryLink id="5fca-7c25-2f31-d34b" name="Legiones Astartes" hidden="false" targetId="f321-f2d7-7d68-8f93" primary="false"/>
+        <categoryLink id="02c0-5dc5-d18f-4e66" name="Character" hidden="false" targetId="ae54-92c7-3e66-59f7" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="a982-93b4-a61f-163f" name="Legiones Astartes (Alpha Legion)" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3433-17ec-2af3-fe5e" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="60a7-d2df-02b5-3afd" type="min"/>
+          </constraints>
+          <rules>
+            <rule id="44b7-d0c5-e1b1-3a05" name="The Alpha Legion" publicationId="ca571888--pubN67459" page="124" hidden="false">
+              <description>• Mutable Tactics: An Alpha Legion army must pick one of the following special rules at the point where Warlord Traits have been selected for the game. This rule then applies to all of the units in the detachment with the Legiones Astartes (Alpha Legion) special rule for the duration of this game:
+- Scout
+- Infiltrate
+- Tank Hunters
+- Counter-attack
+- Move Through Cover
+- Adamantium Will
+• Martial Hubris: In any mission where secondary objectives are being used, and an Alpha Legion army is your army’s primary detachment, if the Alpha Legion army has suffered more units destroyed than their enemy at the end of the game, then their enemy gains 1 Victory point.
+(In the case of Shattered Legions. The army only gains both of these benifits if the Warlord is Alpha Legion)</description>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="0722-9027-d123-14e5" name="Legiones Astartes" hidden="false" targetId="23a4-a37f-e8e8-c756" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="c5b1-fe5c-0b33-4e2b" name="Combat Blade" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a56f-c420-b032-bb94" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2bdf-0022-6ac9-33cf" type="min"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="8d9e-86f5-c0e2-da5a" name="New InfoLink" hidden="false" targetId="730c-b70b-1e8f-f2e9" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="2e28-2ad8-325f-2b75" name="Power Dagger" publicationId="ca571888--pubN67459" page="" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="04b4-60ea-bda8-b640" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="1675-ee72-9ac5-07da" name="Power Dagger" publicationId="ca571888--pubN67459" page="" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
+                <characteristic name="Strength" typeId="537472656e67746823232344415441232323">-1</characteristic>
+                <characteristic name="AP" typeId="415023232344415441232323">3</characteristic>
+                <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Specialist Weapon, Rending</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="4688-9e8b-389e-f052" name="Venom Spheres" publicationId="ca571888--pubN67459" page="" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a249-789b-db02-8d1a" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="4570-911f-cc05-759e" name="Venom Spheres" publicationId="ca571888--pubN67459" page="" hidden="false">
+              <description>Replaces Frag grenades.  Assault grenade that grants Hammer of Wrath to user.</description>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="5f00-829e-6588-d8bb" name="Hammer of Wrath" hidden="false" targetId="6f66-b417-6004-0916" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="a63d-720f-59ae-2662" name="Heavy Sniper Rifle" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="40de-6b74-77aa-235b" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4059-f653-af28-9e42" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="2f61-393b-94a9-d0d5" name="Heavy Sniper Rifle (Rapid Fire)" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="52616e676523232344415441232323">36&quot;</characteristic>
+                <characteristic name="Strength" typeId="537472656e67746823232344415441232323">5</characteristic>
+                <characteristic name="AP" typeId="415023232344415441232323">4</characteristic>
+                <characteristic name="Type" typeId="5479706523232344415441232323">Salvo 2/4, Rending</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="d90e-7d18-05cd-2f9b" name="Heavy Sniper Rifle (Single-Shot)" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="52616e676523232344415441232323">36&quot;</characteristic>
+                <characteristic name="Strength" typeId="537472656e67746823232344415441232323">6</characteristic>
+                <characteristic name="AP" typeId="415023232344415441232323">3</characteristic>
+                <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 1, Rending, Lethal, Ignores Cover</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="646c-9f55-7b32-b033" name="Lethal" hidden="false">
+              <description>This attack inflicts two wounds per unsaved wounding hit.</description>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="e840-2b34-defd-9449" name="Rending" hidden="false" targetId="8269-2cd6-9236-16e7" type="rule"/>
+            <infoLink id="c750-b0f0-812a-80c8" name="Ignores Cover" hidden="false" targetId="476c-b962-06e5-d12e" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="f422-3312-ae39-0e5d" name="Frag and Krak Grenades" hidden="false" collective="false" import="true" targetId="0a53-b471-df87-7b83" type="selectionEntry"/>
+        <entryLink id="dfc6-79c4-071f-4e25" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="8e2a-0525-9100-3264" type="selectionEntry"/>
+        <entryLink id="78b2-ff29-9bde-b3b8" name="Melta Bombs" hidden="false" collective="false" import="true" targetId="4c62-8983-4a1b-d1c6" type="selectionEntry"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="100.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="984d-5135-e1be-f8e8" name="Additional Ammunition Types" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5f09-f343-6ca9-6776" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ca9a-5e32-2d16-4e8e" type="min"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="bfc2-ff01-435a-949b" name="New CategoryLink" hidden="false" targetId="1fb0-1499-5637-4715" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="7bff-6c80-faa4-66b3" name="Dark Angels: Acid Bolts" hidden="false" collective="false" import="true" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1445-c8d0-6c21-9c6a" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <profiles>
+            <profile id="0b07-4a78-8314-1581" name="Dark Angels: Acid Bolts" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
+              <characteristics>
+                <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Bolt Pistols and Bolters of Command, Destroyer and Veteran Squads gain AP D3+2 (roll for each wound)</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="15.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="c2ed-e63b-b05a-9884" name="Emperors Children: Rapture Bolts" hidden="false" collective="false" import="true" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0a28-2fed-0e5c-e9e2" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <profiles>
+            <profile id="b80d-dbd4-9246-d3e3" name="Emperors Children: Rapture Bolts" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
+              <characteristics>
+                <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Bolt Pistols and Bolters of Command, Veteran and Tactical Squads gain Fleshbane on to hit rolls of 6 (excluding Snap Shots).</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="8a0d-7ed1-bc1a-3f49" name="Fleshbane" hidden="false" targetId="4575-0a0a-caaf-e4bf" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="4d0c-3350-9f50-958d" name="Iron Warriors: Shrapnel Bolts" hidden="false" collective="false" import="true" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1660-f879-3beb-0c0b" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <profiles>
+            <profile id="c888-debc-746c-b133" name="Iron Warriors: Shrapnel Bolts" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
+              <characteristics>
+                <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Bolters of Legiones Astartes (Iron Warriors) gain Pinning.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="e7f2-8101-d121-1a11" name="Pinning" hidden="false" targetId="f624-f475-e5ec-0dfa" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="526d-69a5-9c5c-3ff3" name="White Scars: Hyper Velocity Bolts" hidden="false" collective="false" import="true" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="391e-b071-6cbc-c41a" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <profiles>
+            <profile id="6f6a-4630-7f81-2603" name="White Scars: Hyper Velocity Bolts" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
+              <characteristics>
+                <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Bolters of Infantry units increase range to 30”</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="1766-0ae0-05b9-d6b9" name="Imperial Fists: Artisan Bolts" hidden="false" collective="false" import="true" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ccb3-6eea-535f-86a5" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <profiles>
+            <profile id="3af8-ea52-27d1-589f" name="Imperial Fists: Artisan Bolts" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
+              <characteristics>
+                <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Bolters of Command, Veteran and Terminator Squads gain Master-crafted.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="811d-ce48-3a41-cd9e" name="Master-crafted" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="5033-09d6-d460-b0d6" name="Thousand Sons: Asphyx Light Shells" page="" hidden="false" collective="false" import="true" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="476c-3cc9-7506-2a80" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <profiles>
+            <profile id="a604-edff-e958-d693" name="Thousand Sons: Asphyx Light Shells" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
+              <characteristics>
+                <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Bolters of Infantry units rolls of 6 to hit (excluding Snap Shots) gain Shred.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="4a70-0b47-95b3-772d" name="Shred" hidden="false" targetId="89da-0cb5-bee4-8ec2" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="305c-e78f-1562-7c69" name="Word Bearers: Hex-bolts" hidden="false" collective="false" import="true" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4997-fb0a-fb78-aca8" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <profiles>
+            <profile id="a157-d598-7e51-d9ee" name="Word Bearers: Hex-bolts" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
+              <characteristics>
+                <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Bolt Pistols and Bolters of all Legiones Astartes (Word Bearers) gain Soul Blaze</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="2cb6-1d6e-a0e1-8881" name="Soul Blaze" hidden="false" targetId="acb1-64c4-ef54-3a55" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="4a46-587e-4afa-e979" name="Salamanders: Pyre bolts" hidden="false" collective="false" import="true" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e2d7-e297-5b99-cbac" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <profiles>
+            <profile id="6e4c-83f5-e8df-c82f" name="Salamanders: Pyre bolts" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
+              <characteristics>
+                <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Bolters of Tactical, Breacher and Veteran Squads gain Deflagrate.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="9f6d-f63d-8251-cae2" name="Deflagrate" hidden="false" targetId="b46a-a3ec-91a5-5001" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="dae3-db2d-8f5a-16f7" name="Raven Guard: Scorpius Light" hidden="false" collective="false" import="true" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4b8d-2642-cc86-8114" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <profiles>
+            <profile id="0f08-c445-6069-e70c" name="Raven Guard: Scorpius Light" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
+              <characteristics>
+                <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Bolters of Veteran, Tactical and Recon squads gain: If the remained stationary in the preceding movement phase, they may choose to fire their bolters with the following profile type: Heavy 1, To hit rolls of 6 gain AP2, excluding Snap Shots</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="15.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="bb14-011f-75ae-4715" name="Alpha Legion: Banestrike" hidden="true" collective="false" import="true" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="eac6-9b93-9a5a-a30b" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <profiles>
+            <profile id="5433-0684-53b9-94ee" name="Alpha Legion: Banestrike" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
+              <characteristics>
+                <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Bolt Pistols and Bolters of Infantry units gain AP3 on rolls of 6 to wound.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="15.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="1f3c-fa79-2c31-7e0c" name="Militia: Hot-Shot" hidden="false" collective="false" import="true" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6ebb-bd17-f334-0fb1" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <profiles>
+            <profile id="e21f-3f4f-2a5f-3dc0" name="Militia: Hot-Shot" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
+              <characteristics>
+                <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Militia Grenadier squads equipped with Auxilia Rifles may instead choose to use the following profile when shooting:
+Range 18&quot;, Str 3, AP 3, Assault 1, Gets Hot!</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="8467-69bb-c985-df1e" name="Gets Hot" hidden="false" targetId="f4fd-d519-4769-5510" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="40.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="b9c4-ac44-4fce-4231" name="Sons of Horus: Banestrike" hidden="false" collective="false" import="true" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="550e-dd7c-23b2-c37b" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <profiles>
+            <profile id="27e8-4f42-314e-e9f1" name="Sons of Horus: Banestrike" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
+              <characteristics>
+                <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Bolters of Legiones Astartes: gain AP3 on rolls of 6 to wound.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="15.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="193f-0e89-a431-f7f3" name="Death Guard: Toxin Bolts" hidden="false" collective="false" import="true" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0f9b-69d0-8106-dc52" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <profiles>
+            <profile id="e38f-16d1-4f55-c7c4" name="Death Guard: Toxin Bolts" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
+              <characteristics>
+                <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Bolters of Infantry units gain Poisoned (3+), Gets Hot.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="5381-2b3e-882f-ef2a" name="Gets Hot" hidden="false" targetId="f4fd-d519-4769-5510" type="rule"/>
+            <infoLink id="ff9d-298a-b13d-ddec" name="Poisoned" hidden="false" targetId="a5ff-1cb1-bee4-d809" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="10.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="a606-871a-b0e0-4f95" name="Ultramarines: Banestrike" hidden="false" collective="false" import="true" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c52d-5459-0d1f-8a9e" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <profiles>
+            <profile id="22e1-7567-365c-6091" name="Ultramarines: Banestrike" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
+              <characteristics>
+                <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Bolters of Tactical, Breacher and Veteran Squads: gain AP3 on rolls of 6 to wound.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="15.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="11aa-7e82-390f-8582" name="Iron Hands: Splinter Bolts" hidden="false" collective="false" import="true" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b7d6-8217-4fe9-45d4" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <profiles>
+            <profile id="6cb3-9da0-4261-4cd1" name="Iron Hands: Splinter Bolts" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
+              <characteristics>
+                <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Bolters of Infantry units ignore Feel No Pain.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="12d8-0181-2e21-a6e5" name="Blood Angels: Hammer Bolts" hidden="false" collective="false" import="true" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="59f6-638d-8c1d-75dd" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <profiles>
+            <profile id="cfa6-d19a-fcc6-25c3" name="Blood Angels: Hammer Bolts" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
+              <characteristics>
+                <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Bolters of Tactical and Veteran Squads gain Strikedown.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="94b1-e988-8845-f110" name="Strikedown" hidden="false" targetId="dd83-7fb9-6f58-0c96" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="f72a-9a47-ac49-0c09" name="Night Lords: Kraken Light Bolts" hidden="false" collective="false" import="true" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2732-8ccb-cc97-ee5d" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <profiles>
+            <profile id="a1e3-14d7-16b4-8000" name="Night Lords: Kraken Light Bolts" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
+              <characteristics>
+                <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Bolters of Tactical, Veteran and Terror Squads become AP4.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="10.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="5d7f-4810-2ae6-4be9" name="Manstopper Rounds (Indepentant Characters Only)" hidden="false" collective="false" import="true" type="upgrade">
+          <profiles>
+            <profile id="2540-31e5-6a33-e828" name="Manstopper Rounds" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
+              <characteristics>
+                <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Archaeotech Pistols gain a One Use S8 AP2 attack</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="baa4-0db8-c40c-4a14" name="Splintex rounds (Indepentant Characters Only)" hidden="false" collective="false" import="true" type="upgrade">
+          <profiles>
+            <profile id="8363-6b3d-3118-ac31" name="Splintex rounds" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
+              <characteristics>
+                <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Archaeotech Pistols gain the option to make S2 AP4 Blast, Rending attacks.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="a034-3ecd-8c03-cb93" name="Rending" hidden="false" targetId="8269-2cd6-9236-16e7" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f5eb-f2a0-c980-a02a" name="Additional Psychic Disciplines" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e94f-9a92-64c3-f193" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="580f-c060-0787-2c00" type="min"/>
+      </constraints>
+      <rules>
+        <rule id="a101-067a-71b5-e5f4" name="Additional Psychic Disciplines" hidden="false">
+          <description>Any Psyker may choose to replace their Primaris power (if they have selected one) a power from one of the following additional Psychic Disciplines.</description>
+        </rule>
+      </rules>
+      <categoryLinks>
+        <categoryLink id="83a2-ba38-4e9e-0758" name="New CategoryLink" hidden="false" targetId="1fb0-1499-5637-4715" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="24cb-9da6-b111-21d7" name="Ectomancy" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="74c4-db30-2654-790b" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="9448-84fa-cedc-6b99" name="Electrosurge" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="29d1-e43f-6434-5ced" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="11fb-85ac-0abf-25f2" name="Electrosurge" hidden="false" typeId="9c33-b0c8-74bd-e5a7" typeName="Psychic Power (Attack)">
+                  <characteristics>
+                    <characteristic name="Warp Charge" typeId="c1b6-4261-dee4-923a">1</characteristic>
+                    <characteristic name="Power Category" typeId="668e-d504-8244-7422">Witchfire</characteristic>
+                    <characteristic name="Range" typeId="5bf6-378a-0cb7-b079">18&quot;</characteristic>
+                    <characteristic name="Strength" typeId="12da-9b3e-f37b-bc35">5</characteristic>
+                    <characteristic name="AP" typeId="10b5-aa5b-ccde-79cc">4</characteristic>
+                    <characteristic name="Type" typeId="20e7-cbcb-1781-a732">Assault 6, Target models are automatically hit</characteristic>
+                    <characteristic name="Details" typeId="a812-390d-dff6-dabd"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="9c5c-93b2-dd90-329e" name="Electropulse" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f4cc-0a79-3726-4e1b" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="3f32-5fa4-554c-407c" name="Electropulse" hidden="false" typeId="9c33-b0c8-74bd-e5a7" typeName="Psychic Power (Attack)">
+                  <characteristics>
+                    <characteristic name="Warp Charge" typeId="c1b6-4261-dee4-923a">1</characteristic>
+                    <characteristic name="Power Category" typeId="668e-d504-8244-7422">Witchfire (Nova)</characteristic>
+                    <characteristic name="Range" typeId="5bf6-378a-0cb7-b079">9&quot;</characteristic>
+                    <characteristic name="Strength" typeId="12da-9b3e-f37b-bc35">1</characteristic>
+                    <characteristic name="AP" typeId="10b5-aa5b-ccde-79cc">-</characteristic>
+                    <characteristic name="Type" typeId="20e7-cbcb-1781-a732">Haywire, All models are automatically hit once</characteristic>
+                    <characteristic name="Details" typeId="a812-390d-dff6-dabd"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink id="ccd0-bdd7-6d71-934a" name="Haywire" hidden="false" targetId="6970-1bf3-b33e-5dce" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="24bf-35f6-030d-6615" name="Magnetokinesis" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="094a-b1cf-1029-45d3" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="5055-d29c-a25e-918f" name="Magnetokinesis" hidden="false" typeId="ae70-4738-0161-bec0" typeName="Psychic Power">
+                  <characteristics>
+                    <characteristic name="Warp Charge" typeId="5ffd-b800-c317-532a">2</characteristic>
+                    <characteristic name="Power Category" typeId="f04c-a782-d794-ddad">Malediction</characteristic>
+                    <characteristic name="Range" typeId="fd64-cbc4-94de-24cc">18&quot;</characteristic>
+                    <characteristic name="Details" typeId="ad96-dfa4-b4ed-656d">Magnetokinesis is a Malediction with range 18”. The target unit is immediately moved by the caster up to 6” as though they were Jump Infantry. In the following player turn, the unit counts as having moved and cannot Charge. Cannot be used on a unit that is Zooming Swooping or Locked in combat.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="2108-ac55-196b-78b9" name="Tempestas" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bc21-d335-71ae-ebfc" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="5995-ed51-8118-949a" name="Living Lightning" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4cde-cd30-ea30-b88a" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="acdb-85aa-bb6a-c723" name="Living Lightning" hidden="false" typeId="9c33-b0c8-74bd-e5a7" typeName="Psychic Power (Attack)">
+                  <characteristics>
+                    <characteristic name="Warp Charge" typeId="c1b6-4261-dee4-923a">1</characteristic>
+                    <characteristic name="Power Category" typeId="668e-d504-8244-7422">Witchfire</characteristic>
+                    <characteristic name="Range" typeId="5bf6-378a-0cb7-b079">18&quot;</characteristic>
+                    <characteristic name="Strength" typeId="12da-9b3e-f37b-bc35">7</characteristic>
+                    <characteristic name="AP" typeId="10b5-aa5b-ccde-79cc">-</characteristic>
+                    <characteristic name="Type" typeId="20e7-cbcb-1781-a732">Assault 2</characteristic>
+                    <characteristic name="Details" typeId="a812-390d-dff6-dabd"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="437f-520f-430f-92f8" name="Virumancy" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d824-2100-ee02-2e85" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="bc76-fb70-037f-31d7" name="Plague Wind" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="52a7-f5f3-7e91-5c9b" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="7343-4ef5-0081-116e" name="Plague Wind" hidden="false" typeId="9c33-b0c8-74bd-e5a7" typeName="Psychic Power (Attack)">
+                  <characteristics>
+                    <characteristic name="Warp Charge" typeId="c1b6-4261-dee4-923a">1</characteristic>
+                    <characteristic name="Power Category" typeId="668e-d504-8244-7422">Witchfire</characteristic>
+                    <characteristic name="Range" typeId="5bf6-378a-0cb7-b079">Template</characteristic>
+                    <characteristic name="Strength" typeId="12da-9b3e-f37b-bc35">1</characteristic>
+                    <characteristic name="AP" typeId="10b5-aa5b-ccde-79cc">4</characteristic>
+                    <characteristic name="Type" typeId="20e7-cbcb-1781-a732">Poisoned (4+), Torrent</characteristic>
+                    <characteristic name="Details" typeId="a812-390d-dff6-dabd"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink id="c50a-6b1c-0bab-d1ac" name="Poisoned" hidden="false" targetId="a5ff-1cb1-bee4-d809" type="rule"/>
+                <infoLink id="506e-8846-248c-744f" name="Torrent" hidden="false" targetId="5039-18f0-a9ed-0938" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="9e81-e111-b56c-5b0a" name="Geomancy" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3f25-1da8-4856-f6f3" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="8f71-fc22-d8f9-d5ef" name="Warp Quake" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6716-21f4-3571-8bed" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="04ca-baae-0708-b356" name="Warp Quake" hidden="false" typeId="ae70-4738-0161-bec0" typeName="Psychic Power">
+                  <characteristics>
+                    <characteristic name="Warp Charge" typeId="5ffd-b800-c317-532a">1</characteristic>
+                    <characteristic name="Power Category" typeId="f04c-a782-d794-ddad">Witchfire</characteristic>
+                    <characteristic name="Range" typeId="fd64-cbc4-94de-24cc">24&quot;</characteristic>
+                    <characteristic name="Details" typeId="ad96-dfa4-b4ed-656d">Warp Quake is a Witchfire power with range 24” that may only target buildings or ruins. Roll a d6; on a 1-3, the terrain suffers a glancing hit, on a 4+, a penetrating hit. Units in the targeted terrain suffer d6 Str6 AP- hits.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="2e3e-7cec-a485-1683" name="Scorched Earth" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a7c-9f26-0af5-bdc1" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="55cb-5131-aa4d-01c4" name="Scorched Earth" hidden="false" typeId="ae70-4738-0161-bec0" typeName="Psychic Power">
+                  <characteristics>
+                    <characteristic name="Warp Charge" typeId="5ffd-b800-c317-532a">2</characteristic>
+                    <characteristic name="Power Category" typeId="f04c-a782-d794-ddad">Witchfire</characteristic>
+                    <characteristic name="Range" typeId="fd64-cbc4-94de-24cc">24&quot;</characteristic>
+                    <characteristic name="Details" typeId="ad96-dfa4-b4ed-656d">Scorced Earth is a Witchfire with range 24” Choose a point on the board and scatter it 2d6”. All units within 6” of this point are hit by a S5 AP4, Assault 1, Ignores Cover, Soul Blaze hit.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="1eac-3732-4d19-0e13" name="Technomancy" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1c4c-cd57-8fa3-226f" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="0aa4-5392-b85a-d0fd" name="Blessing of the Machine" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8eba-13e8-8247-ea31" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="498f-5694-9038-7aae" name="Blessing of the Machine" hidden="false" typeId="ae70-4738-0161-bec0" typeName="Psychic Power">
+                  <characteristics>
+                    <characteristic name="Warp Charge" typeId="5ffd-b800-c317-532a">1</characteristic>
+                    <characteristic name="Power Category" typeId="f04c-a782-d794-ddad">Blessing</characteristic>
+                    <characteristic name="Range" typeId="fd64-cbc4-94de-24cc">24&quot;</characteristic>
+                    <characteristic name="Details" typeId="ad96-dfa4-b4ed-656d">Blessing of the Machine is a Blessing that can be targeted on vehicles. The model ignore Crew Shaken and Crew Stunned results, and gains Power of the Machine Spirit, or, if it already has this rule, +1BS instead.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink id="1930-dc41-e52a-731e" name="Power of the Machine Spirit" hidden="false" targetId="0ac1-dfc1-295b-50a6" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="8088-1952-51c1-4ab0" name="Fury of Mars" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f74d-eca3-4861-3261" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="4e86-0a0f-cf38-8e2a" name="Fury of Mars" hidden="false" typeId="9c33-b0c8-74bd-e5a7" typeName="Psychic Power (Attack)">
+                  <characteristics>
+                    <characteristic name="Warp Charge" typeId="c1b6-4261-dee4-923a">2</characteristic>
+                    <characteristic name="Power Category" typeId="668e-d504-8244-7422">Witchfire (Beam)</characteristic>
+                    <characteristic name="Range" typeId="5bf6-378a-0cb7-b079">18&quot;</characteristic>
+                    <characteristic name="Strength" typeId="12da-9b3e-f37b-bc35">1</characteristic>
+                    <characteristic name="AP" typeId="10b5-aa5b-ccde-79cc">-</characteristic>
+                    <characteristic name="Type" typeId="20e7-cbcb-1781-a732">Assault 1, Haywire</characteristic>
+                    <characteristic name="Details" typeId="a812-390d-dff6-dabd"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink id="5b97-93e2-3a1b-318b" name="Haywire" hidden="false" targetId="6970-1bf3-b33e-5dce" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="e630-5055-335b-e2fa" name="Machine Curse" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="045b-d790-3324-8608" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="f6a7-f5be-7e8a-da56" name="Machine Curse" hidden="false" typeId="9c33-b0c8-74bd-e5a7" typeName="Psychic Power (Attack)">
+                  <characteristics>
+                    <characteristic name="Warp Charge" typeId="c1b6-4261-dee4-923a">1</characteristic>
+                    <characteristic name="Power Category" typeId="668e-d504-8244-7422">Witchfire</characteristic>
+                    <characteristic name="Range" typeId="5bf6-378a-0cb7-b079">18&quot;</characteristic>
+                    <characteristic name="Strength" typeId="12da-9b3e-f37b-bc35">1</characteristic>
+                    <characteristic name="AP" typeId="10b5-aa5b-ccde-79cc">-</characteristic>
+                    <characteristic name="Type" typeId="20e7-cbcb-1781-a732">Assault d3, Haywire, Target unit is automatically hit</characteristic>
+                    <characteristic name="Details" typeId="a812-390d-dff6-dabd"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink id="7be3-2189-daee-5e85" name="Haywire" hidden="false" targetId="6970-1bf3-b33e-5dce" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="f3c4-4c7f-5d43-bde5" name="Receptomancy" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7100-d635-c017-666d" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="b162-0f1f-ecb6-e68a" name="Shockwave" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6c3b-62ff-6bde-6fb8" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="50b6-fef9-1f5f-0844" name="Shockwave" hidden="false" typeId="9c33-b0c8-74bd-e5a7" typeName="Psychic Power (Attack)">
+                  <characteristics>
+                    <characteristic name="Warp Charge" typeId="c1b6-4261-dee4-923a">2</characteristic>
+                    <characteristic name="Power Category" typeId="668e-d504-8244-7422">Witchfire (Nova)</characteristic>
+                    <characteristic name="Range" typeId="5bf6-378a-0cb7-b079">9&quot;</characteristic>
+                    <characteristic name="Strength" typeId="12da-9b3e-f37b-bc35">5</characteristic>
+                    <characteristic name="AP" typeId="10b5-aa5b-ccde-79cc"/>
+                    <characteristic name="Type" typeId="20e7-cbcb-1781-a732">Assault 1, Pinning</characteristic>
+                    <characteristic name="Details" typeId="a812-390d-dff6-dabd"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink id="a52e-02bc-6817-4bb0" name="Pinning" hidden="false" targetId="f624-f475-e5ec-0dfa" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="b1c3-196f-f8ea-12e9" name="Sensory Overload" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e2d8-ac0a-687c-7b75" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="f666-d5e5-c5d9-cb98" name="Sensory Overload" hidden="false" typeId="9c33-b0c8-74bd-e5a7" typeName="Psychic Power (Attack)">
+                  <characteristics>
+                    <characteristic name="Warp Charge" typeId="c1b6-4261-dee4-923a">2</characteristic>
+                    <characteristic name="Power Category" typeId="668e-d504-8244-7422">Witchfire</characteristic>
+                    <characteristic name="Range" typeId="5bf6-378a-0cb7-b079">9&quot;</characteristic>
+                    <characteristic name="Strength" typeId="12da-9b3e-f37b-bc35">4</characteristic>
+                    <characteristic name="AP" typeId="10b5-aa5b-ccde-79cc">4</characteristic>
+                    <characteristic name="Type" typeId="20e7-cbcb-1781-a732">Assault 4, Blind, Concussive, Pinning</characteristic>
+                    <characteristic name="Details" typeId="a812-390d-dff6-dabd"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink id="20f2-5beb-4973-e954" name="Blind" hidden="false" targetId="7dae-4d12-baba-e529" type="rule"/>
+                <infoLink id="27a9-40f7-c89c-0f28" name="Concussive" hidden="false" targetId="9d85-46f7-f5e6-a5f7" type="rule"/>
+                <infoLink id="2b86-3514-ffa4-2c42" name="Pinning" hidden="false" targetId="f624-f475-e5ec-0dfa" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="b92e-3379-932a-c1f8" name="Sanguinary" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="816b-bac1-e4f0-ef12" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="79fa-5635-693e-cdd8" name="Fear of the Darkness" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9550-c3fc-08bd-f52f" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="7cf0-1d7a-94be-32fc" name="Fear of the Darkness" hidden="false" typeId="ae70-4738-0161-bec0" typeName="Psychic Power">
+                  <characteristics>
+                    <characteristic name="Warp Charge" typeId="5ffd-b800-c317-532a">1</characteristic>
+                    <characteristic name="Power Category" typeId="f04c-a782-d794-ddad">Malediction</characteristic>
+                    <characteristic name="Range" typeId="fd64-cbc4-94de-24cc">18&quot;</characteristic>
+                    <characteristic name="Details" typeId="ad96-dfa4-b4ed-656d">Fear of the Darkness is a Malediction with range 18”. If the power is successfully manifested, The target unit must take a Morale test at -2Ld.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="f479-a2b1-4a8c-def1" name="Sinistrum" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a6be-69e9-8b09-1d2e" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="f16d-5ffe-0f52-3fe7" name="Veil of Time" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="da0e-061e-1f20-22ab" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="301b-dd85-5322-d196" name="Veil of Time" hidden="false" typeId="ae70-4738-0161-bec0" typeName="Psychic Power">
+                  <characteristics>
+                    <characteristic name="Warp Charge" typeId="5ffd-b800-c317-532a">2</characteristic>
+                    <characteristic name="Power Category" typeId="f04c-a782-d794-ddad">Blessing</characteristic>
+                    <characteristic name="Range" typeId="fd64-cbc4-94de-24cc">Psyker</characteristic>
+                    <characteristic name="Details" typeId="ad96-dfa4-b4ed-656d">Veil of Time is a Blessing that targets the Psyker. Whilst the power is in effect, all models in the unit may re-roll failed saves, however the unit will only pass the test on a re-roll of 4+.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="2e39-cb0e-c1dd-4e5d" name="Fires of Wrath" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d854-21cd-b1fb-8d90" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="37da-cf52-fec9-5b71" name="Fires of Wrath" hidden="false" typeId="9c33-b0c8-74bd-e5a7" typeName="Psychic Power (Attack)">
+                  <characteristics>
+                    <characteristic name="Warp Charge" typeId="c1b6-4261-dee4-923a">1</characteristic>
+                    <characteristic name="Power Category" typeId="668e-d504-8244-7422">Witchfire</characteristic>
+                    <characteristic name="Range" typeId="5bf6-378a-0cb7-b079">18&quot;</characteristic>
+                    <characteristic name="Strength" typeId="12da-9b3e-f37b-bc35">5</characteristic>
+                    <characteristic name="AP" typeId="10b5-aa5b-ccde-79cc">3</characteristic>
+                    <characteristic name="Type" typeId="20e7-cbcb-1781-a732">Assault 1, Blast</characteristic>
+                    <characteristic name="Details" typeId="a812-390d-dff6-dabd"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="4284-13e4-c3e2-41e9" name="Ancient Fury" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2df0-a7a8-f92e-9465" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="aa11-70cc-d19b-c367" name="Ancient Fury" hidden="false" typeId="9c33-b0c8-74bd-e5a7" typeName="Psychic Power (Attack)">
+                  <characteristics>
+                    <characteristic name="Warp Charge" typeId="c1b6-4261-dee4-923a">1</characteristic>
+                    <characteristic name="Power Category" typeId="668e-d504-8244-7422">Witchfire (Beam)</characteristic>
+                    <characteristic name="Range" typeId="5bf6-378a-0cb7-b079">18&quot;</characteristic>
+                    <characteristic name="Strength" typeId="12da-9b3e-f37b-bc35">6</characteristic>
+                    <characteristic name="AP" typeId="10b5-aa5b-ccde-79cc">4</characteristic>
+                    <characteristic name="Type" typeId="20e7-cbcb-1781-a732">Assault 1, Pinning</characteristic>
+                    <characteristic name="Details" typeId="a812-390d-dff6-dabd"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink id="a178-6961-aa79-1c16" name="Pinning" hidden="false" targetId="f624-f475-e5ec-0dfa" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="cfe1-d37b-7896-38f1" name="Interromancy" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="90a9-d189-080f-0370" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="7ec3-3e63-4df5-1c21" name="Seed of Fear" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="da38-ae03-0426-72b9" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="92db-b3cd-f1be-72f8" name="Seed of Fear" hidden="false" typeId="ae70-4738-0161-bec0" typeName="Psychic Power">
+                  <characteristics>
+                    <characteristic name="Warp Charge" typeId="5ffd-b800-c317-532a">1</characteristic>
+                    <characteristic name="Power Category" typeId="f04c-a782-d794-ddad">Witchfire (Nova)</characteristic>
+                    <characteristic name="Range" typeId="fd64-cbc4-94de-24cc">9&quot;</characteristic>
+                    <characteristic name="Details" typeId="ad96-dfa4-b4ed-656d">Seed of Fear is a Witchfire (Nova) with range 9” If this power is successfully manifested, all affected units take Morale, Pinning and Fear tests on 3d6 whilst it is in effect.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="785c-67e7-9246-59ac" name="Repugnance" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7c51-1087-4c92-7716" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="7661-58cd-7581-8dce" name="Repugnance" hidden="false" typeId="ae70-4738-0161-bec0" typeName="Psychic Power">
+                  <characteristics>
+                    <characteristic name="Warp Charge" typeId="5ffd-b800-c317-532a">1</characteristic>
+                    <characteristic name="Power Category" typeId="f04c-a782-d794-ddad">Blessing</characteristic>
+                    <characteristic name="Range" typeId="fd64-cbc4-94de-24cc">24&quot;</characteristic>
+                    <characteristic name="Details" typeId="ad96-dfa4-b4ed-656d">Repugnance is a Blessing with range 24” that targets a friendly unit. Whilst this power is in effect, the target unit gains Rage.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink id="34c2-8aa5-e387-56f8" name="Rage" hidden="false" targetId="988c-d4d0-9418-1165" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="4717-66e6-a381-fab2" name="Frenzy (Traitor only)" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4658-ec5a-46fc-fe27" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="fd6b-3e07-750d-8c25" name="Frenzy" hidden="false" typeId="ae70-4738-0161-bec0" typeName="Psychic Power">
+                  <characteristics>
+                    <characteristic name="Warp Charge" typeId="5ffd-b800-c317-532a">1</characteristic>
+                    <characteristic name="Power Category" typeId="f04c-a782-d794-ddad">Blessing</characteristic>
+                    <characteristic name="Range" typeId="fd64-cbc4-94de-24cc">12&quot;</characteristic>
+                    <characteristic name="Details" typeId="ad96-dfa4-b4ed-656d">Frenzy is a Blessing with range 12”. Whilst this power is in effect, the target units gains a random bonus (roll a d6):
+♦ 1-2: +1 Initiative
+♦ 3-4: +1 Strength
+♦ 5-6: +1 Attack</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="d273-e12a-a287-d944" name="Exotic Melee Weapns" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ebdc-5dfd-b192-c666" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7d49-71f3-5d4b-5b6f" type="min"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="5abc-20e2-c0cd-94ef" name="New CategoryLink" hidden="false" targetId="1fb0-1499-5637-4715" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="c2f2-1a9a-8b5e-a277" name="Independant Characters Only" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5865-ce3d-f2c5-b466" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="81b8-ba4b-aa0c-f7b6" type="min"/>
+          </constraints>
+          <rules>
+            <rule id="21c5-ca1b-db81-40cb" name="Exotic Melee Weapns" hidden="false">
+              <description>Any Independent Character may exchange a power fist for an Exotic Melee Weapon:
+</description>
+            </rule>
+          </rules>
+          <selectionEntries>
+            <selectionEntry id="74b1-fda9-c21d-13ae" name="Nanofractal Falchion" hidden="false" collective="false" import="true" type="upgrade">
+              <profiles>
+                <profile id="44f0-f186-354f-5cf2" name="Nanofractal Falchion" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
+                    <characteristic name="Strength" typeId="537472656e67746823232344415441232323">User</characteristic>
+                    <characteristic name="AP" typeId="415023232344415441232323">3</characteristic>
+                    <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Rending, Fleshbane</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink id="f0e6-c84e-9472-faa7" name="Rending" hidden="false" targetId="8269-2cd6-9236-16e7" type="rule"/>
+                <infoLink id="6aa6-3ff5-997b-9cd4" name="Fleshbane" hidden="false" targetId="4575-0a0a-caaf-e4bf" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="769a-9182-e68b-00fb" name="Hydragyros Executioner Blade" hidden="false" collective="false" import="true" type="upgrade">
+              <profiles>
+                <profile id="a6ed-eb98-a4c6-d860" name="Hydragyros Executioner Blade" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
+                    <characteristic name="Strength" typeId="537472656e67746823232344415441232323">+2</characteristic>
+                    <characteristic name="AP" typeId="415023232344415441232323">2</characteristic>
+                    <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Two-handed, Grants –2 Initiative</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink id="8f79-9e0c-5de5-05c7" name="Two-Handed" hidden="false" targetId="b11c-0ef4-af6b-d96f" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="4c36-40a5-ca06-50b7" name="Hurricane Talons" hidden="false" collective="false" import="true" type="upgrade">
+              <profiles>
+                <profile id="01b8-7f6f-9a35-3b26" name="Hurricane Talons" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
+                    <characteristic name="Strength" typeId="537472656e67746823232344415441232323">User</characteristic>
+                    <characteristic name="AP" typeId="415023232344415441232323">3</characteristic>
+                    <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Shred, Paired Weapons (+1 Attack), Storm of Claws</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules>
+                <rule id="7fa9-a608-2ab6-9e15" name="Storm of Claws" hidden="false">
+                  <description>The bearer fights with an additional D3 extra attacks, rolled each round of combat. However, all attacks are made with a WS penalty equal to the number of bonus attacks.</description>
+                </rule>
+              </rules>
+              <infoLinks>
+                <infoLink id="976b-4715-67e2-e33b" name="Paired Weapons" hidden="false" targetId="f495-679e-1976-68d1" type="rule"/>
+                <infoLink id="388c-6014-4a64-b0c8" name="Shred" hidden="false" targetId="89da-0cb5-bee4-8ec2" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="98a7-6a1f-f55d-41aa" name="Gyrocyclic Reaver Blade" hidden="false" collective="false" import="true" type="upgrade">
+              <profiles>
+                <profile id="e7ed-d81d-5746-4bf8" name="Gyrocyclic Reaver Blade" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
+                    <characteristic name="Strength" typeId="537472656e67746823232344415441232323">+1</characteristic>
+                    <characteristic name="AP" typeId="415023232344415441232323">3</characteristic>
+                    <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Grants +1 Attack</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="9e2d-68f0-ef28-a143" name="Charnabal Longsword" hidden="false" collective="false" import="true" type="upgrade">
+              <profiles>
+                <profile id="c0f4-6a14-0f5c-c51e" name="Charnabal Longsword" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
+                    <characteristic name="Strength" typeId="537472656e67746823232344415441232323">+1</characteristic>
+                    <characteristic name="AP" typeId="415023232344415441232323">5</characteristic>
+                    <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Two-handed, Shred, Rending, Duellist&apos;s Edge</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink id="91af-eb99-47b0-b5fc" name="Shred" hidden="false" targetId="89da-0cb5-bee4-8ec2" type="rule"/>
+                <infoLink id="7d8e-fb90-fef1-7f73" name="Two-Handed" hidden="false" targetId="b11c-0ef4-af6b-d96f" type="rule"/>
+                <infoLink id="87fb-2ac3-3945-d385" name="Duelist&apos;s Edge" hidden="false" targetId="1a79-befa-05cf-ab0d" type="rule"/>
+                <infoLink id="8659-e9e7-f25e-8eb4" name="Rending" hidden="false" targetId="8269-2cd6-9236-16e7" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="a091-2aca-c1de-6912" name="Bioceramic Razorglaive" hidden="false" collective="false" import="true" type="upgrade">
+              <profiles>
+                <profile id="97f4-2f2c-fa57-28f8" name="Bioceramic Razorglaive" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
+                    <characteristic name="Strength" typeId="537472656e67746823232344415441232323">User</characteristic>
+                    <characteristic name="AP" typeId="415023232344415441232323">2</characteristic>
+                    <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Grants +1 Initiative, Brittle</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules>
+                <rule id="3d6b-850e-716e-f319" name="Brittle" hidden="false">
+                  <description>If a user of this weapon hits with all of their attacks during a single round of combat, after resolving those attacks its AP value is reduced to (-) for the remainder of the battle.</description>
+                </rule>
+              </rules>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="5b28-f840-4f3a-138c" name="Artificer Mirrorswords" hidden="false" collective="false" import="true" type="upgrade">
+              <profiles>
+                <profile id="b50f-39bd-e4f8-1c31" name="Artificer Mirrorswords" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
+                    <characteristic name="Strength" typeId="537472656e67746823232344415441232323">User</characteristic>
+                    <characteristic name="AP" typeId="415023232344415441232323">3</characteristic>
+                    <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Riposte, Paired Weapons (+1 Attack)</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules>
+                <rule id="e88e-4858-b518-02ff" name="Riposte" hidden="false">
+                  <description>Attacks directed at the wielder of these weapons suffer -1 to hit.</description>
+                </rule>
+              </rules>
+              <infoLinks>
+                <infoLink id="1825-4a98-b1ac-1650" name="Paired Weapons" hidden="false" targetId="f495-679e-1976-68d1" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="db9e-b092-bf6f-fad5" name="Arcanite Shock Maul" hidden="false" collective="false" import="true" type="upgrade">
+              <profiles>
+                <profile id="c324-ad74-d4ae-4dfd" name="Arcanite Shock Maul" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
+                    <characteristic name="Strength" typeId="537472656e67746823232344415441232323">+3</characteristic>
+                    <characteristic name="AP" typeId="415023232344415441232323">4</characteristic>
+                    <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Two-handed, Arcing Discharge</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules>
+                <rule id="6c48-9481-78d4-1595" name="Arcing Discharge" hidden="false">
+                  <description>Any model wounded by attacks from this weapon suffers the effects of the Concussive rule, whether the wound is saved or not.</description>
+                </rule>
+              </rules>
+              <infoLinks>
+                <infoLink id="3bdc-7b7b-f562-7951" name="Concussive" hidden="false" targetId="9d85-46f7-f5e6-a5f7" type="rule"/>
+                <infoLink id="0195-eed2-8007-c21a" name="Two-Handed" hidden="false" targetId="b11c-0ef4-af6b-d96f" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="49ed-206a-e958-accd" name="Aetheric Shredder Knife" hidden="false" collective="false" import="true" type="upgrade">
+              <profiles>
+                <profile id="d2e3-0b68-a12a-6f69" name="Aetheric Shredder Knife" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
+                    <characteristic name="Strength" typeId="537472656e67746823232344415441232323">User</characteristic>
+                    <characteristic name="AP" typeId="415023232344415441232323">2</characteristic>
+                    <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Dimensional Edge</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules>
+                <rule id="506d-b355-f224-9065" name="Dimensional Edge" hidden="false">
+                  <description>Attacks from this weapon only ever cause wounds on a roll of 6, however no invulnerable saves or Feel No Pain rolls may be taken</description>
+                </rule>
+              </rules>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="78bb-3696-4f0d-d46d" name="Accelerator Hammer" hidden="false" collective="false" import="true" type="upgrade">
+              <profiles>
+                <profile id="ae4d-90af-1ed9-0742" name="Accelerator Hammer" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
+                    <characteristic name="Strength" typeId="537472656e67746823232344415441232323">+3</characteristic>
+                    <characteristic name="AP" typeId="415023232344415441232323">1</characteristic>
+                    <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Two-handed, Sunder, Delayed Strike</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules>
+                <rule id="c153-f356-25dd-7d5b" name="Delayed Strike" hidden="false">
+                  <description>The bearer of this weapon halves their Initiative and Attack value when using this weapon, rounding up.</description>
+                </rule>
+              </rules>
+              <infoLinks>
+                <infoLink id="5241-c397-13df-9d1b" name="Two-Handed" hidden="false" targetId="b11c-0ef4-af6b-d96f" type="rule"/>
+                <infoLink id="b843-e49e-cd94-0c9f" name="Sunder" hidden="false" targetId="841f-9119-9f9d-5058" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="be3f-cab1-3d55-d42a" name="Characters (Including Independent Characters)" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="93ff-3836-2804-a995" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6dd5-cb03-1958-ff20" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="270a-0bb6-b354-6b75" name="Cthonian Culling Blade" hidden="false" collective="false" import="true" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="550e-dd7c-23b2-c37b" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6780-81e2-601f-a7bd" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="f1e1-51a7-d8b7-aa97" name="Cthonian Culling Blade" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
+                    <characteristic name="Strength" typeId="537472656e67746823232344415441232323">User</characteristic>
+                    <characteristic name="AP" typeId="415023232344415441232323">3</characteristic>
+                    <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Rending (5+)</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink id="860a-f688-6f4e-2b23" name="Rending" hidden="false" targetId="8269-2cd6-9236-16e7" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="1b80-5b44-0e03-b9e4" name="Albian Power Gladius" hidden="false" collective="false" import="true" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b7d6-8217-4fe9-45d4" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ccfb-6afc-2a35-2498" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="cf2b-9e0c-60d8-0ae2" name="Albian Power Gladius" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
+                    <characteristic name="Strength" typeId="537472656e67746823232344415441232323">User</characteristic>
+                    <characteristic name="AP" typeId="415023232344415441232323">3</characteristic>
+                    <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Rending (5+)</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink id="3f2d-769e-840d-434c" name="Rending" hidden="false" targetId="8269-2cd6-9236-16e7" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6277-fb4b-0461-2f0e" name="Vanus Assassin" publicationId="0e6e-8c19-c436-39c4" hidden="true" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="a82a-f8d9-d454-b227" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <profiles>
+        <profile id="f069-7db1-9e25-e801" name="Assassin Adept" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="6277-fb4b-0461-2f0e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="23ed-fe91-96ad-52e3" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry (Character)</characteristic>
+            <characteristic name="WS" typeId="575323232344415441232323">5</characteristic>
+            <characteristic name="BS" typeId="425323232344415441232323">5</characteristic>
+            <characteristic name="S" typeId="5323232344415441232323">4</characteristic>
+            <characteristic name="T" typeId="5423232344415441232323">4</characteristic>
+            <characteristic name="W" typeId="5723232344415441232323">2</characteristic>
+            <characteristic name="I" typeId="4923232344415441232323">5</characteristic>
+            <characteristic name="A" typeId="4123232344415441232323">3</characteristic>
+            <characteristic name="LD" typeId="4c4423232344415441232323">10</characteristic>
+            <characteristic name="Save" typeId="5361766523232344415441232323">4+</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="660c-c3d7-9d42-974d" name="Remote Operator" hidden="false">
+          <description>A Vanus is unusual in that no model is necessary for the Assassin, as only the Cyber Occularis are deployed. An Adept has 3 Cyber Occularis, a Master has 4. These models are counted as a single unit for Kill Points, Attrition, Last Man Standing etc. The Vanus model’s rules are given for completeness, but are not normally used in a game.</description>
+        </rule>
+        <rule id="956b-8f2b-d5bf-dc61" name="Independent Operative" hidden="false">
+          <description>The model can never join or be joined by other models.</description>
+        </rule>
+        <rule id="245a-39b5-553e-c401" name="Lightning Reflexes" hidden="false">
+          <description>A model with this special rule has a 4+ invulnerable save. Additionally, they do not suffer the penalty to their Initiative for charging enemies through difficult terrain.</description>
+        </rule>
+        <rule id="d9ae-a830-0251-1565" name="No Escape" hidden="false">
+          <description>Enemy models suffer -2 to Look Out Sir tests against wounds inflicted by this model.</description>
+        </rule>
+        <rule id="addd-8076-8ca5-d7cc" name="Accidents Happen" hidden="false">
+          <description>At the end of deployment, nominate 1 enemy model to suffer –D3W and –D3Ld, to a minimum of 1. Wounds are AP2 but the model may take invulnerable saves as normal</description>
+        </rule>
+        <rule id="5555-7cc1-198b-1832" name="Knowledge is Power" hidden="false">
+          <description>During deployment, nominate one friendly unit to gain Preferred Enemy against one nominated enemy unit. Additionally, the controlling player may force their opponent to reroll one reserve roll each turn.</description>
+        </rule>
+        <rule id="2aea-77e3-90cf-3170" name="Execute the Mandate" hidden="false">
+          <description>Gain +1VP at the end of the game if the enemy’s Warlord was removed as a casualty as the result of a Wound inflicted by a model with this rule.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="b6c6-f33b-ff37-b940" name="Infiltrate" hidden="false" targetId="34c7-8b61-a5b8-a301" type="rule"/>
+        <infoLink id="758c-06e1-2bef-0e72" name="Move Through Cover" hidden="false" targetId="6d06-5ea0-9a17-ca97" type="rule"/>
+        <infoLink id="5af0-f5ac-cd67-b08c" name="Stealth" hidden="false" targetId="0d66-14c9-d2f4-708b" type="rule"/>
+        <infoLink id="e691-b35f-2673-a33b" name="Fearless" hidden="false" targetId="dc70-e199-5525-e78c" type="rule"/>
+        <infoLink id="8815-2211-b6c6-48b7" name="Preferred Enemy" hidden="false" targetId="4dd2-fcb0-de6a-5b70" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="6e18-40ad-4625-9725" name="Infantry" hidden="false" targetId="1ab3-f1ac-f724-8544" primary="false"/>
+        <categoryLink id="4a20-257e-8c75-0cc1" name="Character" hidden="false" targetId="ae54-92c7-3e66-59f7" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="23ed-fe91-96ad-52e3" name="An Assassin Adept can be upgraded to a Master" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a6aa-4e04-47a2-9b5d" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="bcd2-39a2-e0cb-7f2d" name="Assassin Master" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+              <characteristics>
+                <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry (Character)</characteristic>
+                <characteristic name="WS" typeId="575323232344415441232323">6</characteristic>
+                <characteristic name="BS" typeId="425323232344415441232323">6</characteristic>
+                <characteristic name="S" typeId="5323232344415441232323">4</characteristic>
+                <characteristic name="T" typeId="5423232344415441232323">4</characteristic>
+                <characteristic name="W" typeId="5723232344415441232323">3</characteristic>
+                <characteristic name="I" typeId="4923232344415441232323">6</characteristic>
+                <characteristic name="A" typeId="4123232344415441232323">4</characteristic>
+                <characteristic name="LD" typeId="4c4423232344415441232323">10</characteristic>
+                <characteristic name="Save" typeId="5361766523232344415441232323">4+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="35.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="2ec0-543e-18fa-5c54" name="Cyber Occularis" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="59c7-d810-01df-9736" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ba43-45ec-77f1-9a66" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="e7dd-1db2-99e3-4b09" name="Cyber Occularis" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+              <characteristics>
+                <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Jet Pack Infantry (but not Bulky)</characteristic>
+                <characteristic name="WS" typeId="575323232344415441232323">2</characteristic>
+                <characteristic name="BS" typeId="425323232344415441232323">3</characteristic>
+                <characteristic name="S" typeId="5323232344415441232323">2</characteristic>
+                <characteristic name="T" typeId="5423232344415441232323">3</characteristic>
+                <characteristic name="W" typeId="5723232344415441232323">1</characteristic>
+                <characteristic name="I" typeId="4923232344415441232323">4</characteristic>
+                <characteristic name="A" typeId="4123232344415441232323">1</characteristic>
+                <characteristic name="LD" typeId="4c4423232344415441232323">9</characteristic>
+                <characteristic name="Save" typeId="5361766523232344415441232323">3+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="d1e5-8a79-26d2-f50d" name="Independent Operative" hidden="false">
+              <description>The model can never join or be joined by other models.</description>
+            </rule>
+            <rule id="9ef7-3cde-2220-8388" name="Cyber Occularis" hidden="false">
+              <description>Cyber Occularis cannot Score or Contest and do not block Line of Sight</description>
+            </rule>
+            <rule id="6275-f2c1-e87a-73b1" name="Warning Relay" hidden="false">
+              <description>Confers Interceptor on friendly units in 3”.</description>
+            </rule>
+            <rule id="0ec4-3fb1-38d2-e945" name="Augur Sweep" hidden="false">
+              <description>Enemy units within 12” suffer -1 to cover saves.</description>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="4439-5a9e-6676-3921" name="Stealth" hidden="false" targetId="0d66-14c9-d2f4-708b" type="rule"/>
+            <infoLink id="2d48-f67b-9d1c-ff6b" name="Fearless" hidden="false" targetId="dc70-e199-5525-e78c" type="rule"/>
+            <infoLink id="c812-5255-8d15-c980" name="Jink" hidden="false" targetId="d3e5-b43d-a89c-3bd8" type="rule"/>
+          </infoLinks>
+          <selectionEntries>
+            <selectionEntry id="4746-b46a-0adc-a598" name="Data Burst" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="877e-c945-ca8a-b2c3" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9645-e5ec-db12-7fec" type="min"/>
+              </constraints>
+              <profiles>
+                <profile id="8bbc-d936-6773-9804" name="Data Burst" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="52616e676523232344415441232323">12&quot;</characteristic>
+                    <characteristic name="Strength" typeId="537472656e67746823232344415441232323">(X+)</characteristic>
+                    <characteristic name="AP" typeId="415023232344415441232323">-</characteristic>
+                    <characteristic name="Type" typeId="5479706523232344415441232323">Assault 2, Machine Corruption</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules>
+                <rule id="4b17-d650-6acb-b8b3" name="Machine Corruption" hidden="false">
+                  <description>Against vehicles, treat this as Haywire. Against other models, the roll to wound is equal to the armour save of the target. Models with Cybernetica Cortex suffer double Wounds.</description>
+                </rule>
+              </rules>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="5f97-802e-e060-9850" name="Djinn Skein" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0f00-4c9b-cfe1-cb58" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c6b1-4cb0-c13b-c9a8" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="5900-01af-4fe8-8ca8" name="Djinn Skein" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
+              <characteristics>
+                <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Each Cyber Occularis functions as a Nuncio Vox. Additionally, at the beginning of each Shooting phase, nominate 1 friendly unit within 6” of a single Cyber Occularis to gain +1BS for the duration of the phase</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="a44a-beb9-049b-095f" name="Cogitator Gauntlet" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="77cb-541c-6328-707d" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="12cc-65f8-6274-b31c" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="dc73-084b-ca82-2151" name="Cogitator Gauntlet" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="52616e676523232344415441232323">Melee</characteristic>
+                <characteristic name="Strength" typeId="537472656e67746823232344415441232323">User</characteristic>
+                <characteristic name="AP" typeId="415023232344415441232323">-</characteristic>
+                <characteristic name="Type" typeId="5479706523232344415441232323">Machine Corruption</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="ccba-93fe-4aa5-e80c" name="Machine Corruption" hidden="false">
+              <description>Against vehicles, treat this as Haywire. Against other models, the roll to wound is equal to the armour save of the target. Models with Cybernetica Cortex suffer double Wounds.</description>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="04e4-55db-6480-da74" name="Haywire" hidden="false" targetId="6970-1bf3-b33e-5dce" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="points" value="115.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ceb1-cf74-814f-f02a" name="Venenum Assassin" publicationId="0e6e-8c19-c436-39c4" hidden="true" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="a82a-f8d9-d454-b227" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <profiles>
+        <profile id="6091-fd57-fb16-99ba" name="Assassin Adept" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="ceb1-cf74-814f-f02a" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5fc0-5392-c9bc-6227" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry (Character)</characteristic>
+            <characteristic name="WS" typeId="575323232344415441232323">5</characteristic>
+            <characteristic name="BS" typeId="425323232344415441232323">5</characteristic>
+            <characteristic name="S" typeId="5323232344415441232323">4</characteristic>
+            <characteristic name="T" typeId="5423232344415441232323">4</characteristic>
+            <characteristic name="W" typeId="5723232344415441232323">2</characteristic>
+            <characteristic name="I" typeId="4923232344415441232323">5</characteristic>
+            <characteristic name="A" typeId="4123232344415441232323">3</characteristic>
+            <characteristic name="LD" typeId="4c4423232344415441232323">10</characteristic>
+            <characteristic name="Save" typeId="5361766523232344415441232323">4+</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="8996-138b-7403-e791" name="Independent Operative" hidden="false">
+          <description>The model can never join or be joined by other models.</description>
+        </rule>
+        <rule id="ad18-a3a9-38c0-29f4" name="No Escape" hidden="false">
+          <description>Enemy models suffer -2 to Look Out Sir tests against wounds inflicted by this model.</description>
+        </rule>
+        <rule id="1339-4d30-6835-5a4d" name="Execute the Mandate" hidden="false">
+          <description>Gain +1VP at the end of the game if the enemy’s Warlord was removed as a casualty as the result of a Wound inflicted by a model with this rule.</description>
+        </rule>
+        <rule id="93a5-3add-50fd-3b90" name="Envenomation" hidden="false">
+          <description>Prior to the start of turn 1, nominate one non-vehicle unit to suffer one effect:
+a penalty of -1T for the duration of the game
+a penalty of -1WS and BS for the game
+cannot Run or perform Sweeping Advances
+one Special Rule the unit possesses ceases to have any effect</description>
+        </rule>
+        <rule id="82f3-75c7-946f-a91b" name="Lightning Reflexes" hidden="false">
+          <description>A model with this special rule has a 4+ invulnerable save. Additionally, they do not suffer the penalty to their Initiative for charging enemies through difficult terrain.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="c35a-d232-ad60-3d1d" name="Stealth" hidden="false" targetId="0d66-14c9-d2f4-708b" type="rule"/>
+        <infoLink id="0f0a-216d-0f3b-120a" name="Fearless" hidden="false" targetId="dc70-e199-5525-e78c" type="rule"/>
+        <infoLink id="6014-c17b-1db5-6999" name="Infiltrate" hidden="false" targetId="34c7-8b61-a5b8-a301" type="rule"/>
+        <infoLink id="8ee6-54fa-3fcf-ffec" name="Move Through Cover" hidden="false" targetId="6d06-5ea0-9a17-ca97" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="bd65-fe5d-25d9-d40f" name="Infantry" hidden="false" targetId="1ab3-f1ac-f724-8544" primary="false"/>
+        <categoryLink id="d8b6-94f3-2468-2ce4" name="Character" hidden="false" targetId="ae54-92c7-3e66-59f7" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="5fc0-5392-c9bc-6227" name="An Assassin Adept can be upgraded to a Master" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f5cb-77f4-5f00-b5b4" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="80a5-0649-5f75-d68d" name="Assassin Master" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+              <characteristics>
+                <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry (Character)</characteristic>
+                <characteristic name="WS" typeId="575323232344415441232323">6</characteristic>
+                <characteristic name="BS" typeId="425323232344415441232323">6</characteristic>
+                <characteristic name="S" typeId="5323232344415441232323">4</characteristic>
+                <characteristic name="T" typeId="5423232344415441232323">4</characteristic>
+                <characteristic name="W" typeId="5723232344415441232323">3</characteristic>
+                <characteristic name="I" typeId="4923232344415441232323">6</characteristic>
+                <characteristic name="A" typeId="4123232344415441232323">4</characteristic>
+                <characteristic name="LD" typeId="4c4423232344415441232323">10</characteristic>
+                <characteristic name="Save" typeId="5361766523232344415441232323">4+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="35.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="2d29-15fe-4a00-1318" name="Venom-Gun" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2ee1-ecd2-3803-ca94" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="993d-db5a-086f-683c" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="fddc-0fed-0a57-91c6" name="Venom-Gun" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="52616e676523232344415441232323">18&quot;</characteristic>
+                <characteristic name="Strength" typeId="537472656e67746823232344415441232323">X</characteristic>
+                <characteristic name="AP" typeId="415023232344415441232323">5</characteristic>
+                <characteristic name="Type" typeId="5479706523232344415441232323">Assault 2, Poison (2+), Rending</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="cd0b-1917-6984-8f91" name="Poisoned" hidden="false" targetId="a5ff-1cb1-bee4-d809" type="rule"/>
+            <infoLink id="634d-7728-24ee-50c4" name="Rending" hidden="false" targetId="8269-2cd6-9236-16e7" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="12ce-ea9c-f98d-594c" name="Nemesis Vial" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c551-b49b-31ba-dfcb" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="71fb-3662-8ad1-6604" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="2d3b-de17-8def-eba7" name="Nemesis Vial" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="52616e676523232344415441232323">Melee</characteristic>
+                <characteristic name="Strength" typeId="537472656e67746823232344415441232323">X</characteristic>
+                <characteristic name="AP" typeId="415023232344415441232323">4</characteristic>
+                <characteristic name="Type" typeId="5479706523232344415441232323">Rending, Poison (2+), Instant Death, One User, Singular</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="1f65-198b-8e13-49d7" name="Singular" hidden="false">
+              <description>The model can only make 1 Attack with this weapon and cannot gain bonuses Attacks for charging etc.</description>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="f3c2-bc24-936b-592c" name="Poisoned" hidden="false" targetId="a5ff-1cb1-bee4-d809" type="rule"/>
+            <infoLink id="0cc9-6acf-79fd-cd45" name="Rending" hidden="false" targetId="8269-2cd6-9236-16e7" type="rule"/>
+            <infoLink id="e673-e170-6eb0-83c2" name="One Use Only/One Shot Only" hidden="false" targetId="3789-00ab-3f47-eb36" type="rule"/>
+            <infoLink id="ec58-4f8d-5219-b96d" name="Instant Death" hidden="false" targetId="fbf1-6913-ff9f-5a4f" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="b998-4f99-c1ad-cb9f" name="Virus Grenade" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="43f3-b3f1-172a-fd69" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="14f8-486c-60d1-0cb6" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="1b3a-d583-8c05-22ef" name="Virus Grenade" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="52616e676523232344415441232323">8&quot;</characteristic>
+                <characteristic name="Strength" typeId="537472656e67746823232344415441232323">X</characteristic>
+                <characteristic name="AP" typeId="415023232344415441232323">-</characteristic>
+                <characteristic name="Type" typeId="5479706523232344415441232323">Assault 1, Blast, Viral Lode, Poison (2+), One Use</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="2d22-ecfb-ed21-0374" name="Viral Lode" hidden="false">
+              <description>If one or more models are removed after resolving this attack, place another Blast marker within 5” of the location of any casualty. Resolve this as a new attack using the profile given above. Continue this process until no more casualties are caused.</description>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="66ab-f591-433f-f878" name="Poisoned" hidden="false" targetId="a5ff-1cb1-bee4-d809" type="rule"/>
+            <infoLink id="a621-5632-eb42-58d7" name="One Use Only/One Shot Only" hidden="false" targetId="3789-00ab-3f47-eb36" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="915a-b746-5b4c-0f87" name="Toxin Cordes" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6fcf-e4c9-3cc6-0b81" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6e15-a35f-a7ee-2de8" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="672b-a0b7-8e22-2fb9" name="Toxin Cordes" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="52616e676523232344415441232323">Melee</characteristic>
+                <characteristic name="Strength" typeId="537472656e67746823232344415441232323">X</characteristic>
+                <characteristic name="AP" typeId="415023232344415441232323">-</characteristic>
+                <characteristic name="Type" typeId="5479706523232344415441232323">Paired Weapon, Poison (2+)</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="67f6-c9ce-4903-18e5" name="Paired Weapons" hidden="false" targetId="f495-679e-1976-68d1" type="rule"/>
+            <infoLink id="cb57-a27f-610c-8c99" name="Poisoned" hidden="false" targetId="a5ff-1cb1-bee4-d809" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="points" value="115.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="693c-5450-e295-ce1f" name="Sisters of Silence Oblivion Knight-Centura" hidden="true" collective="false" import="true" type="upgrade">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="a82a-f8d9-d454-b227" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <profiles>
+        <profile id="8a61-7a46-e912-8b0e" name="Oblivion Knight-Centura" publicationId="0e6e-8c19-c436-39c4" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+          <characteristics>
+            <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry (Character)</characteristic>
+            <characteristic name="WS" typeId="575323232344415441232323">5</characteristic>
+            <characteristic name="BS" typeId="425323232344415441232323">4</characteristic>
+            <characteristic name="S" typeId="5323232344415441232323">3</characteristic>
+            <characteristic name="T" typeId="5423232344415441232323">3</characteristic>
+            <characteristic name="W" typeId="5723232344415441232323">3</characteristic>
+            <characteristic name="I" typeId="4923232344415441232323">5</characteristic>
+            <characteristic name="A" typeId="4123232344415441232323">3</characteristic>
+            <characteristic name="LD" typeId="4c4423232344415441232323">9</characteristic>
+            <characteristic name="Save" typeId="5361766523232344415441232323">2+</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="3a75-6fad-5c72-692e" name="Ex Oblivio" publicationId="0e6e-8c19-c436-39c4" page="" hidden="false">
+          <description>Psychic models or units of any kind within 6&quot; of models with tis rul at the start of their Psychic phase do not generate additional warp charge dice.
+
+If any Psyker model is in base contact with a model that has this special rule at the start of any Psychic phase they must immediately make a Leadership text before Warp Charge is rolled for. If this test is failed they must immediately suffer Perils of the Warp at -1and may not use any psychic powers durung this phase should they survive this.</description>
+        </rule>
+        <rule id="9f75-7fbd-b36c-a3d4" name="Psykic Anathema" publicationId="0e6e-8c19-c436-39c4" page="" hidden="false">
+          <description>Models witht his rule ar eimmune to all psychic powers and cannot be affected by them. They also ignore any Telepathy Discipline Blessings on enemy units which would negatively affect the models which this rule. This does not extend to Transport Vehicles.
+
+All units with in 12&quot; of any model with this rule suffer -1 to their Leadership value increasing to -2 if the model is a Psyker. Models with Fearless or the Psychic Anathema are not subject to this effect. This affects friend and foe equally.
+
+Units within 12&quot; of models with this rule must re-roll Deny the Witch tests.
+
+All units with Daemon within 12&quot; of any model with this rule suffer -1 to their Toughness of if they have armour instead of toughness they add +1 to all rolls on the Vehicle damage table.
+
+All models with psychic powers suffer a penalty to roll to manifest psychic powers when near any model with this rule. -1 within 12&quot;, increasting to -2 when in base contact.</description>
+        </rule>
+        <rule id="cdba-9cc2-2d14-b83d" name="Fanatic Discipline" hidden="false">
+          <description>Fearless, Hatred (Psykers)</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="8ecb-4d7f-ab18-16e3" name="New InfoLink" hidden="false" targetId="a080-af1b-fb2e-4860" type="rule"/>
+        <infoLink id="deb5-9421-f3ba-1576" name="New InfoLink" publicationId="0e6e-8c19-c436-39c4" hidden="false" targetId="9d85-46f7-f5e6-a5f7" type="rule"/>
+        <infoLink id="639c-8403-3fdb-bcf4" name="Fearless" hidden="false" targetId="dc70-e199-5525-e78c" type="rule"/>
+        <infoLink id="cf51-d6fa-fe09-31a4" name="Hatred" hidden="false" targetId="7c6c-4e25-e4d4-9728" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Hatred (Psykers)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="c714-d012-4a3b-d931" name="Independent Character" hidden="false" targetId="1d9c-cc5a-0f91-2590" primary="false"/>
+        <categoryLink id="e1f9-bd7e-fbce-dfb8" name="Infantry" hidden="false" targetId="1ab3-f1ac-f724-8544" primary="false"/>
+        <categoryLink id="d45c-a975-0515-7a73" name="Character" hidden="false" targetId="ae54-92c7-3e66-59f7" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="fce8-1df6-3e10-9fa7" name="Enhanced Voidsheen Cloak" publicationId="0e6e-8c19-c436-39c4" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f77b-86e7-4438-2dd9" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="25e5-58fc-cff6-dc20" type="min"/>
+          </constraints>
+          <rules>
+            <rule id="e3a5-01c4-89ec-fe63" name="Enhanced Voidsheen Cloak" publicationId="0e6e-8c19-c436-39c4" hidden="false">
+              <description>Provides the wearer with a 4++, which increases to a 3++ vs Template and Blast weapons</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="a083-686d-39e1-1966" name="Artificer Armour" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6fe4-bd52-b36a-c571" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d0be-bbf5-45f4-8987" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="0b56-bfff-3058-b2aa" name="New InfoLink" hidden="false" targetId="4b6b-08cb-a956-0eb3" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="bf90-21c8-2a81-6c4e" name="Frag, Krak, and Psyk-Out Grenades" publicationId="0e6e-8c19-c436-39c4" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b6ec-d6e9-76cd-ce39" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3fb9-f444-f337-3910" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="d406-0df3-09e3-da65" name="New InfoLink" hidden="false" targetId="d890-1b84-bbd9-12d3" type="profile"/>
+            <infoLink id="dc9d-ec2c-292e-b07a" name="New InfoLink" hidden="false" targetId="d9f7-775b-1047-f335" type="profile"/>
+            <infoLink id="4a3d-00ba-8d9a-665a" name="New InfoLink" hidden="false" targetId="9430-a4d5-6f01-57e2" type="rule"/>
+            <infoLink id="47d2-c651-2b64-a6d7" name="Psyk-Out Grenade (Thrown)" hidden="false" targetId="764e-da44-1175-5ac6" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="5eee-651e-6052-eba0" name="Exchange Execution Blade for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="ef24-cd29-6607-b733">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="695b-f54d-b42e-54f2" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0789-204a-379c-57f0" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="8c6a-abcb-4b46-b7f2" name="Divining Blades" hidden="true" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="f5f0-fdd8-422f-a0bc" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a248-79a4-a7c8-b2a2" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="52dd-6a27-64aa-9be0" name="Divining Blades" publicationId="ca571888--pubN103311" page="306" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="52616e676523232344415441232323">Melee</characteristic>
+                    <characteristic name="Strength" typeId="537472656e67746823232344415441232323">+2</characteristic>
+                    <characteristic name="AP" typeId="415023232344415441232323">1</characteristic>
+                    <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Instant Death, Master-Crafted, Psy-Lash, Two Handed.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink id="9476-d56d-9348-0b01" name="Instant Death" hidden="false" targetId="fbf1-6913-ff9f-5a4f" type="rule"/>
+                <infoLink id="9f2d-042f-f277-fe7e" name="Master-crafted" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule"/>
+                <infoLink id="bfa8-d4e2-113f-9dc7" name="Psy-Lash" hidden="false" targetId="6f38-4691-2eda-8e1b" type="rule"/>
+                <infoLink id="0a89-c4da-1787-22db" name="Two-Handed" hidden="false" targetId="b11c-0ef4-af6b-d96f" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="50.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="ef24-cd29-6607-b733" name="Execution Blade" publicationId="0e6e-8c19-c436-39c4" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="46fe-39a0-3305-1829" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="efde-2fc8-ac53-562a" name="Execution Blade" publicationId="0e6e-8c19-c436-39c4" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
+                    <characteristic name="Strength" typeId="537472656e67746823232344415441232323">+1</characteristic>
+                    <characteristic name="AP" typeId="415023232344415441232323">3</characteristic>
+                    <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Two-Handed, Piercing Cut, Duellist&apos;s Edge</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules>
+                <rule id="bd2f-3687-0e73-5204" name="Piercing Cut" publicationId="0e6e-8c19-c436-39c4" hidden="false">
+                  <description>To Hit rolls of 5 or 6 made for attacks with this weapon are resolved seperately at AP2</description>
+                </rule>
+              </rules>
+              <infoLinks>
+                <infoLink id="8297-dfca-9afa-db8f" name="Duelist&apos;s Edge" hidden="false" targetId="1a79-befa-05cf-ab0d" type="rule"/>
+                <infoLink id="a120-0d93-04a3-7279" name="New InfoLink" hidden="false" targetId="b11c-0ef4-af6b-d96f" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="b803-2267-bf1c-9ffd" name="Paragon Blade" page="0" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="120f-f07a-7294-3fea" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="fa53-2b9a-7c54-ee04" name="Paragon Blade" publicationId="ca571888--pubN80998" page="" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
+                    <characteristic name="Strength" typeId="537472656e67746823232344415441232323">+1</characteristic>
+                    <characteristic name="AP" typeId="415023232344415441232323">2</characteristic>
+                    <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Murderous Strike, Specialist Weapon</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules>
+                <rule id="36f7-7ff3-6585-4227" name="Murderous Strike" page="0" hidden="false">
+                  <description>Causes Instant Death on a To Wound roll of 6</description>
+                </rule>
+              </rules>
+              <costs>
+                <cost name="pts" typeId="points" value="20.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="2422-f683-7478-5e96" name="Power Axe" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="6451-c59d-bbf5-5b7f" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="ae00-8d49-c5c4-8010" name="New InfoLink" hidden="false" targetId="b3af-1eca-6629-4894" type="profile"/>
+                <infoLink id="882c-5fda-05c7-d6c2" name="Unwieldy" hidden="false" targetId="5eea-958c-d623-c3c9" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="26a4-5eed-6ec6-dbf5" name="Proteus Neuro-Lash" publicationId="0e6e-8c19-c436-39c4" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="335d-3d55-bf00-421f" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="5c78-74ab-1221-b6b5" name="Proteus Neuro-Lash" publicationId="0e6e-8c19-c436-39c4" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
+                    <characteristic name="Strength" typeId="537472656e67746823232344415441232323">+1</characteristic>
+                    <characteristic name="AP" typeId="415023232344415441232323">-</characteristic>
+                    <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Two-Handed, Electro-Arc, Sweeping Strikes</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules>
+                <rule id="1c57-8c98-14e1-64e2" name="Electro-Arc" publicationId="0e6e-8c19-c436-39c4" hidden="false">
+                  <description>Total all hits caused by weapons with this special rule durring an Assault phase, before making any To Wound rolls, then roll a single D6 for each of these hits. Any rolls of 3+ cause an additional hit at AP- with the Poisoned (4+)special rule.</description>
+                </rule>
+                <rule id="092f-9e67-4a93-7e9f" name="Sweeping Strikes" publicationId="0e6e-8c19-c436-39c4" hidden="false">
+                  <description>The bearer may choose to use the number of enemy models within 3&quot; that are locked in combat with them instead of their Attacks score to determine the number of attacks they may make in any Assault phase.</description>
+                </rule>
+              </rules>
+              <infoLinks>
+                <infoLink id="5c54-4827-257b-28b0" name="New InfoLink" hidden="false" targetId="b11c-0ef4-af6b-d96f" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="1cf3-f63d-a6d8-8ed8" name="Exchange Bolt Pistol for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="609c-a0d3-fad0-6813">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d5f9-e245-8a63-17b6" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f526-cf3f-14d9-0330" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="813b-8ff9-bad7-d341" name="Archaeotech Pistol" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ccc6-c619-a4d8-dba5" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="0775-f607-fceb-e7d9" name="New InfoLink" hidden="false" targetId="cf65-5d4c-24a3-92d2" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="609c-a0d3-fad0-6813" name="Bolt Pistol" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8a90-dc9d-b019-4b86" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="146f-d4eb-f5cd-154a" name="New InfoLink" hidden="false" targetId="ec83-0776-ef74-9cc2" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="8692-fff1-9fd3-497b" name="Hand Flamer" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0f87-0e0e-e421-798f" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="6b6a-5c75-c61b-0818" name="New InfoLink" hidden="false" targetId="21b6-668e-d5ef-a8da" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="bf4b-b964-cfe6-54ad" name="Needle Pistol" publicationId="ca571888--pubN92115" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="25a2-d74d-0eda-2a07" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="f9d1-3105-f218-afd3" name="Needle Pistol" publicationId="ca571888--pubN92115" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="52616e676523232344415441232323">12</characteristic>
+                    <characteristic name="Strength" typeId="537472656e67746823232344415441232323">2</characteristic>
+                    <characteristic name="AP" typeId="415023232344415441232323">5</characteristic>
+                    <characteristic name="Type" typeId="5479706523232344415441232323">Pistol, Poisoned (4+), Rending</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink id="64b5-f08a-abf1-f9dd" name="New InfoLink" hidden="false" targetId="8269-2cd6-9236-16e7" type="rule"/>
+                <infoLink id="cf9f-f6a4-7f6e-fd82" name="New InfoLink" hidden="false" targetId="a5ff-1cb1-bee4-d809" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="a2f0-fc19-bb14-7aae" name="Plasma Pistol" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="200f-ad0d-f916-33e7" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="6f07-a799-def5-4156" name="New InfoLink" hidden="false" targetId="f9fd-36be-dc19-401f" type="profile"/>
+                <infoLink id="f5e8-5ed8-5e03-bb12" name="Gets Hot" hidden="false" targetId="f4fd-d519-4769-5510" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="15.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="9640-ab93-ba04-82b6" name="Upgrade one weapon to be Master-Crafted" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1bd7-fbfe-fe89-d1fd" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="be13-d531-7fce-2f3a" name="Bolt Pistol Group" hidden="false" collective="false" import="true" type="upgrade">
+              <infoLinks>
+                <infoLink id="0cba-d590-73c0-bcf7" name="New InfoLink" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="c10d-79f0-589c-2881" name="Execution Blade Group" hidden="false" collective="false" import="true" type="upgrade">
+              <infoLinks>
+                <infoLink id="ae5e-a9a2-a4e7-d405" name="New InfoLink" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="453b-9700-b6be-67ea" name="Psyarkana" hidden="false" collective="false" import="true">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="693c-5450-e295-ce1f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8c6a-abcb-4b46-b7f2" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="58ce-59a8-7af9-ae84" value="0">
+              <conditions>
+                <condition field="selections" scope="693c-5450-e295-ce1f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8c6a-abcb-4b46-b7f2" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="58ce-59a8-7af9-ae84" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="2197-eebe-21b2-3e12" name="Icon of the Blazing Sun" hidden="false" collective="false" import="true" targetId="b2fe-de24-0c45-9b4d" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false"/>
+              </modifiers>
+            </entryLink>
+            <entryLink id="71da-0a25-2573-5ba8" name="Terminal Lucidity Injectors" hidden="false" collective="false" import="true" targetId="66e2-6760-fb6a-edc3" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false"/>
+              </modifiers>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="a1c2-edc7-cc84-eea9" name="Company Cadre" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d5ab-dcaa-dbba-5375" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9a57-6333-188c-403c" type="min"/>
+          </constraints>
+          <rules>
+            <rule id="2070-e1c4-33f5-208e" name="Company Cadre Structure" publicationId="0e6e-8c19-c436-39c4" hidden="false">
+              <description>For each HQ unit with this special rule, at least three other units with this rule can be included in the same detachment. If no HQ model is included, then these units may not be selected. Additionally, choose one of the following rules to apply to all models with this rule in the detachment: Infiltrate, Crusader, Stealth, Overawe (+1 to combat resolution)</description>
+            </rule>
+          </rules>
+          <selectionEntries>
+            <selectionEntry id="3b8e-e7ee-d7ae-1bd5" name="Stealth" hidden="false" collective="false" import="true" type="upgrade">
+              <infoLinks>
+                <infoLink id="1b85-d14a-b026-1686" name="Stealth" hidden="false" targetId="0d66-14c9-d2f4-708b" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="4c9e-dd51-8584-ea29" name="Overawe" hidden="false" collective="false" import="true" type="upgrade">
+              <rules>
+                <rule id="5567-8cab-c62d-4990" name="Overawe" hidden="false">
+                  <description>+1 to Combat Resolutions</description>
+                </rule>
+              </rules>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="cf23-4d90-0dd5-2fc9" name="Crusader" hidden="false" collective="false" import="true" type="upgrade">
+              <infoLinks>
+                <infoLink id="4131-c2f4-9824-b43f" name="Crusader" hidden="false" targetId="2b06-29a6-641a-b22e" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="3281-ec30-7bbf-64bf" name="Infiltrate" hidden="false" collective="false" import="true" type="upgrade">
+              <infoLinks>
+                <infoLink id="de32-5997-6abf-1406" name="Infiltrate" hidden="false" targetId="34c7-8b61-a5b8-a301" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="points" value="75.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f07b-6978-8f48-6c0f" name="Combi-weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0770-0dac-1c23-cffe" type="max"/>
+      </constraints>
+      <entryLinks>
+        <entryLink id="6e6c-7c34-b7f0-e989" name="Combi-weapon" hidden="false" collective="false" import="true" targetId="7660-b542-e9a6-0cbb" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ee70-f3a2-17f8-f39e" name="Combat Shield" page="0" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="722a-f10e-ed12-a36a" name="Combat Shield" publicationId="ca571888--pubN82424" page="89" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
+          <characteristics>
+            <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Confers 6+ invulnverable save, increasing to a 5+ in close combat.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name="pts" typeId="points" value="5.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="c6b8-8b0b-8a31-6aa3" name="Artificer Armour" hidden="false" collective="false" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="40ee-ffe7-04df-4130" name="Artificer Armour" hidden="false" targetId="4b6b-08cb-a956-0eb3" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4cc7-2161-170d-16ba" name="Auxiliary Drive" page="0" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d6c8-07bf-ac83-df04" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="8ca2-7b56-76b1-f138" hidden="false" targetId="c5c3-cf81-76c6-b0c0" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2b1e-4478-2200-10b8" name="Dozer Blade" page="0" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="728a-f4e3-29a3-cde7" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="f6a6-9c81-9fbe-edfa" name="New InfoLink" hidden="false" targetId="35a2-2083-1522-cd61" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="5.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2276-994b-8721-ac3d" name="Hunter-killer Missile" page="0" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8fb8-979a-13d1-8e95" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="142a-9492-bb98-f6db" name="Hunter-killer Missile" hidden="false" targetId="a117-de7b-6200-3076" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="5.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="eaec-b433-8e4d-1da5" name="Twin-linked Bolter" page="0" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e441-850a-32c6-155e" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="da68-29dc-0949-54d1" name="Twin-Linked Boltgun" hidden="false" targetId="37fc-8473-3879-14a4" type="profile"/>
+        <infoLink id="3e14-d2c7-f9b5-6bf9" name="Twin-linked" hidden="false" targetId="10a8-8d89-0bec-3e21" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="00ee-3a61-8872-d01e" name="Rhino Armoured Carrier, Legion" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="638e-bf35-aaae-6ff9" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="059a-6f4a-1835-9b59" name="Legion Rhino (Transport)" hidden="false" typeId="307d-047f-ca13-706b" typeName="Transport">
+          <characteristics>
+            <characteristic name="Capacity" typeId="8285-4205-b6cd-8473">10</characteristic>
+            <characteristic name="Fire Points" typeId="b270-a7f9-22b2-3702">Two - Top Hatch</characteristic>
+            <characteristic name="Access Points" typeId="d17b-0342-b1dc-b8e7">Three. One on each side of the Hull and one at the rear.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="cb78-54ac-5946-047a" name="Legion Rhino" publicationId="ca571888--pubN82424" page="35" hidden="false" typeId="56656869636c6523232344415441232323" typeName="Vehicle">
+          <characteristics>
+            <characteristic name="BS" typeId="425323232344415441232323">4</characteristic>
+            <characteristic name="Front" typeId="46726f6e7423232344415441232323">11</characteristic>
+            <characteristic name="Side" typeId="5369646523232344415441232323">11</characteristic>
+            <characteristic name="Rear" typeId="5265617223232344415441232323">10</characteristic>
+            <characteristic name="HP" typeId="485023232344415441232323">3</characteristic>
+            <characteristic name="Type" typeId="5479706523232344415441232323">Tank, Transport</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="0806-cb63-f890-9cc5" name="Repair" publicationId="ca571888--pubN82424" page="35" hidden="false">
+          <description>In the Shooting phase instead of firing a weapon, the Rhino may attempt to repair an Immobilised result on a D6 roll of a 6.</description>
+        </rule>
+      </rules>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="b0b5-48dd-2cdd-1c1d" name="May take any of the following:" hidden="false" collective="false" import="true">
+          <entryLinks>
+            <entryLink id="1aa8-be57-c81b-3526" name="Extra Armour" hidden="false" collective="false" import="true" targetId="a6cd-f04b-711e-c083" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="points" value="0.0">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="607f-5517-b4b7-6e46" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </entryLink>
+            <entryLink id="43ee-39b4-9047-8d54" name="Dozer Blade" hidden="false" collective="false" import="true" targetId="2b1e-4478-2200-10b8" type="selectionEntry"/>
+            <entryLink id="abb0-434f-5dab-c6ab" name="Auxiliary Drive" hidden="false" collective="false" import="true" targetId="4cc7-2161-170d-16ba" type="selectionEntry"/>
+            <entryLink id="fce1-53e4-1efb-5700" name="Hunter-killer Missile" hidden="false" collective="false" import="true" targetId="2276-994b-8721-ac3d" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="ad0e-49ab-b31e-a270" name="Psyarkana" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="02d9-850d-a7d0-85b4" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="57fe-0e48-6757-4171" name="Armatus Necrotechnica" hidden="false" collective="false" import="true" targetId="e78c-d1a1-c20f-dae8" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false"/>
+              </modifiers>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="a68a-e763-b4f1-f0d4" name="Twin-linked Bolter" hidden="false" collective="false" import="true" targetId="eaec-b433-8e4d-1da5" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3dc0-cb32-d109-780c" type="min"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="d074-6b01-bc5f-3d9e" name="May take a Pintle-Mounted Weapon:" hidden="false" collective="false" import="true" targetId="04d3-346a-f264-9573" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="35.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f0e7-972c-32ed-82de" name="Bolter with Banestrike Rounds" hidden="false" collective="false" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="8f9c-a692-2669-d767" name="Banestrike Bolter Shells" hidden="false" targetId="86aa-1007-998b-5b44" type="profile"/>
+        <infoLink id="1a82-2a70-8c9a-e2b5" name="Bolter with Banestrike Rounds" hidden="false" targetId="0cc3-b3b0-0880-9366" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0b5b-7b9a-5afc-382b" name="Venom Spheres" publicationId="ca571888--pubN67459" page="89" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8d93-953d-42d6-2a30" type="max"/>
+      </constraints>
+      <rules>
+        <rule id="8455-0957-14d2-b705" name="Venom Spheres" publicationId="ca571888--pubN67459" page="89" hidden="false">
+          <description>Replaces Frag grenades.  Assault grenade that grants Hammer of Wrath to user.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="ad89-b0fc-dea1-e5e2" name="Hammer of Wrath" hidden="false" targetId="6f66-b417-6004-0916" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="586c-391b-172f-6e2a" name="Blessed Autosimulacra" page="0" hidden="false" collective="false" import="true" type="upgrade">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b7d6-8217-4fe9-45d4" type="equalTo"/>
+          </conditions>
+        </modifier>
+        <modifier type="set" field="points" value="0.0">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="607f-5517-b4b7-6e46" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a118-6830-15b7-547b" type="max"/>
+      </constraints>
+      <rules>
+        <rule id="2d6d-b528-3ab0-d1dd" name="Blessed Autosimulacra" publicationId="ca571888--pubN85920" page="206" hidden="false">
+          <description>If the vehicle has lost a hull point, at the end of the controlling players turn roll a D6. On a result of a 6 one lost hull point is restored.</description>
+        </rule>
+      </rules>
+      <costs>
+        <cost name="pts" typeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6909-7d6f-d291-7cd4" name="Dreadnought Chainfist" hidden="false" collective="false" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="bab8-f58e-0f71-76a9" name="Dreadnought Chainfist" hidden="false" targetId="a657-004f-4150-f1ec" type="profile"/>
+        <infoLink id="02b5-7b7a-1b75-6015" name="New InfoLink" hidden="false" targetId="e182-50cd-0867-9a8d" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ec29-0748-6778-ff60" name="Graviton Gun" page="0" hidden="false" collective="false" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="755e-b121-a74c-314e" name="Graviton Gun" hidden="false" targetId="481b32ee-2904-c9e0-8612-35ff2bcab65a" type="profile"/>
+        <infoLink id="7306-5545-eec9-14be" name="Graviton Pulse" hidden="false" targetId="2d57-8425-0ec0-a9cf" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="15.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="90d6-af34-57e7-f86b" name="Plasma Blaster" page="0" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="a2cf-0f2b-b9db-7ad2" name="Plasma Blaster" publicationId="ca571888--pubN82424" page="84" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="52616e676523232344415441232323">18&quot;</characteristic>
+            <characteristic name="Strength" typeId="537472656e67746823232344415441232323">7</characteristic>
+            <characteristic name="AP" typeId="415023232344415441232323">2</characteristic>
+            <characteristic name="Type" typeId="5479706523232344415441232323">Assault 2, Gets Hot!</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="f087-1da4-ca11-4cd6" name="New InfoLink" hidden="false" targetId="f4fd-d519-4769-5510" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="15.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="92a6-0345-f839-580a" name="Dreadnought Close Combat Weapon" hidden="false" collective="false" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="7ffd-7c88-c12d-c313" name="Dreadnought Close Combat Weapon" hidden="false" targetId="3b26-3098-155f-0e58" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f950-fb54-77e2-dd71" name="Heavy Conversion Beamer" publicationId="ca571888--pubN82424" page="0" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1b26-bfa7-0adf-d24b" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="3e58-98cf-e72c-4152" name="Heavy Conversion Beamer (1)" publicationId="ca571888--pubN82424" page="82" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="52616e676523232344415441232323">&lt; 18&quot;</characteristic>
+            <characteristic name="Strength" typeId="537472656e67746823232344415441232323">6</characteristic>
+            <characteristic name="AP" typeId="415023232344415441232323">-</characteristic>
+            <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 1, Large Blast, Firing Calibration</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="038a-df1d-6611-0267" name="Heavy Conversion Beamer (2)" publicationId="ca571888--pubN82424" page="82" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="52616e676523232344415441232323">18&quot; - 42&quot;</characteristic>
+            <characteristic name="Strength" typeId="537472656e67746823232344415441232323">8</characteristic>
+            <characteristic name="AP" typeId="415023232344415441232323">4</characteristic>
+            <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 1, Large Blast, Firing Calibration</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="d10a-04b1-39d4-0f37" name="Heavy Conversion Beamer (3)" publicationId="ca571888--pubN82424" page="82" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="52616e676523232344415441232323">42&quot; - 72&quot;</characteristic>
+            <characteristic name="Strength" typeId="537472656e67746823232344415441232323">10</characteristic>
+            <characteristic name="AP" typeId="415023232344415441232323">1</characteristic>
+            <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 1, Large Blast, Firing Calibration</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="8392-6757-5041-4401" name="Firing Calibration" publicationId="ca571888--pubN82424" page="82" hidden="false">
+          <description>This weapon may not be fired if the model carrying it has moved in the same turn, regardless of the Relentless special rule or if the carrying model is a vehicle, etc...</description>
+        </rule>
+      </rules>
+      <costs>
+        <cost name="pts" typeId="points" value="35.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="d767-9faf-0ede-97f8" name="Kheres Pattern Assault Cannon" page="0" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5cec-fd84-9952-b582" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="b454-bce7-7ba2-1e02" name="Kheres Assault Cannon" hidden="false" targetId="4ffe-bba3-82e3-987b" type="profile"/>
+        <infoLink id="2662-0425-529c-6f48" name="Rending" hidden="false" targetId="8269-2cd6-9236-16e7" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ba00-b40e-b481-d400" name="Plasma Cannon" page="0" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1766-11c7-fa51-d073" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="6572-b5f3-f448-4651" name="New InfoLink" hidden="false" targetId="13df-d6b0-3f33-bf9b" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4ba2-3e2c-7341-0531" name="Toxiferno Cannon" publicationId="ca571888--pubN103311" page="302" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="0e0a-6663-a25c-9deb" name="Toxiferno Cannon" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="52616e676523232344415441232323">Template</characteristic>
+            <characteristic name="Strength" typeId="537472656e67746823232344415441232323">7</characteristic>
+            <characteristic name="AP" typeId="415023232344415441232323">4</characteristic>
+            <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 1, Shred, Tainted</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="701c-3d87-c152-8dcb" name="Tainted" publicationId="ca571888--pubN103311" page="302" hidden="false">
+          <description>Any successful wound dealt by a weapon with this special rule removes the effects of any psychic blessing which is active on the target unit. In addition, any To Wound roll of a 6 with this weapon is resolved at AP2.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="822f-8e57-0ddb-8f66" name="Shred" hidden="false" targetId="89da-0cb5-bee4-8ec2" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7bda-a8bf-ca97-d24f" name="Twin-linked Autocannon" publicationId="ca571888--pubN106502" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="457b-f381-e143-ad2d" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="c4f2-f008-be06-b6e1" name="Twin-Linked Autocannon" hidden="false" targetId="423f-013f-cb9f-b6bb" type="profile"/>
+        <infoLink id="882c-24ad-a73d-ffe6" name="Twin-linked" hidden="false" targetId="10a8-8d89-0bec-3e21" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1a63-1b4b-0a42-d511" name="Twin-linked Heavy Bolter" page="0" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7aa5-d484-569e-3cb0" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="8a3a-aa24-fffe-76b6" name="Twin-Linked Heavy Bolter" hidden="false" targetId="d9ce-23de-9b51-0707" type="profile"/>
+        <infoLink id="5348-2ea6-e0c9-acbc" name="Twin-linked" hidden="false" targetId="10a8-8d89-0bec-3e21" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="22ce-9b78-54de-af31" name="Twin-linked Lascannon" page="0" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="37f6-6d2a-2af9-de57" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="3ff9-d6f6-b018-837f" name="Twin-Linked Lascannon" hidden="false" targetId="2cd1-0fb3-7484-e486" type="profile"/>
+        <infoLink id="5588-5872-ba0a-86de" name="New InfoLink" hidden="false" targetId="10a8-8d89-0bec-3e21" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ee2b-3989-4638-7684" name="Twin-linked Volkite Culverin" publicationId="ca571888--pubN82424" page="129" hidden="false" collective="false" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="57a5-7da6-91c7-2845" name="Twin-Linked Volkite Culverin" hidden="false" targetId="dfaa-aab3-67ce-cd36" type="profile"/>
+        <infoLink id="d697-e31a-27d2-b95b" name="Deflagrate" hidden="false" targetId="b46a-a3ec-91a5-5001" type="rule"/>
+        <infoLink id="08a5-4855-13ce-d0b4" name="Twin-linked" hidden="false" targetId="10a8-8d89-0bec-3e21" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9df4-1c2f-6e51-68a3" name="Twin-linked Heavy Flamer (Salamanders)" page="0" hidden="false" collective="false" import="true" type="upgrade">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e2d7-e297-5b99-cbac" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="cba1-8322-7ba4-363f" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="24a0-220b-a09d-077f" name="Twin-Linked Heavy Flamer" hidden="false" targetId="b55d-dcfd-d708-8149" type="profile">
+          <modifiers>
+            <modifier type="increment" field="537472656e67746823232344415441232323" value="1"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="11ee-38bc-4253-bb6e" name="Twin-linked" hidden="false" targetId="10a8-8d89-0bec-3e21" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7562-9af8-67f3-2533" name="Searchlight and Smoke Launchers" page="0" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f7d7-81f0-1ae7-f692" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="112d-d861-df6c-cbc0" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="7c90-fb8c-5476-3687" name="Smoke Launchers" hidden="false" targetId="6875-ee73-2a85-6a97" type="profile"/>
+        <infoLink id="f856-31c2-1754-396a" name="Searchlight" hidden="false" targetId="9bb4-3833-5343-0dd9" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4c19-2579-80d0-6490" name="Shrapnel Bolts" page="0" hidden="false" collective="false" import="true" type="upgrade">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1660-f879-3beb-0c0b" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="09a6-238e-c3a3-3985" type="max"/>
+      </constraints>
+      <rules>
+        <rule id="ba36-d13d-2062-0e88" name="Shrapnel Bolts" publicationId="ca571888--pubN67459" page="81" hidden="false">
+          <description>Heavy Bolters gain Pinning and reduce AP value to 5.
+
+All Heavy Bolters/Twin-linked Heavy Bolters/Quad Heavy Bolters in unit are affected.</description>
+        </rule>
+      </rules>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0760-1529-35e8-a884" name="Havoc Launcher" page="0" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="463c-a8a5-a640-cfb4" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="a310-4e83-95e8-1e75" name="Havoc Launcher" publicationId="ca571888--pubN82424" page="83" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="52616e676523232344415441232323">48&quot;</characteristic>
+            <characteristic name="Strength" typeId="537472656e67746823232344415441232323">5</characteristic>
+            <characteristic name="AP" typeId="415023232344415441232323">5</characteristic>
+            <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 1, Blast (3&quot;), Twin-linked</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name="pts" typeId="points" value="15.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1524-ecd3-80b0-453c" name="Cortus Class Dreadnought Talon" publicationId="0e6e-8c19-c436-39c4" page="27" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="e311-3444-48fa-86a5" name="Vehicle" hidden="false" targetId="8c70-1182-84f5-c93a" primary="false"/>
+        <categoryLink id="a039-6a2a-4f51-ffca" name="Walker" hidden="false" targetId="dd38-7d09-0bc8-df0d" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="17cb-be38-c492-d766" name="Cortus Dreadnought" hidden="false" collective="false" import="true" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="25ba-7102-bb0d-0d26" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="798c-df41-574b-ea16" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="bcb9-c1c3-e860-eae5" name="Atomantic Deflector" publicationId="ca571888--pubN89821" page="239" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
+              <characteristics>
+                <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Grants a 5+ Invulnerable save against shooting attacks and explosions which originate from the front arc.  In addition, when suffering a Vehicle Explodes results, add 1&quot; to the radius of the blast.  </characteristic>
+              </characteristics>
+            </profile>
+            <profile id="4bf0-c835-2122-11d4" name="Atomantic Overcharge" publicationId="ca571888--pubN89821" page="239" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
+              <characteristics>
+                <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">At the beginning of the controlling players turn, they may declare that the Contemptor-Cortus is overcharging its Atomantic reactor.  They may then apply one of the following bonuses until the end of the player turn:  - Rage special rule - 1&quot; Move and Charge distances - 2&quot; Run distance - 1 Initiative  At the end of its player turn, rolla  D6.  On a roll of a 1, lose a hull point.  If this is enough to wreck the dreadnought, it suffers an immediate Vehicle Explodes and the blast is increased by D3&quot; instead of the usual 1&quot;.  </characteristic>
+              </characteristics>
+            </profile>
+            <profile id="eb97-c678-8388-8f49" name="Unstable Internment" publicationId="ca571888--pubN89821" page="239" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
+              <characteristics>
+                <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Must always make Sweeping Advances when able, but may never be counted as a scoring unit.  </characteristic>
+              </characteristics>
+            </profile>
+            <profile id="ec28-dbd2-5fc7-49a2" name="Cortus Dreadnought" hidden="false" typeId="57616c6b657223232344415441232323" typeName="Walker">
+              <modifiers>
+                <modifier type="increment" field="4123232344415441232323" value="1">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="17cb-be38-c492-d766" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e7d3-aa89-fb59-d733" type="equalTo"/>
+                            <condition field="selections" scope="17cb-be38-c492-d766" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6e23-90c4-a3bf-030a" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="17cb-be38-c492-d766" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6e23-90c4-a3bf-030a" type="equalTo"/>
+                            <condition field="selections" scope="17cb-be38-c492-d766" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="28f6-b43f-4914-4a29" type="equalTo"/>
+                            <condition field="selections" scope="17cb-be38-c492-d766" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e7d3-aa89-fb59-d733" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="17cb-be38-c492-d766" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6e23-90c4-a3bf-030a" type="equalTo"/>
+                            <condition field="selections" scope="17cb-be38-c492-d766" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="28f6-b43f-4914-4a29" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="17cb-be38-c492-d766" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="28f6-b43f-4914-4a29" type="equalTo"/>
+                            <condition field="selections" scope="17cb-be38-c492-d766" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e7d3-aa89-fb59-d733" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <characteristics>
+                <characteristic name="WS" typeId="575323232344415441232323">4</characteristic>
+                <characteristic name="BS" typeId="425323232344415441232323">4</characteristic>
+                <characteristic name="S" typeId="5323232344415441232323">6</characteristic>
+                <characteristic name="Front" typeId="46726f6e7423232344415441232323">12</characteristic>
+                <characteristic name="Side" typeId="5369646523232344415441232323">11</characteristic>
+                <characteristic name="Rear" typeId="5265617223232344415441232323">10</characteristic>
+                <characteristic name="I" typeId="4923232344415441232323">4</characteristic>
+                <characteristic name="A" typeId="4123232344415441232323">3</characteristic>
+                <characteristic name="HP" typeId="485023232344415441232323">3</characteristic>
+                <characteristic name="Type" typeId="5479706523232344415441232323">Walker</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="e0f7-0a92-a09b-6dfd" name="Dreadnought Talon" hidden="false" targetId="fb2f-6a13-3268-d621" type="rule"/>
+            <infoLink id="0351-9cf8-2c42-cab1" page="" hidden="false" targetId="69e5-fc02-1f9d-63c2" type="rule"/>
+            <infoLink id="472d-4c3a-6145-c412" name="" hidden="false" targetId="6d06-5ea0-9a17-ca97" type="rule"/>
+          </infoLinks>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="95a6-e711-6824-84d4" name="Dedicated Transport" hidden="false" collective="false" import="true">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d6f8-507d-cced-29b2" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="a933-2376-3ec1-2362" name="Dreadnought Drop Pod, Legion" hidden="false" collective="false" import="true" targetId="ac51-a37c-bb2c-07de" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditions>
+                        <condition field="selections" scope="1524-ecd3-80b0-453c" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="17cb-be38-c492-d766" type="greaterThan"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </entryLink>
+                <entryLink id="3db9-3f7c-ec8c-b773" name="anv" hidden="false" collective="false" import="true" targetId="cc5e-a4e6-83f9-7077" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="1524-ecd3-80b0-453c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="17cb-be38-c492-d766" type="greaterThan"/>
+                            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="948d-71e8-6673-6add" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                  <categoryLinks>
+                    <categoryLink id="efd2-049d-ce48-63cf" name="Dedicated Transport" hidden="false" targetId="93ab-5925-3957-7ae1" primary="false"/>
+                  </categoryLinks>
+                </entryLink>
+                <entryLink id="ff4c-7382-8c70-c516" name="Drop Pod" hidden="false" collective="false" import="true" targetId="2dcf-da0f-297d-fccf" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="948d-71e8-6673-6add" type="equalTo"/>
+                            <condition field="selections" scope="1524-ecd3-80b0-453c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="17cb-be38-c492-d766" type="greaterThan"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="bca4-8a94-cf1d-4007" name="Exchange Dreadnought Close Combat Weapon with inbuilt twin-linked bolter for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="6e23-90c4-a3bf-030a">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="4e2c-819b-2e82-a7fe" type="max"/>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="0df1-d5c7-cc56-4569" type="min"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="6e23-90c4-a3bf-030a" name="Dreadnought Close Combat Weapon" hidden="false" collective="false" import="true" targetId="92a6-0345-f839-580a" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8f3e-30e1-1369-6dd4" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="1ff1-a53c-03a9-2b99" name="Twin-linked Heavy Flamer (Salamanders)" hidden="false" collective="false" import="true" targetId="9df4-1c2f-6e51-68a3" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="cba1-8322-7ba4-363f" value="2.0"/>
+                  </modifiers>
+                </entryLink>
+                <entryLink id="56eb-b326-9d1e-cac9" name="Twin-linked Autocannon" hidden="false" collective="false" import="true" targetId="7bda-a8bf-ca97-d24f" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="points" value="5"/>
+                    <modifier type="set" field="457b-f381-e143-ad2d" value="2.0"/>
+                  </modifiers>
+                </entryLink>
+                <entryLink id="0523-4354-c077-a8c1" name="New EntryLink" hidden="false" collective="false" import="true" targetId="d1c0-746f-2b39-5f17" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ab2b-30a3-a6a1-a461" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="b532-5d4c-f7d5-a885" name="Twin-linked Lascannon" hidden="false" collective="false" import="true" targetId="22ce-9b78-54de-af31" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="points" value="25.0"/>
+                    <modifier type="set" field="37f6-6d2a-2af9-de57" value="2.0"/>
+                  </modifiers>
+                </entryLink>
+                <entryLink id="9036-1f3a-4d82-043c" name="Twin-linked Heavy Bolter" hidden="false" collective="false" import="true" targetId="1a63-1b4b-0a42-d511" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="7aa5-d484-569e-3cb0" value="2.0"/>
+                  </modifiers>
+                </entryLink>
+                <entryLink id="28f6-b43f-4914-4a29" name="Dreadnought Chainfist" hidden="false" collective="false" import="true" targetId="6909-7d6f-d291-7cd4" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e8fd-43df-fc29-45ca" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="3409-f531-6ad4-87a3" name="Twin-linked Missile Launcher" hidden="false" collective="false" import="true" targetId="3188-9e2c-f132-a58c" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="8b5e-8cd8-59ef-b427" value="2.0"/>
+                  </modifiers>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="e7d3-aa89-fb59-d733" name="Siege Wrecker" hidden="false" collective="false" import="true" targetId="a996-0116-00e4-08e3" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="c6e6-36b3-97ce-a33d" value="2.0"/>
+                  </modifiers>
+                </entryLink>
+                <entryLink id="4722-d29f-b670-7daf" name="Flamestorm Cannon" hidden="false" collective="false" import="true" targetId="166c-a7be-a9c4-ddb5" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e3c5-9c4a-30d6-5772" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="0c7b-97c2-5918-535f" name="Legion-specific upgrade" hidden="false" collective="false" import="true">
+              <entryLinks>
+                <entryLink id="8788-8870-dc36-2af4" name="Shrapnel Bolts" hidden="false" collective="false" import="true" targetId="4c19-2579-80d0-6490" type="selectionEntry"/>
+                <entryLink id="cb38-570a-d3f1-01f6" name="Molecular Acid Shells" hidden="false" collective="false" import="true" targetId="82fb-0eed-d1da-4dc5" type="selectionEntry"/>
+                <entryLink id="7322-2f47-f77e-a2b4" name="Chem-munitions" hidden="false" collective="false" import="true" targetId="b432-5750-528f-98f3" type="selectionEntry"/>
+                <entryLink id="669b-7b30-aab5-0bab" name="Blessed Autosimulacra" hidden="false" collective="false" import="true" targetId="586c-391b-172f-6e2a" type="selectionEntry"/>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="284d-e597-a9e6-44c8" name="May be equipped with one of the following:" hidden="false" collective="false" import="true">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1be0-8f62-dbe9-8d4f" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="28fb-0b8f-1913-3029" name="2 Hunter Killer Missiles" hidden="false" collective="false" import="true" type="upgrade">
+                  <infoLinks>
+                    <infoLink id="f63d-e2c8-2927-1213" name="Hunter-killer Missile" hidden="false" targetId="a117-de7b-6200-3076" type="profile"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="5f04-6590-6e91-3913" name="1 Hunter Killer Missile" hidden="false" collective="false" import="true" type="upgrade">
+                  <infoLinks>
+                    <infoLink id="429d-e74e-4fde-ba76" name="Hunter-killer Missile" hidden="false" targetId="a117-de7b-6200-3076" type="profile"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <entryLinks>
+                <entryLink id="7c37-b0e2-1681-c773" name="Havoc Launcher" hidden="false" collective="false" import="true" targetId="0760-1529-35e8-a884" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="500d-1d0d-e495-c830" name="Searchlight and Smoke Launchers" hidden="false" collective="false" import="true" targetId="7562-9af8-67f3-2533" type="selectionEntry"/>
+            <entryLink id="6da9-58cc-098e-f426" name="Frag Assault Launchers" hidden="false" collective="false" import="true" targetId="74a6-8330-48b9-049d" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="points" value="0.0"/>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e53d-fd1b-685c-4a4b" type="min"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="c0f2-c392-ef75-4fcf" name="Extra Armour" hidden="false" collective="false" import="true" targetId="4167-42c8-42d8-1ce0" type="selectionEntry"/>
+            <entryLink id="f492-5717-7714-64d0" name="Dreadnought CCW In-built:" hidden="false" collective="false" import="true" targetId="2c3d-7775-ab39-65d4" type="selectionEntryGroup">
+              <modifiers>
+                <modifier type="increment" field="aebf-ecd1-3dad-8b1f" value="1.0">
+                  <repeats>
+                    <repeat field="selections" scope="17cb-be38-c492-d766" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="28f6-b43f-4914-4a29" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="17cb-be38-c492-d766" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6e23-90c4-a3bf-030a" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="17cb-be38-c492-d766" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e7d3-aa89-fb59-d733" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+                <modifier type="increment" field="2755-7b1e-b0b5-02f1" value="1.0">
+                  <repeats>
+                    <repeat field="selections" scope="17cb-be38-c492-d766" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="28f6-b43f-4914-4a29" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="17cb-be38-c492-d766" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6e23-90c4-a3bf-030a" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="17cb-be38-c492-d766" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e7d3-aa89-fb59-d733" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="115.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="cc5e-a4e6-83f9-7077" name="Anvillus Pattern Dreadclaw Drop Pod" hidden="false" collective="false" import="true" type="upgrade">
+      <modifiers>
+        <modifier type="set" field="points" value="100.0">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="550e-dd7c-23b2-c37b" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8362-0ed9-8d7b-0002" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="ce2d-468e-e261-fd26" name="Anvillus Pattern Dreadclaw Drop Pod (Transport)" publicationId="ca571888--pubN82424" page="55" hidden="false" typeId="307d-047f-ca13-706b" typeName="Transport">
+          <characteristics>
+            <characteristic name="Capacity" typeId="8285-4205-b6cd-8473">10 or a single Dreadnought *see Dreadclaw Transport Capacity rule</characteristic>
+            <characteristic name="Fire Points" typeId="b270-a7f9-22b2-3702">None</characteristic>
+            <characteristic name="Access Points" typeId="d17b-0342-b1dc-b8e7">One access hatch beneath the hull. Passengers can disembark at ground level within 2&quot; of the hull.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="db94-4fea-4315-62fd" name="Anvillus Pattern Dreadclaw Drop Pod" publicationId="ca571888--pubN82424" page="55" hidden="false" typeId="56656869636c6523232344415441232323" typeName="Vehicle">
+          <characteristics>
+            <characteristic name="BS" typeId="425323232344415441232323">-</characteristic>
+            <characteristic name="Front" typeId="46726f6e7423232344415441232323">12</characteristic>
+            <characteristic name="Side" typeId="5369646523232344415441232323">12</characteristic>
+            <characteristic name="Rear" typeId="5265617223232344415441232323">12</characteristic>
+            <characteristic name="HP" typeId="485023232344415441232323">3</characteristic>
+            <characteristic name="Type" typeId="5479706523232344415441232323">Flyer, Hover, Transport</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="3a72-a4e8-eecd-ee10" name="Dreadclaw Transport Capacity" publicationId="ca571888--pubN82424" page="55" hidden="false">
+          <description>The Dreadclaw has a transport capacity of 10 or can be used to transport a single Dreadnought from the following list:
+
+Legion Dreadnought
+Legion Mortis Dreadnought
+Contemptor Dreadnought
+Contemptor Mortis
+Contemptor-Cortus</description>
+        </rule>
+        <rule id="9c71-0046-8088-70e2" name="Heat Blast" publicationId="ca571888--pubN82424" page="75" hidden="false">
+          <description>May be used when the model arrives from Deep strike or later when operating in Hover mode.  No models may embark or disembark on the turn this attack is used.
+
+Heat Blast (Deep Strike): Immediately after deploying, measure a radius of 3D3&quot; horizontally from the main hull.  Any model caught in the blast suffers a S6 AP5 hit with no cover saves.  Vehicles are struck on their weakest armour value.  This counts as a flamer based attack.
+
+Heat Blast (Fire Sweep): Any unit the model passes over suffers a S6 AP5 hit with no cover saves.  Vehicles are struck on their weakest armour value.  This counts as a flamer based attack.  Unit being hit determines wound allocation.  On a D6 of 1, the Drop Pod suffers a penetrating hit.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="254c-c229-ba30-96c1" name="New InfoLink" hidden="false" targetId="45cf-653a-4ff6-f22d" type="rule"/>
+        <infoLink id="23e0-308e-638f-0ebd" name="New InfoLink" hidden="false" targetId="d219-2314-4834-c054" type="rule"/>
+        <infoLink id="ab1f-cd08-1716-79d9" name="Drop Pod Assault" hidden="false" targetId="782b-fe56-c2e2-76a3" type="rule"/>
+        <infoLink id="35e7-2169-2afa-4b73" name="Inertial Guidance System" hidden="false" targetId="46bd-edb5-d2b5-42be" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="d5a4-5794-1039-a782" name="Deep Strike" hidden="false" targetId="685b-1231-2899-7552" primary="false"/>
+        <categoryLink id="d1bb-d73c-12ea-ff58" name="Drop Pod" hidden="false" targetId="cb67-ac31-6c00-e520" primary="false"/>
+        <categoryLink id="ff91-df78-a386-baf8" name="Vehicle" hidden="false" targetId="8c70-1182-84f5-c93a" primary="false"/>
+        <categoryLink id="2607-3430-7f1f-dcb6" name="Transport" hidden="false" targetId="0be9-0976-aa16-eea7" primary="false"/>
+        <categoryLink id="2fec-9bae-c92b-4d3d" name="Skimmer" hidden="false" targetId="1302-97fa-834e-edc6" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="995c-1d81-566a-c97e" name="Frag Assault Launchers" page="0" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f458-2b75-2759-c594" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="09e6-2ebd-d433-1faf" type="min"/>
+          </constraints>
+          <rules>
+            <rule id="826a-5752-c36c-bb4d" name="Frag Assault Launchers" publicationId="ca571888--pubN82424" page="125" hidden="false">
+              <description>Any unit charging into close combat on the same turn it disembarks from a transport vehicle equipped with frag assault launchers counts as having frag grenades.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="pts" typeId="points" value="10.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="d5b9-9c41-a39c-d51f" name="Legion-specific upgrade" hidden="false" collective="false" import="true">
+          <entryLinks>
+            <entryLink id="d15b-8f08-820c-0231" name="Blessed Autosimulacra" hidden="false" collective="false" import="true" targetId="586c-391b-172f-6e2a" type="selectionEntry"/>
+            <entryLink id="3dbf-e631-6fa9-b59a" name="Chem-munitions" hidden="false" collective="false" import="true" targetId="b432-5750-528f-98f3" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="points" value="115.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ac51-a37c-bb2c-07de" name="Dreadnought Drop Pod, Legion" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5392-5783-aaac-71f6" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="a35d-d4ff-2020-7571" name="Legion Dreadnought Drop Pod (Transport)" publicationId="ca571888--pubN82424" page="47" hidden="false" typeId="307d-047f-ca13-706b" typeName="Transport">
+          <characteristics>
+            <characteristic name="Capacity" typeId="8285-4205-b6cd-8473">1 Dreadnought variant (Inlcluding Contemptors)</characteristic>
+            <characteristic name="Fire Points" typeId="b270-a7f9-22b2-3702">Open-Topped</characteristic>
+            <characteristic name="Access Points" typeId="d17b-0342-b1dc-b8e7">-</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="3fa5-d4f1-d1c3-90f4" name="Drop Pod" publicationId="ca571888--pubN82424" page="49" hidden="false" typeId="56656869636c6523232344415441232323" typeName="Vehicle">
+          <characteristics>
+            <characteristic name="BS" typeId="425323232344415441232323">4</characteristic>
+            <characteristic name="Front" typeId="46726f6e7423232344415441232323">12</characteristic>
+            <characteristic name="Side" typeId="5369646523232344415441232323">12</characteristic>
+            <characteristic name="Rear" typeId="5265617223232344415441232323">12</characteristic>
+            <characteristic name="HP" typeId="485023232344415441232323">3</characteristic>
+            <characteristic name="Type" typeId="5479706523232344415441232323">Open-topped</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="0e30-07fd-47e2-4205" name="Burning Retros" publicationId="ca571888--pubN82424" page="37" hidden="false">
+          <description>Legion Dreadnought Drop Pods have the Shrouded special rule on the game turn that they arrive (also applying to interceptor fire or similar effects).  Upon landing, the doors open automatically, but the Dreadnought does not have to deploy.  In this case, the Dreadnought benefits from the effects of Shrouded, as do any units whose line of sight passes through or over the Drop Pod on the game turn of its arrival.</description>
+        </rule>
+        <rule id="8573-141f-77d9-faad" name="Immobile" publicationId="ca571888--pubN82424" page="46" hidden="false">
+          <description>Once it has been deployed, a Drop Pod cannot move and counts as a vehicle that has suffered an irreparable Immobilised result (although no Hull Point loss is suffered).</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="1afe-d0d5-cc9d-e014" name="New InfoLink" hidden="false" targetId="45cf-653a-4ff6-f22d" type="rule"/>
+        <infoLink id="2f8a-54d0-6851-3f7e" name="Drop Pod Assault" hidden="false" targetId="782b-fe56-c2e2-76a3" type="rule"/>
+        <infoLink id="ee26-affc-d77c-0484" name="Inertial Guidance System" hidden="false" targetId="46bd-edb5-d2b5-42be" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="4e98-a857-e7a3-e09e" name="Deep Strike" hidden="false" targetId="685b-1231-2899-7552" primary="false"/>
+        <categoryLink id="0021-4577-2279-061a" name="Drop Pod" hidden="false" targetId="cb67-ac31-6c00-e520" primary="false"/>
+        <categoryLink id="20c6-e85d-8e19-5491" name="Dedicated Transport" hidden="false" targetId="93ab-5925-3957-7ae1" primary="false"/>
+        <categoryLink id="4ea7-8e84-e28f-e139" name="Transport" hidden="false" targetId="0be9-0976-aa16-eea7" primary="false"/>
+        <categoryLink id="bd4b-ff0c-7376-205e" name="Vehicle" hidden="false" targetId="8c70-1182-84f5-c93a" primary="false"/>
+      </categoryLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="2a8c-983a-329e-7d2a" name="Legion-specific upgrade" hidden="false" collective="false" import="true">
+          <entryLinks>
+            <entryLink id="680d-73b6-0814-ba99" name="Blessed Autosimulacra" hidden="false" collective="false" import="true" targetId="586c-391b-172f-6e2a" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="points" value="100.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3188-9e2c-f132-a58c" name="Twin-linked Missile Launcher" publicationId="ca571888--pubN106502" page="" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8b5e-8cd8-59ef-b427" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="1205-5a26-cc9e-a4f9" name="New InfoLink" hidden="false" targetId="40e6-c95c-7c8d-cf02" type="profile">
+          <modifiers>
+            <modifier type="append" field="5479706523232344415441232323" value=", Twin-Linked"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="0d2f-de65-d992-8b65" name="New InfoLink" hidden="false" targetId="1e33-d8ec-f833-b584" type="profile">
+          <modifiers>
+            <modifier type="append" field="5479706523232344415441232323" value=", Twin-Linked"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="f85c-eec2-ec33-7d1b" name="Twin-linked" hidden="false" targetId="10a8-8d89-0bec-3e21" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="25.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a996-0116-00e4-08e3" name="Siege Wrecker" page="0" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c6e6-36b3-97ce-a33d" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="bb8d-76f0-37f9-9d59" name="" hidden="false" targetId="51100eb8-f6e6-7048-df0a-84f0163a38bd" type="profile"/>
+        <infoLink id="01d6-751f-0ad7-cdfe" name="Wrecker" hidden="false" targetId="fe2f-3220-3fef-b177" type="rule"/>
+        <infoLink id="bcf0-d720-966e-49f8" name="New InfoLink" hidden="false" targetId="9d85-46f7-f5e6-a5f7" type="rule"/>
+        <infoLink id="0a9f-f3d9-b31f-7522" name="New InfoLink" hidden="false" targetId="7ee3-d437-bc44-3630" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="5.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="166c-a7be-a9c4-ddb5" name="Flamestorm Cannon" page="0" hidden="false" collective="false" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="e62b-a7c4-ac51-8191" name="Flamestorm Cannon" hidden="false" targetId="c2dc-5db9-b18b-d360" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="15.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2dcf-da0f-297d-fccf" name="Drop Pod" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="eaca-0b25-ee42-d4b7" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="d792-87c9-6ee7-1e86" name="Legion Drop Pod (Transport)" hidden="false" typeId="307d-047f-ca13-706b" typeName="Transport">
+          <characteristics>
+            <characteristic name="Capacity" typeId="8285-4205-b6cd-8473">10, or 1 Legion Dreadnought, or 1 Rapier Carrier and crew</characteristic>
+            <characteristic name="Fire Points" typeId="b270-a7f9-22b2-3702">Open-Topped</characteristic>
+            <characteristic name="Access Points" typeId="d17b-0342-b1dc-b8e7">-</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="560a-0283-501c-6925" name="Drop Pod" publicationId="ca571888--pubN82424" page="49" hidden="false" typeId="56656869636c6523232344415441232323" typeName="Vehicle">
+          <characteristics>
+            <characteristic name="BS" typeId="425323232344415441232323">4</characteristic>
+            <characteristic name="Front" typeId="46726f6e7423232344415441232323">12</characteristic>
+            <characteristic name="Side" typeId="5369646523232344415441232323">12</characteristic>
+            <characteristic name="Rear" typeId="5265617223232344415441232323">12</characteristic>
+            <characteristic name="HP" typeId="485023232344415441232323">3</characteristic>
+            <characteristic name="Type" typeId="5479706523232344415441232323">Open-topped</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="ee04-b252-11a4-2664" name="Immobile" hidden="false" targetId="6eef-be21-4016-bfe3" type="rule"/>
+        <infoLink id="2904-14a0-d9ec-b036" name="Drop Pod Assault" hidden="false" targetId="782b-fe56-c2e2-76a3" type="rule"/>
+        <infoLink id="3544-8bd5-7a9c-ad9b" name="Inertial Guidance System" hidden="false" targetId="46bd-edb5-d2b5-42be" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="3f02-9870-5fb3-5905" name="Drop Pod" hidden="false" targetId="cb67-ac31-6c00-e520" primary="false"/>
+        <categoryLink id="1c6c-75b8-2332-f132" name="Deep Strike" hidden="false" targetId="685b-1231-2899-7552" primary="false"/>
+        <categoryLink id="5968-14b2-0782-6b79" name="Dedicated Transport" hidden="false" targetId="93ab-5925-3957-7ae1" primary="false"/>
+        <categoryLink id="0c62-1cc6-5db5-6792" name="Transport" hidden="false" targetId="0be9-0976-aa16-eea7" primary="false"/>
+        <categoryLink id="75da-cbfd-2f05-a5eb" name="Vehicle" hidden="false" targetId="8c70-1182-84f5-c93a" primary="false"/>
+      </categoryLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="4441-3851-69af-dd82" name="Legion-specific upgrade" hidden="false" collective="false" import="true">
+          <entryLinks>
+            <entryLink id="b966-acb4-71a1-8c84" name="Blessed Autosimulacra" hidden="false" collective="false" import="true" targetId="586c-391b-172f-6e2a" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="e81e-0b46-a309-99af" name="Twin-linked Bolter" hidden="false" collective="false" import="true" targetId="eaec-b433-8e4d-1da5" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="14a8-d9c6-773c-18cb" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5cf5-4213-231a-1f09" type="min"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="35.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5b59-2afd-e6f0-44f4" name="Bike with Twin-linked Bolter, Space Marine" page="0" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2911-1bd9-d58d-ad9d" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="b6c0-0669-77c2-05e5" name="New InfoLink" hidden="false" targetId="0434-8c4b-9614-73dd" type="profile"/>
+        <infoLink id="f501-3cbc-498a-f62a" name="Twin-Linked Boltgun" hidden="false" targetId="37fc-8473-3879-14a4" type="profile"/>
+        <infoLink id="9bdc-e411-dd57-0eb0" name="Hammer of Wrath" hidden="false" targetId="6f66-b417-6004-0916" type="rule"/>
+        <infoLink id="7006-4443-5f2e-81aa" name="New InfoLink" hidden="false" targetId="d3e5-b43d-a89c-3bd8" type="rule"/>
+        <infoLink id="b375-f945-93d7-5ace" name="Relentless" hidden="false" targetId="3c7d-a1fa-c68b-caad" type="rule"/>
+        <infoLink id="63d5-599f-24a3-ece2" name="New InfoLink" hidden="false" targetId="abc9-8566-bb61-4b7c" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="d9ec-cd03-0f59-e96b" name="Bike" hidden="false" targetId="0c41-9db4-3ae3-67ce" primary="false"/>
+      </categoryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="baaf-8622-e173-2b64" name="Master-Crafted Bolter" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="cb7f-2fe5-ee7a-56ae" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="bacd-6e43-1328-cffc" name="Master-crafted" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule"/>
+        <infoLink id="e32d-7423-a787-5306" name="New InfoLink" hidden="false" targetId="09fd-8af1-a6b1-51f7" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="04fe-9fca-5752-e7dc" name="Conversion Beamer" publicationId="ca571888--pubN82424" page="0" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7c53-7dfc-8fc5-db7f" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="b700-ea3b-4139-27b9" name="Conversion Beamer (1)" publicationId="ca571888--pubN82424" page="82" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="52616e676523232344415441232323">&lt; 18&quot;</characteristic>
+            <characteristic name="Strength" typeId="537472656e67746823232344415441232323">6</characteristic>
+            <characteristic name="AP" typeId="415023232344415441232323">-</characteristic>
+            <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 1, Blast</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="eb14-4cfa-006d-02e4" name="Conversion Beamer (2)" publicationId="ca571888--pubN82424" page="82" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="52616e676523232344415441232323">18&quot; - 42&quot;</characteristic>
+            <characteristic name="Strength" typeId="537472656e67746823232344415441232323">8</characteristic>
+            <characteristic name="AP" typeId="415023232344415441232323">4</characteristic>
+            <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 1, Blast</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="b6d5-c35c-2608-9012" name="Conversion Beamer (3)" publicationId="ca571888--pubN82424" page="82" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="52616e676523232344415441232323">42&quot; - 72&quot;</characteristic>
+            <characteristic name="Strength" typeId="537472656e67746823232344415441232323">10</characteristic>
+            <characteristic name="AP" typeId="415023232344415441232323">1</characteristic>
+            <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 1, Blast</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7d04-bb7c-cffb-f005" name="Independent Techmarines, Legion" hidden="false" collective="false" import="true" type="upgrade">
+      <selectionEntries>
+        <selectionEntry id="bd53-9cb3-68e0-3f14" name="Legion Independent Techmarines" publicationId="0e6e-8c19-c436-39c4" hidden="false" collective="false" import="true" type="unit">
+          <modifiers>
+            <modifier type="remove" field="category" value="1ab3-f1ac-f724-8544">
+              <conditions>
+                <condition field="selections" scope="bd53-9cb3-68e0-3f14" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="db95-0c14-c334-4453" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="f139-0622-c255-2d75" value="1.0">
+              <repeats>
+                <repeat field="points" scope="roster" value="500.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="any" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f139-0622-c255-2d75" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="015b-3196-2794-6f28" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="34e8-9706-0515-7dec" name="Legion Independent Tech Marine" publicationId="0e6e-8c19-c436-39c4" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+              <characteristics>
+                <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">4</characteristic>
+                <characteristic name="WS" typeId="575323232344415441232323">4</characteristic>
+                <characteristic name="BS" typeId="425323232344415441232323">4</characteristic>
+                <characteristic name="S" typeId="5323232344415441232323">4</characteristic>
+                <characteristic name="T" typeId="5423232344415441232323">4</characteristic>
+                <characteristic name="W" typeId="5723232344415441232323">1</characteristic>
+                <characteristic name="I" typeId="4923232344415441232323">4</characteristic>
+                <characteristic name="A" typeId="4123232344415441232323">1</characteristic>
+                <characteristic name="LD" typeId="4c4423232344415441232323">8</characteristic>
+                <characteristic name="Save" typeId="5361766523232344415441232323">2+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="de6a-6eea-718d-db97" name="Armorium" hidden="false">
+              <description>Legion Techmarines bring both their expertise and equipment which can greatly enhance the capabilities of a Legionary squad. A Techmarine assigned to a Squad unlocks:
+♦Suspensor webs: +5 points per model equipped with a weapon with the Heavy type.
+♦Biocorrosive Ammunition: +2 points per model equipped with a Rotor Cannon.
+♦Sabot Rounds: +2 points per model equipped with an Autocannon and that weapons gains Sunder.</description>
+            </rule>
+            <rule id="3347-6c01-2010-59bf" name="Supernumerary" hidden="false">
+              <description>0-1 Legion Techmarines may be taken for each full 500 points in the detachment. These models use a single Elites Force Organisation slot. Each Legion Techmarine must be deployed as either:
+♦ A separate unit which may be joined by Servo-automata and may be equipped with a Rhino as a Dedicated Transport, or
+♦ Assigned to one of your squads during deployment and may not voluntarily leave it during the game. Only
+squads entirely comprising models with the Infantry type and the Legiones Astartes special rule are eligible
+to be joined, and squads equipped with Terminator armour may not be joined.
+
+If equipped with a Jump Pack then they may only join eligible squads with the Jump Infantry type. If equipped with a Legion Space Marine Bike then they may only join eligible squads with the Bike type instead.
+</description>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="709c-631b-5875-a1ea" name="Battlesmith" hidden="false" targetId="9edbc777-7d2b-011b-7488-335b14870be5" type="rule"/>
+          </infoLinks>
+          <categoryLinks>
+            <categoryLink id="c5bc-11ec-82fa-cfd4" name="Infantry" hidden="false" targetId="1ab3-f1ac-f724-8544" primary="false"/>
+            <categoryLink id="1204-ad65-98e7-8cc7" name="Legiones Astartes" hidden="false" targetId="f321-f2d7-7d68-8f93" primary="false"/>
+            <categoryLink id="a20d-c595-53e3-a4e3" name="Character" hidden="false" targetId="ae54-92c7-3e66-59f7" primary="false"/>
+          </categoryLinks>
+          <selectionEntries>
+            <selectionEntry id="7ee2-9e6f-0487-2370" name="Suspensor Web" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="00ca-c0b2-b6d2-6524" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0ed1-21e3-a62c-e9d2" type="min"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="062d-c34f-96d8-320e" name="Suspensor Web" hidden="false" targetId="3d78-f901-8afc-00ff" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="5686-be4b-c692-714c" name="May exchange their Power Axe for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="c1b9-9938-3b91-e549">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1a5b-2100-03ce-4d06" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a11b-0b7f-7199-4b25" type="min"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="c1b9-9938-3b91-e549" name="Power Axe" hidden="false" collective="false" import="true" targetId="7b92-ab87-86a1-ab2e" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b4e7-0c7f-2306-cee4" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="5cdd-3859-e6af-2300" name="Thunder Hammer" hidden="false" collective="false" import="true" targetId="925c-50d4-0101-e0e7" type="selectionEntry"/>
+                <entryLink id="1ca3-8fa9-d66d-f61d" name="Tainted Weapon" hidden="false" collective="false" import="true" targetId="104d-2c15-b4b8-c299" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="points" value="0.0"/>
+                  </modifiers>
+                </entryLink>
+                <entryLink id="d828-c2b7-dd24-43f5" name="Nostraman Chainglaive" hidden="false" collective="false" import="true" targetId="b6e5-70ca-8084-765d" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="points" value="0.0"/>
+                  </modifiers>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="1b37-94cf-0897-aa69" name="May select one of the following:" hidden="false" collective="false" import="true">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8d40-932b-8d80-25eb" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="f8f5-3edd-9cc4-d0b2" name="Servo Arm" hidden="false" collective="false" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b2c3-94c7-bb7a-16e1" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="f266-1a37-0028-9a4e" name="Servo Arm" hidden="false" targetId="c3a5-c40c-b493-5cf6" type="profile"/>
+                  </infoLinks>
+                  <categoryLinks>
+                    <categoryLink id="4c26-a0e3-e919-3616" name="Infantry" hidden="false" targetId="1ab3-f1ac-f724-8544" primary="false"/>
+                  </categoryLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="25e5-7eb1-8938-0d67" name="Jump Pack" hidden="false" collective="false" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e17f-9c74-a670-88be" type="max"/>
+                  </constraints>
+                  <categoryLinks>
+                    <categoryLink id="b3ca-2343-28d6-cca2" name="Jump Units" hidden="false" targetId="a787-4801-eb77-f2cf" primary="false"/>
+                    <categoryLink id="4687-1a1b-fbcc-7a93" name="Infantry" hidden="false" targetId="1ab3-f1ac-f724-8544" primary="false"/>
+                    <categoryLink id="7f36-9ccd-d7ca-92c9" name="Deep Strike" hidden="false" targetId="685b-1231-2899-7552" primary="false"/>
+                  </categoryLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <entryLinks>
+                <entryLink id="db95-0c14-c334-4453" name="Bike with Twin-linked Bolter, Space Marine" hidden="false" collective="false" import="true" targetId="5b59-2afd-e6f0-44f4" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="15.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="aa6c-92b2-1b86-a55f" name="May exchange Bolt Pistol for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="112e-5041-3e10-7691">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2051-90ae-6241-1a30" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7484-6b41-ea96-1d05" type="min"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="112e-5041-3e10-7691" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="6026-d507-935a-7200" type="selectionEntry"/>
+                <entryLink id="5e1a-bd7b-994b-5397" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="f832-f4b2-6aaf-ad83" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="035e-0812-e583-7ef4" name="Inferno Pistol " hidden="false" collective="false" import="true" targetId="13f8-6607-3525-4298" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="59f6-638d-8c1d-75dd" type="equalTo"/>
+                            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e2d7-e297-5b99-cbac" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="3df4-8573-3686-9584" name="May be equiped with one of the following:" hidden="false" collective="false" import="true">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9bbf-fd79-882f-8522" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="e7f5-471a-c13e-ea9d" name="Conversion Beamer" hidden="false" collective="false" import="true" targetId="04fe-9fca-5752-e7dc" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="30.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="17e2-ca92-2dd6-6d4d" name="Volkite Charger" hidden="false" collective="false" import="true" targetId="f0c0-384d-440f-c03b" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="1af4-cd53-cbe0-8e67" name="Graviton Gun" hidden="false" collective="false" import="true" targetId="8447-9662-22bd-5c6c" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="15.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="dac0-6efd-dc26-c5cd" name="Combi-weapon" hidden="false" collective="false" import="true" targetId="f07b-6978-8f48-6c0f" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="a003-5d07-5061-5696" name="Master-Crafted Bolter" hidden="false" collective="false" import="true" targetId="baaf-8622-e173-2b64" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="074b-ec8d-2999-9bcd" name="May Techmarine may be equipped with any of the following:" hidden="false" collective="false" import="true">
+              <entryLinks>
+                <entryLink id="0c56-dcef-630f-7070" name="Augury Scanner" hidden="false" collective="false" import="true" targetId="7e20-c85a-2e04-dd0b" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="15.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="5ebf-869b-1899-c645" name="Melta Bombs" hidden="false" collective="false" import="true" targetId="4c62-8983-4a1b-d1c6" type="selectionEntry"/>
+                <entryLink id="58b1-8354-4fd3-44cb" name="Cyber-familiar" hidden="false" collective="false" import="true" targetId="0146-2962-d352-0eb6" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false"/>
+                  </modifiers>
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="cd36-fac4-bdac-5b7f" name="Rad Grenades" hidden="false" collective="false" import="true" targetId="e16f-613e-1606-bfbc" type="selectionEntry"/>
+                <entryLink id="f314-405f-8ca5-d9ae" name="Nuncio-vox" hidden="false" collective="false" import="true" targetId="3b07-bf87-1e36-9181" type="selectionEntry"/>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="549b-8ce2-e573-c31b" name="Armorium Options" hidden="false" collective="false" import="true">
+              <selectionEntries>
+                <selectionEntry id="f6c9-33d5-bd94-2b54" name="Biocorrosive Ammunition (Rotor Cannons Only)" hidden="false" collective="false" import="true" type="upgrade">
+                  <infoLinks>
+                    <infoLink id="6c61-f24e-5386-43f9" name="Bio-Corrosive Rounds" hidden="false" targetId="ab48-8dc9-50b7-0fa9" type="profile"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="2.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="1b9f-d278-f5db-5d87" name="Sabot Rounds (Autocannons Only)" hidden="false" collective="false" import="true" type="upgrade">
+                  <infoLinks>
+                    <infoLink id="a37a-3d52-4730-fb8e" name="Autocannon: Sabot" hidden="false" targetId="d706-b010-f97a-ff5e" type="profile"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="2.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="ae59-024c-24f1-1356" name="Suspensor Webs (Heavy Weapons Only)" hidden="false" collective="false" import="true" type="upgrade">
+                  <infoLinks>
+                    <infoLink id="fd82-b734-e454-f244" name="Suspensor Web" hidden="false" targetId="3d78-f901-8afc-00ff" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="70b3-679c-6182-00a6" name="May be accompanied by up to four Servo-automata:" hidden="false" collective="false" import="true">
+              <constraints>
+                <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0144-3e52-63f5-3b83" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="14af-a871-ee97-c533" name="Servo-automata" page="23" hidden="false" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="bd53-9cb3-68e0-3f14" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="db95-0c14-c334-4453" type="equalTo"/>
+                            <condition field="selections" scope="bd53-9cb3-68e0-3f14" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="25e5-7eb1-8938-0d67" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8fae-e39e-e03f-df48" type="max"/>
+                  </constraints>
+                  <profiles>
+                    <profile id="d756-393d-f31c-4496" name="Servo-automata" publicationId="ca571888--pubN82424" page="23" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+                      <characteristics>
+                        <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323"/>
+                        <characteristic name="WS" typeId="575323232344415441232323">3</characteristic>
+                        <characteristic name="BS" typeId="425323232344415441232323">3</characteristic>
+                        <characteristic name="S" typeId="5323232344415441232323">4</characteristic>
+                        <characteristic name="T" typeId="5423232344415441232323">5</characteristic>
+                        <characteristic name="W" typeId="5723232344415441232323">1</characteristic>
+                        <characteristic name="I" typeId="4923232344415441232323">1</characteristic>
+                        <characteristic name="A" typeId="4123232344415441232323">1</characteristic>
+                        <characteristic name="LD" typeId="4c4423232344415441232323">6</characteristic>
+                        <characteristic name="Save" typeId="5361766523232344415441232323">5+</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <rules>
+                    <rule id="4785-7630-523f-bc7c" name="Cybernetica" publicationId="ca571888--pubN82424" page="23" hidden="false">
+                      <description>If Servo-automata are no longer accompanied by a legion Techmarine, they must take a Pinning test at the start of each Movement phase unless they are already engaged in combat.</description>
+                    </rule>
+                  </rules>
+                  <selectionEntryGroups>
+                    <selectionEntryGroup id="fbdf-240e-ab9f-2dbf" name="Servo-automata may exchange bolter for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="6828-3954-02e1-37ad">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0f21-09e9-9707-e067" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3097-bd27-b512-9a88" type="max"/>
+                      </constraints>
+                      <selectionEntries>
+                        <selectionEntry id="9ceb-98fb-67f9-8d11" name="Missile Launcher" hidden="false" collective="false" import="true" type="upgrade">
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a46d-ded0-ad87-7fb2" type="max"/>
+                          </constraints>
+                          <infoLinks>
+                            <infoLink id="7d16-c992-ed40-c8e9" name="New InfoLink" hidden="false" targetId="40e6-c95c-7c8d-cf02" type="profile"/>
+                            <infoLink id="a340-a3cb-116f-ad25" name="New InfoLink" hidden="false" targetId="1e33-d8ec-f833-b584" type="profile"/>
+                          </infoLinks>
+                          <selectionEntries>
+                            <selectionEntry id="0ff4-369e-5419-e96e" name="Rad Missiles" hidden="false" collective="false" import="true" type="upgrade">
+                              <modifiers>
+                                <modifier type="set" field="hidden" value="true">
+                                  <conditions>
+                                    <condition field="selections" scope="bd53-9cb3-68e0-3f14" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cd36-fac4-bdac-5b7f" type="equalTo"/>
+                                  </conditions>
+                                </modifier>
+                              </modifiers>
+                              <constraints>
+                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="82c1-e533-1bef-75a7" type="max"/>
+                              </constraints>
+                              <infoLinks>
+                                <infoLink id="03b2-da9b-977d-f601" name="Rad Missile" hidden="false" targetId="fd99-1d8e-87fa-e8e8" type="profile"/>
+                              </infoLinks>
+                              <costs>
+                                <cost name="pts" typeId="points" value="10.0"/>
+                              </costs>
+                            </selectionEntry>
+                          </selectionEntries>
+                          <costs>
+                            <cost name="pts" typeId="points" value="15.0"/>
+                          </costs>
+                        </selectionEntry>
+                      </selectionEntries>
+                      <entryLinks>
+                        <entryLink id="13a8-820c-6e79-331d" name="Flamer" hidden="false" collective="false" import="true" targetId="4cc6-e521-dc9a-c117" type="selectionEntry">
+                          <costs>
+                            <cost name="pts" typeId="points" value="5.0"/>
+                          </costs>
+                        </entryLink>
+                        <entryLink id="bcee-bc05-c2fd-3083" name="Power Fist" hidden="false" collective="false" import="true" targetId="fcef-f5ac-16a3-9401" type="selectionEntry">
+                          <costs>
+                            <cost name="pts" typeId="points" value="15.0"/>
+                          </costs>
+                        </entryLink>
+                        <entryLink id="1014-3bf4-76ee-740e" name="Lascutter" hidden="false" collective="false" import="true" targetId="aa86-c18f-a485-9c87" type="selectionEntry">
+                          <costs>
+                            <cost name="pts" typeId="points" value="5.0"/>
+                          </costs>
+                        </entryLink>
+                        <entryLink id="c0a0-378b-7ac2-6d5d" name="Rotor Cannon" hidden="false" collective="false" import="true" targetId="9468-9f57-8a24-bbe2" type="selectionEntry">
+                          <costs>
+                            <cost name="pts" typeId="points" value="5.0"/>
+                          </costs>
+                        </entryLink>
+                        <entryLink id="bf31-24f1-3f51-eb5b" name="Heavy Bolter" hidden="false" collective="false" import="true" targetId="a161-76b3-9ef1-da7b" type="selectionEntry">
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a8f1-19be-dbb0-55d7" type="max"/>
+                          </constraints>
+                          <costs>
+                            <cost name="pts" typeId="points" value="10.0"/>
+                          </costs>
+                        </entryLink>
+                        <entryLink id="869b-eefd-51f6-eae7" name="Multi-melta" hidden="false" collective="false" import="true" targetId="d1c0-746f-2b39-5f17" type="selectionEntry">
+                          <modifiers>
+                            <modifier type="set" field="points" value="10"/>
+                          </modifiers>
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ca17-a0f5-e252-e5e0" type="max"/>
+                          </constraints>
+                        </entryLink>
+                        <entryLink id="6828-3954-02e1-37ad" name="Bolter" hidden="false" collective="false" import="true" targetId="d6f9-09fd-83af-070d" type="selectionEntry">
+                          <modifiers>
+                            <modifier type="set" field="points" value="0.0"/>
+                          </modifiers>
+                        </entryLink>
+                      </entryLinks>
+                    </selectionEntryGroup>
+                  </selectionEntryGroups>
+                  <entryLinks>
+                    <entryLink id="ebaf-8a0b-0868-1b76" name="Chainswords/Combat Blades" hidden="false" collective="false" import="true" targetId="1087-66c1-c342-9cdc" type="selectionEntry"/>
+                  </entryLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="12.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="1ae7-d944-c4a7-92fc" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="c6b8-8b0b-8a31-6aa3" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9bc2-a6ad-4a28-1c34" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="254a-7989-9170-73e8" type="min"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="9ec9-518a-d263-1957" name="New EntryLink" hidden="false" collective="false" import="true" targetId="0a53-b471-df87-7b83" type="selectionEntry"/>
+            <entryLink id="a837-2aa1-d0fb-c101" name="Legion-specific upgrade:" hidden="false" collective="false" import="true" targetId="efe5-effa-a371-ae4e" type="selectionEntryGroup"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="25.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e16f-613e-1606-bfbc" name="Rad Grenades" page="0" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2e31-1858-0dd5-a3fc" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="eb25-6468-050e-454f" name="Rad Grenades" hidden="false" targetId="6176-c8fa-7b50-26a2" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0146-2962-d352-0eb6" name="Cyber-familiar" page="0" hidden="false" collective="false" import="true" type="upgrade">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b7d6-8217-4fe9-45d4" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="bdaf-74de-5192-ecdc" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="b267-aa42-1840-05ab" name="Cyber-familiar" publicationId="ca571888--pubN82424" page="89" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
+          <characteristics>
+            <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">A Cyber-familiar adds 1 to its owners Invulnerable save (to a maximum of 3) or provides an Invulnerable save of a 6.   In addition they allow the owner to re-roll failed characteristic tests other than Leadership tests and failed Dangerous Terrain tests.  </characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name="pts" typeId="points" value="15.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="aa86-c18f-a485-9c87" name="Lascutter" page="0" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1c1d-1453-e413-1359" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="6ae8-67eb-c86f-d0dd" name="Lascutter" publicationId="ca571888--pubN82424" page="87" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
+            <characteristic name="Strength" typeId="537472656e67746823232344415441232323">9</characteristic>
+            <characteristic name="AP" typeId="415023232344415441232323">2</characteristic>
+            <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Unwieldy, Cumbersome</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="e963-de26-929e-cf5c" name="Cumbersome" hidden="false" targetId="c2af-0e00-294d-8d82" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9468-9f57-8a24-bbe2" name="Rotor Cannon" page="0" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="69c1-6c9e-cb48-2674" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="b0d2-14e6-c51c-8da2" hidden="false" targetId="871025a3-7729-f97d-378d-804c3571cdf3" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ff4e-9474-9ad9-8975" name="Ulfhednar Pack" publicationId="0e6e-8c19-c436-39c4" hidden="true" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="0a1c-44d8-4d14-c203" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <rules>
+        <rule id="0227-2a75-4104-726a" name="Uncontrollable Ferocity" hidden="false">
+          <description>A unit of Ulfhednar may not be joined by any other model of any kind.</description>
+        </rule>
+        <rule id="c92f-f3c8-4cef-2395" name="Mindless Savager" hidden="false">
+          <description>A unit of Ulfhednar never counts as a Scoring unit, regardless of the provisions of the mission being played. Furthermore, the Pack cannot be embarked in any transport vehicle.</description>
+        </rule>
+        <rule id="489d-e103-8f5e-6d01" name="Warriors Mettle" hidden="false">
+          <description>Models with this special rule may not voluntarily Go to Ground, but may re-roll failed Pinning tests and may make Charge moves after running or after firing their bolters, suffering -1 to their Charge distances if they do so. If an Independent Character which does not have the Warrior’s Mettle special rule joins a unit of Grey Slayers, they may not benefit from this rule until that Independent Character leaves the unit. Legion Apothecaries which join a unit with this special rule are considered to be wholly a part of the unit they have joined and may benefit from this special rule.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="c54d-bc66-f06b-e78a" name="Stubborn" hidden="false" targetId="7be5-30af-1a02-0a89" type="rule"/>
+        <infoLink id="f158-b10a-e362-64df" name="Bulky" hidden="false" targetId="38d5-b6eb-bda8-2497" type="rule"/>
+        <infoLink id="8846-a81a-4fc3-1b39" name="Fear" hidden="false" targetId="52ff-4074-570b-4ea1" type="rule"/>
+        <infoLink id="52be-9af8-6f97-b08e" name="Feel No Pain (6+)" hidden="false" targetId="85da-2f19-3756-44de" type="rule"/>
+        <infoLink id="7b9f-3c67-ebd0-7797" name="Fleet" hidden="false" targetId="69e5-fc02-1f9d-63c2" type="rule"/>
+        <infoLink id="6956-9002-d801-3c14" name="Furious Charge" hidden="false" targetId="3aa7-9a8f-1e0d-921d" type="rule"/>
+        <infoLink id="213c-c146-98a6-25d9" name="Move Through Cover" hidden="false" targetId="6d06-5ea0-9a17-ca97" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="4a2c-de2b-4eb6-f4aa" name="Infantry" hidden="false" targetId="1ab3-f1ac-f724-8544" primary="false"/>
+        <categoryLink id="9f7e-cfba-48ac-eb7c" name="Legiones Astartes" hidden="false" targetId="f321-f2d7-7d68-8f93" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="790e-bfdf-5c79-f133" name="Ulfhednar" page="" hidden="false" collective="false" import="true" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a4ed-0f66-6104-ef92" type="min"/>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ec0f-3687-3212-699e" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="3f49-3585-7b80-3281" name="Ulfhednar" page="" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+              <characteristics>
+                <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry</characteristic>
+                <characteristic name="WS" typeId="575323232344415441232323">5</characteristic>
+                <characteristic name="BS" typeId="425323232344415441232323">2</characteristic>
+                <characteristic name="S" typeId="5323232344415441232323">5</characteristic>
+                <characteristic name="T" typeId="5423232344415441232323">4</characteristic>
+                <characteristic name="W" typeId="5723232344415441232323">2</characteristic>
+                <characteristic name="I" typeId="4923232344415441232323">5</characteristic>
+                <characteristic name="A" typeId="4123232344415441232323">2</characteristic>
+                <characteristic name="LD" typeId="4c4423232344415441232323">8</characteristic>
+                <characteristic name="Save" typeId="5361766523232344415441232323">3+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="35.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="4e80-f1c1-4ae5-73b1" name="Claws" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="88f5-0c8d-432b-5bc6" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5cfa-0c0d-45ed-a46e" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="2f41-fe7a-f9a1-1106" name="Claws" hidden="false">
+              <description>A model equipped with claws count as having 2 close combat weapons with the Rending special rule.</description>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="b42b-c95b-79ed-e5e4" name="Rending" hidden="false" targetId="8269-2cd6-9236-16e7" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="2f00-901d-eed4-a370" name="New EntryLink" hidden="false" collective="false" import="true" targetId="0a96-04b6-7340-91a4" type="selectionEntry"/>
+        <entryLink id="3fb7-5c61-9e26-a940" name="   VI: Space Wolves" hidden="false" collective="false" import="true" targetId="0a1c-44d8-4d14-c203" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="afc2-e31c-ab9b-2003" type="min"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="25.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="eefe-b2cd-3f41-7c84" name="Assault Support Squad, Legion" publicationId="0e6e-8c19-c436-39c4" page="" hidden="false" collective="false" import="true" type="unit">
+      <rules>
+        <rule id="5932-1865-ff7e-965e" name="Restricted" hidden="false">
+          <description>A detachment must have more Assault (or Night Raptor or Dark Fury) Squads than Assault Support Squads.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="4bc8-5970-9987-6656" name="Support Squad" hidden="false" targetId="2c16-3b25-a714-a656" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="7a06-7399-fe05-9fa9" name="Infantry" hidden="false" targetId="1ab3-f1ac-f724-8544" primary="false"/>
+        <categoryLink id="2bad-e079-0dd3-7842" name="Jump Units" hidden="false" targetId="a787-4801-eb77-f2cf" primary="false"/>
+        <categoryLink id="1f15-f1c9-240d-f75f" name="Legiones Astartes" hidden="false" targetId="f321-f2d7-7d68-8f93" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="3f5d-64a1-c7b9-b60d" name="Assault Space Marines, Legion" page="0" hidden="false" collective="false" import="true" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="74da-e81e-9d8a-fbc1" type="min"/>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b692-c16b-9226-98e1" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="5584-0f69-d5b8-2b59" name="Legion Assault Space Marine" publicationId="ca571888--pubN82424" page="31" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+              <characteristics>
+                <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Jump Infantry</characteristic>
+                <characteristic name="WS" typeId="575323232344415441232323">4</characteristic>
+                <characteristic name="BS" typeId="425323232344415441232323">4</characteristic>
+                <characteristic name="S" typeId="5323232344415441232323">4</characteristic>
+                <characteristic name="T" typeId="5423232344415441232323">4</characteristic>
+                <characteristic name="W" typeId="5723232344415441232323">1</characteristic>
+                <characteristic name="I" typeId="4923232344415441232323">4</characteristic>
+                <characteristic name="A" typeId="4123232344415441232323">1</characteristic>
+                <characteristic name="LD" typeId="4c4423232344415441232323">8</characteristic>
+                <characteristic name="Save" typeId="5361766523232344415441232323">3+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="15.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="6d8e-e0a6-5fb4-f1d3" name="Standard Wargear" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d84d-0bd7-a6e5-0be8" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9187-d8d0-bc78-0bb4" type="min"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="9a64-4a35-7153-ccaa" name="Frag and Krak Grenades" hidden="false" collective="false" import="true" targetId="0a53-b471-df87-7b83" type="selectionEntry"/>
+            <entryLink id="e150-34c3-3460-56a9" name="New EntryLink" hidden="false" collective="false" import="true" targetId="0a96-04b6-7340-91a4" type="selectionEntry"/>
+            <entryLink id="2607-98c2-a982-3f76" name="Jump Packs" hidden="false" collective="false" import="true" targetId="bdb7-38c9-5aeb-fc05" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="1250-804f-3e4e-e7fa" name="Assault Sergeant, Legion" hidden="false" collective="false" import="true" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="01ae-2f6b-1236-7645" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="76bd-57f5-3297-3630" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="39f5-ddd6-73ec-78bb" name="Legion Assault Sergeant" publicationId="ca571888--pubN82424" page="31" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+              <modifiers>
+                <modifier type="set" field="5361766523232344415441232323" value="2+">
+                  <conditions>
+                    <condition field="selections" scope="1250-804f-3e4e-e7fa" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b700-b599-f7b0-c1ec" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <characteristics>
+                <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Jump Infantry (Character)</characteristic>
+                <characteristic name="WS" typeId="575323232344415441232323">4</characteristic>
+                <characteristic name="BS" typeId="425323232344415441232323">4</characteristic>
+                <characteristic name="S" typeId="5323232344415441232323">4</characteristic>
+                <characteristic name="T" typeId="5423232344415441232323">4</characteristic>
+                <characteristic name="W" typeId="5723232344415441232323">1</characteristic>
+                <characteristic name="I" typeId="4923232344415441232323">4</characteristic>
+                <characteristic name="A" typeId="4123232344415441232323">2</characteristic>
+                <characteristic name="LD" typeId="4c4423232344415441232323">9</characteristic>
+                <characteristic name="Save" typeId="5361766523232344415441232323">3+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <categoryLinks>
+            <categoryLink id="11bd-01b1-cbdf-75ed" name="Character" hidden="false" targetId="ae54-92c7-3e66-59f7" primary="false"/>
+          </categoryLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="055a-0c2d-f8ad-77c8" name="Legion-specific upgrade:" hidden="false" collective="false" import="true">
+          <categoryLinks>
+            <categoryLink id="19ca-69b1-d6d1-8813" name="Infantry" hidden="false" targetId="1ab3-f1ac-f724-8544" primary="false"/>
+            <categoryLink id="074d-c156-71c2-e8da" name="Jump Units" hidden="false" targetId="a787-4801-eb77-f2cf" primary="false"/>
+            <categoryLink id="1ce1-d740-bbe0-76e6" name="Legiones Astartes" hidden="false" targetId="f321-f2d7-7d68-8f93" primary="false"/>
+          </categoryLinks>
+          <entryLinks>
+            <entryLink id="0f43-c4b5-b2d9-c841" name="Dark Channelling" hidden="false" collective="false" import="true" targetId="96e9-6cf6-7b41-d10d" type="selectionEntry"/>
+            <entryLink id="e1ea-efcd-a1c8-8a23" name="Sonic Shriekers" hidden="false" collective="false" import="true" targetId="45cd-edae-7a23-95c6" type="selectionEntry">
+              <modifiers>
+                <modifier type="increment" field="points" value="2.0">
+                  <repeats>
+                    <repeat field="selections" scope="eefe-b2cd-3f41-7c84" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e691-ca90-8d84-e998" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="decrement" field="points" value="5.0"/>
+              </modifiers>
+            </entryLink>
+            <entryLink id="fc40-d264-aabd-0128" name="Cult Arcana" hidden="false" collective="false" import="true" targetId="52df-ddc4-325b-ec5a" type="selectionEntryGroup"/>
+            <entryLink id="b1ec-e608-a353-4986" name="Chem-munitions" hidden="false" collective="false" import="true" targetId="b432-5750-528f-98f3" type="selectionEntry"/>
+            <entryLink id="7682-e9e9-9da2-d2d4" name="Trophies of Judgement (Character)" hidden="false" collective="false" import="true" targetId="08f5-92aa-cd97-91cc" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2732-8ccb-cc97-ee5d" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="26fd-8ef9-a053-2ff3" name="All models may take:" hidden="false" collective="false" import="true">
+          <entryLinks>
+            <entryLink id="8fbf-9fe7-dded-60b0" name="Combat Shield" hidden="false" collective="false" import="true" targetId="ee70-f3a2-17f8-f39e" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="name" value="Combat Shields"/>
+                <modifier type="increment" field="points" value="3.0">
+                  <repeats>
+                    <repeat field="selections" scope="eefe-b2cd-3f41-7c84" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3f5d-64a1-c7b9-b60d" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="67dc-779e-7931-20fd" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="3.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="2fa4-7ee9-0d83-59ea" name="Melta Bombs" hidden="false" collective="false" import="true" targetId="4c62-8983-4a1b-d1c6" type="selectionEntry">
+              <modifiers>
+                <modifier type="increment" field="points" value="5.0">
+                  <repeats>
+                    <repeat field="selections" scope="eefe-b2cd-3f41-7c84" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3f5d-64a1-c7b9-b60d" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="b044-11c3-ec84-a889" name="Squad Weapons" hidden="false" collective="false" import="true">
+          <selectionEntryGroups>
+            <selectionEntryGroup id="6845-e1b4-49e0-a61b" name="All models may exchange Bolt Pistol for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="9583-162b-13df-41cf">
+              <modifiers>
+                <modifier type="set" field="fed0-8803-0eb5-6240" value="0.0">
+                  <conditions>
+                    <condition field="selections" scope="eefe-b2cd-3f41-7c84" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8a13-fcf2-c008-1b34" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="3231-5092-f34a-c839" value="0.0">
+                  <conditions>
+                    <condition field="selections" scope="eefe-b2cd-3f41-7c84" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8a13-fcf2-c008-1b34" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3231-5092-f34a-c839" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fed0-8803-0eb5-6240" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="7585-f83d-3765-2f16" name="Inferno Pistol " hidden="false" collective="false" import="true" targetId="13f8-6607-3525-4298" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="59f6-638d-8c1d-75dd" type="equalTo"/>
+                            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e2d7-e297-5b99-cbac" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                    <modifier type="increment" field="points" value="10.0">
+                      <repeats>
+                        <repeat field="selections" scope="eefe-b2cd-3f41-7c84" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3f5d-64a1-c7b9-b60d" repeats="1" roundUp="false"/>
+                      </repeats>
+                    </modifier>
+                    <modifier type="decrement" field="points" value="15.0"/>
+                  </modifiers>
+                </entryLink>
+                <entryLink id="91ae-298e-6669-73a3" name="New EntryLink" hidden="false" collective="false" import="true" targetId="f832-f4b2-6aaf-ad83" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="increment" field="points" value="10.0">
+                      <repeats>
+                        <repeat field="selections" scope="eefe-b2cd-3f41-7c84" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3f5d-64a1-c7b9-b60d" repeats="1" roundUp="false"/>
+                      </repeats>
+                    </modifier>
+                    <modifier type="decrement" field="points" value="15.0"/>
+                  </modifiers>
+                </entryLink>
+                <entryLink id="7f0d-8e9f-52ce-7501" name="Volkite Serpenta" hidden="false" collective="false" import="true" targetId="ae27-c659-fffd-1561" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="increment" field="points" value="2.0">
+                      <repeats>
+                        <repeat field="selections" scope="eefe-b2cd-3f41-7c84" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3f5d-64a1-c7b9-b60d" repeats="1" roundUp="false"/>
+                      </repeats>
+                    </modifier>
+                    <modifier type="decrement" field="points" value="3.0"/>
+                  </modifiers>
+                </entryLink>
+                <entryLink id="910b-50cb-aa8f-14c6" name="Hand Flamer" hidden="false" collective="false" import="true" targetId="8a98-53c5-6fab-b3a7" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="increment" field="points" value="5.0">
+                      <repeats>
+                        <repeat field="selections" scope="eefe-b2cd-3f41-7c84" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3f5d-64a1-c7b9-b60d" repeats="1" roundUp="false"/>
+                      </repeats>
+                    </modifier>
+                    <modifier type="decrement" field="points" value="15.0"/>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="de65-77a7-d304-ecda" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="c034-66f4-10cf-7720" name="Lightning Claw" hidden="false" collective="false" import="true" targetId="26db-484d-3757-03c8" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="increment" field="points" value="5.0">
+                      <repeats>
+                        <repeat field="selections" scope="eefe-b2cd-3f41-7c84" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3f5d-64a1-c7b9-b60d" repeats="1" roundUp="false"/>
+                      </repeats>
+                    </modifier>
+                    <modifier type="decrement" field="points" value="15.0"/>
+                  </modifiers>
+                </entryLink>
+                <entryLink id="9583-162b-13df-41cf" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="6026-d507-935a-7200" type="selectionEntry"/>
+                <entryLink id="32e0-a0a6-16b3-14e2" name="Raven&apos;s Talons" hidden="false" collective="false" import="true" targetId="d491-f3be-c649-cc6b" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="increment" field="points" value="15.0">
+                      <repeats>
+                        <repeat field="selections" scope="eefe-b2cd-3f41-7c84" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3f5d-64a1-c7b9-b60d" repeats="1" roundUp="false"/>
+                      </repeats>
+                    </modifier>
+                    <modifier type="decrement" field="points" value="10.0"/>
+                  </modifiers>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="30cd-ceae-5571-e257" name="All models may exchange Heavy Chainsword for" hidden="false" collective="false" import="true" defaultSelectionEntryId="bde3-7db5-bc7a-40c3">
+              <modifiers>
+                <modifier type="set" field="5a6a-d940-f730-7643" value="0.0">
+                  <conditions>
+                    <condition field="selections" scope="eefe-b2cd-3f41-7c84" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8a13-fcf2-c008-1b34" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="e4fa-28d2-3c10-4f66" value="0.0">
+                  <conditions>
+                    <condition field="selections" scope="eefe-b2cd-3f41-7c84" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8a13-fcf2-c008-1b34" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e4fa-28d2-3c10-4f66" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5a6a-d940-f730-7643" type="min"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="c00b-a1ec-c894-1773" name="Power Axe" hidden="false" collective="false" import="true" targetId="7b92-ab87-86a1-ab2e" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="increment" field="points" value="5.0">
+                      <repeats>
+                        <repeat field="selections" scope="eefe-b2cd-3f41-7c84" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3f5d-64a1-c7b9-b60d" repeats="1" roundUp="false"/>
+                      </repeats>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="10db-83e6-020a-0bc2" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="c0a7-b3e2-b7e5-5553" name="Heavy Chainblade" hidden="false" collective="false" import="true" targetId="0107-eaa7-f76e-b341" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="increment" field="points" value="2.0">
+                      <repeats>
+                        <repeat field="selections" scope="eefe-b2cd-3f41-7c84" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3f5d-64a1-c7b9-b60d" repeats="1" roundUp="false"/>
+                      </repeats>
+                    </modifier>
+                    <modifier type="decrement" field="points" value="5.0"/>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="edfe-8349-1212-9d3f" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="bde3-7db5-bc7a-40c3" name="Heavy Chainsword" hidden="false" collective="false" import="true" targetId="81ad-7f0f-bf68-9139" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="3084-84ae-fa24-4036" value="1.0"/>
+                    <modifier type="set" field="points" value="0.0"/>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="990b-3397-3fec-106e" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="0441-f028-f832-e18e" name="Power Maul" hidden="false" collective="false" import="true" targetId="e8a2-42e8-82a7-8dd9" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="increment" field="points" value="5.0">
+                      <repeats>
+                        <repeat field="selections" scope="eefe-b2cd-3f41-7c84" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3f5d-64a1-c7b9-b60d" repeats="1" roundUp="false"/>
+                      </repeats>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9334-37c2-e126-d504" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="e7a1-340c-bf22-a8b0" name="Power Lance" hidden="false" collective="false" import="true" targetId="233d-238b-6940-2740" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="increment" field="points" value="5.0">
+                      <repeats>
+                        <repeat field="selections" scope="eefe-b2cd-3f41-7c84" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3f5d-64a1-c7b9-b60d" repeats="1" roundUp="false"/>
+                      </repeats>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0bef-b99b-d61f-d7d6" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="90d0-eeb4-c961-ae1b" name="Power Sword" hidden="false" collective="false" import="true" targetId="3e90-5ca1-8abe-0275" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="increment" field="points" value="5.0">
+                      <repeats>
+                        <repeat field="selections" scope="eefe-b2cd-3f41-7c84" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3f5d-64a1-c7b9-b60d" repeats="1" roundUp="false"/>
+                      </repeats>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4f1d-a973-a33d-956c" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="4282-bc5c-e446-cc47" name="Lightning Claw" hidden="false" collective="false" import="true" targetId="26db-484d-3757-03c8" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="b2ab-5b47-b382-d02f" value="1.0"/>
+                    <modifier type="increment" field="points" value="5.0">
+                      <repeats>
+                        <repeat field="selections" scope="eefe-b2cd-3f41-7c84" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3f5d-64a1-c7b9-b60d" repeats="1" roundUp="false"/>
+                      </repeats>
+                    </modifier>
+                    <modifier type="decrement" field="points" value="15.0"/>
+                  </modifiers>
+                </entryLink>
+                <entryLink id="ac85-c035-c272-b546" name="Raven&apos;s Talons" hidden="false" collective="false" import="true" targetId="d491-f3be-c649-cc6b" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="increment" field="points" value="15.0">
+                      <repeats>
+                        <repeat field="selections" scope="eefe-b2cd-3f41-7c84" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3f5d-64a1-c7b9-b60d" repeats="1" roundUp="false"/>
+                      </repeats>
+                    </modifier>
+                    <modifier type="decrement" field="points" value="10.0"/>
+                  </modifiers>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="6d65-b32e-7172-bd4b" name="Or both for a pair of Raven&apos;s Talons:" hidden="false" collective="false" import="true">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4b8d-2642-cc86-8114" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dfff-5d69-376b-645b" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="8a13-fcf2-c008-1b34" name="Pair of Raven&apos;s Talons" hidden="false" collective="false" import="true" targetId="a8e8-37e5-3b8e-ccef" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="decrement" field="points" value="10.0"/>
+                    <modifier type="increment" field="points" value="20.0">
+                      <repeats>
+                        <repeat field="selections" scope="eefe-b2cd-3f41-7c84" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3f5d-64a1-c7b9-b60d" repeats="1" roundUp="false"/>
+                      </repeats>
+                    </modifier>
+                  </modifiers>
+                  <costs>
+                    <cost name="pts" typeId="points" value="20.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="3c72-d2bb-3467-3f10" name="Sergeant&apos;s Weapons" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8ac6-04a0-4d2a-60a5" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="7784-3472-bec7-280e" name="Exchange Heavy Chainsword for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="b747-781c-a10c-1e2b">
+              <modifiers>
+                <modifier type="set" field="d3b1-8f94-41da-8275" value="0.0">
+                  <conditions>
+                    <condition field="selections" scope="eefe-b2cd-3f41-7c84" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3705-a190-37bc-7751" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="fc53-31b2-7941-56be" value="0.0">
+                  <conditions>
+                    <condition field="selections" scope="eefe-b2cd-3f41-7c84" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3705-a190-37bc-7751" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d3b1-8f94-41da-8275" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fc53-31b2-7941-56be" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="b747-781c-a10c-1e2b" name="Heavy Chainsword" hidden="false" collective="false" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f0dd-7d3e-380c-591b" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="aaa7-10e8-53ce-e13b" name="Two-Handed" hidden="false" targetId="b11c-0ef4-af6b-d96f" type="rule"/>
+                    <infoLink id="ce8d-fa1d-3947-de6a" name="Heavy Chainsword" hidden="false" targetId="0fef-f304-fdfe-b082" type="profile"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <entryLinks>
+                <entryLink id="78ee-005c-d3d3-a66b" name="Lightning Claw" hidden="false" collective="false" import="true" targetId="26db-484d-3757-03c8" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="e6aa-b992-5819-6013" name="Thunder Hammer" hidden="false" collective="false" import="true" targetId="925c-50d4-0101-e0e7" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="20.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="5988-ff03-1c20-d265" name="Power Fist" hidden="false" collective="false" import="true" targetId="fcef-f5ac-16a3-9401" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="15.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="9be9-12df-b85d-2e25" name="Heavy Chainblade" hidden="false" collective="false" import="true" targetId="0107-eaa7-f76e-b341" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d3d-4a3c-5a5b-d65e" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="2.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="5893-9fc2-bfe7-90c7" name="Power Axe" hidden="false" collective="false" import="true" targetId="7b92-ab87-86a1-ab2e" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c704-1334-3c79-1c15" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="fe04-94dd-09b0-d61f" name="Power Lance" hidden="false" collective="false" import="true" targetId="233d-238b-6940-2740" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f04-627c-c1a3-e8f3" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="a76c-e181-7e6a-d26e" name="Power Maul" hidden="false" collective="false" import="true" targetId="e8a2-42e8-82a7-8dd9" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7f4d-e0cc-a891-1801" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="1f20-be81-e549-8e61" name="Power Sword" hidden="false" collective="false" import="true" targetId="3e90-5ca1-8abe-0275" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5339-b5cb-f0a8-e504" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="52e7-d80c-0f16-9ddc" name="Phoenix Spear" hidden="false" collective="false" import="true" targetId="bca4-ae83-c058-2822" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="15.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="4376-35e9-66ab-64f9" name="Nostraman Chainglaive" hidden="false" collective="false" import="true" targetId="b6e5-70ca-8084-765d" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="6901-0abd-34c2-dfbe" name="Power Scythe" hidden="false" collective="false" import="true" targetId="3410-908e-d98d-593d" type="selectionEntry"/>
+                <entryLink id="5228-6898-e0bb-b2af" name="Calibanite War Blade" hidden="false" collective="false" import="true" targetId="5bc2-ceb4-2e34-7004" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="d4e4-c04c-4217-3560" name="Power Glaive" hidden="false" collective="false" import="true" targetId="fd9c-9193-2c50-e929" type="selectionEntry"/>
+                <entryLink id="7bb0-8888-a102-4854" name="Raven&apos;s Talons" hidden="false" collective="false" import="true" targetId="d491-f3be-c649-cc6b" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="15.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="efe5-5499-8c3e-16d9" name="Albian Power Gladius" hidden="false" collective="false" import="true" targetId="1b80-5b44-0e03-b9e4" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="15.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="f9f7-7fa1-5147-7914" name="Cthonian Culling Blade" hidden="false" collective="false" import="true" targetId="270a-0bb6-b354-6b75" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="15.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="ede8-8e00-cf5f-7ea1" name="Tainted Weapon" hidden="false" collective="false" import="true" targetId="104d-2c15-b4b8-c299" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="points" value="5.0"/>
+                  </modifiers>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="274f-9005-e33c-c73c" name="Exchange Bolt Pistol for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="3b3c-f138-b803-8eaa">
+              <modifiers>
+                <modifier type="set" field="c691-303e-048f-5259" value="0.0">
+                  <conditions>
+                    <condition field="selections" scope="eefe-b2cd-3f41-7c84" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3705-a190-37bc-7751" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="e956-08db-2d2d-803e" value="0.0">
+                  <conditions>
+                    <condition field="selections" scope="eefe-b2cd-3f41-7c84" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3705-a190-37bc-7751" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e956-08db-2d2d-803e" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c691-303e-048f-5259" type="min"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="c779-924b-3c0b-2574" name="Volkite Serpenta" hidden="false" collective="false" import="true" targetId="ae27-c659-fffd-1561" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="2.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="c195-ad04-349b-6bca" name="Power Fist" hidden="false" collective="false" import="true" targetId="fcef-f5ac-16a3-9401" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="15.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="35ce-31df-ee6f-87ea" name="Thunder Hammer" hidden="false" collective="false" import="true" targetId="925c-50d4-0101-e0e7" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="20.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="a868-e286-2b8e-bd3b" name="Lightning Claw" hidden="false" collective="false" import="true" targetId="26db-484d-3757-03c8" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="425f-ffbd-0ecf-3cb6" name="Hand Flamer" hidden="false" collective="false" import="true" targetId="8a98-53c5-6fab-b3a7" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1aac-0f54-91e1-3043" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="3b3c-f138-b803-8eaa" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="6026-d507-935a-7200" type="selectionEntry"/>
+                <entryLink id="a6a3-a015-ffab-4649" name="Inferno Pistol " hidden="false" collective="false" import="true" targetId="13f8-6607-3525-4298" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="59f6-638d-8c1d-75dd" type="equalTo"/>
+                            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e2d7-e297-5b99-cbac" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="b9b1-dfc0-ef7e-5852" name="Phoenix Spear" hidden="false" collective="false" import="true" targetId="bca4-ae83-c058-2822" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="15.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="fcad-9773-d15d-9f29" name="New EntryLink" hidden="false" collective="false" import="true" targetId="f832-f4b2-6aaf-ad83" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="240d-bf56-945c-a2ed" name="Raven&apos;s Talons" hidden="false" collective="false" import="true" targetId="d491-f3be-c649-cc6b" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="15.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="c594-fcef-2bae-65b9" name="Or both for a pair of Raven&apos;s Talons:" hidden="false" collective="false" import="true">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4b8d-2642-cc86-8114" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5da4-285d-8fc8-ef9e" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="3705-a190-37bc-7751" name="Pair of Raven&apos;s Talons" hidden="false" collective="false" import="true" targetId="a8e8-37e5-3b8e-ccef" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="20.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="be53-40d4-9651-d218" name="Sergeant may take" hidden="false" collective="false" import="true">
+          <entryLinks>
+            <entryLink id="b700-b599-f7b0-c1ec" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="c6b8-8b0b-8a31-6aa3" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b3be-c149-5524-4e7e" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="15.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="7c38-1ec9-1377-829c" name="Combat Shield" hidden="false" collective="false" import="true" targetId="ee70-f3a2-17f8-f39e" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="eefe-b2cd-3f41-7c84" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8fbf-9fe7-dded-60b0" type="atLeast"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9ff5-4a23-9947-3e4d" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="3.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="1e8f-3ab9-a443-c451" name="New EntryLink" hidden="false" collective="false" import="true" targetId="4c62-8983-4a1b-d1c6" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="eefe-b2cd-3f41-7c84" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2fa4-7ee9-0d83-59ea" type="atLeast"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </entryLink>
+            <entryLink id="a255-7e0a-da54-da78" name="Legion-specific upgrade:" hidden="false" collective="false" import="true" targetId="efe5-effa-a371-ae4e" type="selectionEntryGroup"/>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="points" value="40.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="13f8-6607-3525-4298" name="Inferno Pistol " page="0" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ccce-cd4b-c78d-16d1" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="1c62-c1ad-5e57-ef5e" name="Inferno Pistol" hidden="false" targetId="a733-2f33-1e47-8359" type="profile"/>
+        <infoLink id="8c68-2d07-7893-44bf" name="Melta" hidden="false" targetId="21c0-62ff-3ed2-17a7" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="15.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="8a98-53c5-6fab-b3a7" name="Hand Flamer" publicationId="ca571888--pubN89821" page="259" hidden="false" collective="false" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="f3ee-48ca-e925-218d" name="Hand Flamer" publicationId="ca571888--pubN89821" page="259" hidden="false" targetId="21b6-668e-d5ef-a8da" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="15.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0107-eaa7-f76e-b341" name="Heavy Chainblade" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="616c-0dc8-a552-fcb7" name="Heavy Chainblade" publicationId="ca571888--pubN66580" page="106" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
+            <characteristic name="Strength" typeId="537472656e67746823232344415441232323">+2</characteristic>
+            <characteristic name="AP" typeId="415023232344415441232323">4</characteristic>
+            <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Two-handed</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="ba3c-bb11-86fe-c72f" name="Two-Handed" hidden="false" targetId="b11c-0ef4-af6b-d96f" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="5.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="96e9-6cf6-7b41-d10d" name="Dark Channelling" page="0" hidden="false" collective="false" import="true" type="upgrade">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b385-ebdb-8a45-d657" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4997-fb0a-fb78-aca8" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3a53-7c43-0ab0-cafd" type="max"/>
+      </constraints>
+      <rules>
+        <rule id="a9bc-d3fe-e726-f99c" name="Dark Channelling" publicationId="ca571888--pubN67459" page="73" hidden="false">
+          <description>Roll a D6 at the beginning of the game for each unit with Dark Channelling.  The effects of this roll do not affect any Independent Characters or other models which join the unit.
+
+1-3: Unit gains Zealot
+4-5: Unit gains 1 Strength
+6: Unit gains Daemon special rule.  No longer scoring in any game type and counts as destroyed at the end of the game for VP.</description>
+        </rule>
+      </rules>
+      <costs>
+        <cost name="pts" typeId="points" value="25.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5aa7-c454-3656-3a3f" name="Veteran Reconnaisance Squad, Legion" publicationId="0e6e-8c19-c436-39c4" page="" hidden="false" collective="false" import="true" type="unit">
+      <rules>
+        <rule id="6290-6b27-734b-0a32" name="Restricted" hidden="false">
+          <description>A detachment must have more Assault (or Night Raptor or Dark Fury) Squads than Assault Support Squads.</description>
+        </rule>
+        <rule id="0c91-dd05-6add-502d" name="Recon Specialist" publicationId="0e6e-8c19-c436-39c4" hidden="false">
+          <description>Every Recon Marine, including the Sergeant, must choose one of the following specialisations, gaining the wargear and rules listed below. Note that not all members must take the same specialisation:
+Saboteur: Melta Bombs and Chainsword Sniper: Sniper Rifle, +1BS and the Marksman special rule
+Tracker: Bolt Gun, Kraken Bolts, Combat Blade and Acute Senses
+Hunter: Shot Gun, Chainblade, +1A and Acute Senses</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="7317-f6dd-8923-3a05" name="Support Squad" hidden="false" targetId="2c16-3b25-a714-a656" type="rule"/>
+        <infoLink id="d89b-cdcf-b755-232f" name="Scout" hidden="false" targetId="9b30-1da3-eb8d-ce7a" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="f921-e56d-9226-de8d" name="Infantry" hidden="false" targetId="1ab3-f1ac-f724-8544" primary="false"/>
+        <categoryLink id="dc64-15fa-e036-5c96" name="Legiones Astartes" hidden="false" targetId="f321-f2d7-7d68-8f93" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="207d-f051-c030-61eb" name="Veteran Recon Marines" page="0" hidden="false" collective="false" import="true" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9ed6-d74b-7476-492c" type="min"/>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4d85-96a0-6023-248b" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="5e3c-851c-6f44-40d2" name="Veteran Recon Marines" publicationId="0e6e-8c19-c436-39c4" page="" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+              <modifiers>
+                <modifier type="set" field="5361766523232344415441232323" value="4+">
+                  <conditions>
+                    <condition field="selections" scope="5aa7-c454-3656-3a3f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="06ee-6a55-d4ff-0628" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <characteristics>
+                <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry</characteristic>
+                <characteristic name="WS" typeId="575323232344415441232323">4</characteristic>
+                <characteristic name="BS" typeId="425323232344415441232323">4</characteristic>
+                <characteristic name="S" typeId="5323232344415441232323">4</characteristic>
+                <characteristic name="T" typeId="5423232344415441232323">4</characteristic>
+                <characteristic name="W" typeId="5723232344415441232323">1</characteristic>
+                <characteristic name="I" typeId="4923232344415441232323">4</characteristic>
+                <characteristic name="A" typeId="4123232344415441232323">1</characteristic>
+                <characteristic name="LD" typeId="4c4423232344415441232323">8</characteristic>
+                <characteristic name="Save" typeId="5361766523232344415441232323">3+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="15.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="e513-7fa1-1e5a-3168" name="Standard Wargear" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e4f8-126c-5e00-8735" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="20fc-9e50-e241-7e07" type="min"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="777a-ca4b-1d8a-1e25" name="Frag and Krak Grenades" hidden="false" collective="false" import="true" targetId="0a53-b471-df87-7b83" type="selectionEntry"/>
+            <entryLink id="1aed-7368-b78c-115b" name="Bolt Pistols" hidden="false" collective="false" import="true" targetId="fe8d-1baa-d58d-00bc" type="selectionEntry"/>
+            <entryLink id="9078-a360-d44c-21e5" name="Shroud Bombs" hidden="false" collective="false" import="true" targetId="9993-3291-85b5-25f8" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="5ddc-4dd1-2d59-177b" name="Veteran Recon Marine Sergeant" hidden="false" collective="false" import="true" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="27eb-cfb6-9f35-db77" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="cee3-5214-38d4-ac32" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="1f3d-69f8-7f8b-4107" name="Veteran Recon Marine Sergeant" publicationId="0e6e-8c19-c436-39c4" page="" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+              <modifiers>
+                <modifier type="set" field="5361766523232344415441232323" value="4+">
+                  <conditions>
+                    <condition field="selections" scope="5aa7-c454-3656-3a3f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="06ee-6a55-d4ff-0628" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <characteristics>
+                <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry (Character)</characteristic>
+                <characteristic name="WS" typeId="575323232344415441232323">4</characteristic>
+                <characteristic name="BS" typeId="425323232344415441232323">4</characteristic>
+                <characteristic name="S" typeId="5323232344415441232323">4</characteristic>
+                <characteristic name="T" typeId="5423232344415441232323">4</characteristic>
+                <characteristic name="W" typeId="5723232344415441232323">1</characteristic>
+                <characteristic name="I" typeId="4923232344415441232323">4</characteristic>
+                <characteristic name="A" typeId="4123232344415441232323">2</characteristic>
+                <characteristic name="LD" typeId="4c4423232344415441232323">9</characteristic>
+                <characteristic name="Save" typeId="5361766523232344415441232323">3+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <categoryLinks>
+            <categoryLink id="8dc9-3bc5-b137-865f" name="Character" hidden="false" targetId="ae54-92c7-3e66-59f7" primary="false"/>
+          </categoryLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="edee-cbb8-a9e9-4755" name="Sergeant may take:" hidden="false" collective="false" import="true">
+          <categoryLinks>
+            <categoryLink id="3ae7-0ed9-9060-07ab" name="Infantry" hidden="false" targetId="1ab3-f1ac-f724-8544" primary="false"/>
+            <categoryLink id="ec99-5440-d463-22f6" name="Jump Units" hidden="false" targetId="a787-4801-eb77-f2cf" primary="false"/>
+            <categoryLink id="92d2-d9b2-c98c-222b" name="Legiones Astartes" hidden="false" targetId="f321-f2d7-7d68-8f93" primary="false"/>
+          </categoryLinks>
+          <entryLinks>
+            <entryLink id="5d62-3fd6-dfe1-85c5" name="Legion-specific upgrade:" hidden="false" collective="false" import="true" targetId="efe5-effa-a371-ae4e" type="selectionEntryGroup"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="d9cb-4510-3fef-1ded" name="All models may take:" hidden="false" collective="false" import="true">
+          <entryLinks>
+            <entryLink id="61e9-855e-7e07-2cd4" name="Cameleoline" hidden="false" collective="false" import="true" targetId="1e21-5a9f-873b-fdc7" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false"/>
+                <modifier type="increment" field="points" value="1.0">
+                  <repeats>
+                    <repeat field="selections" scope="5aa7-c454-3656-3a3f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+                <modifier type="decrement" field="points" value="5.0"/>
+              </modifiers>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="e26e-52a6-8af6-7a07" name="Sergeant&apos;s Weapons" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1b5b-b409-4b3b-162e" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="b48d-150d-a6ce-8606" name="Exchange Chainsword for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="a8c6-8f23-f9e8-5502">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cff0-f5af-2d20-f903" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8a8a-1548-bde9-bdc4" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="919a-12f8-e1d0-467b" name="Lightning Claw" hidden="false" collective="false" import="true" targetId="26db-484d-3757-03c8" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="a6a3-bd46-a080-3aed" name="Power Fist" hidden="false" collective="false" import="true" targetId="fcef-f5ac-16a3-9401" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="15.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="54e8-2dd3-9292-ce61" name="Power Axe" hidden="false" collective="false" import="true" targetId="7b92-ab87-86a1-ab2e" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9b99-5f6d-20ef-3d46" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="6935-16d6-8bbc-4054" name="Power Maul" hidden="false" collective="false" import="true" targetId="e8a2-42e8-82a7-8dd9" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a715-d759-26a0-3364" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="f5ff-a3b3-6cab-841d" name="Power Sword" hidden="false" collective="false" import="true" targetId="3e90-5ca1-8abe-0275" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fd7f-db75-064a-980c" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="f9c5-0235-dd7e-a541" name="Phoenix Spear" hidden="false" collective="false" import="true" targetId="bca4-ae83-c058-2822" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="15.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="3892-d070-da22-735a" name="Nostraman Chainglaive" hidden="false" collective="false" import="true" targetId="b6e5-70ca-8084-765d" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="ee4c-c8d0-cd64-05ab" name="Power Scythe" hidden="false" collective="false" import="true" targetId="3410-908e-d98d-593d" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="15.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="294e-cf19-1b32-759f" name="Calibanite War Blade" hidden="false" collective="false" import="true" targetId="5bc2-ceb4-2e34-7004" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="3580-c6c4-d632-9087" name="Power Glaive" hidden="false" collective="false" import="true" targetId="fd9c-9193-2c50-e929" type="selectionEntry"/>
+                <entryLink id="8c9b-c993-0102-79cb" name="Raven&apos;s Talons" hidden="false" collective="false" import="true" targetId="d491-f3be-c649-cc6b" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="20.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="894b-eaf8-115f-d389" name="Albian Power Gladius" hidden="false" collective="false" import="true" targetId="1b80-5b44-0e03-b9e4" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="15.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="6226-d7a2-2ea7-db0b" name="Cthonian Culling Blade" hidden="false" collective="false" import="true" targetId="270a-0bb6-b354-6b75" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="15.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="f5c7-2c8a-8038-3527" name="Tainted Weapon" hidden="false" collective="false" import="true" targetId="104d-2c15-b4b8-c299" type="selectionEntry"/>
+                <entryLink id="a8c6-8f23-f9e8-5502" name="Chainsword/Combat Blade" hidden="false" collective="false" import="true" targetId="4b1e-680b-1d39-e4f1" type="selectionEntry"/>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="2fcd-f3dc-7a99-1147" name="Exchange Bolt Pistol for:" hidden="false" collective="false" import="true">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4b7f-1e75-d411-843a" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a8b-1ae8-5276-8020" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="8e49-fe0b-8400-e79d" name="Volkite Serpenta" hidden="false" collective="false" import="true" targetId="ae27-c659-fffd-1561" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="2.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="fac7-125a-8e40-52a8" name="New EntryLink" hidden="false" collective="false" import="true" targetId="f832-f4b2-6aaf-ad83" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="b254-a583-5228-2aa2" name="Inferno Pistol " hidden="false" collective="false" import="true" targetId="13f8-6607-3525-4298" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="59f6-638d-8c1d-75dd" type="equalTo"/>
+                            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e2d7-e297-5b99-cbac" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="3ea7-c686-11af-e596" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="6026-d507-935a-7200" type="selectionEntry"/>
+                <entryLink id="6b86-71fd-48a8-5aea" name="Hand Flamer" hidden="false" collective="false" import="true" targetId="8a98-53c5-6fab-b3a7" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6e62-5026-e0ef-d2db" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="8faf-32d0-6169-00f0" name="The squad can be equipped with one model with" hidden="false" collective="false" import="true">
+          <entryLinks>
+            <entryLink id="5cb7-99be-49df-9eba" name="Nuncio-vox" hidden="false" collective="false" import="true" targetId="3b07-bf87-1e36-9181" type="selectionEntry"/>
+            <entryLink id="65c7-55ca-e3c8-cbcb" name="Augury Scanner" hidden="false" collective="false" import="true" targetId="7e20-c85a-2e04-dd0b" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="8589-625f-5203-e2bb" name="Recon Specialists" hidden="false" collective="false" import="true">
+          <modifiers>
+            <modifier type="increment" field="bfc1-1c2e-1023-2756" value="1.0">
+              <repeats>
+                <repeat field="selections" scope="5aa7-c454-3656-3a3f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+            <modifier type="increment" field="8fb9-95f2-beac-5f49" value="1.0">
+              <repeats>
+                <repeat field="selections" scope="5aa7-c454-3656-3a3f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8fb9-95f2-beac-5f49" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bfc1-1c2e-1023-2756" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="0c45-12bd-86c7-fa7d" name="Hunter" hidden="false" collective="false" import="true" type="upgrade">
+              <profiles>
+                <profile id="05cb-c5e1-6024-394f" name="Veteran Recon Marines (Hunter)" publicationId="0e6e-8c19-c436-39c4" page="" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+                  <modifiers>
+                    <modifier type="set" field="5361766523232344415441232323" value="4+">
+                      <conditions>
+                        <condition field="selections" scope="5aa7-c454-3656-3a3f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="06ee-6a55-d4ff-0628" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <characteristics>
+                    <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry</characteristic>
+                    <characteristic name="WS" typeId="575323232344415441232323">4</characteristic>
+                    <characteristic name="BS" typeId="425323232344415441232323">4</characteristic>
+                    <characteristic name="S" typeId="5323232344415441232323">4</characteristic>
+                    <characteristic name="T" typeId="5423232344415441232323">4</characteristic>
+                    <characteristic name="W" typeId="5723232344415441232323">1</characteristic>
+                    <characteristic name="I" typeId="4923232344415441232323">4</characteristic>
+                    <characteristic name="A" typeId="4123232344415441232323">2</characteristic>
+                    <characteristic name="LD" typeId="4c4423232344415441232323">8</characteristic>
+                    <characteristic name="Save" typeId="5361766523232344415441232323">3+</characteristic>
+                  </characteristics>
+                </profile>
+                <profile id="92d2-8efc-2a6a-eb69" name="Veteran Recon Marines Sergeant (Hunter)" publicationId="0e6e-8c19-c436-39c4" page="" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+                  <modifiers>
+                    <modifier type="set" field="5361766523232344415441232323" value="4+">
+                      <conditions>
+                        <condition field="selections" scope="5aa7-c454-3656-3a3f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="06ee-6a55-d4ff-0628" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <characteristics>
+                    <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry (Character)</characteristic>
+                    <characteristic name="WS" typeId="575323232344415441232323">4</characteristic>
+                    <characteristic name="BS" typeId="425323232344415441232323">4</characteristic>
+                    <characteristic name="S" typeId="5323232344415441232323">4</characteristic>
+                    <characteristic name="T" typeId="5423232344415441232323">4</characteristic>
+                    <characteristic name="W" typeId="5723232344415441232323">1</characteristic>
+                    <characteristic name="I" typeId="4923232344415441232323">4</characteristic>
+                    <characteristic name="A" typeId="4123232344415441232323">3</characteristic>
+                    <characteristic name="LD" typeId="4c4423232344415441232323">9</characteristic>
+                    <characteristic name="Save" typeId="5361766523232344415441232323">3+</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink id="1c7c-d909-8dec-de57" name="Acute Senses" hidden="false" targetId="e15d-1437-cfb2-b8dd" type="rule"/>
+              </infoLinks>
+              <selectionEntries>
+                <selectionEntry id="b8a4-d7f7-7873-8a66" name="Chainblade" hidden="false" collective="false" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="123b-bad1-bdd1-773e" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e49c-8c5d-25e5-5426" type="min"/>
+                  </constraints>
+                  <profiles>
+                    <profile id="6986-52a1-8fac-6f78" name="Chainblade" publicationId="0e6e-8c19-c436-39c4" page="" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+                      <characteristics>
+                        <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
+                        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">User</characteristic>
+                        <characteristic name="AP" typeId="415023232344415441232323">4</characteristic>
+                        <characteristic name="Type" typeId="5479706523232344415441232323">Melee</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <costs>
+                    <cost name="pts" typeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="1ec3-99c0-8afd-2691" name="Shotgun" hidden="false" collective="false" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="751d-59b4-ed1c-cb8b" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ddb3-75b4-1f7f-c489" type="min"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="d6b2-dcb8-914a-e8e8" name="Space Marine Shotgun" hidden="false" targetId="0638-4e71-e65e-9a04" type="profile"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="da6b-1878-3d17-2fb6" name="Tracker" hidden="false" collective="false" import="true" type="upgrade">
+              <profiles>
+                <profile id="a881-7dad-ac9f-fff2" name="Kraken Bolt Shells" publicationId="ca571888--pubN82424" page="85" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="52616e676523232344415441232323">30&quot;</characteristic>
+                    <characteristic name="Strength" typeId="537472656e67746823232344415441232323">4</characteristic>
+                    <characteristic name="AP" typeId="415023232344415441232323">4</characteristic>
+                    <characteristic name="Type" typeId="5479706523232344415441232323">Rapid Fire</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink id="6fb5-3742-a0d1-ead4" name="Acute Senses" hidden="false" targetId="e15d-1437-cfb2-b8dd" type="rule"/>
+              </infoLinks>
+              <entryLinks>
+                <entryLink id="2706-c280-1bfd-c5d4" name="Close Combat Weapon" hidden="false" collective="false" import="true" targetId="3060-5ce0-cb9d-3bbd" type="selectionEntry"/>
+                <entryLink id="1156-506c-eff9-c2c1" name="Bolters" hidden="false" collective="false" import="true" targetId="ac90-ce47-65c6-f5f3" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="e19b-2937-d45a-345f" name="Sniper" hidden="false" collective="false" import="true" type="upgrade">
+              <profiles>
+                <profile id="f9ef-5450-49ef-81dd" name="Veteran Recon Marines (Sniper)" publicationId="0e6e-8c19-c436-39c4" page="" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+                  <modifiers>
+                    <modifier type="set" field="5361766523232344415441232323" value="4+">
+                      <conditions>
+                        <condition field="selections" scope="5aa7-c454-3656-3a3f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="06ee-6a55-d4ff-0628" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <characteristics>
+                    <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry</characteristic>
+                    <characteristic name="WS" typeId="575323232344415441232323">4</characteristic>
+                    <characteristic name="BS" typeId="425323232344415441232323">5</characteristic>
+                    <characteristic name="S" typeId="5323232344415441232323">4</characteristic>
+                    <characteristic name="T" typeId="5423232344415441232323">4</characteristic>
+                    <characteristic name="W" typeId="5723232344415441232323">1</characteristic>
+                    <characteristic name="I" typeId="4923232344415441232323">4</characteristic>
+                    <characteristic name="A" typeId="4123232344415441232323">1</characteristic>
+                    <characteristic name="LD" typeId="4c4423232344415441232323">8</characteristic>
+                    <characteristic name="Save" typeId="5361766523232344415441232323">3+</characteristic>
+                  </characteristics>
+                </profile>
+                <profile id="0f59-dade-0e6d-d84a" name="Veteran Recon Marines Sergeant (Sniper)" publicationId="0e6e-8c19-c436-39c4" page="" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+                  <modifiers>
+                    <modifier type="set" field="5361766523232344415441232323" value="4+">
+                      <conditions>
+                        <condition field="selections" scope="5aa7-c454-3656-3a3f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="06ee-6a55-d4ff-0628" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <characteristics>
+                    <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry (Character)</characteristic>
+                    <characteristic name="WS" typeId="575323232344415441232323">4</characteristic>
+                    <characteristic name="BS" typeId="425323232344415441232323">5</characteristic>
+                    <characteristic name="S" typeId="5323232344415441232323">4</characteristic>
+                    <characteristic name="T" typeId="5423232344415441232323">4</characteristic>
+                    <characteristic name="W" typeId="5723232344415441232323">1</characteristic>
+                    <characteristic name="I" typeId="4923232344415441232323">4</characteristic>
+                    <characteristic name="A" typeId="4123232344415441232323">2</characteristic>
+                    <characteristic name="LD" typeId="4c4423232344415441232323">9</characteristic>
+                    <characteristic name="Save" typeId="5361766523232344415441232323">3+</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules>
+                <rule id="150f-7099-2cec-a048" name="Marksman" hidden="false">
+                  <description>All attacks are Precision Shots (excluding Snap Shots). If the target unit suffers any casualties from such shots, that unit suffers a Pinning test.</description>
+                </rule>
+              </rules>
+              <selectionEntries>
+                <selectionEntry id="0f3d-6ac9-95b9-f432" name="Sniper Rifle" page="0" hidden="false" collective="false" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6373-77cf-e92a-5095" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ba98-3546-af84-d1e0" type="min"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="604f-d290-1eab-948c" name="Sniper Rifle" hidden="false" targetId="45a4-5982-7f8b-fb33" type="profile"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="c245-84f0-4f8b-78c0" name="Saboteur" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="e321-94b4-a0b8-8020" name="Chainsword" hidden="false" collective="false" import="true" targetId="a76d-339e-15a2-0352" type="selectionEntry"/>
+                <entryLink id="8bb8-dc0a-eb7c-a929" name="Melta Bombs" hidden="false" collective="false" import="true" targetId="4c62-8983-4a1b-d1c6" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="points" value="0.0"/>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b9af-0ee7-88d0-dc24" type="min"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="ad6d-dbe6-07ee-8337" name="All models may exchange their Power Armour for Recon Armour:" hidden="false" collective="false" import="true" defaultSelectionEntryId="cbdd-4ce1-964f-2182">
+          <entryLinks>
+            <entryLink id="cbdd-4ce1-964f-2182" name="New EntryLink" hidden="false" collective="false" import="true" targetId="0a96-04b6-7340-91a4" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="ceed-2412-dfeb-bceb" value="0.0"/>
+              </modifiers>
+            </entryLink>
+            <entryLink id="06ee-6a55-d4ff-0628" name="Recon Armour" hidden="false" collective="false" import="true" targetId="cdad-0c91-70a8-0e50" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="c099-cbf8-f40d-b7ce" name="Legion-specific upgrade:" hidden="false" collective="false" import="true">
+          <categoryLinks>
+            <categoryLink id="7cb9-b250-093e-171d" name="Infantry" hidden="false" targetId="1ab3-f1ac-f724-8544" primary="false"/>
+            <categoryLink id="4d07-34f6-13d1-164f" name="Jump Units" hidden="false" targetId="a787-4801-eb77-f2cf" primary="false"/>
+            <categoryLink id="c677-22fc-8304-d3e4" name="Legiones Astartes" hidden="false" targetId="f321-f2d7-7d68-8f93" primary="false"/>
+          </categoryLinks>
+          <entryLinks>
+            <entryLink id="afdd-edcc-0bb2-8bbd" name="Sonic Shriekers" hidden="false" collective="false" import="true" targetId="45cd-edae-7a23-95c6" type="selectionEntry">
+              <modifiers>
+                <modifier type="increment" field="points" value="2.0">
+                  <repeats>
+                    <repeat field="selections" scope="5aa7-c454-3656-3a3f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e691-ca90-8d84-e998" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="decrement" field="points" value="5.0"/>
+              </modifiers>
+            </entryLink>
+            <entryLink id="f1af-a8b2-32d4-8530" name="Cult Arcana" hidden="false" collective="false" import="true" targetId="52df-ddc4-325b-ec5a" type="selectionEntryGroup"/>
+            <entryLink id="ea96-812a-af9a-1d3b" name="Trophies of Judgement (Character)" hidden="false" collective="false" import="true" targetId="08f5-92aa-cd97-91cc" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2732-8ccb-cc97-ee5d" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="points" value="40.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9993-3291-85b5-25f8" name="Shroud Bombs" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c1f5-5d6a-e102-c0c3" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f130-4652-95b9-7327" type="min"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="06ee-12dc-48c2-b336" name="Shroud Bomb" hidden="false" targetId="17f3-89d3-0f42-1c09" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="cdad-0c91-70a8-0e50" name="Recon Armour" page="0" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8caf-2b26-5421-8ff1" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="d28e-a199-3fb9-83bd" name="Recon Armour" publicationId="ca571888--pubN82424" page="" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
+          <characteristics>
+            <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Recon armour provides a +4 armour save and the model gains Infiltrate &amp; Move Through Cover</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="26d4-9ffb-dc54-c348" name="New InfoLink" hidden="false" targetId="34c7-8b61-a5b8-a301" type="rule"/>
+        <infoLink id="0ced-cc32-25dd-606d" name="New InfoLink" hidden="false" targetId="6d06-5ea0-9a17-ca97" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3b07-bf87-1e36-9181" name="Nuncio-vox" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="44f6-64d8-993d-83d3" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="6aae-323a-7004-4ae0" name="New InfoLink" hidden="false" targetId="2a0e-e1f0-5ea0-5799" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="c5ba-7647-23ba-c728" name="Breacher Support Squad, Legion" publicationId="0e6e-8c19-c436-39c4" page="" hidden="false" collective="false" import="true" type="unit">
+      <rules>
+        <rule id="cf3f-1771-681d-4cde" name="Restricted" hidden="false">
+          <description>A detachment must have more Breacher (or Phalanx Warder or Medusan Immortal) Squads than Breacher Support Squads.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="1664-2d02-88e7-053e" name="Support Squad" hidden="false" targetId="2c16-3b25-a714-a656" type="rule"/>
+        <infoLink id="aed3-df61-3f8c-1ec0" name="Hardened Armour" hidden="false" targetId="7439f6fd-4c50-f88a-eb41-81d9b9c9eed8" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="1190-e292-662f-843f" name="Infantry" hidden="false" targetId="1ab3-f1ac-f724-8544" primary="false"/>
+        <categoryLink id="da47-a8cf-3c69-0b94" name="Legiones Astartes" hidden="false" targetId="f321-f2d7-7d68-8f93" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="5f26-92ce-00a2-fc84" name="Space Marine Breacher, Legion" page="0" hidden="false" collective="false" import="true" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="dc78-1f75-34d9-564f" type="min"/>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="cb0e-57e5-97c2-d6c8" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="72e3-c375-c13d-831c" name="Breacher" publicationId="0e6e-8c19-c436-39c4" page="" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+              <characteristics>
+                <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry</characteristic>
+                <characteristic name="WS" typeId="575323232344415441232323">4</characteristic>
+                <characteristic name="BS" typeId="425323232344415441232323">4</characteristic>
+                <characteristic name="S" typeId="5323232344415441232323">4</characteristic>
+                <characteristic name="T" typeId="5423232344415441232323">4</characteristic>
+                <characteristic name="W" typeId="5723232344415441232323">1</characteristic>
+                <characteristic name="I" typeId="4923232344415441232323">4</characteristic>
+                <characteristic name="A" typeId="4123232344415441232323">1</characteristic>
+                <characteristic name="LD" typeId="4c4423232344415441232323">8</characteristic>
+                <characteristic name="Save" typeId="5361766523232344415441232323">3+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="15.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="2d7b-92a4-5b61-36e2" name="Standard Wargear" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ad3e-ebd9-8d5d-f97d" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f818-13c0-9cba-d6e3" type="min"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="fb4b-6650-76b7-a8e0" name="Frag and Krak Grenades" hidden="false" collective="false" import="true" targetId="0a53-b471-df87-7b83" type="selectionEntry"/>
+            <entryLink id="def3-14fb-3c45-1228" name="New EntryLink" hidden="false" collective="false" import="true" targetId="0a96-04b6-7340-91a4" type="selectionEntry"/>
+            <entryLink id="f371-123a-a1f0-3e36" name="Boarding Shield" hidden="false" collective="false" import="true" targetId="4a79-b52c-8dcf-ec72" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="77dd-d8df-e7ca-149f" type="min"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="293a-0dd2-8837-9f2a" name="Breacher Sergeant, Legion" hidden="false" collective="false" import="true" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f103-8805-97fd-39d5" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a193-9405-b7b9-b4d1" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="795d-a90b-552f-998b" name="Breacher Sergeant" publicationId="0e6e-8c19-c436-39c4" page="" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+              <modifiers>
+                <modifier type="set" field="5361766523232344415441232323" value="2+">
+                  <conditions>
+                    <condition field="selections" scope="c5ba-7647-23ba-c728" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ea78-f457-c9fd-6ee5" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <characteristics>
+                <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry (Character)</characteristic>
+                <characteristic name="WS" typeId="575323232344415441232323">4</characteristic>
+                <characteristic name="BS" typeId="425323232344415441232323">4</characteristic>
+                <characteristic name="S" typeId="5323232344415441232323">4</characteristic>
+                <characteristic name="T" typeId="5423232344415441232323">4</characteristic>
+                <characteristic name="W" typeId="5723232344415441232323">1</characteristic>
+                <characteristic name="I" typeId="4923232344415441232323">4</characteristic>
+                <characteristic name="A" typeId="4123232344415441232323">2</characteristic>
+                <characteristic name="LD" typeId="4c4423232344415441232323">9</characteristic>
+                <characteristic name="Save" typeId="5361766523232344415441232323">3+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <categoryLinks>
+            <categoryLink id="5e6d-224f-a3a9-5ad9" name="Character" hidden="false" targetId="ae54-92c7-3e66-59f7" primary="false"/>
+          </categoryLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="6e2d-d6a4-3413-93b7" name="Legion-specific upgrade:" hidden="false" collective="false" import="true">
+          <categoryLinks>
+            <categoryLink id="8be3-d7d9-d110-3739" name="Infantry" hidden="false" targetId="1ab3-f1ac-f724-8544" primary="false"/>
+            <categoryLink id="13c9-68e2-3c87-0c53" name="Jump Units" hidden="false" targetId="a787-4801-eb77-f2cf" primary="false"/>
+            <categoryLink id="3a02-4343-7cc2-c4ac" name="Legiones Astartes" hidden="false" targetId="f321-f2d7-7d68-8f93" primary="false"/>
+          </categoryLinks>
+          <entryLinks>
+            <entryLink id="236c-aa14-0f4f-a67a" name="Dark Channelling" hidden="false" collective="false" import="true" targetId="96e9-6cf6-7b41-d10d" type="selectionEntry"/>
+            <entryLink id="f3a3-144c-1aca-80b5" name="Sonic Shriekers" hidden="false" collective="false" import="true" targetId="45cd-edae-7a23-95c6" type="selectionEntry">
+              <modifiers>
+                <modifier type="increment" field="points" value="2.0">
+                  <repeats>
+                    <repeat field="selections" scope="c5ba-7647-23ba-c728" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e691-ca90-8d84-e998" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="decrement" field="points" value="5.0"/>
+              </modifiers>
+            </entryLink>
+            <entryLink id="34b0-3427-0d55-bd7a" name="Cult Arcana" hidden="false" collective="false" import="true" targetId="52df-ddc4-325b-ec5a" type="selectionEntryGroup"/>
+            <entryLink id="8b17-1f73-a790-49ca" name="Chem-munitions" hidden="false" collective="false" import="true" targetId="b432-5750-528f-98f3" type="selectionEntry"/>
+            <entryLink id="597e-7046-625e-82b1" name="Trophies of Judgement (Character)" hidden="false" collective="false" import="true" targetId="08f5-92aa-cd97-91cc" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2732-8ccb-cc97-ee5d" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="1b53-7718-3bd8-d888" name="All models may take:" hidden="false" collective="false" import="true">
+          <entryLinks>
+            <entryLink id="d16c-d674-ac07-969c" name="Melta Bombs" hidden="false" collective="false" import="true" targetId="4c62-8983-4a1b-d1c6" type="selectionEntry">
+              <modifiers>
+                <modifier type="increment" field="points" value="5.0">
+                  <repeats>
+                    <repeat field="selections" scope="c5ba-7647-23ba-c728" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5f26-92ce-00a2-fc84" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="9390-bf39-7ec7-ebca" name="Squad Weapons" hidden="false" collective="false" import="true">
+          <selectionEntryGroups>
+            <selectionEntryGroup id="0c28-161f-346a-2e3d" name="All models may exchange Bolt Pistol for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="74c7-6a20-720a-f200">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f399-07c8-206c-1fae" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5050-f861-aa91-8adf" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="74c7-6a20-720a-f200" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="6026-d507-935a-7200" type="selectionEntry"/>
+                <entryLink id="bc6a-5e8d-f7cd-f36a" name="Chainsword/Combat Blade" hidden="false" collective="false" import="true" targetId="4b1e-680b-1d39-e4f1" type="selectionEntry"/>
+                <entryLink id="87d2-7c6d-ff4d-afbd" name="Chainaxe" hidden="false" collective="false" import="true" targetId="4a8a-4994-c863-7723" type="selectionEntry"/>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="1530-2344-dc6f-ec85" name="All models may exchange Flamer for" hidden="false" collective="false" import="true" defaultSelectionEntryId="76eb-5ad7-4cb3-a73f">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="021f-860a-247b-5d91" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="26d2-468c-1638-c1e0" type="min"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="76eb-5ad7-4cb3-a73f" name="Flamer" hidden="false" collective="false" import="true" targetId="4cc6-e521-dc9a-c117" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="points" value="0.0"/>
+                  </modifiers>
+                </entryLink>
+                <entryLink id="bd11-e46c-f24d-27c9" name="Volkite Charger" hidden="false" collective="false" import="true" targetId="f0c0-384d-440f-c03b" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="points" value="0.0"/>
+                  </modifiers>
+                </entryLink>
+                <entryLink id="1e78-a09d-d26c-372d" name="Volkite Caliver" hidden="false" collective="false" import="true" targetId="d2de-62ef-b3e5-1f6d" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="increment" field="points" value="5.0">
+                      <repeats>
+                        <repeat field="selections" scope="c5ba-7647-23ba-c728" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                      </repeats>
+                    </modifier>
+                  </modifiers>
+                </entryLink>
+                <entryLink id="5608-0f2c-2ea7-9021" name="Graviton Gun" hidden="false" collective="false" import="true" targetId="8447-9662-22bd-5c6c" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="decrement" field="points" value="15.0"/>
+                    <modifier type="increment" field="points" value="5.0">
+                      <repeats>
+                        <repeat field="selections" scope="c5ba-7647-23ba-c728" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                      </repeats>
+                    </modifier>
+                  </modifiers>
+                </entryLink>
+                <entryLink id="e079-5f53-3821-f4a4" name="Meltagun" hidden="false" collective="false" import="true" targetId="a22d-ceac-5063-54e1" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="decrement" field="points" value="15.0"/>
+                    <modifier type="increment" field="points" value="10.0">
+                      <repeats>
+                        <repeat field="selections" scope="c5ba-7647-23ba-c728" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                      </repeats>
+                    </modifier>
+                  </modifiers>
+                </entryLink>
+                <entryLink id="dd1e-dbb9-a9b9-ad0d" name="Lascutter" hidden="false" collective="false" import="true" targetId="5fe0-432a-1edf-00a3" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="decrement" field="points" value="10.0"/>
+                    <modifier type="increment" field="points" value="5.0">
+                      <repeats>
+                        <repeat field="selections" scope="c5ba-7647-23ba-c728" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                      </repeats>
+                    </modifier>
+                  </modifiers>
+                </entryLink>
+                <entryLink id="53f9-2300-5bd4-4ad2" name="Plasma gun" hidden="false" collective="false" import="true" targetId="0f13-bded-1c10-bc38" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="decrement" field="points" value="15.0"/>
+                    <modifier type="increment" field="points" value="15.0">
+                      <repeats>
+                        <repeat field="selections" scope="c5ba-7647-23ba-c728" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                      </repeats>
+                    </modifier>
+                  </modifiers>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="4c3d-6dad-b735-1e0b" name="Sergeant&apos;s Weapons" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6462-558f-310b-ae91" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="adc3-5a9e-f3f4-f2ab" name="Exchange Bolt Pistol for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="e6b9-803f-f02e-242a">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6c4c-d3c4-4209-8ad6" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5de6-cd86-6c59-908a" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="e075-2c3e-824c-dc55" name="Lightning Claw" hidden="false" collective="false" import="true" targetId="26db-484d-3757-03c8" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="1e00-1171-f670-6fc4" name="Thunder Hammer" hidden="false" collective="false" import="true" targetId="925c-50d4-0101-e0e7" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="20.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="6c0a-fc55-4594-6f04" name="Power Fist" hidden="false" collective="false" import="true" targetId="fcef-f5ac-16a3-9401" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="15.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="2ea3-5b2d-b119-44ce" name="Power Axe" hidden="false" collective="false" import="true" targetId="7b92-ab87-86a1-ab2e" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6b7c-ab73-0d1e-1d0b" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="410f-8c76-d91f-db81" name="Power Lance" hidden="false" collective="false" import="true" targetId="233d-238b-6940-2740" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="db75-cb68-0787-3f34" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="84a7-b78b-a77e-9559" name="Power Maul" hidden="false" collective="false" import="true" targetId="e8a2-42e8-82a7-8dd9" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5272-e272-7e41-6ee7" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="f9ec-bb5b-d09a-aa42" name="Power Sword" hidden="false" collective="false" import="true" targetId="3e90-5ca1-8abe-0275" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6e20-602d-862b-c9cb" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="7e00-310e-55ff-5585" name="Phoenix Spear" hidden="false" collective="false" import="true" targetId="bca4-ae83-c058-2822" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="15.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="297a-d2aa-18eb-8fe3" name="Nostraman Chainglaive" hidden="false" collective="false" import="true" targetId="b6e5-70ca-8084-765d" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="5fc1-df2b-3625-7621" name="Power Scythe" hidden="false" collective="false" import="true" targetId="3410-908e-d98d-593d" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="15.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="9f27-5b77-d82d-2212" name="Calibanite War Blade" hidden="false" collective="false" import="true" targetId="5bc2-ceb4-2e34-7004" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="ea01-6cfd-df32-9789" name="Power Glaive" hidden="false" collective="false" import="true" targetId="fd9c-9193-2c50-e929" type="selectionEntry"/>
+                <entryLink id="719a-d91b-7989-a1aa" name="Raven&apos;s Talons" hidden="false" collective="false" import="true" targetId="d491-f3be-c649-cc6b" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="20.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="897e-a1ba-bdd7-15a6" name="Albian Power Gladius" hidden="false" collective="false" import="true" targetId="1b80-5b44-0e03-b9e4" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="15.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="0f2d-f7be-5cd8-f00d" name="Cthonian Culling Blade" hidden="false" collective="false" import="true" targetId="270a-0bb6-b354-6b75" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="15.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="ae6b-9b42-7cbb-c942" name="Tainted Weapon" hidden="false" collective="false" import="true" targetId="104d-2c15-b4b8-c299" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="e6b9-803f-f02e-242a" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="6026-d507-935a-7200" type="selectionEntry"/>
+                <entryLink id="a68c-c069-fc70-3d99" name="Hand Flamer" hidden="false" collective="false" import="true" targetId="8a98-53c5-6fab-b3a7" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="36b5-0019-9100-4000" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="7f46-4ddf-49c9-576d" name="Inferno Pistol " hidden="false" collective="false" import="true" targetId="13f8-6607-3525-4298" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="59f6-638d-8c1d-75dd" type="equalTo"/>
+                            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e2d7-e297-5b99-cbac" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="b595-6c6d-64e4-28f2" name="New EntryLink" hidden="false" collective="false" import="true" targetId="f832-f4b2-6aaf-ad83" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="55d2-9039-632c-f5a0" name="Volkite Serpenta" hidden="false" collective="false" import="true" targetId="ae27-c659-fffd-1561" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="2.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="d15f-43f7-ffba-ee11" name="Sergeant may take" hidden="false" collective="false" import="true">
+          <entryLinks>
+            <entryLink id="ea78-f457-c9fd-6ee5" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="c6b8-8b0b-8a31-6aa3" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0f73-5faf-f942-41a4" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="15.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="3865-125e-2f16-e71a" name="New EntryLink" hidden="false" collective="false" import="true" targetId="4c62-8983-4a1b-d1c6" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="c5ba-7647-23ba-c728" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d16c-d674-ac07-969c" type="atLeast"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </entryLink>
+            <entryLink id="9c07-9e6d-5c13-ecfc" name="Legion-specific upgrade:" hidden="false" collective="false" import="true" targetId="efe5-effa-a371-ae4e" type="selectionEntryGroup"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="313e-8843-0fe2-5f44" name="The squad can be equipped with one model with" hidden="false" collective="false" import="true">
+          <entryLinks>
+            <entryLink id="359f-17d8-5ec4-62cc" name="Nuncio-vox" hidden="false" collective="false" import="true" targetId="3b07-bf87-1e36-9181" type="selectionEntry"/>
+            <entryLink id="defb-cc6e-f5e2-747c" name="Vexilla, Legion" hidden="false" collective="false" import="true" targetId="accb-c5f0-45dc-1996" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="77c1-c5fe-bec6-a562" name="Dedicated Transport" hidden="false" collective="false" import="true">
+          <entryLinks>
+            <entryLink id="86e9-6bc6-2f3d-003d" name="Land Raider Proteus" hidden="false" collective="false" import="true" targetId="8107-4220-2d1b-c16f" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="points" value="65.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="accb-c5f0-45dc-1996" name="Vexilla, Legion" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="54f0-ac80-94a6-13ac" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="531f-dca2-318c-5baa" name="New InfoLink" hidden="false" targetId="d187-89fe-0b05-808e" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="d2de-62ef-b3e5-1f6d" name="Volkite Caliver" page="0" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ab9d-7295-9cc2-6f6b" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="52b3-9ba3-925f-393d" name="Volkite Caliver" hidden="false" targetId="626c-d79c-9bb7-3407" type="profile"/>
+        <infoLink id="9a52-4583-a506-3ece" name="Deflagrate" hidden="false" targetId="b46a-a3ec-91a5-5001" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="8107-4220-2d1b-c16f" name="Land Raider Proteus" publicationId="ca571888--pubN82424" page="0" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c541-f4e2-0f3c-bd28" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="801b-d9b1-3c9f-c40c" name="Land Raider Proteus" publicationId="ca571888--pubN67536" page="218" hidden="false" typeId="56656869636c6523232344415441232323" typeName="Vehicle">
+          <characteristics>
+            <characteristic name="BS" typeId="425323232344415441232323">4</characteristic>
+            <characteristic name="Front" typeId="46726f6e7423232344415441232323">14</characteristic>
+            <characteristic name="Side" typeId="5369646523232344415441232323">14</characteristic>
+            <characteristic name="Rear" typeId="5265617223232344415441232323">14</characteristic>
+            <characteristic name="HP" typeId="485023232344415441232323">4</characteristic>
+            <characteristic name="Type" typeId="5479706523232344415441232323">Vehicle (Tank, Transport)</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="0eb9-318c-5393-adb8" name="Land Raider Proteus (Transport)" publicationId="ca571888--pubN82424" page="52" hidden="false" typeId="307d-047f-ca13-706b" typeName="Transport">
+          <modifiers>
+            <modifier type="set" field="8285-4205-b6cd-8473" value="8">
+              <conditions>
+                <condition field="selections" scope="8107-4220-2d1b-c16f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="053d-eb88-3739-91fe" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="Capacity" typeId="8285-4205-b6cd-8473">10.</characteristic>
+            <characteristic name="Fire Points" typeId="b270-a7f9-22b2-3702">None.</characteristic>
+            <characteristic name="Access Points" typeId="d17b-0342-b1dc-b8e7">2. One on each side of the hull.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="c75f-24ea-770e-f00e" name="Machine Spirit" hidden="false" targetId="a4e8-8d27-18a5-4a96" type="rule"/>
+      </infoLinks>
+      <selectionEntries>
+        <selectionEntry id="053d-eb88-3739-91fe" name="Explorator Augury Web" page="0" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7b2a-05b5-1b53-6b97" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="baab-51ae-6d1c-66d9" name="Explorator Augury Web" hidden="false">
+              <description>At the start of the controlling player&apos;s turn, prior to any reserve rolls, declare which mode is being used - it remains until their next player turn.  Disruption Mode: the oppsoing player suffers -1 to their reserve rolls.  Relay Mode: Owning player&apos;s reserve rolls may be re-rolled, whether successful or not.  Reduces transport capacity to 8.</description>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="a5ed-98e7-a141-0e41" name="New InfoLink" hidden="false" targetId="9b30-1da3-eb8d-ce7a" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="50.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="43f9-2fa1-9b1a-0c6b" name="Legion-specific upgrade" hidden="false" collective="false" import="true">
+          <entryLinks>
+            <entryLink id="e6ef-542d-a1dc-578b" name="Chem-munitions" hidden="false" collective="false" import="true" targetId="b432-5750-528f-98f3" type="selectionEntry"/>
+            <entryLink id="2066-028f-afc6-b42b" name="Shrapnel Bolts" hidden="false" collective="false" import="true" targetId="4c19-2579-80d0-6490" type="selectionEntry"/>
+            <entryLink id="ea06-a037-3e72-23ca" name="Blessed Autosimulacra" hidden="false" collective="false" import="true" targetId="586c-391b-172f-6e2a" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="d60a-6a09-41a5-573c" name="May take any of the following:" hidden="false" collective="false" import="true">
+          <entryLinks>
+            <entryLink id="1126-cf3e-c2c9-e89a" name="Extra Armour" hidden="false" collective="false" import="true" targetId="a6cd-f04b-711e-c083" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="points" value="0.0">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="607f-5517-b4b7-6e46" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </entryLink>
+            <entryLink id="99b4-8b63-bfd4-ab77" name="Hunter-killer Missile" hidden="false" collective="false" import="true" targetId="2276-994b-8721-ac3d" type="selectionEntry"/>
+            <entryLink id="bc2e-f16e-6b72-b08a" name="Dozer Blade" hidden="false" collective="false" import="true" targetId="2b1e-4478-2200-10b8" type="selectionEntry"/>
+            <entryLink id="d336-eb35-318c-8332" name="Armoured Ceramite" hidden="false" collective="false" import="true" targetId="eef6-a613-e479-7274" type="selectionEntry"/>
+            <entryLink id="5287-2638-7176-5847" name="Auxiliary Drive" hidden="false" collective="false" import="true" targetId="4cc7-2161-170d-16ba" type="selectionEntry"/>
+            <entryLink id="a14a-4098-d181-78b9" name="Frag Assault Launchers" hidden="false" collective="false" import="true" targetId="74a6-8330-48b9-049d" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="e6d9-cc02-f583-a630" name="May take a Hull-mounted:" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="edee-f036-7e8a-adf7" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="bb47-e7c6-c462-dd9e" name="Twin-linked Iliastus Pattern Assault Cannon" hidden="false" collective="false" import="true" targetId="9bad-ecc1-c521-136d" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="points" value="35"/>
+                <modifier type="set" field="name" value="Hull-Mounted Twin-Linked Iliastus Assault Cannon"/>
+              </modifiers>
+            </entryLink>
+            <entryLink id="8e96-907e-1d68-bef6" name="Twin-linked Heavy Bolter" hidden="false" collective="false" import="true" targetId="1a63-1b4b-0a42-d511" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="name" value="Hull-Mounted Twin-Linked Heavy Bolter"/>
+              </modifiers>
+              <costs>
+                <cost name="pts" typeId="points" value="20.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="3d15-a91e-a53f-f4ac" name="Twin-linked Heavy Flamer" hidden="false" collective="false" import="true" targetId="8ad4-5065-9a78-66f4" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="points" value="20.0"/>
+                <modifier type="set" field="name" value="Hull-Mounted Twin-Linked Heavy Flamer"/>
+              </modifiers>
+            </entryLink>
+            <entryLink id="3cbd-f08f-dae7-7809" name="Twin-linked Lascannon" hidden="false" collective="false" import="true" targetId="22ce-9b78-54de-af31" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="points" value="30"/>
+                <modifier type="set" field="name" value="Hull-Mounted Twin-Linked Lascannon"/>
+              </modifiers>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="3405-4b66-a998-e97b" name="Psyarkana" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6cc0-fbac-38b4-5ae0" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="6ed1-38e7-65ca-923b" name="Armatus Necrotechnica" hidden="false" collective="false" import="true" targetId="e78c-d1a1-c20f-dae8" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false"/>
+              </modifiers>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="2b93-413d-1099-a974" name="Searchlight and Smoke Launchers" hidden="false" collective="false" import="true" targetId="7562-9af8-67f3-2533" type="selectionEntry"/>
+        <entryLink id="293d-2a12-151f-eab7" name="May take a Pintle-Mounted Weapon:" hidden="false" collective="false" import="true" targetId="04d3-346a-f264-9573" type="selectionEntryGroup"/>
+        <entryLink id="d805-e86f-4734-c651" name="Twin-linked Lascannon" hidden="false" collective="false" import="true" targetId="22ce-9b78-54de-af31" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="37f6-6d2a-2af9-de57" value="2.0"/>
+            <modifier type="set" field="37f6-6d2a-2af9-de57" value="2.0"/>
+            <modifier type="append" field="name" value="Sponsons"/>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="30f8-c252-116c-fe55" type="min"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="180.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="8ad4-5065-9a78-66f4" name="Twin-linked Heavy Flamer" page="0" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d5bc-b2d4-365c-508c" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="c486-02aa-198e-3117" name="Twin-Linked Heavy Flamer" hidden="false" targetId="b55d-dcfd-d708-8149" type="profile"/>
+        <infoLink id="435e-ed08-b8e2-c799" name="Twin-linked" hidden="false" targetId="10a8-8d89-0bec-3e21" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9bad-ecc1-c521-136d" name="Twin-linked Iliastus Pattern Assault Cannon" page="0" hidden="false" collective="false" import="true" type="upgrade">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="59f6-638d-8c1d-75dd" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7a64-cfea-6200-8feb" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="7559-3561-35b1-009b" name="Twin-linked Iliastus Pattern Assault Cannon" publicationId="ca571888--pubN67459" page="97" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="52616e676523232344415441232323">24&quot;</characteristic>
+            <characteristic name="Strength" typeId="537472656e67746823232344415441232323">6</characteristic>
+            <characteristic name="AP" typeId="415023232344415441232323">4</characteristic>
+            <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 4, Rending, Malfunction</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="f78b-8b2d-0b59-2dcc" name="Malfunction" publicationId="ca571888--pubN67459" page="97" hidden="false">
+          <description>When rolling to hit, if three or more results of &quot;1&quot; are rolled, a malfunction has occured and the weapon may not be used for the rest of the game.</description>
+        </rule>
+      </rules>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="74a6-8330-48b9-049d" name="Frag Assault Launchers" page="0" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d926-c104-30eb-8a33" type="max"/>
+      </constraints>
+      <rules>
+        <rule id="27ae-8d00-4dc9-abb1" name="Frag Assault Launchers" publicationId="ca571888--pubN82424" page="125" hidden="false">
+          <description>Any unit charging into close combat on the same turn it disembarks from a transport vehicle equipped with frag assault launchers counts as having frag grenades.</description>
+        </rule>
+      </rules>
+      <costs>
+        <cost name="pts" typeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4a79-b52c-8dcf-ec72" name="Boarding Shield" page="0" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="cc58-bbf7-95a5-9cca" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="ca98-c2de-c3b8-128a" name="Boarding Shield" publicationId="ca571888--pubN82424" page="89" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
+          <characteristics>
+            <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Confers 6+ invulnverable save, increasing to a 5+ in close combat.  User is treated as having defensive grenades, but may never claim the extra attack for being armed with an additional close combat weapon.  </characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="34da-0cfb-85e5-1573" name="XIIth Legion Triarii Breacher Squad" publicationId="0e6e-8c19-c436-39c4" page="" hidden="true" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3d14-4976-b582-a736" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <rules>
+        <rule id="0ddf-ef5e-837c-efd2" name="Restricted" hidden="false">
+          <description>A detachment must have more Breacher (or Phalanx Warder or Medusan Immortal) Squads than Breacher Support Squads.</description>
+        </rule>
+        <rule id="628c-641a-56e8-319d" name="Triarii Breachers" hidden="false">
+          <description>Triarii Breacher Squads may be taken in place of Breacher Squads and/or Breacher Support Squads in a Legion Breacher Company. In this case, Triarii become Troops choices.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="da4b-c6d6-e0d2-ae86" name="Support Squad" hidden="false" targetId="2c16-3b25-a714-a656" type="rule"/>
+        <infoLink id="fb72-5f02-3f37-8fd5" name="Hardened Armour" hidden="false" targetId="7439f6fd-4c50-f88a-eb41-81d9b9c9eed8" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="7fb4-6a2f-3b0f-14a4" name="Infantry" hidden="false" targetId="1ab3-f1ac-f724-8544" primary="false"/>
+        <categoryLink id="297d-5fbd-a827-c98f" name="Legiones Astartes" hidden="false" targetId="f321-f2d7-7d68-8f93" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="7c16-9d68-7d62-7a51" name="Triarii Breacher" page="0" hidden="false" collective="false" import="true" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="560d-4db2-3cdb-360f" type="min"/>
+            <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f266-376c-48af-3403" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="3c5a-e70c-b449-b4ea" name="Triarii Breacher" publicationId="0e6e-8c19-c436-39c4" page="" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+              <characteristics>
+                <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry</characteristic>
+                <characteristic name="WS" typeId="575323232344415441232323">4</characteristic>
+                <characteristic name="BS" typeId="425323232344415441232323">4</characteristic>
+                <characteristic name="S" typeId="5323232344415441232323">4</characteristic>
+                <characteristic name="T" typeId="5423232344415441232323">4</characteristic>
+                <characteristic name="W" typeId="5723232344415441232323">1</characteristic>
+                <characteristic name="I" typeId="4923232344415441232323">4</characteristic>
+                <characteristic name="A" typeId="4123232344415441232323">1</characteristic>
+                <characteristic name="LD" typeId="4c4423232344415441232323">8</characteristic>
+                <characteristic name="Save" typeId="5361766523232344415441232323">3+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="15.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="514d-0d2c-1332-3c40" name="Standard Wargear" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f03f-1bf9-4e65-a6d4" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b4cd-85b5-c96b-0bd2" type="min"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="bc82-e31d-64cf-400a" name="Frag and Krak Grenades" hidden="false" collective="false" import="true" targetId="0a53-b471-df87-7b83" type="selectionEntry"/>
+            <entryLink id="f6a0-2b09-957a-bc41" name="New EntryLink" hidden="false" collective="false" import="true" targetId="0a96-04b6-7340-91a4" type="selectionEntry"/>
+            <entryLink id="3438-c6da-3113-dfd9" name="Boarding Shield" hidden="false" collective="false" import="true" targetId="4a79-b52c-8dcf-ec72" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8991-699f-a9cd-234d" type="min"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="8a23-d033-c09f-c179" name="Bolt Pistols" hidden="false" collective="false" import="true" targetId="fe8d-1baa-d58d-00bc" type="selectionEntry"/>
+            <entryLink id="1eb9-4cb2-95ba-96c0" name="Chainaxe" hidden="false" collective="false" import="true" targetId="4a8a-4994-c863-7723" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d6b6-e6ba-ea7a-c8b6" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ea3e-7eb8-8c5c-1648" type="min"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="f828-1e5b-274d-bfe9" name="Triarii Breacher Sergeant" hidden="false" collective="false" import="true" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="026c-84e2-5199-b678" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6632-f0ac-4e12-72fe" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="08a3-59be-9fdf-b2ff" name="Triarii Breacher Sergeant" publicationId="0e6e-8c19-c436-39c4" page="" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+              <modifiers>
+                <modifier type="set" field="5361766523232344415441232323" value="2+">
+                  <conditions>
+                    <condition field="selections" scope="34da-0cfb-85e5-1573" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d12f-3b38-15cc-f0d0" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <characteristics>
+                <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry (Character)</characteristic>
+                <characteristic name="WS" typeId="575323232344415441232323">4</characteristic>
+                <characteristic name="BS" typeId="425323232344415441232323">4</characteristic>
+                <characteristic name="S" typeId="5323232344415441232323">4</characteristic>
+                <characteristic name="T" typeId="5423232344415441232323">4</characteristic>
+                <characteristic name="W" typeId="5723232344415441232323">1</characteristic>
+                <characteristic name="I" typeId="4923232344415441232323">4</characteristic>
+                <characteristic name="A" typeId="4123232344415441232323">2</characteristic>
+                <characteristic name="LD" typeId="4c4423232344415441232323">9</characteristic>
+                <characteristic name="Save" typeId="5361766523232344415441232323">3+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <categoryLinks>
+            <categoryLink id="346f-59f6-8cde-d3b2" name="Character" hidden="false" targetId="ae54-92c7-3e66-59f7" primary="false"/>
+          </categoryLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="2446-4141-5353-5de0" name="All models may take:" hidden="false" collective="false" import="true">
+          <entryLinks>
+            <entryLink id="7e67-7958-d718-25f7" name="Melta Bombs" hidden="false" collective="false" import="true" targetId="4c62-8983-4a1b-d1c6" type="selectionEntry">
+              <modifiers>
+                <modifier type="increment" field="points" value="5.0">
+                  <repeats>
+                    <repeat field="selections" scope="34da-0cfb-85e5-1573" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c16-9d68-7d62-7a51" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="2cc2-533d-156b-3d81" name="Sergeant&apos;s Weapons" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="da14-dfda-8457-bd9d" type="max"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d628-c5c4-5e5b-20cc" type="min"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="77f2-ab65-7755-f59c" name="Exchange Bolt Pistol for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="53f1-d577-2aab-fe67">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1350-0d0b-d4b5-14a7" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="815b-f714-5ea8-ffa3" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="53f1-d577-2aab-fe67" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="6026-d507-935a-7200" type="selectionEntry"/>
+                <entryLink id="d950-e711-1f38-f4f0" name="Hand Flamer" hidden="false" collective="false" import="true" targetId="8a98-53c5-6fab-b3a7" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2d6d-eebf-d35f-a8e2" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="8ff2-bac0-df37-dcb1" name="New EntryLink" hidden="false" collective="false" import="true" targetId="f832-f4b2-6aaf-ad83" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="ec57-9fce-8d15-e4a7" name="Volkite Serpenta" hidden="false" collective="false" import="true" targetId="ae27-c659-fffd-1561" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="2.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="6676-43a8-6cc5-44e2" name="Exchange Chainaxe for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="b2ec-886f-1bdd-852c">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4d04-9530-9a9d-ce9b" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ebb-85d3-ccc7-9070" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="1922-4715-7ed1-9535" name="Lightning Claw" hidden="false" collective="false" import="true" targetId="26db-484d-3757-03c8" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="7018-6757-bf08-e9df" name="Thunder Hammer" hidden="false" collective="false" import="true" targetId="925c-50d4-0101-e0e7" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="20.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="4bc8-795f-4c92-2453" name="Power Fist" hidden="false" collective="false" import="true" targetId="fcef-f5ac-16a3-9401" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="15.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="25a1-f19d-6532-b45f" name="Power Axe" hidden="false" collective="false" import="true" targetId="7b92-ab87-86a1-ab2e" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="de22-3ee0-9524-2a3f" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="ed91-94f9-97d0-ffe5" name="Power Lance" hidden="false" collective="false" import="true" targetId="233d-238b-6940-2740" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3701-8f05-af73-05c8" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="2043-dccb-0771-13e7" name="Power Maul" hidden="false" collective="false" import="true" targetId="e8a2-42e8-82a7-8dd9" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b006-7f00-67f5-29c4" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="d69b-91d2-1d3e-7eed" name="Power Sword" hidden="false" collective="false" import="true" targetId="3e90-5ca1-8abe-0275" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e2cb-77be-d0a0-cf7a" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="b2ec-886f-1bdd-852c" name="Chainaxe" hidden="false" collective="false" import="true" targetId="4a8a-4994-c863-7723" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9ca7-6002-80dd-aacb" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="adc1-a774-2410-62d4" name="Sergeant may take" hidden="false" collective="false" import="true">
+          <entryLinks>
+            <entryLink id="d12f-3b38-15cc-f0d0" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="c6b8-8b0b-8a31-6aa3" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b14a-53da-204e-f718" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="15.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="d855-6cee-4e68-54e6" name="New EntryLink" hidden="false" collective="false" import="true" targetId="4c62-8983-4a1b-d1c6" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="34da-0cfb-85e5-1573" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7e67-7958-d718-25f7" type="atLeast"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </entryLink>
+            <entryLink id="5736-bae1-fb4a-9a3d" name="Legion-specific upgrade:" hidden="false" collective="false" import="true" targetId="efe5-effa-a371-ae4e" type="selectionEntryGroup"/>
+            <entryLink id="e068-b471-6c38-61ac" name="Breaching Charge" hidden="false" collective="false" import="true" targetId="0267-083e-86de-3c0f" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7c04-140d-c242-c89b" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="7a39-edff-b84a-7ff5" name="The squad can be equipped with one model with" hidden="false" collective="false" import="true">
+          <entryLinks>
+            <entryLink id="6661-1f31-1a0e-ff25" name="Nuncio-vox" hidden="false" collective="false" import="true" targetId="3b07-bf87-1e36-9181" type="selectionEntry"/>
+            <entryLink id="ac01-2fd7-8454-3297" name="Vexilla, Legion" hidden="false" collective="false" import="true" targetId="accb-c5f0-45dc-1996" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="120e-0893-9033-2001" name="Dedicated Transport" hidden="false" collective="false" import="true">
+          <entryLinks>
+            <entryLink id="c276-5c38-5bf4-de29" name="Land Raider Proteus" hidden="false" collective="false" import="true" targetId="8107-4220-2d1b-c16f" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="55bb-7c13-784f-301b" name="For every 5 models in the squad, one can exchange their Chainaxe for a:" hidden="false" collective="false" import="true">
+          <modifiers>
+            <modifier type="increment" field="6887-dc3d-d600-3f95" value="1.0">
+              <repeats>
+                <repeat field="selections" scope="34da-0cfb-85e5-1573" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6887-dc3d-d600-3f95" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="c9a8-6ed4-bac7-37b8" name="Meltagun" hidden="false" collective="false" import="true" targetId="a22d-ceac-5063-54e1" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="c23b-b876-e683-4f04" value="4.0"/>
+              </modifiers>
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="cfe9-bd31-fb5a-037d" name="Plasma gun" hidden="false" collective="false" import="true" targetId="0f13-bded-1c10-bc38" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="5f3e-444b-2315-5e66" value="4.0"/>
+              </modifiers>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="points" value="65.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0183-7594-8997-5b90" name="Sky Stalker Jetbike Squad on Bullock Jetcycles, Legion" publicationId="0e6e-8c19-c436-39c4" page="" hidden="false" collective="false" import="true" type="unit">
+      <infoLinks>
+        <infoLink id="b93e-41b3-712a-db1e" name="New InfoLink" hidden="false" targetId="d219-2314-4834-c054" type="rule"/>
+        <infoLink id="d11e-89a3-2adb-8d2e" name="Space Marine Jetbike" hidden="false" targetId="3c28-4994-00ed-bbe5" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="8387-a844-6a96-2025" name="Jetbike" hidden="false" targetId="d45f-b4ad-cc22-c7be" primary="false"/>
+        <categoryLink id="274f-34c3-e948-ecab" name="Legiones Astartes" hidden="false" targetId="f321-f2d7-7d68-8f93" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="4e0d-cc93-1794-90c0" name="Space Marine Sky Stalker on Bullock Jetcycle" page="0" hidden="false" collective="false" import="true" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a6d1-3f26-7b0c-3c73" type="min"/>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7a1f-455e-d7e5-5d93" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="f771-7b78-bf2b-6901" name="Sky Stalker on Bullock Jetcycle" publicationId="ca571888--pubN82424" page="51" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+              <characteristics>
+                <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Jetbike</characteristic>
+                <characteristic name="WS" typeId="575323232344415441232323">4</characteristic>
+                <characteristic name="BS" typeId="425323232344415441232323">4</characteristic>
+                <characteristic name="S" typeId="5323232344415441232323">4</characteristic>
+                <characteristic name="T" typeId="5423232344415441232323">5</characteristic>
+                <characteristic name="W" typeId="5723232344415441232323">1</characteristic>
+                <characteristic name="I" typeId="4923232344415441232323">4</characteristic>
+                <characteristic name="A" typeId="4123232344415441232323">1</characteristic>
+                <characteristic name="LD" typeId="4c4423232344415441232323">8</characteristic>
+                <characteristic name="Save" typeId="5361766523232344415441232323">3+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="25.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="8408-73f3-fee7-fe10" name="Sky Hunter Sergeant on Bullock Jetcycle" page="0" hidden="false" collective="false" import="true" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9a70-a6fa-3a9f-57ec" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9687-7be5-ea97-7af3" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="5209-b09f-a1f9-daef" name="Sky Stalker Sergeant on Bullock Jetcycle" publicationId="ca571888--pubN82424" page="51" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+              <characteristics>
+                <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Jetbike</characteristic>
+                <characteristic name="WS" typeId="575323232344415441232323">4</characteristic>
+                <characteristic name="BS" typeId="425323232344415441232323">4</characteristic>
+                <characteristic name="S" typeId="5323232344415441232323">4</characteristic>
+                <characteristic name="T" typeId="5423232344415441232323">5</characteristic>
+                <characteristic name="W" typeId="5723232344415441232323">1</characteristic>
+                <characteristic name="I" typeId="4923232344415441232323">4</characteristic>
+                <characteristic name="A" typeId="4123232344415441232323">2</characteristic>
+                <characteristic name="LD" typeId="4c4423232344415441232323">9</characteristic>
+                <characteristic name="Save" typeId="5361766523232344415441232323">3+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="15.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="d21a-0574-d321-fc73" name="Standard Wargear" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="468a-fb39-325b-ea10" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8ade-2af0-904d-cde7" type="min"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="0df6-f6b4-7491-840c" name="New EntryLink" hidden="false" collective="false" import="true" targetId="0a96-04b6-7340-91a4" type="selectionEntry"/>
+            <entryLink id="94f2-1a1a-44e7-6afa" name="New EntryLink" hidden="false" collective="false" import="true" targetId="0a53-b471-df87-7b83" type="selectionEntry"/>
+            <entryLink id="e4c4-0505-3920-0975" name="New EntryLink" hidden="false" collective="false" import="true" targetId="fe8d-1baa-d58d-00bc" type="selectionEntry"/>
+            <entryLink id="cd5d-9c1b-9e9c-d2c7" name="Chainswords/Combat Blades" hidden="false" collective="false" import="true" targetId="1087-66c1-c342-9cdc" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cd42-bde2-77c9-bad2" type="min"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="a0bf-370b-a831-3d9d" name="Legion-specific upgrades:" hidden="false" collective="false" import="true">
+          <entryLinks>
+            <entryLink id="0ab0-9bbd-ea05-cdfd" name="Molecular Acid Shells" hidden="true" collective="false" import="true" targetId="82fb-0eed-d1da-4dc5" type="selectionEntry">
+              <modifiers>
+                <modifier type="increment" field="ba38-696f-1a46-b052" value="1.0">
+                  <repeats>
+                    <repeat field="selections" scope="0183-7594-8997-5b90" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+                <modifier type="decrement" field="ba38-696f-1a46-b052" value="1.0"/>
+                <modifier type="set" field="hidden" value="false">
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="0183-7594-8997-5b90" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1908-2f79-4a60-17ef" type="equalTo"/>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1445-c8d0-6c21-9c6a" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+            </entryLink>
+            <entryLink id="ba43-39ac-9565-6bba" name="Trophies of Judgement (Character)" hidden="false" collective="false" import="true" targetId="08f5-92aa-cd97-91cc" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2732-8ccb-cc97-ee5d" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </entryLink>
+            <entryLink id="71ca-d857-e67e-7ae7" name="Chem-munitions" hidden="false" collective="false" import="true" targetId="b432-5750-528f-98f3" type="selectionEntry"/>
+            <entryLink id="2862-875b-9ee4-a8f4" name="Shrapnel Bolts" hidden="false" collective="false" import="true" targetId="4c19-2579-80d0-6490" type="selectionEntry"/>
+            <entryLink id="b39d-01b1-6475-ab0a" name="Cult Arcana" hidden="false" collective="false" import="true" targetId="52df-ddc4-325b-ec5a" type="selectionEntryGroup"/>
+            <entryLink id="dc5b-c197-f992-fb0a" name="Sonic Shriekers" hidden="false" collective="false" import="true" targetId="45cd-edae-7a23-95c6" type="selectionEntry">
+              <modifiers>
+                <modifier type="increment" field="points" value="2.0">
+                  <repeats>
+                    <repeat field="selections" scope="0183-7594-8997-5b90" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e691-ca90-8d84-e998" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="decrement" field="points" value="5.0"/>
+              </modifiers>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="962f-4008-a4e6-e3b1" name="All members of the squad can equip their Bullock Jetcycles with:" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5e42-985f-a169-c9e3" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="ce78-c5c6-0861-54b9" name="Twin-linked Plasma Gun" hidden="false" collective="false" import="true" targetId="a4c9-c943-a1e1-324e" type="selectionEntry">
+              <modifiers>
+                <modifier type="increment" field="points" value="20.0">
+                  <repeats>
+                    <repeat field="selections" scope="0183-7594-8997-5b90" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+            </entryLink>
+            <entryLink id="bdec-6c1d-67ba-b7f3" name="Hurricane Bolter" hidden="false" collective="false" import="true" targetId="bfa7-fc02-60e9-c200" type="selectionEntry">
+              <modifiers>
+                <modifier type="increment" field="points" value="5.0">
+                  <repeats>
+                    <repeat field="selections" scope="0183-7594-8997-5b90" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2666-a661-db6b-7b5a" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="1908-2f79-4a60-17ef" name="Heavy Bolter" hidden="false" collective="false" import="true" targetId="a161-76b3-9ef1-da7b" type="selectionEntry">
+              <modifiers>
+                <modifier type="increment" field="points" value="10.0">
+                  <repeats>
+                    <repeat field="selections" scope="0183-7594-8997-5b90" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c351-1a94-e683-1637" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="2673-baf8-e9e9-6081" name="Twin-linked Grenade Launcher" hidden="false" collective="false" import="true" targetId="0a8e-da3f-59da-dc04" type="selectionEntry">
+              <modifiers>
+                <modifier type="increment" field="points" value="8.0">
+                  <repeats>
+                    <repeat field="selections" scope="0183-7594-8997-5b90" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+            </entryLink>
+            <entryLink id="bbd2-b3b2-85d7-d0b7" name="Twin-linked Bolter" hidden="false" collective="false" import="true" targetId="eaec-b433-8e4d-1da5" type="selectionEntry">
+              <modifiers>
+                <modifier type="increment" field="points" value="1.0">
+                  <repeats>
+                    <repeat field="selections" scope="0183-7594-8997-5b90" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+            </entryLink>
+            <entryLink id="ad0e-88e1-2e1c-e8ef" name="Heavy Flamer" hidden="true" collective="false" import="true" targetId="ead9-305c-a7e7-323e" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e2d7-e297-5b99-cbac" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="points" value="10.0">
+                  <repeats>
+                    <repeat field="selections" scope="0183-7594-8997-5b90" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="2de5-8427-10a2-a1ac" name="All members may be equipped wit:" hidden="false" collective="false" import="true">
+          <entryLinks>
+            <entryLink id="5482-ffef-15a7-68fc" name="New EntryLink" hidden="false" collective="false" import="true" targetId="4c62-8983-4a1b-d1c6" type="selectionEntry">
+              <modifiers>
+                <modifier type="increment" field="points" value="5.0">
+                  <repeats>
+                    <repeat field="selections" scope="0183-7594-8997-5b90" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4e0d-cc93-1794-90c0" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="e2d0-8736-7f02-9d64" name="Any model may exchange their Chainsword for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="6d69-00a6-c7f7-3179">
+          <modifiers>
+            <modifier type="increment" field="0df8-43e6-ebab-5f24" value="1.0">
+              <repeats>
+                <repeat field="selections" scope="0183-7594-8997-5b90" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4e0d-cc93-1794-90c0" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+            <modifier type="increment" field="4541-062a-7d22-ac20" value="1.0">
+              <repeats>
+                <repeat field="selections" scope="0183-7594-8997-5b90" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4e0d-cc93-1794-90c0" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4541-062a-7d22-ac20" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0df8-43e6-ebab-5f24" type="min"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="6d69-00a6-c7f7-3179" name="Chainsword/Combat Blade" hidden="false" collective="false" import="true" targetId="4b1e-680b-1d39-e4f1" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="2adf-e0a8-708b-592c" value="9.0"/>
+              </modifiers>
+            </entryLink>
+            <entryLink id="d15e-9960-3a03-4936" name="Chainaxe" hidden="false" collective="false" import="true" targetId="4a8a-4994-c863-7723" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="32e0-d3ad-3121-712a" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="9cdf-7ec2-4d4e-feb7" name="Power Axe" hidden="false" collective="false" import="true" targetId="7b92-ab87-86a1-ab2e" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8319-e54a-423d-7641" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="ee88-7a68-273e-3841" name="Power Lance" hidden="false" collective="false" import="true" targetId="233d-238b-6940-2740" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f23f-4266-67df-79b6" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="31aa-e512-8562-e48a" name="Power Maul" hidden="false" collective="false" import="true" targetId="e8a2-42e8-82a7-8dd9" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1f21-f507-5a0b-f9e0" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="b899-56bc-ca0c-4b15" name="Power Sword" hidden="false" collective="false" import="true" targetId="3e90-5ca1-8abe-0275" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4862-1764-3ee3-330b" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="6cdf-b78d-ce25-4cbe" name="Sergeant may exchange Bolt Pistol and/or Chainsword for:" hidden="false" collective="false" import="true">
+          <modifiers>
+            <modifier type="set" field="fe6a-3b32-06c3-94a9" value="1.0">
+              <conditions>
+                <condition field="selections" scope="0183-7594-8997-5b90" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2f7a-809e-287b-fa65" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="ac9b-4054-5897-8a1d" value="1.0">
+              <conditions>
+                <condition field="selections" scope="0183-7594-8997-5b90" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2f7a-809e-287b-fa65" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fe6a-3b32-06c3-94a9" type="max"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ac9b-4054-5897-8a1d" type="min"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="f2ca-644a-2f5e-f684" name="New EntryLink" hidden="false" collective="false" import="true" targetId="f832-f4b2-6aaf-ad83" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="600f-e4b7-e871-b01d" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="cfd4-55df-e09e-df0c" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="6026-d507-935a-7200" type="selectionEntry"/>
+            <entryLink id="ad65-bb7b-9ca7-5068" name="Chainsword/Combat Blade" hidden="false" collective="false" import="true" targetId="4b1e-680b-1d39-e4f1" type="selectionEntry"/>
+            <entryLink id="5958-20cd-9c70-d49b" name="Hand Flamer" hidden="false" collective="false" import="true" targetId="8a98-53c5-6fab-b3a7" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5137-bf67-163f-801a" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="fc62-930d-6d7b-714f" name="Inferno Pistol " hidden="false" collective="false" import="true" targetId="13f8-6607-3525-4298" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="59f6-638d-8c1d-75dd" type="equalTo"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e2d7-e297-5b99-cbac" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+                <modifier type="set" field="ccce-cd4b-c78d-16d1" value="2.0"/>
+              </modifiers>
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="969d-060e-5da3-9424" name="Volkite Serpenta" hidden="false" collective="false" import="true" targetId="ae27-c659-fffd-1561" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="e51d-cf89-f58a-6004" value="1.0"/>
+              </modifiers>
+              <costs>
+                <cost name="pts" typeId="points" value="2.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="6c3a-ac72-057e-bfb9" name="Albian Power Gladius" hidden="false" collective="false" import="true" targetId="1b80-5b44-0e03-b9e4" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="ccfb-6afc-2a35-2498" value="2.0"/>
+              </modifiers>
+              <costs>
+                <cost name="pts" typeId="points" value="15.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="eac4-98f0-7774-3f7a" name="Calibanite War Blade" hidden="false" collective="false" import="true" targetId="5bc2-ceb4-2e34-7004" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="7252-254f-2165-a459" value="2.0"/>
+              </modifiers>
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="b212-8cde-63f3-5e19" name="Cthonian Culling Blade" hidden="false" collective="false" import="true" targetId="270a-0bb6-b354-6b75" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="6780-81e2-601f-a7bd" value="2.0"/>
+              </modifiers>
+              <costs>
+                <cost name="pts" typeId="points" value="15.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="a605-dc61-1620-f609" name="Lightning Claw" hidden="false" collective="false" import="true" targetId="26db-484d-3757-03c8" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="b2ab-5b47-b382-d02f" value="2.0"/>
+              </modifiers>
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="581c-2c62-b9a3-eaac" name="Nostraman Chainglaive" hidden="false" collective="false" import="true" targetId="b6e5-70ca-8084-765d" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="15c3-7b4b-538e-2506" name="Phoenix Spear" hidden="false" collective="false" import="true" targetId="bca4-ae83-c058-2822" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="points" value="15.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="0f45-6ca7-c100-339b" name="Power Axe" hidden="false" collective="false" import="true" targetId="7b92-ab87-86a1-ab2e" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c2a8-fd88-4ea0-2c13" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="ffd4-344c-bfc4-72f2" name="Power Fist" hidden="false" collective="false" import="true" targetId="fcef-f5ac-16a3-9401" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="08c8-6244-a2d6-50a0" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="15.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="444b-70d4-607b-d00c" name="Power Glaive" hidden="false" collective="false" import="true" targetId="fd9c-9193-2c50-e929" type="selectionEntry"/>
+            <entryLink id="7147-04cb-19bb-c38f" name="Power Lance" hidden="false" collective="false" import="true" targetId="233d-238b-6940-2740" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c9b3-349d-cbaa-3b6e" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="02c5-1ff5-cbaf-da5b" name="Power Maul" hidden="false" collective="false" import="true" targetId="e8a2-42e8-82a7-8dd9" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="99b4-c3ec-e04d-86d6" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="a306-3e26-3ccd-7535" name="Power Scythe" hidden="false" collective="false" import="true" targetId="3410-908e-d98d-593d" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="points" value="15.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="bfed-95bf-dc12-ff84" name="Power Sword" hidden="false" collective="false" import="true" targetId="3e90-5ca1-8abe-0275" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d38b-0aa3-93fd-df73" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="cd8f-4deb-346e-3274" name="Raven&apos;s Talons" hidden="false" collective="false" import="true" targetId="d491-f3be-c649-cc6b" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="50ed-2ebb-cfe1-eda6" value="1.0"/>
+              </modifiers>
+              <costs>
+                <cost name="pts" typeId="points" value="20.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="886f-17e0-260d-61e0" name="Tainted Weapon" hidden="false" collective="false" import="true" targetId="104d-2c15-b4b8-c299" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="b3ba-7370-7a61-aa33" value="2.0"/>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af20-6f26-4db2-eae5" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="dc5d-665b-d780-3c36" name="Thunder Hammer" hidden="false" collective="false" import="true" targetId="925c-50d4-0101-e0e7" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="b12c-09c9-fd19-2a1d" value="1.0"/>
+              </modifiers>
+              <costs>
+                <cost name="pts" typeId="points" value="20.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="2f7a-809e-287b-fa65" name="Pair of Raven&apos;s Talons" hidden="false" collective="false" import="true" targetId="a8e8-37e5-3b8e-ccef" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="points" value="30.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="points" value="50.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a4c9-c943-a1e1-324e" name="Twin-linked Plasma Gun" publicationId="ca571888--pubN82424" page="" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="086c-97b6-8474-83a3" name="Twin-linked Plasma Gun" publicationId="ca571888--pubN106502" page="" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="52616e676523232344415441232323">24&quot;</characteristic>
+            <characteristic name="Strength" typeId="537472656e67746823232344415441232323">7</characteristic>
+            <characteristic name="AP" typeId="415023232344415441232323">2</characteristic>
+            <characteristic name="Type" typeId="5479706523232344415441232323">Rapid Fire, Gets Hot, Twin-linked</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="c583-59c8-cad9-f209" name="Twin-linked" hidden="false" targetId="10a8-8d89-0bec-3e21" type="rule"/>
+        <infoLink id="0678-f3c3-a5db-39da" name="Gets Hot" hidden="false" targetId="f4fd-d519-4769-5510" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="bfa7-fc02-60e9-c200" name="Hurricane Bolter" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="c976-8bb0-93ee-d56a" name="Hurricane Bolter" publicationId="0e6e-8c19-c436-39c4" page="" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="52616e676523232344415441232323">24&quot;</characteristic>
+            <characteristic name="Strength" typeId="537472656e67746823232344415441232323">4</characteristic>
+            <characteristic name="AP" typeId="415023232344415441232323">5</characteristic>
+            <characteristic name="Type" typeId="5479706523232344415441232323">Rapid Fire 3, Twin-linked</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="74ad-2f65-7b84-aaf3" name="Twin-linked" hidden="false" targetId="10a8-8d89-0bec-3e21" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0a8e-da3f-59da-dc04" name="Twin-linked Grenade Launcher" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="aa61-660a-0704-ec1e" name="Twin-linked Grenade Launcher (Frag)" publicationId="ca571888--pubN106502" page="177" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="52616e676523232344415441232323">24&quot;</characteristic>
+            <characteristic name="Strength" typeId="537472656e67746823232344415441232323">3</characteristic>
+            <characteristic name="AP" typeId="415023232344415441232323">6</characteristic>
+            <characteristic name="Type" typeId="5479706523232344415441232323">Rapid Fire, Blast (3&quot;), Twin-linked</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="5432-581f-9d7c-a62f" name="Twin-linked Grenade Launcher (Krak)" publicationId="ca571888--pubN106502" page="177" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="52616e676523232344415441232323">24&quot;</characteristic>
+            <characteristic name="Strength" typeId="537472656e67746823232344415441232323">6</characteristic>
+            <characteristic name="AP" typeId="415023232344415441232323">4</characteristic>
+            <characteristic name="Type" typeId="5479706523232344415441232323">Assault 1, Twin-linked</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="de82-43ad-4183-d4ee" name="Twin-linked" hidden="false" targetId="10a8-8d89-0bec-3e21" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="fd86-a3a0-adcc-63b5" name="Sky Stalker Jetbike Squad on Corvex Jetbikes, Legion" publicationId="0e6e-8c19-c436-39c4" page="" hidden="false" collective="false" import="true" type="unit">
+      <infoLinks>
+        <infoLink id="2766-8b93-38ac-d07c" name="New InfoLink" hidden="false" targetId="d219-2314-4834-c054" type="rule"/>
+        <infoLink id="1c6f-65b2-96e8-cf15" name="Space Marine Jetbike" hidden="false" targetId="3c28-4994-00ed-bbe5" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="d718-be51-6dd4-0fb7" name="Jetbike" hidden="false" targetId="d45f-b4ad-cc22-c7be" primary="false"/>
+        <categoryLink id="6397-0f8d-cbf9-6b11" name="Legiones Astartes" hidden="false" targetId="f321-f2d7-7d68-8f93" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="3f01-7cde-b658-31eb" name="Space Marine Sky Stalker" page="0" hidden="false" collective="false" import="true" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="775e-70ae-99d0-b9d7" type="min"/>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed60-a7c2-5f83-499f" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="fb0d-e191-ba10-730a" name="Sky Stalker on Corvex Jetbike" publicationId="0e6e-8c19-c436-39c4" page="" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+              <characteristics>
+                <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Jetbike</characteristic>
+                <characteristic name="WS" typeId="575323232344415441232323">4</characteristic>
+                <characteristic name="BS" typeId="425323232344415441232323">4</characteristic>
+                <characteristic name="S" typeId="5323232344415441232323">4</characteristic>
+                <characteristic name="T" typeId="5423232344415441232323">5</characteristic>
+                <characteristic name="W" typeId="5723232344415441232323">1</characteristic>
+                <characteristic name="I" typeId="4923232344415441232323">4</characteristic>
+                <characteristic name="A" typeId="4123232344415441232323">1</characteristic>
+                <characteristic name="LD" typeId="4c4423232344415441232323">8</characteristic>
+                <characteristic name="Save" typeId="5361766523232344415441232323">2+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="25.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="7981-000a-67c0-65d4" name="Sky Hunter Sergeant" page="0" hidden="false" collective="false" import="true" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0290-1971-ab82-bd29" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a0ae-b165-4f0b-6c08" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="139f-1f66-1e4d-9f2d" name="Sky Stalker Sergeant on Corvex Jetbike" publicationId="0e6e-8c19-c436-39c4" page="" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+              <characteristics>
+                <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Jetbike</characteristic>
+                <characteristic name="WS" typeId="575323232344415441232323">4</characteristic>
+                <characteristic name="BS" typeId="425323232344415441232323">4</characteristic>
+                <characteristic name="S" typeId="5323232344415441232323">4</characteristic>
+                <characteristic name="T" typeId="5423232344415441232323">5</characteristic>
+                <characteristic name="W" typeId="5723232344415441232323">1</characteristic>
+                <characteristic name="I" typeId="4923232344415441232323">4</characteristic>
+                <characteristic name="A" typeId="4123232344415441232323">2</characteristic>
+                <characteristic name="LD" typeId="4c4423232344415441232323">9</characteristic>
+                <characteristic name="Save" typeId="5361766523232344415441232323">2+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="15.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="efef-803d-1214-bd38" name="Standard Wargear" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cfe6-492d-945d-f5ac" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="46e5-0faa-e783-0761" type="min"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="5a42-7b28-b1db-6d76" name="New EntryLink" hidden="false" collective="false" import="true" targetId="0a96-04b6-7340-91a4" type="selectionEntry"/>
+            <entryLink id="8cf5-c829-a41e-f8f2" name="New EntryLink" hidden="false" collective="false" import="true" targetId="0a53-b471-df87-7b83" type="selectionEntry"/>
+            <entryLink id="83ca-30ca-ba0a-eb1b" name="New EntryLink" hidden="false" collective="false" import="true" targetId="fe8d-1baa-d58d-00bc" type="selectionEntry"/>
+            <entryLink id="7718-e77d-7ca1-f3c2" name="Chainswords/Combat Blades" hidden="false" collective="false" import="true" targetId="1087-66c1-c342-9cdc" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eab0-c8e7-3410-752d" type="min"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="edf3-3a32-0f86-2f75" name="Legion-specific upgrades:" hidden="false" collective="false" import="true">
+          <entryLinks>
+            <entryLink id="ba1f-cd88-da75-ed32" name="Molecular Acid Shells" hidden="true" collective="false" import="true" targetId="82fb-0eed-d1da-4dc5" type="selectionEntry">
+              <modifiers>
+                <modifier type="increment" field="ba38-696f-1a46-b052" value="1.0">
+                  <repeats>
+                    <repeat field="selections" scope="fd86-a3a0-adcc-63b5" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+                <modifier type="decrement" field="ba38-696f-1a46-b052" value="1.0"/>
+                <modifier type="set" field="hidden" value="false">
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="fd86-a3a0-adcc-63b5" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c990-4692-d9a7-ee44" type="equalTo"/>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1445-c8d0-6c21-9c6a" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+            </entryLink>
+            <entryLink id="3cfc-bfab-fc25-1573" name="Trophies of Judgement (Character)" hidden="false" collective="false" import="true" targetId="08f5-92aa-cd97-91cc" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2732-8ccb-cc97-ee5d" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </entryLink>
+            <entryLink id="a79d-734d-c768-a197" name="Chem-munitions" hidden="false" collective="false" import="true" targetId="b432-5750-528f-98f3" type="selectionEntry"/>
+            <entryLink id="b4e9-01bd-cfc7-02cf" name="Shrapnel Bolts" hidden="false" collective="false" import="true" targetId="4c19-2579-80d0-6490" type="selectionEntry"/>
+            <entryLink id="1fa8-5880-4707-0915" name="Cult Arcana" hidden="false" collective="false" import="true" targetId="52df-ddc4-325b-ec5a" type="selectionEntryGroup"/>
+            <entryLink id="d497-3931-bcad-06c1" name="Sonic Shriekers" hidden="false" collective="false" import="true" targetId="45cd-edae-7a23-95c6" type="selectionEntry">
+              <modifiers>
+                <modifier type="increment" field="points" value="2.0">
+                  <repeats>
+                    <repeat field="selections" scope="fd86-a3a0-adcc-63b5" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e691-ca90-8d84-e998" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="decrement" field="points" value="5.0"/>
+              </modifiers>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="5084-a045-d843-c656" name="All members of the squad can equip their Corvex Jetbikes with:" hidden="false" collective="false" import="true" defaultSelectionEntryId="c990-4692-d9a7-ee44">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5d2e-70c0-621e-a696" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e77c-e2b2-ac1c-68dc" type="min"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="ef3f-b850-e7fa-2a3b" name="Volkite Culverin" hidden="false" collective="false" import="true" targetId="dbd1-57bb-ee82-416c" type="selectionEntry">
+              <modifiers>
+                <modifier type="increment" field="points" value="25.0">
+                  <repeats>
+                    <repeat field="selections" scope="fd86-a3a0-adcc-63b5" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+            </entryLink>
+            <entryLink id="c990-4692-d9a7-ee44" name="Heavy Bolter" hidden="false" collective="false" import="true" targetId="a161-76b3-9ef1-da7b" type="selectionEntry">
+              <modifiers>
+                <modifier type="increment" field="points" value="15.0">
+                  <repeats>
+                    <repeat field="selections" scope="fd86-a3a0-adcc-63b5" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7ef7-b761-45af-0655" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="0de0-f5da-a9a5-86ab" name="Plasma Cannon" hidden="false" collective="false" import="true" targetId="ba00-b40e-b481-d400" type="selectionEntry">
+              <modifiers>
+                <modifier type="increment" field="points" value="25.0">
+                  <repeats>
+                    <repeat field="selections" scope="fd86-a3a0-adcc-63b5" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+            </entryLink>
+            <entryLink id="f756-d819-420f-1981" name="Heavy Flamer" hidden="true" collective="false" import="true" targetId="ead9-305c-a7e7-323e" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e2d7-e297-5b99-cbac" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="points" value="15.0">
+                  <repeats>
+                    <repeat field="selections" scope="fd86-a3a0-adcc-63b5" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="15a9-394b-1dd5-6db2" name="Sergeant may exchange Bolt Pistol and/or Chainsword for:" hidden="false" collective="false" import="true">
+          <modifiers>
+            <modifier type="set" field="29a3-b73f-1d77-757b" value="1.0">
+              <conditions>
+                <condition field="selections" scope="fd86-a3a0-adcc-63b5" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1849-a959-9942-914a" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="9c3b-46db-c959-b8fd" value="1.0">
+              <conditions>
+                <condition field="selections" scope="fd86-a3a0-adcc-63b5" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1849-a959-9942-914a" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="29a3-b73f-1d77-757b" type="max"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9c3b-46db-c959-b8fd" type="min"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="c9fd-1c90-c63d-414b" name="New EntryLink" hidden="false" collective="false" import="true" targetId="f832-f4b2-6aaf-ad83" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4860-d75f-d380-e4a2" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="5b74-3428-2c2f-0cf4" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="6026-d507-935a-7200" type="selectionEntry"/>
+            <entryLink id="e207-aed5-6ad6-d76e" name="Chainsword/Combat Blade" hidden="false" collective="false" import="true" targetId="4b1e-680b-1d39-e4f1" type="selectionEntry"/>
+            <entryLink id="b6a5-e8ee-ebc8-bc0b" name="Hand Flamer" hidden="false" collective="false" import="true" targetId="8a98-53c5-6fab-b3a7" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2022-07c3-a011-012e" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="7c0e-a9e4-4f52-ae53" name="Inferno Pistol " hidden="false" collective="false" import="true" targetId="13f8-6607-3525-4298" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="59f6-638d-8c1d-75dd" type="equalTo"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e2d7-e297-5b99-cbac" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+                <modifier type="set" field="ccce-cd4b-c78d-16d1" value="2.0"/>
+              </modifiers>
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="3181-7c0c-cb74-3cd7" name="Volkite Serpenta" hidden="false" collective="false" import="true" targetId="ae27-c659-fffd-1561" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="e51d-cf89-f58a-6004" value="1.0"/>
+              </modifiers>
+              <costs>
+                <cost name="pts" typeId="points" value="2.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="68d1-054a-edc0-945c" name="Albian Power Gladius" hidden="false" collective="false" import="true" targetId="1b80-5b44-0e03-b9e4" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="ccfb-6afc-2a35-2498" value="2.0"/>
+              </modifiers>
+              <costs>
+                <cost name="pts" typeId="points" value="15.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="45d3-a9a6-e4dd-bc6f" name="Calibanite War Blade" hidden="false" collective="false" import="true" targetId="5bc2-ceb4-2e34-7004" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="7252-254f-2165-a459" value="2.0"/>
+              </modifiers>
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="13ab-9552-655e-4406" name="Cthonian Culling Blade" hidden="false" collective="false" import="true" targetId="270a-0bb6-b354-6b75" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="6780-81e2-601f-a7bd" value="2.0"/>
+              </modifiers>
+              <costs>
+                <cost name="pts" typeId="points" value="15.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="2449-b99c-66b3-848e" name="Lightning Claw" hidden="false" collective="false" import="true" targetId="26db-484d-3757-03c8" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="b2ab-5b47-b382-d02f" value="2.0"/>
+              </modifiers>
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="1f64-fc18-e331-4eea" name="Nostraman Chainglaive" hidden="false" collective="false" import="true" targetId="b6e5-70ca-8084-765d" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="36d1-704f-6f14-17a2" name="Phoenix Spear" hidden="false" collective="false" import="true" targetId="bca4-ae83-c058-2822" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="points" value="15.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="9d34-f0c8-b703-9af6" name="Power Axe" hidden="false" collective="false" import="true" targetId="7b92-ab87-86a1-ab2e" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b1ef-b5f1-15f0-1354" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="6ecb-ec26-6b69-43a1" name="Power Fist" hidden="false" collective="false" import="true" targetId="fcef-f5ac-16a3-9401" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aa96-969b-5a01-acae" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="15.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="f500-d6f2-b851-989b" name="Power Glaive" hidden="false" collective="false" import="true" targetId="fd9c-9193-2c50-e929" type="selectionEntry"/>
+            <entryLink id="fc9c-9187-99c0-29eb" name="Power Lance" hidden="false" collective="false" import="true" targetId="233d-238b-6940-2740" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3d64-38d0-2ddb-24e8" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="dda5-af42-48c5-b30f" name="Power Maul" hidden="false" collective="false" import="true" targetId="e8a2-42e8-82a7-8dd9" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2e22-caab-a491-47a4" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="d990-3eed-7544-149d" name="Power Scythe" hidden="false" collective="false" import="true" targetId="3410-908e-d98d-593d" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="points" value="15.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="e4fb-fbc2-5737-0e06" name="Power Sword" hidden="false" collective="false" import="true" targetId="3e90-5ca1-8abe-0275" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bed8-4ada-bc80-5a2c" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="9b4c-ecda-09d6-ac4b" name="Raven&apos;s Talons" hidden="false" collective="false" import="true" targetId="d491-f3be-c649-cc6b" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="50ed-2ebb-cfe1-eda6" value="1.0"/>
+              </modifiers>
+              <costs>
+                <cost name="pts" typeId="points" value="20.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="b26e-cd11-806e-7898" name="Tainted Weapon" hidden="false" collective="false" import="true" targetId="104d-2c15-b4b8-c299" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="b3ba-7370-7a61-aa33" value="2.0"/>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e655-a136-c8b1-29a2" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="3bf4-6ca4-8bee-9a0b" name="Thunder Hammer" hidden="false" collective="false" import="true" targetId="925c-50d4-0101-e0e7" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="b12c-09c9-fd19-2a1d" value="1.0"/>
+              </modifiers>
+              <costs>
+                <cost name="pts" typeId="points" value="20.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="1849-a959-9942-914a" name="Pair of Raven&apos;s Talons" hidden="false" collective="false" import="true" targetId="a8e8-37e5-3b8e-ccef" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="points" value="30.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="points" value="50.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="dbd1-57bb-ee82-416c" name="Volkite Culverin" page="0" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2a9d-071b-c182-db67" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="e109-a3dc-d100-be75" name="Volkite Culverin" hidden="false" targetId="34d1-b4db-3e75-ccce" type="profile"/>
+        <infoLink id="c22e-22a1-03da-e734" name="Deflagrate" hidden="false" targetId="b46a-a3ec-91a5-5001" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2097-6e3d-13c4-b9e1" name="Autocannon" publicationId="ca571888--pubN106502" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8e35-8d7e-1a9b-47f9" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="b71c-2719-e0c8-e5b5" name="Autocannon" hidden="false" targetId="d55f-eed0-800f-5789" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2b92-e606-8fb0-3117" name="Mars Pattern Land Speeder" page="0" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="d95a-c19a-bae0-157e" name="Deep Strike" hidden="false" targetId="685b-1231-2899-7552" primary="false"/>
+        <categoryLink id="442f-bc0f-f5c8-3082" name="Skimmer" hidden="false" targetId="1302-97fa-834e-edc6" primary="false"/>
+        <categoryLink id="8f9c-6fde-b8b7-6a0f" name="Vehicle" hidden="false" targetId="8c70-1182-84f5-c93a" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="94b9-84e3-2ce9-21ff" name="Mars Pattern Land Speeder" page="0" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="fd40-97d8-2768-2dd7" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="59f8-861e-2900-5eba" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="004c-12fa-b1c6-5dc4" name="Mars Pattern Land Speeder" publicationId="0e6e-8c19-c436-39c4" page="" hidden="false" typeId="56656869636c6523232344415441232323" typeName="Vehicle">
+              <characteristics>
+                <characteristic name="BS" typeId="425323232344415441232323">4</characteristic>
+                <characteristic name="Front" typeId="46726f6e7423232344415441232323">11</characteristic>
+                <characteristic name="Side" typeId="5369646523232344415441232323">10</characteristic>
+                <characteristic name="Rear" typeId="5265617223232344415441232323">10</characteristic>
+                <characteristic name="HP" typeId="485023232344415441232323">2</characteristic>
+                <characteristic name="Type" typeId="5479706523232344415441232323">Skimmer, Fast</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="7c61-c99e-a774-b8fc" name="Scout" hidden="false" targetId="9b30-1da3-eb8d-ce7a" type="rule"/>
+            <infoLink id="5276-80c3-2e06-43b5" name="Grav-backwash" hidden="false" targetId="0ab8-c3dc-fe69-c2f6" type="rule"/>
+            <infoLink id="fdc1-5f43-c2de-254f" name="New InfoLink" hidden="false" targetId="d219-2314-4834-c054" type="rule"/>
+          </infoLinks>
+          <categoryLinks>
+            <categoryLink id="284e-ea3a-57ea-48e1" name="Deep Strike" hidden="false" targetId="685b-1231-2899-7552" primary="false"/>
+            <categoryLink id="a5c2-8bcc-7188-b05f" name="New CategoryLink" hidden="false" targetId="f01c-3731-7dbd-62f4" primary="true"/>
+            <categoryLink id="36b4-6b19-edcf-a158" name="Skimmer" hidden="false" targetId="1302-97fa-834e-edc6" primary="false"/>
+            <categoryLink id="cef7-510b-e4ce-a21f" name="Vehicle" hidden="false" targetId="8c70-1182-84f5-c93a" primary="false"/>
+          </categoryLinks>
+          <selectionEntries>
+            <selectionEntry id="d7b2-de3b-e93d-094a" name="May take a Second Heavy Bolter" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4244-2329-2672-4817" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="d2fb-107d-5d9a-bfa7" name="Any model may exchange any Heavy Bolter (not including dual HB) for:" hidden="false" collective="false" import="true">
+              <modifiers>
+                <modifier type="set" field="af4b-78b9-6ed3-92a0" value="2.0">
+                  <conditions>
+                    <condition field="selections" scope="94b9-84e3-2ce9-21ff" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d7b2-de3b-e93d-094a" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="51df-fa9d-e621-8d99" value="2.0">
+                  <conditions>
+                    <condition field="selections" scope="94b9-84e3-2ce9-21ff" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d7b2-de3b-e93d-094a" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="af4b-78b9-6ed3-92a0" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="51df-fa9d-e621-8d99" type="min"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="b4d0-1296-4d5e-9225" name="Graviton Gun" hidden="false" collective="false" import="true" targetId="ec29-0748-6778-ff60" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="eed3-65a3-ce87-5f92" value="2.0"/>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eed3-65a3-ce87-5f92" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="1851-aff8-e2ae-aada" name="New EntryLink" hidden="false" collective="false" import="true" targetId="a161-76b3-9ef1-da7b" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="00cb-68ca-6be7-11e2" value="2.0"/>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="00cb-68ca-6be7-11e2" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="c030-6226-1a21-0667" name="Heavy Flamer" hidden="false" collective="false" import="true" targetId="ead9-305c-a7e7-323e" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="3b11-631c-6dde-9819" value="2.0"/>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3b11-631c-6dde-9819" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="403d-daa4-06e2-647a" name="Havoc Launcher" hidden="false" collective="false" import="true" targetId="0760-1529-35e8-a884" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="463c-a8a5-a640-cfb4" value="2.0"/>
+                  </modifiers>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="7a4b-6e14-49fb-93a8" name="Autocannon" hidden="false" collective="false" import="true" targetId="2097-6e3d-13c4-b9e1" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="8e35-8d7e-1a9b-47f9" value="2.0"/>
+                  </modifiers>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="4c71-dde5-46b2-ec42" name="Volkite Culverin" hidden="false" collective="false" import="true" targetId="dbd1-57bb-ee82-416c" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="2a9d-071b-c182-db67" value="2.0"/>
+                  </modifiers>
+                  <costs>
+                    <cost name="pts" typeId="points" value="15.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="1fe7-ca0c-45d6-c375" name="Multi-melta" hidden="false" collective="false" import="true" targetId="d1c0-746f-2b39-5f17" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="322b-7bc4-92e1-0a46" value="2.0"/>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="322b-7bc4-92e1-0a46" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="ad1d-7049-0e86-736f" name="Plasma Cannon" hidden="false" collective="false" import="true" targetId="ba00-b40e-b481-d400" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="1766-11c7-fa51-d073" value="2.0"/>
+                  </modifiers>
+                  <costs>
+                    <cost name="pts" typeId="points" value="20.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="8c4a-ce51-7649-b719" name="Legion-specific upgrade" hidden="false" collective="false" import="true">
+              <entryLinks>
+                <entryLink id="6731-c9da-3e41-3848" name="Blessed Autosimulacra" hidden="false" collective="false" import="true" targetId="586c-391b-172f-6e2a" type="selectionEntry"/>
+                <entryLink id="c2e6-c6c2-754f-bcdc" name="Chem-munitions" hidden="false" collective="false" import="true" targetId="b432-5750-528f-98f3" type="selectionEntry"/>
+                <entryLink id="aebd-85ba-ab63-d0d9" name="Shrapnel Bolts" hidden="false" collective="false" import="true" targetId="4c19-2579-80d0-6490" type="selectionEntry"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="8b8b-ff86-d315-b298" name="Hunter-killer Missile" hidden="false" collective="false" import="true" targetId="2276-994b-8721-ac3d" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="8fb8-979a-13d1-8e95" value="2.0"/>
+              </modifiers>
+            </entryLink>
+            <entryLink id="5c0e-abcd-de1c-fbea" name="Searchlight" hidden="false" collective="false" import="true" targetId="7b19-0e33-9c8d-e56a" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="50.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="points" value="50.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="79c3-8891-b0e9-622a" name="Mars Cutter Pattern Land Speeder Squadron" page="0" hidden="false" collective="false" import="true" type="upgrade">
+      <selectionEntries>
+        <selectionEntry id="da3f-647e-14a0-5d42" name="Mars Cutter Pattern Land Speeder" page="0" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b930-b57a-3a62-e0f3" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6cdf-74c4-f0cb-fc7a" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="25b2-d4ea-823f-b46d" name="Mars Cutter Pattern Land Speeder" publicationId="0e6e-8c19-c436-39c4" page="" hidden="false" typeId="56656869636c6523232344415441232323" typeName="Vehicle">
+              <characteristics>
+                <characteristic name="BS" typeId="425323232344415441232323">4</characteristic>
+                <characteristic name="Front" typeId="46726f6e7423232344415441232323">11</characteristic>
+                <characteristic name="Side" typeId="5369646523232344415441232323">10</characteristic>
+                <characteristic name="Rear" typeId="5265617223232344415441232323">10</characteristic>
+                <characteristic name="HP" typeId="485023232344415441232323">2</characteristic>
+                <characteristic name="Type" typeId="5479706523232344415441232323">Skimmer, Fast, Open Topped</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="8a43-d247-8e34-7439" name="Mars Cutter Pattern Land Speeder" hidden="false" typeId="307d-047f-ca13-706b" typeName="Transport">
+              <characteristics>
+                <characteristic name="Capacity" typeId="8285-4205-b6cd-8473">6</characteristic>
+                <characteristic name="Fire Points" typeId="b270-a7f9-22b2-3702">Open Topped</characteristic>
+                <characteristic name="Access Points" typeId="d17b-0342-b1dc-b8e7">Open Topped</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="10fc-6683-72a0-0c3c" name="Grav-backwash" hidden="false" targetId="0ab8-c3dc-fe69-c2f6" type="rule"/>
+            <infoLink id="5236-5488-3cb4-ec36" name="New InfoLink" hidden="false" targetId="d219-2314-4834-c054" type="rule"/>
+          </infoLinks>
+          <categoryLinks>
+            <categoryLink id="94d5-c7bb-4c69-e4cf" name="Vehicle" hidden="false" targetId="8c70-1182-84f5-c93a" primary="false"/>
+            <categoryLink id="89f3-3aed-5ad0-be91" name="Skimmer" hidden="false" targetId="1302-97fa-834e-edc6" primary="false"/>
+            <categoryLink id="8b04-2ab8-7c00-b0ed" name="Transport" hidden="false" targetId="0be9-0976-aa16-eea7" primary="false"/>
+          </categoryLinks>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="585a-5e42-dad7-0e3d" name="Any model may exchange any Heavy Bolter (not including dual HB) for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="1002-463e-c6b2-9b66">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="09df-3cac-51d4-8b4a" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e99b-5900-d2ac-b9fb" type="min"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="00fa-70da-4853-8e7b" name="Graviton Gun" hidden="false" collective="false" import="true" targetId="ec29-0748-6778-ff60" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f6b4-2901-0dc7-6c42" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="1002-463e-c6b2-9b66" name="New EntryLink" hidden="false" collective="false" import="true" targetId="a161-76b3-9ef1-da7b" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e52d-6dac-1545-b282" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="4249-ca0c-0243-435d" name="Heavy Flamer" hidden="false" collective="false" import="true" targetId="ead9-305c-a7e7-323e" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f34f-64a3-5c6e-699d" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="0c52-39e7-f14c-85de" name="Havoc Launcher" hidden="false" collective="false" import="true" targetId="0760-1529-35e8-a884" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="c731-6bd6-f103-bda5" name="Autocannon" hidden="false" collective="false" import="true" targetId="2097-6e3d-13c4-b9e1" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="008a-f8c8-dbc6-66f7" name="Volkite Culverin" hidden="false" collective="false" import="true" targetId="dbd1-57bb-ee82-416c" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="15.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="298e-0cb1-2fbc-8692" name="Multi-melta" hidden="false" collective="false" import="true" targetId="d1c0-746f-2b39-5f17" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a48a-1006-83f0-fe5e" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="b218-a932-86dd-10c4" name="Plasma Cannon" hidden="false" collective="false" import="true" targetId="ba00-b40e-b481-d400" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="20.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="95dd-d7df-4ee1-e1c1" name="Legion-specific upgrade" hidden="false" collective="false" import="true">
+              <entryLinks>
+                <entryLink id="6f46-72ee-cf43-a163" name="Blessed Autosimulacra" hidden="false" collective="false" import="true" targetId="586c-391b-172f-6e2a" type="selectionEntry"/>
+                <entryLink id="753c-a62d-f784-e1f8" name="Chem-munitions" hidden="false" collective="false" import="true" targetId="b432-5750-528f-98f3" type="selectionEntry"/>
+                <entryLink id="1fc0-8b58-ca4f-3008" name="Shrapnel Bolts" hidden="false" collective="false" import="true" targetId="4c19-2579-80d0-6490" type="selectionEntry"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="1fa5-cd36-8091-901f" name="Hunter-killer Missile" hidden="false" collective="false" import="true" targetId="2276-994b-8721-ac3d" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="8fb8-979a-13d1-8e95" value="2.0"/>
+              </modifiers>
+            </entryLink>
+            <entryLink id="67dd-0bc0-e183-e036" name="Searchlight" hidden="false" collective="false" import="true" targetId="7b19-0e33-9c8d-e56a" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="55.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="points" value="55.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="829f-26e6-6908-aa1f" name="Mars Pattern Javelin Attack Speeder Squadron" page="0" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="e7d9-73b7-4718-026b" name="Skimmer" hidden="false" targetId="1302-97fa-834e-edc6" primary="false"/>
+        <categoryLink id="a62b-5352-23aa-08e3" name="Vehicle" hidden="false" targetId="8c70-1182-84f5-c93a" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="8c5b-654a-d2d2-26d5" name="Mars Pattern Javelin Attack Speeder" page="0" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="17de-d870-f830-34cd" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6461-a3f6-f479-0101" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="0727-fbc5-d310-57a3" name="Mars Javeline Pattern Land Speeder" publicationId="0e6e-8c19-c436-39c4" page="" hidden="false" typeId="56656869636c6523232344415441232323" typeName="Vehicle">
+              <characteristics>
+                <characteristic name="BS" typeId="425323232344415441232323">4</characteristic>
+                <characteristic name="Front" typeId="46726f6e7423232344415441232323">12</characteristic>
+                <characteristic name="Side" typeId="5369646523232344415441232323">11</characteristic>
+                <characteristic name="Rear" typeId="5265617223232344415441232323">10</characteristic>
+                <characteristic name="HP" typeId="485023232344415441232323">2</characteristic>
+                <characteristic name="Type" typeId="5479706523232344415441232323">Skimmer, Fast</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="b194-5e42-13f2-b53b" name="Grav-backwash" hidden="false" targetId="0ab8-c3dc-fe69-c2f6" type="rule"/>
+            <infoLink id="6f84-85f0-0143-7e74" name="Strafing Run" hidden="false" targetId="7911-b951-c819-2f4f" type="rule"/>
+            <infoLink id="d123-7864-88c0-4f54" name="Outflank" hidden="false" targetId="de18-25a0-504b-74be" type="rule"/>
+          </infoLinks>
+          <categoryLinks>
+            <categoryLink id="d64d-4413-c550-ef11" name="New CategoryLink" hidden="false" targetId="f01c-3731-7dbd-62f4" primary="true"/>
+            <categoryLink id="9544-f16f-614a-cbfd" name="Skimmer" hidden="false" targetId="1302-97fa-834e-edc6" primary="false"/>
+            <categoryLink id="bb69-2541-896c-00bf" name="Vehicle" hidden="false" targetId="8c70-1182-84f5-c93a" primary="false"/>
+          </categoryLinks>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="b8c0-29cf-506b-f311" name="Any model may exchange any Heavy Bolter (not including dual HB) for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="5ba0-1e4b-bc8b-7c4e">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b699-f4fc-4e5a-19a4" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3b39-2ae4-83b9-7381" type="min"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="67b0-a133-483e-9d15" name="Graviton Gun" hidden="false" collective="false" import="true" targetId="ec29-0748-6778-ff60" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2eb6-0f6d-6791-2ecc" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="5ba0-1e4b-bc8b-7c4e" name="New EntryLink" hidden="false" collective="false" import="true" targetId="a161-76b3-9ef1-da7b" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2381-1bed-3c1b-c30a" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="b055-1ec4-b665-1056" name="Heavy Flamer" hidden="false" collective="false" import="true" targetId="ead9-305c-a7e7-323e" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4b87-2d35-c4d4-6bfb" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="b1c5-1f72-b127-40f2" name="Havoc Launcher" hidden="false" collective="false" import="true" targetId="0760-1529-35e8-a884" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="a296-e2b0-4a64-449a" name="Autocannon" hidden="false" collective="false" import="true" targetId="2097-6e3d-13c4-b9e1" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="e2c1-bc73-eada-c1f9" name="Volkite Culverin" hidden="false" collective="false" import="true" targetId="dbd1-57bb-ee82-416c" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="15.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="e54e-5139-9cad-cc24" name="Multi-melta" hidden="false" collective="false" import="true" targetId="d1c0-746f-2b39-5f17" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e44f-de3f-aadc-5d72" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="e494-1a7c-c16e-52a5" name="Plasma Cannon" hidden="false" collective="false" import="true" targetId="ba00-b40e-b481-d400" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="20.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="76ad-118f-6af7-d63c" name="Legion-specific upgrade" hidden="false" collective="false" import="true">
+              <entryLinks>
+                <entryLink id="cfd2-7c37-81e9-9a5a" name="Blessed Autosimulacra" hidden="false" collective="false" import="true" targetId="586c-391b-172f-6e2a" type="selectionEntry"/>
+                <entryLink id="5f49-47f9-7bad-ec44" name="Chem-munitions" hidden="false" collective="false" import="true" targetId="b432-5750-528f-98f3" type="selectionEntry"/>
+                <entryLink id="646d-49da-185d-8c9c" name="Shrapnel Bolts" hidden="false" collective="false" import="true" targetId="4c19-2579-80d0-6490" type="selectionEntry"/>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="573c-526d-6e77-706a" name="Any Javelin Attack Speeder may be equipped with one of the following Sponson Mounted weapons" hidden="false" collective="false" import="true">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8d1e-ca5b-d444-5a10" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="4625-a1fd-4b3e-23ab" name="Dual Lascannons" hidden="false" collective="false" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e02a-2341-aaae-bf4b" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="f566-3e9e-584f-5236" name="Lascannon" hidden="false" targetId="1cce-972c-022a-2590" type="profile">
+                      <modifiers>
+                        <modifier type="set" field="5479706523232344415441232323" value="Heavy 2"/>
+                      </modifiers>
+                    </infoLink>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="20.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="97a2-5132-4e27-703f" name="Dual Reaper Autocannons" hidden="false" collective="false" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1824-6ec6-0685-b872" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="1326-ad8b-97ee-de05" name="Reaper Autocannon" hidden="false" targetId="354e-ccd5-bde4-726a" type="profile">
+                      <modifiers>
+                        <modifier type="set" field="5479706523232344415441232323" value="Heavy 4, Twin-linked"/>
+                      </modifiers>
+                    </infoLink>
+                    <infoLink id="fc99-3e14-6577-4527" name="New InfoLink" hidden="false" targetId="10a8-8d89-0bec-3e21" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="15.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="aed3-a7d7-c28f-a3e3" name="Dual Heavy Bolters" hidden="false" collective="false" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7b7e-ec6d-5de0-b949" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="bf55-a919-3408-e9ac" name="Heavy Bolter" hidden="false" targetId="271e-6286-86cc-06dd" type="profile">
+                      <modifiers>
+                        <modifier type="set" field="5479706523232344415441232323" value="Heavy 6"/>
+                      </modifiers>
+                    </infoLink>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="c2ae-5238-d28d-fb1c" name="Twin-linked Cyclone missile launcher" publicationId="ca571888--pubN82424" page="134" hidden="false" collective="false" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cf4f-0e51-5c13-f2c8" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="6850-719d-b28c-2faf" name="New InfoLink" hidden="false" targetId="40e6-c95c-7c8d-cf02" type="profile">
+                      <modifiers>
+                        <modifier type="set" field="5479706523232344415441232323" value="Heavy 2, Blast (3&quot;), Twin-linked"/>
+                      </modifiers>
+                    </infoLink>
+                    <infoLink id="ce87-c6a8-7945-e28a" name="New InfoLink" hidden="false" targetId="1e33-d8ec-f833-b584" type="profile">
+                      <modifiers>
+                        <modifier type="set" field="5479706523232344415441232323" value="Heavy 2, Twin-linked"/>
+                      </modifiers>
+                    </infoLink>
+                    <infoLink id="cc12-bffc-f962-52e1" name="New InfoLink" hidden="false" targetId="10a8-8d89-0bec-3e21" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="25.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="bf8a-6925-ee12-77ac" name="Hunter-killer Missile" hidden="false" collective="false" import="true" targetId="2276-994b-8721-ac3d" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="8fb8-979a-13d1-8e95" value="2.0"/>
+              </modifiers>
+            </entryLink>
+            <entryLink id="2c52-2df9-9485-1373" name="Searchlight" hidden="false" collective="false" import="true" targetId="7b19-0e33-9c8d-e56a" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="55.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="points" value="55.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="c74b-38cc-7b44-348c" name="Salamanders Infernus Destroyer Squad" publicationId="0e6e-8c19-c436-39c4" page="" hidden="true" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="add" field="category" value="a787-4801-eb77-f2cf">
+          <conditions>
+            <condition field="selections" scope="c74b-38cc-7b44-348c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="935f-5b1e-3040-c334" type="equalTo"/>
+          </conditions>
+        </modifier>
+        <modifier type="add" field="category" value="685b-1231-2899-7552">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="c74b-38cc-7b44-348c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="935f-5b1e-3040-c334" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6e6d-6838-22e6-e3a5" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="set" field="hidden" value="false">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e2d7-e297-5b99-cbac" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <rules>
+        <rule id="bdf0-b5b0-d861-ccce" name="Legion Destroyer Squad" hidden="false">
+          <description>When selected as part of a Legion Destroyer Company, Infernus Destroyers may be selected as Troops</description>
+        </rule>
+        <rule id="e8e2-a937-83cd-a25d" name="Rite of War Covenant of Fire" hidden="false">
+          <description>When selected as part of a Covenant of Fire, Infernus Destroyers may be selected as non-compulsory Troop choices (noting they cannot Deep Strike with Jump Packs as per the rules for this Rite of War).</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="1cad-6790-d93e-5ad2" name="Hardened Armour" hidden="false" targetId="7439f6fd-4c50-f88a-eb41-81d9b9c9eed8" type="rule"/>
+        <infoLink id="5034-f6fa-b46d-0aba" name="Counter-attack" hidden="false" targetId="0900-71d5-1937-aa96" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="de14-e9b2-46ec-362d" name="Infantry" hidden="false" targetId="1ab3-f1ac-f724-8544" primary="false"/>
+        <categoryLink id="a7d3-c981-2224-68bd" name="Legiones Astartes" hidden="false" targetId="f321-f2d7-7d68-8f93" primary="false"/>
+        <categoryLink id="f4c7-f65f-1596-f1a4" name="New CategoryLink" hidden="false" targetId="db5f-8f10-8525-28d4" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="aff2-85a4-08e7-7cbe" name="Infernus Destroyer" page="0" hidden="false" collective="false" import="true" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f6a3-908a-3704-2315" type="min"/>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="19a0-adce-2b59-fa36" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="8f36-b681-0abf-82c0" name="Infernus Destroyer" publicationId="0e6e-8c19-c436-39c4" page="" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+              <modifiers>
+                <modifier type="set" field="5361766523232344415441232323" value="2+">
+                  <conditions>
+                    <condition field="selections" scope="c74b-38cc-7b44-348c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="26ab-b167-50c4-4bc3" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="556e6974205479706523232344415441232323" value="Jump Infantry">
+                  <conditions>
+                    <condition field="selections" scope="c74b-38cc-7b44-348c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="935f-5b1e-3040-c334" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <characteristics>
+                <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry</characteristic>
+                <characteristic name="WS" typeId="575323232344415441232323">4</characteristic>
+                <characteristic name="BS" typeId="425323232344415441232323">4</characteristic>
+                <characteristic name="S" typeId="5323232344415441232323">4</characteristic>
+                <characteristic name="T" typeId="5423232344415441232323">4</characteristic>
+                <characteristic name="W" typeId="5723232344415441232323">1</characteristic>
+                <characteristic name="I" typeId="4923232344415441232323">4</characteristic>
+                <characteristic name="A" typeId="4123232344415441232323">2</characteristic>
+                <characteristic name="LD" typeId="4c4423232344415441232323">9</characteristic>
+                <characteristic name="Save" typeId="5361766523232344415441232323">3+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="20.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="0a1b-1aa2-5234-bc0c" name="Standard Wargear" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="eb01-827d-6fb8-90c8" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b81b-5499-f782-27dc" type="min"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="276e-2873-0b02-eb3d" name="Frag and Krak Grenades" hidden="false" collective="false" import="true" targetId="0a53-b471-df87-7b83" type="selectionEntry"/>
+            <entryLink id="d287-5bd9-068e-64d0" name="New EntryLink" hidden="false" collective="false" import="true" targetId="0a96-04b6-7340-91a4" type="selectionEntry"/>
+            <entryLink id="6ea0-050c-34f8-43ca" name="Chainswords/Combat Blades" hidden="false" collective="false" import="true" targetId="1087-66c1-c342-9cdc" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="6400-e125-dfc2-4262" name="Infernus Destroyer Sergeant" hidden="false" collective="false" import="true" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9e32-c72c-7fe5-0341" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0f5a-559f-8243-b948" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="a942-32ce-a4bb-5678" name="Infernus Destroyer Sergeant" publicationId="0e6e-8c19-c436-39c4" page="" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+              <modifiers>
+                <modifier type="set" field="5361766523232344415441232323" value="2+">
+                  <conditions>
+                    <condition field="selections" scope="c74b-38cc-7b44-348c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="26ab-b167-50c4-4bc3" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="556e6974205479706523232344415441232323" value="Jump Infantry (Character)">
+                  <conditions>
+                    <condition field="selections" scope="c74b-38cc-7b44-348c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="935f-5b1e-3040-c334" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <characteristics>
+                <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry (Character)</characteristic>
+                <characteristic name="WS" typeId="575323232344415441232323">4</characteristic>
+                <characteristic name="BS" typeId="425323232344415441232323">4</characteristic>
+                <characteristic name="S" typeId="5323232344415441232323">4</characteristic>
+                <characteristic name="T" typeId="5423232344415441232323">4</characteristic>
+                <characteristic name="W" typeId="5723232344415441232323">1</characteristic>
+                <characteristic name="I" typeId="4923232344415441232323">4</characteristic>
+                <characteristic name="A" typeId="4123232344415441232323">3</characteristic>
+                <characteristic name="LD" typeId="4c4423232344415441232323">9</characteristic>
+                <characteristic name="Save" typeId="5361766523232344415441232323">3+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <categoryLinks>
+            <categoryLink id="db49-942b-a8e8-c043" name="Character" hidden="false" targetId="ae54-92c7-3e66-59f7" primary="false"/>
+          </categoryLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="e24f-fbfc-6e9f-2bcc" name="All models may take:" hidden="false" collective="false" import="true">
+          <selectionEntries>
+            <selectionEntry id="935f-5b1e-3040-c334" name="Jump Packs" hidden="false" collective="false" import="true" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="points" value="5.0">
+                  <repeats>
+                    <repeat field="selections" scope="c74b-38cc-7b44-348c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dadc-acf6-8e05-18ee" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <entryLinks>
+            <entryLink id="e0fa-9533-bd39-5e81" name="Melta Bombs" hidden="false" collective="false" import="true" targetId="4c62-8983-4a1b-d1c6" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="points" value="25.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="26ab-b167-50c4-4bc3" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="c6b8-8b0b-8a31-6aa3" type="selectionEntry">
+              <modifiers>
+                <modifier type="increment" field="points" value="10.0">
+                  <repeats>
+                    <repeat field="selections" scope="c74b-38cc-7b44-348c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bb8a-0e40-20d1-126f" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="ba7d-7911-11ac-e600" name="Psyk-Out Grenade (Thrown" hidden="false" collective="false" import="true" targetId="d0f7-e8a3-4202-87f4" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="16b9-1cb9-c4b7-5431" name="Sergeant&apos;s Weapons" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="cd04-0fc0-c88a-9140" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="0832-8da1-07c9-6ef2" name="Exchange Hand Flamer for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="d2e8-209b-90c4-daf9">
+              <constraints>
+                <constraint field="selections" scope="c74b-38cc-7b44-348c" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3789-69ea-64f1-4164" type="min"/>
+                <constraint field="selections" scope="c74b-38cc-7b44-348c" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8f6d-cf3b-a18f-adbd" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="d2e8-209b-90c4-daf9" name="Hand Flamer" hidden="false" collective="false" import="true" targetId="8a98-53c5-6fab-b3a7" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="points" value="0.0"/>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="d2e8-209b-90c4-daf9" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f161-71c7-a564-e7bb" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="0377-4ede-35cc-9ff9" name="Inferno Pistol " hidden="false" collective="false" import="true" targetId="13f8-6607-3525-4298" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="ccce-cd4b-c78d-16d1" value="2.0"/>
+                  </modifiers>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="f019-cd7b-4dcc-45d7" name="Volkite Serpenta" hidden="false" collective="false" import="true" targetId="ae27-c659-fffd-1561" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="points" value="0.0"/>
+                    <modifier type="set" field="e51d-cf89-f58a-6004" value="2.0"/>
+                  </modifiers>
+                </entryLink>
+                <entryLink id="4ef3-8bee-f521-0520" name="New EntryLink" hidden="false" collective="false" import="true" targetId="f832-f4b2-6aaf-ad83" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="190e-3e42-ee0a-f3e6" value="2.0"/>
+                  </modifiers>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="ff6e-fae9-8207-709e" name="Exchange Chainsword for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="1bee-e157-e14a-b70b">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="65a1-6add-1665-d807" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6864-58ac-22e9-2654" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="166a-5a08-1fab-5820" name="Lightning Claw" hidden="false" collective="false" import="true" targetId="26db-484d-3757-03c8" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="92bf-fa11-642e-01b6" name="Thunder Hammer" hidden="false" collective="false" import="true" targetId="925c-50d4-0101-e0e7" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="20.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="30b6-4b7e-fb3a-e17d" name="Power Fist" hidden="false" collective="false" import="true" targetId="fcef-f5ac-16a3-9401" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="15.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="d4fd-488b-24a7-1fa3" name="Power Axe" hidden="false" collective="false" import="true" targetId="7b92-ab87-86a1-ab2e" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3351-9bd0-96fd-c1c5" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="f6db-4f1e-5364-d6b3" name="Power Lance" hidden="false" collective="false" import="true" targetId="233d-238b-6940-2740" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf6d-90e1-6a39-b241" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="73aa-a401-7381-cc7f" name="Power Maul" hidden="false" collective="false" import="true" targetId="e8a2-42e8-82a7-8dd9" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1014-35cc-6f75-dfd9" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="712c-c7bd-d5d7-3005" name="Power Sword" hidden="false" collective="false" import="true" targetId="3e90-5ca1-8abe-0275" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bb7b-d360-89a1-4511" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="1bee-e157-e14a-b70b" name="Chainsword/Combat Blade" hidden="false" collective="false" import="true" targetId="4b1e-680b-1d39-e4f1" type="selectionEntry"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="8844-6917-0f88-7c7e" name="Sergeant may take" hidden="false" collective="false" import="true">
+          <entryLinks>
+            <entryLink id="b44b-19e5-04c8-7ab3" name="Artificer Weapons" hidden="false" collective="false" import="true" targetId="6627-d992-df6b-a3df" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="da77-e247-c256-1196" name="Dedicated Transport" hidden="false" collective="false" import="true">
+          <entryLinks>
+            <entryLink id="894b-193f-f519-29c4" name="Land Raider Proteus" hidden="false" collective="false" import="true" targetId="8107-4220-2d1b-c16f" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="c74b-38cc-7b44-348c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="935f-5b1e-3040-c334" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </entryLink>
+            <entryLink id="641e-8c22-4586-200c" name="Rhino Armoured Carrier, Legion" hidden="false" collective="false" import="true" targetId="00ee-3a61-8872-d01e" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="c74b-38cc-7b44-348c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="935f-5b1e-3040-c334" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </entryLink>
+            <entryLink id="0db7-f797-0c7a-6562" name="Drop Pod" hidden="false" collective="false" import="true" targetId="2dcf-da0f-297d-fccf" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="948d-71e8-6673-6add" type="equalTo"/>
+                        <condition field="selections" scope="c74b-38cc-7b44-348c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="935f-5b1e-3040-c334" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="571e-45ff-ab08-1db1" name="Any model may exchange any Hand Flamer for a:" hidden="false" collective="false" import="true">
+          <modifiers>
+            <modifier type="increment" field="6ecb-a66b-def4-b143" value="2.0">
+              <repeats>
+                <repeat field="selections" scope="c74b-38cc-7b44-348c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="aff2-85a4-08e7-7cbe" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+            <modifier type="increment" field="aa91-5fd3-5233-5dc2" value="2.0">
+              <repeats>
+                <repeat field="selections" scope="c74b-38cc-7b44-348c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="aff2-85a4-08e7-7cbe" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+            <modifier type="decrement" field="aa91-5fd3-5233-5dc2" value="1.0">
+              <repeats>
+                <repeat field="selections" scope="c74b-38cc-7b44-348c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="16fb-4b91-ec70-d76a" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+            <modifier type="decrement" field="6ecb-a66b-def4-b143" value="1.0">
+              <repeats>
+                <repeat field="selections" scope="c74b-38cc-7b44-348c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="16fb-4b91-ec70-d76a" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="aa91-5fd3-5233-5dc2" type="min"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6ecb-a66b-def4-b143" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="edb9-f2f9-fb63-d443" name="Volkite Serpenta" hidden="false" collective="false" import="true" targetId="ae27-c659-fffd-1561" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="points" value="0.0"/>
+                <modifier type="set" field="e51d-cf89-f58a-6004" value="18.0"/>
+              </modifiers>
+            </entryLink>
+            <entryLink id="212f-167b-ede4-0a13" name="New EntryLink" hidden="false" collective="false" import="true" targetId="f832-f4b2-6aaf-ad83" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="190e-3e42-ee0a-f3e6" value="18.0"/>
+              </modifiers>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="2c74-0e5f-b51c-2847" name="Inferno Pistol " hidden="false" collective="false" import="true" targetId="13f8-6607-3525-4298" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="ccce-cd4b-c78d-16d1" value="18.0"/>
+              </modifiers>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="3330-b7f8-acaa-b1f0" name="Hand Flamer" hidden="false" collective="false" import="true" targetId="8a98-53c5-6fab-b3a7" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="points" value="0.0"/>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="3330-b7f8-acaa-b1f0" value="18.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="fdde-da0a-59d8-694a" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="16fb-4b91-ec70-d76a" name="For every 5 models in the squad, once may replace a Hand Flamer for a:" hidden="false" collective="false" import="true">
+          <modifiers>
+            <modifier type="increment" field="6a97-aee9-e543-70f4" value="1.0">
+              <repeats>
+                <repeat field="selections" scope="c74b-38cc-7b44-348c" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6a97-aee9-e543-70f4" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="e8ce-7067-4743-a393" name="Multi-melta with Suspensor Web" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="755c-37a1-1abb-c84b" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="a36f-f2f1-e181-3d5e" name="Multi-Melta (Suspensor)" publicationId="ca571888--pubN106502" page="178" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="52616e676523232344415441232323">12&quot;</characteristic>
+                    <characteristic name="Strength" typeId="537472656e67746823232344415441232323">8</characteristic>
+                    <characteristic name="AP" typeId="415023232344415441232323">1</characteristic>
+                    <characteristic name="Type" typeId="5479706523232344415441232323">Assault 1, Melta</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink id="9876-6304-ffca-2cbd" name="New InfoLink" hidden="false" targetId="21c0-62ff-3ed2-17a7" type="rule"/>
+                <infoLink id="8609-393f-3c4b-6c33" name="New InfoLink" hidden="false" targetId="4fc7-8b16-afe4-dad3" type="profile"/>
+                <infoLink id="2d88-23c0-40dd-0a8e" name="Suspensor Web" hidden="false" targetId="3d78-f901-8afc-00ff" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <entryLinks>
+            <entryLink id="4f25-3913-5866-1882" name="Heavy Flamer" hidden="false" collective="false" import="true" targetId="ead9-305c-a7e7-323e" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b3b9-2350-e6bd-1a77" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="9148-dd47-6138-b3b3" name="Toxiferran Flamer" hidden="false" collective="false" import="true" targetId="6ea5-16f0-e626-714a" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2c58-310e-fad3-77d8" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="4587-3019-a59d-b85d" name="Grenade launcher with Psyk-out grenades" hidden="false" collective="false" import="true" targetId="bb2a-7bc8-8ec3-52a8" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f46f-bb41-16b2-33ec" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="points" value="45.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="d0f7-e8a3-4202-87f4" name="Psyk-Out Grenades" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1a74-40fb-ac23-8ff1" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="41dd-952f-74fe-1473" name="Psyk-Out Grenade (Thrown)" hidden="false" targetId="764e-da44-1175-5ac6" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="bb2a-7bc8-8ec3-52a8" name="Grenade launcher with Psyk-out grenades" publicationId="ca571888--pubN103311" page="302" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4d47-0447-206c-8c4f" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="2760-dc3e-94ab-1a0a" name="Grenade launcher with Psyk-out grenades" publicationId="ca571888--pubN103311" page="302" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="52616e676523232344415441232323">24&quot;</characteristic>
+            <characteristic name="Strength" typeId="537472656e67746823232344415441232323">2</characteristic>
+            <characteristic name="AP" typeId="415023232344415441232323">-</characteristic>
+            <characteristic name="Type" typeId="5479706523232344415441232323">Assault 1, Blast (3&quot;), Psi-shock</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="6b46-95cb-8eb4-19bb" name="Psy-shock" hidden="false" targetId="5c68-573a-b2b6-3634" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6ea5-16f0-e626-714a" name="Toxiferran Flamer" publicationId="ca571888--pubN103311" page="302" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="25ad-f1f0-67a5-5224" name="Toxiferran Flamer" publicationId="ca571888--pubN103311" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="52616e676523232344415441232323">Template</characteristic>
+            <characteristic name="Strength" typeId="537472656e67746823232344415441232323">4</characteristic>
+            <characteristic name="AP" typeId="415023232344415441232323">5</characteristic>
+            <characteristic name="Type" typeId="5479706523232344415441232323">Assault 1, Poisoned (3+), Tainted</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="5bec-1898-c5d2-c728" name="Tainted" publicationId="ca571888--pubN103311" page="302" hidden="false">
+          <description>Any successful wound dealt by a weapon with this special rule removes the effects of any psychic blessing which is active on the target unit. In addition, any To Wound roll of a 6 with this weapon is resolved at AP2.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="9804-10f9-7bfc-8b72" name="Poisoned" hidden="false" targetId="a5ff-1cb1-bee4-d809" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="402b-5f71-93f2-d28f" name="Heavy Destroyer Squad, Legion" publicationId="0e6e-8c19-c436-39c4" page="" hidden="false" collective="false" import="true" type="unit">
+      <rules>
+        <rule id="f3e4-33c2-35f8-cb68" name="Legion Destroyer Company" hidden="false">
+          <description>When selected as part of a Legion Destroyer Company, Heavy Destroyers may be equipped with Teleportation Transponders for +15 points per squad.</description>
+        </rule>
+        <rule id="ab5b-e3a9-55c2-4e79" name="Lone Killers" publicationId="0e6e-8c19-c436-39c4" hidden="false">
+          <description>The unit cannot be joined by any other model.</description>
+        </rule>
+        <rule id="74d8-0f79-0ded-1a13" name="Gunfighter" publicationId="0e6e-8c19-c436-39c4" hidden="false">
+          <description>The model can fire two identical weapon as one weapon.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="b79e-298f-3eb9-1f40" name="Hardened Armour" hidden="false" targetId="7439f6fd-4c50-f88a-eb41-81d9b9c9eed8" type="rule"/>
+        <infoLink id="89cf-79a0-e41b-0e2d" name="Counter-attack" hidden="false" targetId="0900-71d5-1937-aa96" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="2bc8-a222-bb27-c797" name="Infantry" hidden="false" targetId="1ab3-f1ac-f724-8544" primary="false"/>
+        <categoryLink id="fad3-5944-21a9-7edd" name="Legiones Astartes" hidden="false" targetId="f321-f2d7-7d68-8f93" primary="false"/>
+        <categoryLink id="90e2-db74-9854-5935" name="New CategoryLink" hidden="false" targetId="db5f-8f10-8525-28d4" primary="true"/>
+        <categoryLink id="47bf-0773-7476-e011" name="Terminators" hidden="false" targetId="0eb0-2501-9397-1104" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="0c6f-2344-d7ea-5d54" name="Heavy Destroyer" page="0" hidden="false" collective="false" import="true" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a3b6-bb38-d239-91a6" type="min"/>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="923f-b683-fb0f-1afe" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="ab17-b08e-dc13-9481" name="Heavy Destroyer" publicationId="0e6e-8c19-c436-39c4" page="" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+              <characteristics>
+                <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry</characteristic>
+                <characteristic name="WS" typeId="575323232344415441232323">4</characteristic>
+                <characteristic name="BS" typeId="425323232344415441232323">4</characteristic>
+                <characteristic name="S" typeId="5323232344415441232323">4</characteristic>
+                <characteristic name="T" typeId="5423232344415441232323">4</characteristic>
+                <characteristic name="W" typeId="5723232344415441232323">1</characteristic>
+                <characteristic name="I" typeId="4923232344415441232323">4</characteristic>
+                <characteristic name="A" typeId="4123232344415441232323">2</characteristic>
+                <characteristic name="LD" typeId="4c4423232344415441232323">9</characteristic>
+                <characteristic name="Save" typeId="5361766523232344415441232323">2+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="35.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="3e92-26a4-7436-d180" name="Heavy Destroyer Sergeant" hidden="false" collective="false" import="true" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="51e5-b1e6-067c-a53c" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f586-775d-4b60-ad7d" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="74ea-6db7-6721-5393" name="Heavy Destroyer Sergeant" publicationId="0e6e-8c19-c436-39c4" page="" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+              <characteristics>
+                <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry (Character)</characteristic>
+                <characteristic name="WS" typeId="575323232344415441232323">4</characteristic>
+                <characteristic name="BS" typeId="425323232344415441232323">4</characteristic>
+                <characteristic name="S" typeId="5323232344415441232323">4</characteristic>
+                <characteristic name="T" typeId="5423232344415441232323">4</characteristic>
+                <characteristic name="W" typeId="5723232344415441232323">1</characteristic>
+                <characteristic name="I" typeId="4923232344415441232323">4</characteristic>
+                <characteristic name="A" typeId="4123232344415441232323">3</characteristic>
+                <characteristic name="LD" typeId="4c4423232344415441232323">9</characteristic>
+                <characteristic name="Save" typeId="5361766523232344415441232323">2+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <categoryLinks>
+            <categoryLink id="a1fe-7ec9-1197-a220" name="Character" hidden="false" targetId="ae54-92c7-3e66-59f7" primary="false"/>
+          </categoryLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="a8fc-562f-5898-448b" name="Sergeant&apos;s Weapons" hidden="false" collective="false" import="true">
+          <selectionEntryGroups>
+            <selectionEntryGroup id="aa1e-5d72-322c-38c2" name="May exchange Volkite Chargers for:" hidden="false" collective="false" import="true">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="decb-fa11-db55-ce3f" type="min"/>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ba80-756f-4a27-40d7" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="ec07-47f5-e8d3-d7b2" name="Heavy Flamer with Chem-munitions" hidden="false" collective="false" import="true" type="upgrade">
+                  <profiles>
+                    <profile id="e5e4-82f0-f465-2fbf" name="Heavy Flamer with Chem-munitions" publicationId="ca571888--pubN106502" page="177" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+                      <characteristics>
+                        <characteristic name="Range" typeId="52616e676523232344415441232323">Template</characteristic>
+                        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">5</characteristic>
+                        <characteristic name="AP" typeId="415023232344415441232323">4</characteristic>
+                        <characteristic name="Type" typeId="5479706523232344415441232323">Assault 1, Shred, Gets Hot</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <infoLinks>
+                    <infoLink id="f2a9-856c-4ee1-bdb9" name="Shred" hidden="false" targetId="89da-0cb5-bee4-8ec2" type="rule"/>
+                    <infoLink id="ad2f-8330-a31c-2e15" name="Gets Hot" hidden="false" targetId="f4fd-d519-4769-5510" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <entryLinks>
+                <entryLink id="2ff4-08e9-de93-0e3e" name="Lightning Claw" hidden="false" collective="false" import="true" targetId="26db-484d-3757-03c8" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="b2ab-5b47-b382-d02f" value="2.0"/>
+                  </modifiers>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="7a47-2e5b-75be-750b" name="Thunder Hammer" hidden="false" collective="false" import="true" targetId="925c-50d4-0101-e0e7" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="15.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="097a-dcf3-7025-9d02" name="Power Axe" hidden="false" collective="false" import="true" targetId="7b92-ab87-86a1-ab2e" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5020-b54c-ea30-2497" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="d61d-14c5-1fcb-1527" name="Power Lance" hidden="false" collective="false" import="true" targetId="233d-238b-6940-2740" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ec55-a105-0ec3-e84b" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="589f-894d-cb8f-5e78" name="Volkite Charger" hidden="false" collective="false" import="true" targetId="f0c0-384d-440f-c03b" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="1823-e312-2e06-58c9" value="2.0"/>
+                    <modifier type="set" field="points" value="0.0"/>
+                  </modifiers>
+                </entryLink>
+                <entryLink id="af8d-6ce1-e5c1-768e" name="Power Maul" hidden="false" collective="false" import="true" targetId="e8a2-42e8-82a7-8dd9" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ff83-1aa1-97d6-99ec" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="8bff-f760-c0a6-3813" name="Power Sword" hidden="false" collective="false" import="true" targetId="3e90-5ca1-8abe-0275" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="03f8-94d2-6332-2fc5" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="f2d2-1858-e5a6-faea" name="Chainaxe" hidden="false" collective="false" import="true" targetId="a3a3-3a90-0c2a-cd81" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ba3c-2676-6d32-cf6c" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="6fa5-5781-59f2-58bc" name="Irad-Cleanser" hidden="false" collective="false" import="true" targetId="32e0-80f7-982d-b29a" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d448-0bce-a45b-3941" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="f98f-c8a4-0a92-f229" name="Heavy Bolter" hidden="false" collective="false" import="true" targetId="a161-76b3-9ef1-da7b" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="12bb-7d31-2386-41f9" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="7e3e-84e9-944d-cac7" name="Toxiferran Flamer" hidden="false" collective="false" import="true" targetId="6ea5-16f0-e626-714a" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6765-4ac1-61c7-ff43" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="e684-bbf8-69f6-1e99" name="Sergeant may take" hidden="false" collective="false" import="true">
+          <selectionEntries>
+            <selectionEntry id="5dd0-d309-6ae0-b403" name="Fallout Discharger" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="95f1-c5f1-f36a-dc9d" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="8333-7ff5-87d8-e84a" name="Fallout Discharger" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="52616e676523232344415441232323">Template</characteristic>
+                    <characteristic name="Strength" typeId="537472656e67746823232344415441232323">0</characteristic>
+                    <characteristic name="AP" typeId="415023232344415441232323">-</characteristic>
+                    <characteristic name="Type" typeId="5479706523232344415441232323">One use, Radiation Sickness</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules>
+                <rule id="d66c-bb91-b289-b667" name="Fallout Discharger / Radiation Sickness" hidden="false">
+                  <description>A Fallout Discharger is activated at the beginning of the controlling player’s shooting phase. Any model hit by the Template confers Radiation Sickness to their entire unit. Models affected by Radiation Sickness suffer -1 Toughness (to a minimum of 1) until the end of the player turn. This stacks with the effects of rad grenades, rad missiles rad furnaces etc.</description>
+                </rule>
+              </rules>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <entryLinks>
+            <entryLink id="969d-2283-7c5c-289b" name="Phosphex Bombs" hidden="false" collective="false" import="true" targetId="2049-e6ba-1547-a605" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="74b8-5e2f-2e6c-4735" name="Dedicated Transport" hidden="false" collective="false" import="true">
+          <entryLinks>
+            <entryLink id="9206-1618-cb81-b401" name="Land Raider Proteus" hidden="false" collective="false" import="true" targetId="8107-4220-2d1b-c16f" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="402b-5f71-93f2-d28f" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </entryLink>
+            <entryLink id="d769-cea7-3ef7-7eb2" name="Anvillus Pattern Dreadclaw Drop Pod (Orbital Assault Only)" hidden="false" collective="false" import="true" targetId="cc5e-a4e6-83f9-7077" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="402b-5f71-93f2-d28f" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="1804-9387-5225-968b" name="Any model may exchange any Volkite Charger for:" hidden="false" collective="false" import="true">
+          <modifiers>
+            <modifier type="increment" field="0348-a5d4-a80a-ead3" value="2.0">
+              <repeats>
+                <repeat field="selections" scope="402b-5f71-93f2-d28f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0c6f-2344-d7ea-5d54" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+            <modifier type="increment" field="0a1f-aecc-b6bb-ebe9" value="2.0">
+              <repeats>
+                <repeat field="selections" scope="402b-5f71-93f2-d28f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0c6f-2344-d7ea-5d54" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+            <modifier type="decrement" field="0a1f-aecc-b6bb-ebe9" value="1.0">
+              <repeats>
+                <repeat field="selections" scope="402b-5f71-93f2-d28f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3d74-48ce-7c5b-2332" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+            <modifier type="decrement" field="0348-a5d4-a80a-ead3" value="1.0">
+              <repeats>
+                <repeat field="selections" scope="402b-5f71-93f2-d28f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3d74-48ce-7c5b-2332" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0348-a5d4-a80a-ead3" type="min"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0a1f-aecc-b6bb-ebe9" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="e137-082e-8bb2-46c1" name="Volkite Charger" hidden="false" collective="false" import="true" targetId="f0c0-384d-440f-c03b" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="points" value="0.0"/>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="e137-082e-8bb2-46c1" value="18.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="fabd-e7fd-dd71-95fc" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="41c8-187c-a763-5954" name="Chainaxe" hidden="false" collective="false" import="true" targetId="a3a3-3a90-0c2a-cd81" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="18.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="344d-a22f-d3f2-fd04" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="8213-1c33-1597-94c3" name="Heavy Bolter" hidden="false" collective="false" import="true" targetId="a161-76b3-9ef1-da7b" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="18.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="250d-c49f-9382-f403" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="81ad-cf15-cc95-1a2a" name="Irad-Cleanser" hidden="false" collective="false" import="true" targetId="32e0-80f7-982d-b29a" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="18.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="50ed-af30-c4ad-26b8" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="b3f1-d9ce-cc6d-f5d1" name="Lightning Claw" hidden="false" collective="false" import="true" targetId="26db-484d-3757-03c8" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="b2ab-5b47-b382-d02f" value="18.0"/>
+              </modifiers>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="0b29-faff-53ac-e09b" name="Power Axe" hidden="false" collective="false" import="true" targetId="7b92-ab87-86a1-ab2e" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="18.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2767-5c97-0aae-cd07" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="7d3c-e6ef-9691-276a" name="Power Lance" hidden="false" collective="false" import="true" targetId="233d-238b-6940-2740" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="18.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3140-c5c0-2c55-62f5" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="6c04-4547-49ab-1de9" name="Power Maul" hidden="false" collective="false" import="true" targetId="e8a2-42e8-82a7-8dd9" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="18.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="359e-1b5c-65c2-4046" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="b7fd-a412-24a0-317a" name="Power Sword" hidden="false" collective="false" import="true" targetId="3e90-5ca1-8abe-0275" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="18.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cc51-f526-478f-3800" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="ff45-5606-1b2b-f65f" name="Toxiferran Flamer" hidden="false" collective="false" import="true" targetId="6ea5-16f0-e626-714a" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="18.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="21bb-1f15-796e-d0e5" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="3d74-48ce-7c5b-2332" name="For every 5 models in the squad, once may replace a Hand Flamer for a:" hidden="false" collective="false" import="true">
+          <modifiers>
+            <modifier type="increment" field="317e-8f97-9820-a39b" value="1.0">
+              <repeats>
+                <repeat field="selections" scope="402b-5f71-93f2-d28f" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="317e-8f97-9820-a39b" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="cecf-f289-6081-dfd3" name="Missile Launcher with Rad Missiles" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2f36-a1e1-adea-bacc" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="68b7-aeb3-3d11-8a5a" name="Rad Missile" hidden="false" targetId="fd99-1d8e-87fa-e8e8" type="profile"/>
+                <infoLink id="fd29-ed32-285f-3fae" name="Fleshbane" hidden="false" targetId="4575-0a0a-caaf-e4bf" type="rule"/>
+                <infoLink id="def4-99f1-93a9-5f93" name="Rad-phage" hidden="false" targetId="eefe-09e4-17aa-deb2" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="15.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="318a-bf25-51fc-ce1c" name="Irradiation Engine (without Torrent)" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f3c6-9d41-eb41-34ff" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="728b-f0d4-d985-1d69" name="Irradiation Engine (withiout Torrent)" publicationId="ca571888--pubN106502" page="177" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="52616e676523232344415441232323">Template</characteristic>
+                    <characteristic name="Strength" typeId="537472656e67746823232344415441232323">4</characteristic>
+                    <characteristic name="AP" typeId="415023232344415441232323">3</characteristic>
+                    <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 1, Fleshbane, Rad-phage</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink id="2222-d2e9-5e62-773d" name="Fleshbane" hidden="false" targetId="4575-0a0a-caaf-e4bf" type="rule"/>
+                <infoLink id="c0ba-31e0-0d75-b25f" name="Rad-phage" hidden="false" targetId="eefe-09e4-17aa-deb2" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="15.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <entryLinks>
+            <entryLink id="c4fa-a5c5-287b-fd53" name="Volkite Culverin" hidden="false" collective="false" import="true" targetId="dbd1-57bb-ee82-416c" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="09dc-5e4a-6c7d-d826" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="15.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="f0d3-adc9-5543-f4db" name="Toxiferno Cannon" hidden="false" collective="false" import="true" targetId="4ba2-3e2c-7341-0531" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dc10-c049-a670-5035" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="15.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="efa7-b093-9a60-0528" name="Teleportation Transponder" hidden="false" collective="false" import="true" targetId="c624-e809-3fd3-15bc" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="efd6-c161-db9c-d837" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb3-6eea-535f-86a5" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2732-8ccb-cc97-ee5d" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="set" field="points" value="15.0">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="efd6-c161-db9c-d837" type="equalTo"/>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb3-6eea-535f-86a5" type="equalTo"/>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2732-8ccb-cc97-ee5d" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="60.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2049-e6ba-1547-a605" name="Phosphex Bombs" page="0" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4488-f8d5-8a2d-3bce" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="40fa-d336-8862-a076" name="Phosphex Bomb" hidden="false" targetId="62c4-32da-84f2-5033" type="profile"/>
+        <infoLink id="71ca-c95c-bd2a-36d2" name="Crawling Fire" hidden="false" targetId="91ee-e6c7-272f-49e0" type="rule"/>
+        <infoLink id="4da3-e3ad-5f7b-e480" name="Lingering Death" hidden="false" targetId="3a2e-7a7b-1de3-78c0" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+  </sharedSelectionEntries>
+  <sharedSelectionEntryGroups>
+    <selectionEntryGroup id="1230-9588-bb07-b67f" name="Allegiance" hidden="false" collective="false" import="true">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4ae8-8010-c0e7-d3dd" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1718-0187-c812-ffc3" type="max"/>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7a7a-4be8-635e-210f" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="e348-5834-5741-186f" name="Traitor" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0527-7ef3-bb4d-7d75" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="a82a-f8d9-d454-b227" name="Loyalist" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3b4a-2290-7346-7bc6" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="7660-b542-e9a6-0cbb" name="Combi-weapon" hidden="false" collective="true" import="true">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="49dc-f602-eb56-962e" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a4d7-2814-6ada-7bbe" type="min"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="6d37-0b33-036e-84fe" name="Combi-weapon: Flamer" hidden="false" collective="false" import="true" type="upgrade">
+          <infoLinks>
+            <infoLink id="846b-e3d0-b29f-0eb7" name="Boltgun" hidden="false" targetId="09fd-8af1-a6b1-51f7" type="profile"/>
+            <infoLink id="5373-5afe-49a4-6180" name="Combi-weapon: Flamer" hidden="false" targetId="518c-084b-7a8a-949e" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="a543-f0e1-d772-8937" name="Combi-weapon: Meltagun" hidden="false" collective="false" import="true" type="upgrade">
+          <infoLinks>
+            <infoLink id="d61b-c33a-3f37-dd0c" name="New InfoLink" hidden="false" targetId="09fd-8af1-a6b1-51f7" type="profile"/>
+            <infoLink id="cae4-a3e5-6768-152f" name="New InfoLink" hidden="false" targetId="d30d-adeb-818b-09e3" type="profile"/>
+            <infoLink id="88e3-4f6c-6ecb-a73b" name="New InfoLink" hidden="false" targetId="21c0-62ff-3ed2-17a7" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="4599-9885-2b8a-e4a1" name="Combi-weapon: Plasma gun" hidden="false" collective="false" import="true" type="upgrade">
+          <infoLinks>
+            <infoLink id="e763-3a7f-7485-e956" name="New InfoLink" hidden="false" targetId="09fd-8af1-a6b1-51f7" type="profile"/>
+            <infoLink id="db09-b89f-aaee-2cff" name="New InfoLink" hidden="false" targetId="3729-f674-0501-ebeb" type="profile"/>
+            <infoLink id="e7a4-cbcb-0233-8ff6" name="New InfoLink" hidden="false" targetId="f4fd-d519-4769-5510" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="fae6-c7f9-ba4e-100c" name="Combi-Weapon: Grenade Launcher" hidden="false" collective="false" import="true" type="upgrade">
+          <infoLinks>
+            <infoLink id="5a97-9140-0567-294e" name="Boltgun" hidden="false" targetId="09fd-8af1-a6b1-51f7" type="profile"/>
+            <infoLink id="f6cf-fa04-8902-f547" name="New InfoLink" hidden="false" targetId="aaed-cf64-e81a-0c4f" type="profile"/>
+            <infoLink id="e1a1-19c7-3d87-c1a6" name="New InfoLink" hidden="false" targetId="fe44-0451-8676-ccfb" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="26d0-dc42-8031-f316" name="Combi-weapon: Volkite Charger" hidden="false" collective="false" import="true" type="upgrade">
+          <infoLinks>
+            <infoLink id="6e20-3e15-40a5-feaa" name="New InfoLink" hidden="false" targetId="09fd-8af1-a6b1-51f7" type="profile"/>
+            <infoLink id="7377-68b9-a272-5095" name="New InfoLink" hidden="false" targetId="20ab-d2f5-47a5-dbe2" type="profile"/>
+            <infoLink id="e5ee-c0cd-1bd4-0b2c" name="Deflagrate" hidden="false" targetId="b46a-a3ec-91a5-5001" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="04d3-346a-f264-9573" name="May take a Pintle-Mounted Weapon:" hidden="false" collective="false" import="true">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="10b4-492b-bae4-798b" type="max"/>
+      </constraints>
+      <entryLinks>
+        <entryLink id="a151-eebd-d1ec-1404" name="Twin-linked Bolter" hidden="false" collective="false" import="true" targetId="eaec-b433-8e4d-1da5" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="points" value="5"/>
+            <modifier type="set" field="e441-850a-32c6-155e" value="2.0"/>
+          </modifiers>
+        </entryLink>
+        <entryLink id="e776-88d1-d5bc-db44" name="Havoc Launcher" hidden="false" collective="false" import="true" targetId="0760-1529-35e8-a884" type="selectionEntry"/>
+        <entryLink id="a337-769a-f105-a26b" name="Multi-melta" hidden="false" collective="false" import="true" targetId="d1c0-746f-2b39-5f17" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="points" value="15"/>
+          </modifiers>
+        </entryLink>
+        <entryLink id="9545-230f-92ef-61d2" name="New EntryLink" hidden="false" collective="false" import="true" targetId="a161-76b3-9ef1-da7b" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="points" value="10"/>
+          </modifiers>
+        </entryLink>
+        <entryLink id="cde8-3225-c955-90c4" name="Combi-weapon" hidden="false" collective="false" import="true" targetId="f07b-6978-8f48-6c0f" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="points" value="5.0"/>
+          </modifiers>
+        </entryLink>
+        <entryLink id="4562-27a3-b88d-0500" name="Heavy Flamer" hidden="false" collective="false" import="true" targetId="ead9-305c-a7e7-323e" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="points" value="10"/>
+          </modifiers>
+        </entryLink>
+      </entryLinks>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="cd8f-b95d-b455-e7c9" name="Combi-weapon with Banestrike" hidden="false" collective="false" import="true">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5f6e-d439-dd09-02e4" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6bce-f9f1-19ca-c236" type="min"/>
+      </constraints>
+      <profiles>
+        <profile id="86aa-1007-998b-5b44" name="Banestrike Bolter Shells" publicationId="ca571888--pubN67459" page="9" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
+          <characteristics>
+            <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Reduces range of Boltgun and Combi-bolters to 18&quot; and provides the Banestrike rule.  Weapons with Banestrike change their AP value to 3 on &quot;to-wound&quot; rolls of a 6. </characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <selectionEntries>
+        <selectionEntry id="2ec2-70a4-99ee-ac1a" name="Combi-bolter with Banestrike" hidden="false" collective="false" import="true" type="upgrade">
+          <infoLinks>
+            <infoLink id="7dd6-c335-f621-cf77" name="Bolter with Banestrike Rounds" hidden="false" targetId="0cc3-b3b0-0880-9366" type="profile"/>
+            <infoLink id="7c21-0962-ae11-20e1" name="Twin-linked" hidden="false" targetId="10a8-8d89-0bec-3e21" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="f25c-e3eb-43fe-e056" name="Combi-weapon with Banestrike: Flamer" hidden="false" collective="false" import="true" type="upgrade">
+          <infoLinks>
+            <infoLink id="2b55-e588-8a4f-bf8e" name="New InfoLink" hidden="false" targetId="518c-084b-7a8a-949e" type="profile"/>
+            <infoLink id="3869-fa26-b677-35a8" name="Bolter with Banestrike Rounds" hidden="false" targetId="0cc3-b3b0-0880-9366" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="7.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="72d2-f3e2-71f0-2e29" name="Combi-Weapon with Banestrike: Grenade Launcher" hidden="false" collective="false" import="true" type="upgrade">
+          <infoLinks>
+            <infoLink id="f8ca-b282-3216-e4f9" name="New InfoLink" hidden="false" targetId="aaed-cf64-e81a-0c4f" type="profile"/>
+            <infoLink id="31b9-d806-994f-6b6b" name="New InfoLink" hidden="false" targetId="fe44-0451-8676-ccfb" type="profile"/>
+            <infoLink id="9cdd-5c8c-1fd0-09cc" name="Bolter with Banestrike Rounds" hidden="false" targetId="0cc3-b3b0-0880-9366" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="7.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="bb16-e46c-6b3d-df53" name="Combi-weapon with Banestrike: Meltagun" hidden="false" collective="false" import="true" type="upgrade">
+          <infoLinks>
+            <infoLink id="83f1-9234-b1d5-963f" name="New InfoLink" hidden="false" targetId="d30d-adeb-818b-09e3" type="profile"/>
+            <infoLink id="d95b-42ca-1b05-2d76" name="New InfoLink" hidden="false" targetId="21c0-62ff-3ed2-17a7" type="rule"/>
+            <infoLink id="f92c-10e6-0b45-1239" name="Bolter with Banestrike Rounds" hidden="false" targetId="0cc3-b3b0-0880-9366" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="7.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="39e8-8688-a77c-8644" name="Combi-weapon with Banestrike: Plasma gun" hidden="false" collective="false" import="true" type="upgrade">
+          <infoLinks>
+            <infoLink id="fd61-ab40-0be2-7670" name="New InfoLink" hidden="false" targetId="3729-f674-0501-ebeb" type="profile"/>
+            <infoLink id="d1c7-cd5d-d6c3-f68e" name="New InfoLink" hidden="false" targetId="f4fd-d519-4769-5510" type="rule"/>
+            <infoLink id="2da6-668d-d801-f6be" name="Bolter with Banestrike Rounds" hidden="false" targetId="0cc3-b3b0-0880-9366" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="7.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="15ec-4272-3dae-fef5" name="Combi-weapon with Banestrike: Volkite Charger" hidden="false" collective="false" import="true" type="upgrade">
+          <infoLinks>
+            <infoLink id="ac86-4b8c-344f-bd8c" name="New InfoLink" hidden="false" targetId="20ab-d2f5-47a5-dbe2" type="profile"/>
+            <infoLink id="1295-5088-18f3-8f33" name="Deflagrate" hidden="false" targetId="b46a-a3ec-91a5-5001" type="rule"/>
+            <infoLink id="f925-2e16-7424-504f" name="Bolter with Banestrike Rounds" hidden="false" targetId="0cc3-b3b0-0880-9366" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="7.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="2c3d-7775-ab39-65d4" name="Dreadnought CCW In-built:" hidden="false" collective="false" import="true" defaultSelectionEntryId="971f-3fdb-b4d5-551d">
+      <constraints>
+        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="aebf-ecd1-3dad-8b1f" type="max"/>
+        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2755-7b1e-b0b5-02f1" type="min"/>
+      </constraints>
+      <entryLinks>
+        <entryLink id="bab7-2ef0-0022-ba1d" name="Graviton Gun" hidden="false" collective="false" import="true" targetId="ec29-0748-6778-ff60" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1524-ecd3-80b0-453c" type="instanceOf"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c5f3-3738-8ed3-433b" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="2a93-96a1-0caa-d6da" name="Heavy Flamer" hidden="false" collective="false" import="true" targetId="ead9-305c-a7e7-323e" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="points" value="10"/>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0a89-808a-b614-c8a4" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="011f-8d3d-38b8-3277" name="Meltagun" hidden="false" collective="false" import="true" targetId="a22d-ceac-5063-54e1" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="c23b-b876-e683-4f04" value="2.0"/>
+          </modifiers>
+        </entryLink>
+        <entryLink id="1f17-f4b2-90f9-eb35" name="Plasma Blaster" hidden="false" collective="false" import="true" targetId="90d6-af34-57e7-f86b" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="points" value="20.0"/>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1524-ecd3-80b0-453c" type="instanceOf"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
+        <entryLink id="971f-3fdb-b4d5-551d" name="Twin-linked Bolter" hidden="false" collective="false" import="true" targetId="eaec-b433-8e4d-1da5" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="e441-850a-32c6-155e" value="2.0"/>
+          </modifiers>
+        </entryLink>
+        <entryLink id="24b0-c254-e05c-a980" name="Iliastus Pattern Assault Cannon" hidden="false" collective="false" import="true" targetId="6dee-1245-4b8b-910b" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="points" value="25.0"/>
+            <modifier type="set" field="bd75-ea40-6ec4-1f61" value="2.0"/>
+          </modifiers>
+        </entryLink>
+      </entryLinks>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="9cc1-123b-848a-d8d6" name="Legions" hidden="false" collective="false" import="true">
+      <categoryLinks>
+        <categoryLink id="72a9-ddbd-9167-f014" name="New CategoryLink" hidden="false" targetId="5962-83d3-6a2c-06d0" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="0a1c-44d8-4d14-c203" name="   VI: Space Wolves" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8a9c-7d5b-29a1-8189" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="b3f9-9243-5c8d-423c" name="Bestial Savagery" publicationId="ca571888--pubN92115" page="222" hidden="false">
+              <description>Models with this special rule gain a 1 WS bonus on any turn in which they have successfully charged. Additionally, they gain the Counter-attack special rule, and if any unit with this special rule has won combat on any turn in which they have charged or counter-charged, they must make a sweeping advance if they are able to.</description>
+            </rule>
+            <rule id="3a1c-8d3e-f874-f4d3" name="Hunter&apos;s Gait" hidden="false">
+              <description>Infantry models with this special rule add 1&quot; to their Run and Consolidation distances so long as they are not equipped with jump packs or Terminator armour of any kind.</description>
+            </rule>
+            <rule id="ad2b-7039-f0e2-1384" name="Preternatural Senses" publicationId="ca571888--pubN92115" page="222" hidden="false">
+              <description>Models with this special rule may ignore the effects of Night Fighting, re-roll its dice to determine which table edge they arrive from when outflanking, and infiltrating models may not be set up within 18&quot; of them regardless of line of sight.</description>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="85e6-13ae-9f06-5fe7" name="Legiones Astartes" hidden="false" targetId="23a4-a37f-e8e8-c756" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="eac6-9b93-9a5a-a30b" name=" XX: Alpha Legion" page="" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e2f7-0cb4-1c15-6ed9" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="44b9-0138-fc2f-c478" name="The Alpha Legion" publicationId="ca571888--pubN67459" page="" hidden="false">
+              <description>• Mutable Tactics: An Alpha Legion army must pick one of the following special rules at the point where Warlord Traits have been selected for the game. This rule then applies to all of the units in the detachment with the Legiones Astartes (Alpha Legion) special rule for the duration of this game:
+- Scout
+- Infiltrate
+- Tank Hunters
+- Counter-attack
+- Move Through Cover
+- Adamantium Will
+• Martial Hubris: In any mission where secondary objectives are being used, and an Alpha Legion army is your army’s primary detachment, if the Alpha Legion army has suffered more units destroyed than their enemy at the end of the game, then their enemy gains 1 Victory point.
+(In the case of Shattered Legions. The army only gains both of these benifits if the Warlord is Alpha Legion)</description>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="fe6d-835a-2d1e-29d4" name="Legiones Astartes" hidden="false" targetId="23a4-a37f-e8e8-c756" type="rule"/>
+          </infoLinks>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="43dd-3ef0-813e-f8c1" name="Mutable Tactics" hidden="false" collective="false" import="true">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3f19-b7b1-5f95-a8ec" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ad15-1938-d67e-2308" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="055f-c123-7ebd-336f" name="Infiltrate" hidden="false" collective="false" import="true" type="upgrade">
+                  <infoLinks>
+                    <infoLink id="a09f-714f-c255-5d9d" name="Infiltrate" hidden="false" targetId="34c7-8b61-a5b8-a301" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="a6e5-6a82-0cec-4bfe" name="Scout" hidden="false" collective="false" import="true" type="upgrade">
+                  <infoLinks>
+                    <infoLink id="3bd3-ad12-f91f-115f" name="Scout" hidden="false" targetId="9b30-1da3-eb8d-ce7a" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="6f26-8f73-d423-5eca" name="Tank Hunters" hidden="false" collective="false" import="true" type="upgrade">
+                  <infoLinks>
+                    <infoLink id="6ae3-704d-8089-aa27" name="Tank Hunters" hidden="false" targetId="5d88-bcf6-e410-6e01" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="60f2-d519-5f42-43ba" name="Counter-attack" hidden="false" collective="false" import="true" type="upgrade">
+                  <infoLinks>
+                    <infoLink id="ff61-fda4-0c99-4300" name="Counter-attack" hidden="false" targetId="0900-71d5-1937-aa96" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="1056-321b-5a48-8a5c" name="Move Through Cover" hidden="false" collective="false" import="true" type="upgrade">
+                  <infoLinks>
+                    <infoLink id="2f92-9335-827a-6d44" name="Move Through Cover" hidden="false" targetId="6d06-5ea0-9a17-ca97" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="af94-5c6c-6d5f-91de" name="Adamantium Will" hidden="false" collective="false" import="true" type="upgrade">
+                  <infoLinks>
+                    <infoLink id="59dd-9d8e-7668-c5ea" name="Adamantium Will" hidden="false" targetId="df87-e991-2d30-dc38" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="550e-dd7c-23b2-c37b" name="  XVI: Sons of Horus" page="" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="46e6-a9ac-0b52-649f" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="935a-3fa8-d432-e212" name="The Sons of Horus" publicationId="ca571888--pubN67459" page="80" hidden="false">
+              <description>• The Edge of the Spear: Units with this rule who are held in Reserve (and any transport vehicles they are being carried in) may, if their controlling player wishes, re-roll results of a T’ when making Reserve rolls.
+• Bitter Pride: Units with this special rule cannot benefit from the Warlord Trait of an allied character or an allied Independent Character’s Leadership score.
+• Merciless Fighters: If the number of Sons of Horus infantry models* in a particular close combat is greater than that of the enemy during Initiative step 1 of the Fight sub-phase, then each model with this rule that has already fought may make a single additional attack.
+• Death Dealer: Models with this special rule gain 1 BS when shooting with Pistol, Assault and Rapid Fire weapons at targets 12&quot; or less away (this special rule does not apply when making Snap Shots, Chain Fire or Fury of the Legion attacks).
+*Count Bulky models on both sides as two models each, and very Bulky models as three models each for the purpose of working this out.</description>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="2c0f-950a-1414-5076" name="Legiones Astartes" hidden="false" targetId="23a4-a37f-e8e8-c756" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="b7d6-8217-4fe9-45d4" name="  X: Iron Hands" page="" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="677f-c259-4e69-0745" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="05a5-74ee-2093-0d01" name="The Iron Hands" publicationId="ca571888--pubN67459" page="44" hidden="false">
+              <description>• Inviolate Armour: All models with the Legiones Astartes (Iron Hands) special rule reduce the strength of all shooting attacks against them by -1.
+• Stand and Fight: All models with the Legiones Astartes (Iron Hands) special rule must pass a Leadership test in order to make Sweeping Advances after winning an assault or to make a Run move in the Shooting phase. In addition, models with this rule may not voluntarily Go to Ground.
+• Rigid Tactics: An Iron Hands detachment may not have more units with the Legiones Astartes (Iron Hands) special rule in total (including Independent Characters) with the Jump Infantry, Bike or Jetbike types than it does with the Infantry type. Note that because of this, certain Rites of War are unavailable to Iron Hands armies. (In the case of Shattered Legions. The army does not gain the benifits of Rigid Tactics)</description>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="dce1-d57b-2e7b-90f0" name="Legiones Astartes" hidden="false" targetId="23a4-a37f-e8e8-c756" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="0f9b-69d0-8106-dc52" name="  XIV: Death Guard" page="" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="56d4-b99d-6a91-1cb0" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="5adb-31f9-164c-5573" name="The Death Guard" publicationId="ca571888--pubN67459" page="70" hidden="false">
+              <description>• Remorseless: The Death Guard are immune to Fear and automatically pass any Pinning tests they are called on to make.
+• Sons of Barbarus: Veterans of the most hellish battlefields of the Great Crusade, Death Guard models with this special rule may re-roll failed Dangerous Terrain tests. Models with this rule also gain a Feel No Pain (4) against any wounds inflicted against them by attacks that have the Poison or Fleshbane type ability. This ability cannot be combined with Feel no Pain from other sources.
+• Intractable: When making Sweeping Advance tests, models with this special rule reduce the score they roll by -1.</description>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="1b7e-30f4-ada9-bba6" name="New InfoLink" hidden="false" targetId="5862-0794-3d86-5788" type="rule"/>
+            <infoLink id="a5da-a04d-f5c6-47cf" name="Legiones Astartes" hidden="false" targetId="23a4-a37f-e8e8-c756" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="59f6-638d-8c1d-75dd" name="  IX: Blood Angels" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f72d-9b32-ba8d-e59b" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="867d-4d45-2c52-d6a1" name="The Blood Angels" publicationId="ca571888--pubN103311" page="258" hidden="false">
+              <description>• Encarmine Fury: When fighting in an assault and using a Melee type weapon, any model with the Legiones Astartes (Blood Angels) special rule requires one lower result To Wound than they would normally, to a minimum of 2+. This effect applies regardless of the weapon they are using (for example, if using a Str 4 Melee weapon and attacking a target with a Toughness of 4, the Blood Angel will require a 3 To Wound rather than the usual 4+).
+• Without Remorse, With out Relent: Models with the Legiones Astartes (Blood Angels) special rule must always make Sweeping Advances if they are able to, and may not voluntarily Go To Ground.
+• Host of Angels: With the exception of Dedicated Transports, a Blood Angels Detachment may not have more units with the Vehicle type than it has units with the Legiones Astartes (Blood Angels) special rule.
+Note that because of this, certain Rites of War may be unavailable to Blood Angels armies. (In the case of Shattered Legions. The army does not gain the benifits of Host of Angels)</description>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="d50b-8b77-eccb-9c6b" name="Legiones Astartes" hidden="false" targetId="23a4-a37f-e8e8-c756" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="e2d7-e297-5b99-cbac" name="  XVIII: Salamanders" page="" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f6af-7050-ec5d-4b8d" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="319b-de62-f25f-e75d" name="The Salamanders" publicationId="ca571888--pubN67459" page="106" hidden="false">
+              <description>• Strength of Will: All units with this special rule automatically pass any Fear test they are called on to make and must re-roll a single D6 when Morale checks and Pinning tests are failed.
+• Promethean Gift: All hand flamers, flamers and heavy flamers used by models with this special rule gain 1 Strength to their listed profile. This special rule also extends to all vehicles used by a detachment containing units with this rule. In addition, all enemy flamer-type attacks are at -x Strength when used against models with this rule.
+• Nocturne Born: A unit with the Legiones Astartes (Salamanders) special rule does not add its Initiative value to Sweeping Advance rolls after winning combat. Additionally, they suffer a -1&quot; penalty to all Run and Charge distances to a minimum of 1&quot;.</description>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="156e-e8c3-f55a-3754" name="Legiones Astartes" hidden="false" targetId="23a4-a37f-e8e8-c756" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="1660-f879-3beb-0c0b" name="   IV: Iron Warriors" page="" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="21ac-5c5e-56fc-ad4c" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="bcf6-49dc-fd29-cd9b" name="The Iron Warriors" publicationId="ca571888--pubN67459" page="18" hidden="false">
+              <description>• The Bitter End: In games which would normally have a random game length, the Iron Warriors player’s opponent can opt to play to six full turns instead of the roll to end the game being made. (In the case of Shattered Legions. The army does only gains the benifits of The Bitter End, if the Warlord is an Iron Warrior)</description>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="d9a5-f5b8-997c-469b" name="Legiones Astartes" hidden="false" targetId="23a4-a37f-e8e8-c756" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="1445-c8d0-6c21-9c6a" name="    I: Dark Angels" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3b5e-f384-4b5d-460d" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="cdfa-4f41-128f-7719" name="The Dark Angels" publicationId="ca571888--pubN89821" page="266" hidden="false">
+              <description>• Covenant of Death: For the 1st Legion, no victory is complete unless a foe is slain outright or utterly brought to ruin. If at the end of the game, the opposing force has an equal or greater number of units in play than an army which has Dark Angels as its Primary Detachment (including any allied units in the total) the opposing force gains an additional D3 Victory points. Fleeing units do not count towards working out this total.</description>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="fa5e-4507-8556-9274" name="Legiones Astartes" hidden="false" targetId="23a4-a37f-e8e8-c756" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="3d14-4976-b582-a736" name="  XII: World Eaters" page="" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="826f-063b-ef9c-3f83" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="dda3-aefb-fca9-3b72" name="The World Eaters" publicationId="ca571888--pubN67459" page="52" hidden="false">
+              <description>• Incarnate Violence: Models with the Legiones Astartes (World Eaters) rule may re-roll To Wound rolls of a 1 on any turn in which they charge into combat, unless they are making a Disordered charge.
+Character models with this rule also gain 1 WS when fighting in a challenge.</description>
+            </rule>
+            <rule id="34fc-5138-f80a-b000" name="Savage Tide Rising" publicationId="ca571888--pubN67459" page="52" hidden="false">
+              <description>A World Eaters army representing a Traitor force in games set after Isstvan in the Horus Heresy campaign may, if its controlling player wishes, exchange the Bloodlust component of their Legiones Astartes (World Eaters) special rule with the Blood Madness special rule shown below instead. In non-campaign games, you are also free to use this rule, but must always declare this at the start of the game.
+Your entire army must use the Blood Madness or the Bloodlust rules, you cannot have a mix of the two!</description>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="194c-f896-6099-1360" name="New InfoLink" hidden="false" targetId="988c-d4d0-9418-1165" type="rule"/>
+            <infoLink id="6fb9-edfd-be56-c1be" name="Legiones Astartes" hidden="false" targetId="23a4-a37f-e8e8-c756" type="rule"/>
+          </infoLinks>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="6b13-43e1-321c-f825" name="The Savage Tide Rising: The Doom of the World Eaters Legion" publicationId="ca571888--pubN67459" page="52" hidden="false" collective="false" import="true">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="caf6-98a4-d2c5-c30e" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="81ea-b4b7-ec64-a909" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="f31f-e278-622e-028b" name="Blood Madness" publicationId="ca571888--pubN67459" page="52" hidden="false" collective="false" import="true" type="upgrade">
+                  <rules>
+                    <rule id="8a0e-722f-0288-d91f" name="Blood Madness" publicationId="ca571888--pubN67459" page="52" hidden="false">
+                      <description>Any unit with this rule has the Rage special rule and must always make Sweeping Advances if able and cannot voluntarily Go to Ground or choose to fail a Morale check. In addition, after an assault, models with this special rule must always Consolidate towards the nearest enemy unit that they are able to harm.</description>
+                    </rule>
+                  </rules>
+                  <infoLinks>
+                    <infoLink id="c48e-8357-3b1f-a940" name="New InfoLink" hidden="false" targetId="988c-d4d0-9418-1165" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="0923-adcd-7879-86b4" name="Bloodlust" hidden="false" collective="false" import="true" type="upgrade">
+                  <rules>
+                    <rule id="19c2-9f77-8e20-69ce" name="Bloodlust" publicationId="ca571888--pubN67459" page="52" hidden="false">
+                      <description>After winning an assault, models with this special rule must always consolidate towards the nearest enemy unit they have the ability to harm. Should a unit with this special rule fail a Morale check after being defeated in combat, before rolling for Fall Back, roll a D6. On a roll of 4 they do not flee (and count as passing their Morale check instead), but now become subject to the Rage special rule for the rest of the battle. Place a counter by the unit or otherwise mark that this is the case.</description>
+                    </rule>
+                  </rules>
+                  <infoLinks>
+                    <infoLink id="4cd4-e687-c1ed-08bd" name="New InfoLink" hidden="false" targetId="988c-d4d0-9418-1165" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="2732-8ccb-cc97-ee5d" name="   VIII: Night Lords" page="" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d56b-0648-cc92-2bbd" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="bd05-a320-d56c-d34d" name="The Night Lords" publicationId="ca571888--pubN67459" page="36" hidden="false">
+              <description>• A Talent for Murder: If a unit or units of models with the Legiones Astartes (Night Lords) special rule outnumber one or more enemy infantry units during any Initiative step in which they fight in an assault, they gain 1 To Hit and To Wound. Bulky models count as two models and Very Bulky models as three models for the purposes of working out when the Night Lords outnumber their victims.
+• Nostraman Blood: All models with this special rule fall back 1&quot; further than normal. If they fail a Pinning test, they may, if the controlling player wishes, fall back instead of becoming pinned - just as if they had failed a Morale check for taking casualties in the Shooting phase.
+• Night Vision: All models in a Night Lords primary detachment (not just those with the Legiones Astartes (Night Lords) special rule) have the Night Vision special rule. (In the case of Shattered Legions. All units gain this rule)
+• From the Shadows: All models with this special rule have a cover save of 5 on the first game turn, even in open ground. This rule can be combined with the effects of Stealth, etc, as normal, but other forms of cover the model might be in which provide a higher save supersede it.
+• Seeds of Dissent: If an army’s Warlord is slain, each unit in the army with this special rule must make an immediate Morale check as if they had suffered 25% losses from shooting. (In the case of Shattered Legions. The army does not gain Seeds of Dissent)</description>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="139b-754e-d516-3304" name="New InfoLink" hidden="false" targetId="a225-e39b-3699-c8f8" type="rule"/>
+            <infoLink id="5b52-4719-84d9-3a55" name="Legiones Astartes" hidden="false" targetId="23a4-a37f-e8e8-c756" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="476c-3cc9-7506-2a80" name="  XV: Thousand Sons" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="471f-56e6-a261-72ff" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="4f4d-c60b-7bbe-27c2" name="Covenant of Sorcerers" hidden="false">
+              <description>During the army list creation for a Thousand Sons Detachment, you must determine your Warlord first. Any Warlord chosen for the army must be an Independent Character with a psychic Mastery Level of at least 1 and the highest available Leadership value in the force. Note that this means certain Rites of War will be unavailable to a Thousand Sons force.</description>
+            </rule>
+            <rule id="3ed1-767b-f9ce-e5c6" name="Prosperine Lore" hidden="false">
+              <description>Psykers within the Thousand Sons have access to all of the psychic disciplines found in the Warhammer 40,000 rulebook, except that of Malefic Daemonology. The following also applies:
+• Any HQ independent Character unit who is not already a Psyker can be purchased a Mastery Level of I for 20 points, and may exchange a power weapon with which they have been equipped for a force weapon for 5 points.</description>
+            </rule>
+            <rule id="69e1-d5cc-50f9-3898" name="Signs &amp; Portents" hidden="false">
+              <description>Signs &amp; Portents: The formidable powers of prescience and psychic communion which give the Thousand Sons their unique strengths also make them vulnerable should these powers be found wanting or disrupted as, for example, when the Empyrean might twist from their grasp, instilling the terror of the return of the Flesh Change. Likewise, should the greatest guiding lights of their Order be slain, psychic shock deeply scourges the survivors and a dark fatalism that their doom cannot be thwarted can engulf those who remain at their loss.
+• If any unit within the Thousand Sons Detachment suffers wounds as a result of a Perils of the Warp test, the Detachment&apos;s controlling player must immediately take a Pinning test for every unit in their force with the Legiones Astartes (Thousand Sons) special rule. .
+• If all of the Independent Character units in a Thousand Sons Detachment have been slain, all surviving units that are in the Detachment suffer a -I Ld penalty for the rest of the game and can no longer make Sweeping Advances.</description>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="a880-0f03-a884-645b" name="Legiones Astartes" hidden="false" targetId="23a4-a37f-e8e8-c756" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="0a28-2fed-0e5c-e9e2" name="   III: Emperor&apos;s Children" page="" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e4c7-44aa-c369-800d" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="56ff-aa4a-21d9-f4f1" name="The Emperor&apos;s Children" publicationId="ca571888--pubN67459" page="8" hidden="false">
+              <description>• Exemplars of War: Emperor’s Children units with this special rule have the Crusader special rule, meaning they roll an additional dice when making Run moves and use the highest dice rolled, and add D3 to their total score when making Sweeping Advances roll for each combat). Characters with this rule gain 1 Initiative when fighting in Challenges.
+• Flawless Execution: Models with the Legiones Astartes (Emperor&apos;s Children) rule gain 1 Initiative on any turn in which they charge into combat, unless they are making a Disordered Charge.
+• Martial Pride: In combats where characters with this special rule are involved, an Emperor’s Children controlling player must always issue/accept challenges where possible (although which character fights the challenge is up to them). However, if they are defeated in combat and their challenger is slain, they suffer an additional -1 penalty to their Leadership for the Morale check at the end of combat.</description>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="9238-61d1-d022-7ae4" name="Legiones Astartes" hidden="false" targetId="23a4-a37f-e8e8-c756" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="4997-fb0a-fb78-aca8" name="  XVII: Word Bearers" page="" hidden="false" collective="false" import="true" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="6f18-86b4-27d7-9339" value="0">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e348-5834-5741-186f" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6f18-86b4-27d7-9339" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="f77a-62f4-b9f1-b659" name="The Word Bearers" publicationId="ca571888--pubN67459" page="92" hidden="false">
+              <description>• True Believers: All units with the Legiones Astartes (Word Bearers) special rule roll 3D6 for all Morale checks and must pick the two lowest dice.
+• Cut Them Down: All units with the Legiones Astartes (Word Bearers) special rule must always make Sweeping Advances when possible, and must re-roll Sweeping Advance roll results of a ‘1 ’.
+• Charismatic Leadership: Any primary detachment force chosen from the World Bearers Legion must take a second Compulsory HQ choice on the Force Organisation chart (where a second choice is allowed).
+This choice must always be either a Centurion or a Chaplain Consul. (In the case of Shattered Legions. The army does not gain Charismatic Leadership)</description>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="1426-8dd2-b4b7-0185" name="Legiones Astartes" hidden="false" targetId="23a4-a37f-e8e8-c756" type="rule"/>
+          </infoLinks>
+          <selectionEntries>
+            <selectionEntry id="b385-ebdb-8a45-d657" name="Diabolist in army" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d6dd-92b0-61b6-e6aa" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="4b8d-2642-cc86-8114" name=" XIX: Raven Guard" page="" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2b56-2221-e0f2-6b9a" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="834b-7ea0-c904-aaa7" name="The Raven Guard" publicationId="ca571888--pubN67459" page="114" hidden="false">
+              <description>• By Wing &amp; Talon: Corax strove to forge his Legion into a highly adaptable rapid strike force, in which each component had its own unique role to play in sealing its enemy’s fate, and was trained and equipped accordingly. In order to reflect this, each model with Legiones Astartes (Raven Guard) gains a further special rule(s) depending on its type: - Infantry (except models with Terminator armour of any type): Infiltrate and Fleet - Jump Infantry, Bikes and Jetbikes, Infantry in Terminator Armour: Furious Assault
+• Flesh over Steel: A Raven Guard detachment may not have more units in total with the Vehicle (Tank) type than it does with the Legiones Astartes (Raven Guard) special rule. Note that because of this, certain Rites of War may be unavailable to Raven Guard armies. (In the case of Shattered Legions. The army does not gain Flesh Over Steel)</description>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="823f-683e-9540-6d5c" name="New InfoLink" hidden="false" targetId="34c7-8b61-a5b8-a301" type="rule"/>
+            <infoLink id="765f-2f0b-73bf-d833" name="New InfoLink" hidden="false" targetId="3aa7-9a8f-1e0d-921d" type="rule"/>
+            <infoLink id="a4ff-a16c-e236-cd3b" name="New InfoLink" hidden="false" targetId="69e5-fc02-1f9d-63c2" type="rule"/>
+            <infoLink id="7ed2-a273-4fd6-9bbf" name="Legiones Astartes" hidden="false" targetId="23a4-a37f-e8e8-c756" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="391e-b071-6cbc-c41a" name="   V: White Scars" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a223-559d-5c8b-f64e" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="fb5b-78d6-4f64-3066" name="The White Scars" publicationId="ca571888--pubN89821" page="262" hidden="false">
+              <description>• Swift Action: On any turn in which a unit with this special rule ends the Movement phase at least 6&quot; (or 12&quot; if the unit is of the Bike or Jetbike type) from the point where it began the phase, it may, until the beginning of its controlling player&apos;s next turn, re-roll failed To Wound rolls of a 1 with all attacks.
+• The Eye of the Storm: Renowned for their ability to arrive unannounced and unexpected, the White Scars use their mobility to dictate the flow of any battle in which they fight. An army whose Warlord has the Legiones Astartes (White Scars) special rule may add +1 to the result to Seize the Initiative, as well as to the first Reserves roll of each turn.
+• To Laugh in Death’s Face: An army whose Primary Detachment has the Legiones Astartes (White Scats) special rule may not select more Heavy Support choices than Fast Attack choices. This special rule does not apply when playing Zone Mortalis missions.
+• Born in the Saddle: All models with the Legiones Astartes (White Scars) special rule and the Bike or Jetbike unit type have the Skilled Rider special rule.</description>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="facc-471e-ee19-46be" name="Skilled Rider" hidden="false" targetId="e6e1-afb0-377d-27a8" type="rule"/>
+            <infoLink id="964e-0ee0-f77a-8df0" name="Legiones Astartes" hidden="false" targetId="23a4-a37f-e8e8-c756" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="ccb3-6eea-535f-86a5" name="   VII: Imperial Fists" page="" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9569-75a8-3a29-76b6" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="b13f-9d89-9427-d39b" name="The Imperial Fists" publicationId="ca571888--pubN67459" page="28" hidden="false">
+              <description>• Disciplined Fire: Units with this special rule may add 1 to their BS when using boltguns, bolt pistols, heavy bolters and quad heavy bolters, and when firing the bolter component of a combi-weapon. Heavy Support squads with this special rule also gain the Tank Hunters special rule.
+• Blood and Honour: Models with this rule may not choose to fail Morale checks. In addition, Imperial Fists characters must issue a Challenge in combat if they are able (their controlling player choosing which character makes the Challenge where more than one character is involved). When fighting in Challenges, models with the Legiones Astartes (Imperial Fists) special rule must re-roll failed To Hit rolls of x.
+• Unshakable Defence: Models with the Legiones Astartes (Imperial Fists) special rule are immune to pinning when claiming cover/fighting from fortifications and barricades.
+• The Bitter End: In missions which would normally have a random game length, the Imperial Fists player’s opponent can opt to play to six full turns instead of the roll to end the game being made.</description>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="e1f6-3caf-3233-a77e" name="Legiones Astartes" hidden="false" targetId="23a4-a37f-e8e8-c756" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="c52d-5459-0d1f-8a9e" name="  XIII: Ultramarines" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c7b7-28c5-7415-a13b" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="1b5e-79c7-dfa5-fa58" name="Ultramarines" publicationId="ca571888--pubN67459" page="60" hidden="false">
+              <description>• Interlocking Tactics: The Ultramarines pride themselves above all things on their unity of purpose and their seamless tactical integration in battle. For many years they have been accorded as being the most numerous of the Space Marine Legions and, under their Primarch, they have forged a significant range of tactical doctrines which hone their unity and strength in numbers to lethal advantage.
+Whenever a unit with the Legiones Astartes (Ultramarines) special rule makes a shooting attack against a target which has already been successfully hit in the same Shooting phase by another Ultramarines unit*, they may re-roll rolls of 1 to wound or penetrate the target’s armour. This does not affect Snap Shots or Blast weapons.
+Whenever a unit with the Legiones Astartes (Ultramarines) special rule charges a unit which is already engaged in an assault by another Ultramarines unit and fails to reach the target owing to a failed Charge Range roll, this roll must be re-rolled.
+*For the purposes of this special rule, an Ultramarines unit is defined as any unit in the same detachment drawn from the Space Marine Legion Crusade Army list except Super-heavy vehicles, Flyers, Servo-automata and Battle-automata of any kind.
+(In the case of Shattered Legions. The difinition of which other units count as Ultramarines is extended to all Shattered Legion units in the army with the exception of types listed.)
+• Certainty and Resolve: Any model with the Legiones Astartes (Ultramarines) special rule takes Fear and Regrouping tests on an unmodified Leadership value of 10.
+• Rigid Chain of Command: One potential disadvantage to the uncommon unity the Legion displays is its reliance on a rigid chain of command for its decision making; a chain that can be momentarily broken if a unit commander is slain.
+If all of the HQ units in the Ultramarines detachment are slain, their opponent gains an additional 1 Victory point. In addition, if the army&apos;s Warlord is slain, then every unit in the Ultramarines detachment with the Legiones Astartes (Ultramarines) special rule must take an immediate Pinning test, with the exception of those with the Independent Character special rule or who have had an Independent Character join their unit.
+If Roboute Guilliman is the army’s Warlord, the Rigid Chain of Command rule above is ignored. Instead, if Roboute Guilliman is slain, all units with the Legiones Astartes (Ultramarines) special rule in the army must take an immediate Pinning test. In this case the opposing player gains +1 Victory point for Guilliman being slain, in addition to any gained from objectives such as Slay the Warlord and The Price of Failure. (In the case of Shattered Legions. The army does not gain the Rigid Chain of Command)</description>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="681d-f8aa-e7a3-1025" name="Legiones Astartes" hidden="false" targetId="23a4-a37f-e8e8-c756" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="6ebb-bd17-f334-0fb1" name="Militia" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b9bc-d270-62aa-9618" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="52df-ddc4-325b-ec5a" name="Cult Arcana" hidden="true" collective="false" import="true">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="476c-3cc9-7506-2a80" type="equalTo"/>
+          </conditions>
+        </modifier>
+        <modifier type="set" field="402a-7020-2f3b-45fd" value="1.0">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="476c-3cc9-7506-2a80" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="54b6-1da7-8859-0f8a" type="max"/>
+        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="402a-7020-2f3b-45fd" type="min"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="a21c-a53a-4a8d-82a0" name="Cult Arcana: Athanean (Telepathy)" hidden="false" collective="false" import="true" type="upgrade">
+          <rules>
+            <rule id="875c-617d-a8c4-5b4e" name="Mental Fortitude" hidden="false">
+              <description>Discipline: Telepathy
+
+Units with this special rule are immune to Fear and have the Adamantium Will special rule.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="4f1c-6b83-83dd-0ed8" name="Cult Arcana: Corvidae (Divination)" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8e09-89f0-d0f7-edd3" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="abe4-3fb7-688e-47a8" name="Precognitive Strike" hidden="false">
+              <description>Discipline: Divination
+
+The unit must re-roll failed To Hit rolls of a I when making shooting attacks if it remained stationary in this turn&apos;s Movement phase.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="202b-de41-f12d-b878" name="Cult Arcana: Pavoni (Biomancy)" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2e1c-fb17-e8e4-f443" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="f899-7cf1-e538-f73d" name="Quickblood" hidden="false">
+              <description>Discipline: Biomancy
+
+The unit adds I to its Run and Sweeping Advance distances.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="7ace-324b-f3ee-7608" name="Cult Arcana: Pyrae (Pyromancy)" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="914a-3858-7cd5-b9c0" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="a7ba-547f-42e1-078c" name="Ashen Blow" hidden="false">
+              <description>Discipline: Pyromancy
+
+The unit gains the Hammer of Wrath special rule. If the unit already possess this special rule from another source, it inflicts 2 Hammer of Wrath attacks rather than I when it charges.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="e474-608d-86fc-de9b" name="Cult Arcana: Raptora (Telekinesis)" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6475-5acb-3c80-5d0f" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="8f70-a722-c12e-e6f2" name="Kine Shields" hidden="false">
+              <description>Discipline: Telekinesis
+
+The unit gains a 6+ Invulnerable save, or if it possesses an invulnerable save from another source that increases by I (so that a 5+ becomes a 4+, etc), to a maximum invulnerable save of 3+.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="efe5-effa-a371-ae4e" name="Legion-specific upgrade:" hidden="false" collective="false" import="true">
+      <constraints>
+        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6570-d9bf-6552-3eaa" type="min"/>
+        <constraint field="selections" scope="parent" value="-1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4f58-1c01-d8df-f689" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="6627-d992-df6b-a3df" name="Artificer Weapons" page="0" hidden="false" collective="false" import="true" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e2d7-e297-5b99-cbac" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="bf2d-469f-4f54-bb4b" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="f312-185a-453a-ddc7" name="Artificer Weapons" publicationId="ca571888--pubN67459" page="65" hidden="false">
+              <description>Character with this upgrade may give a single weapon Master-crafted.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="pts" typeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="629e-ac9a-8f6d-3e89" name="Infravisor" page="0" hidden="false" collective="false" import="true" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b8d-2642-cc86-8114" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="176f-bede-1c42-82ce" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="c7c3-0cd5-d008-986b" name="Infravisor" hidden="false" targetId="a8c1-185a-cdd9-b5ce" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="08f5-92aa-cd97-91cc" name="Trophies of Judgement" page="0" hidden="false" collective="false" import="true" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2732-8ccb-cc97-ee5d" type="equalTo"/>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1d9c-cc5a-0f91-2590" type="notInstanceOf"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="set" field="points" value="25.0">
+              <conditions>
+                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1d9c-cc5a-0f91-2590" type="notInstanceOf"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e845-b0f9-b811-d911" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="2eef-295d-d2b9-9fe2" name="Trophies of Judgement" publicationId="ca571888--pubN67459" page="57" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
+              <characteristics>
+                <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Provides Fear special rule</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="45cd-edae-7a23-95c6" name="Sonic Shriekers" hidden="false" collective="false" import="true" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a28-2fed-0e5c-e9e2" type="equalTo"/>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1d9c-cc5a-0f91-2590" type="notInstanceOf"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="48a7-82b5-9be1-edda" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="8baa-dbe8-507d-c8c8" name="Sonic Shrieker" publicationId="ca571888--pubN67459" page="8" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
+              <characteristics>
+                <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Models with a Sonic Shrieker imposes a -1 WS penalty on enemy models in base contact in assault.  Enemies which are immune to Fear are also immune to this effect.  </characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="3846-d863-4501-3d4a" name="Asphyx Shells" hidden="false" collective="false" import="true" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="476c-3cc9-7506-2a80" type="equalTo"/>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1d9c-cc5a-0f91-2590" type="notInstanceOf"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="set" field="points" value="10.0">
+              <conditions>
+                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1d9c-cc5a-0f91-2590" type="instanceOf"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="099b-fa4e-2546-2414" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="5291-677b-054a-dbf1" name="New InfoLink" hidden="false" targetId="89da-0cb5-bee4-8ec2" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="1e21-5a9f-873b-fdc7" name="Cameleoline" page="0" hidden="false" collective="false" import="true" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d45f-b4ad-cc22-c7be" type="instanceOf"/>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b8d-2642-cc86-8114" type="equalTo"/>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1d9c-cc5a-0f91-2590" type="notInstanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0eb0-2501-9397-1104" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0c41-9db4-3ae3-67ce" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a787-4801-eb77-f2cf" type="instanceOf"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b2e7-6342-f7cc-e6a8" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="205f-a79f-4700-e841" name="Cameleoline" page="0" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
+              <characteristics>
+                <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Confers Stealth</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="ccb2-b529-51e1-4b5e" name="Cyber-familiar" hidden="false" collective="false" import="true" targetId="0146-2962-d352-0eb6" type="selectionEntry"/>
+        <entryLink id="1eb5-5e84-a6fb-2e6b" name="Power Dagger" hidden="false" collective="false" import="true" targetId="5348-8a7f-e945-3bd8" type="selectionEntry"/>
+        <entryLink id="a5dd-d1e8-794f-a233" name="Rad Grenades" hidden="false" collective="false" import="true" targetId="e16f-613e-1606-bfbc" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0f9b-69d0-8106-dc52" type="equalTo"/>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0090-7ef6-cdf9-79ce" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="points" value="5.0">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2210-b6b1-7933-6195" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
+      </entryLinks>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="a6d4-6ccf-2b32-6d1b" name="Legion Specialist Gear" hidden="false" collective="false" import="true">
+      <selectionEntries>
+        <selectionEntry id="3410-908e-d98d-593d" name="Power Scythe" page="0" hidden="false" collective="false" import="true" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0f9b-69d0-8106-dc52" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ffaa-e38c-fef4-1bc3" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="a651-9ef8-1793-021c" name="Power Scythe" publicationId="ca571888--pubN89821" page="70" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
+                <characteristic name="Strength" typeId="537472656e67746823232344415441232323">1</characteristic>
+                <characteristic name="AP" typeId="415023232344415441232323">2</characteristic>
+                <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Two-handed, Reaping Blow</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="225e-fbf4-be54-115c" name="Reaping Blow" hidden="false" targetId="cf7d-85ff-dfca-8b39" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="fd9c-9193-2c50-e929" name="Power Glaive" hidden="false" collective="false" import="true" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="391e-b071-6cbc-c41a" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7516-0f8f-8435-7b7a" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="508e-176a-7a96-0a11" name="Power Glaive" publicationId="ca571888--pubN89821" page="263" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
+                <characteristic name="Strength" typeId="537472656e67746823232344415441232323">User/+1</characteristic>
+                <characteristic name="AP" typeId="415023232344415441232323">3/2</characteristic>
+                <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Versatile</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="7e8b-b404-d6ee-c4ea" name="Versatile" publicationId="ca571888--pubN89821" page="263" hidden="false">
+              <description>A weapon with this type uses the Str and AP before the slash if wielded in one hand alongside another item of wargear, and the Str and AP after the slash if used as though it had the Two-handed special rule.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="pts" typeId="points" value="25.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="5348-8a7f-e945-3bd8" name="Power Dagger" publicationId="ca571888--pubN67459" page="89" hidden="true" collective="false" import="true" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="eac6-9b93-9a5a-a30b" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a63f-87a2-534b-f249" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="aea3-c990-dcb4-5049" name="Power Dagger" publicationId="ca571888--pubN67459" page="89" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
+                <characteristic name="Strength" typeId="537472656e67746823232344415441232323">-1</characteristic>
+                <characteristic name="AP" typeId="415023232344415441232323">3</characteristic>
+                <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Specialist Weapon, Rending</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="82fb-0eed-d1da-4dc5" name="Molecular Acid Shells" hidden="false" collective="false" import="true" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1445-c8d0-6c21-9c6a" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ba38-696f-1a46-b052" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="e5a0-6055-90eb-9448" name="Molecular acid shells" publicationId="ca571888--pubN89821" page="267" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="52616e676523232344415441232323">36&quot;</characteristic>
+                <characteristic name="Strength" typeId="537472656e67746823232344415441232323">2</characteristic>
+                <characteristic name="AP" typeId="415023232344415441232323">D6</characteristic>
+                <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 3, Poison (2)</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="6dee-1245-4b8b-910b" name="Iliastus Pattern Assault Cannon" page="0" hidden="false" collective="false" import="true" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="59f6-638d-8c1d-75dd" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="bd75-ea40-6ec4-1f61" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="0c9e-3b4d-b5d8-d785" name="Iliastus Assault Cannon" publicationId="ca571888--pubN67459" page="97" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="52616e676523232344415441232323">24&quot;</characteristic>
+                <characteristic name="Strength" typeId="537472656e67746823232344415441232323">6</characteristic>
+                <characteristic name="AP" typeId="415023232344415441232323">4</characteristic>
+                <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 4, Rending, Malfunction</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="ed18-a75b-af9a-06e8" name="Malfunction" publicationId="ca571888--pubN67459" page="97" hidden="false">
+              <description>When rolling to hit, if three or more results of &quot;1&quot; are rolled, a malfunction has occured and the weapon may not be used for the rest of the game.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="8387-2b28-1fa6-71e1" name="Terranic Greatsword" hidden="false" collective="false" import="true" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1445-c8d0-6c21-9c6a" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1bdf-a533-1ca2-06f5" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="7bbc-43f2-18e3-9c3e" name="Terranic Greatsword" publicationId="ca571888--pubN89821" page="267" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
+                <characteristic name="Strength" typeId="537472656e67746823232344415441232323">2</characteristic>
+                <characteristic name="AP" typeId="415023232344415441232323">3</characteristic>
+                <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Two-handed, Instant Death</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="f356-8cb5-2e97-19e2" name="Instant Death" hidden="false" targetId="fbf1-6913-ff9f-5a4f" type="rule"/>
+            <infoLink id="8d40-1a55-da90-1436" name="Two-Handed" hidden="false" targetId="b11c-0ef4-af6b-d96f" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="15.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="104d-2c15-b4b8-c299" name="Tainted Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4997-fb0a-fb78-aca8" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b3ba-7370-7a61-aa33" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="927e-4058-a220-7979" name="Tainted Weapon" publicationId="ca571888--pubN67459" page="73" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
+                <characteristic name="Strength" typeId="537472656e67746823232344415441232323">User</characteristic>
+                <characteristic name="AP" typeId="415023232344415441232323">-</characteristic>
+                <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Specialist Weapon, Instant Death</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="4e65-9042-384e-e1b6" name="Instant Death" hidden="false" targetId="fbf1-6913-ff9f-5a4f" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="10.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="1fa4-33f3-0377-eae9" name="Solarite Power Gauntlet" page="0" hidden="false" collective="false" import="true" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1d9c-cc5a-0f91-2590" type="notInstanceOf"/>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb3-6eea-535f-86a5" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="642e-cf6b-f5d5-035a" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="8fb0-7371-da45-7df8" name="Solarite Power Gauntlet" publicationId="ca571888--pubN67459" page="97" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
+                <characteristic name="Strength" typeId="537472656e67746823232344415441232323">x2</characteristic>
+                <characteristic name="AP" typeId="415023232344415441232323">1</characteristic>
+                <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Master-crafted, Unwieldy</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="d0ce-11f4-bcc7-fd4a" name="New InfoLink" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule"/>
+            <infoLink id="d06e-aa64-2983-a505" name="New InfoLink" hidden="false" targetId="5eea-958c-d623-c3c9" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="25.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="bca4-ae83-c058-2822" name="Phoenix Spear" page="0" hidden="false" collective="false" import="true" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a28-2fed-0e5c-e9e2" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="53db-f2e4-36f3-a41e" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="9e29-1f27-017d-364f" name="Phoenix Spear" publicationId="ca571888--pubN67459" page="28" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
+                <characteristic name="Strength" typeId="537472656e67746823232344415441232323">1/User</characteristic>
+                <characteristic name="AP" typeId="415023232344415441232323">2/3</characteristic>
+                <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Two-handed</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="a8e8-37e5-3b8e-ccef" name="Pair of Raven&apos;s Talons" page="0" hidden="false" collective="false" import="true" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b8d-2642-cc86-8114" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8d7f-b6d0-74ed-93a7" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="f52b-8ca4-2377-33b0" name="Raven&apos;s Talons" publicationId="ca571888--pubN67459" page="105" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
+                <characteristic name="Strength" typeId="537472656e67746823232344415441232323">User</characteristic>
+                <characteristic name="AP" typeId="415023232344415441232323">3</characteristic>
+                <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Shred, Master-crafted, Rending, Specialist Weapon</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="1552-90e9-ad52-aaed" name="Rending" hidden="false" targetId="8269-2cd6-9236-16e7" type="rule"/>
+            <infoLink id="a778-747f-5448-1e3e" name="Shred" hidden="false" targetId="89da-0cb5-bee4-8ec2" type="rule"/>
+            <infoLink id="36da-b123-225f-64b3" name="Specialist Weapon" hidden="false" targetId="7ee3-d437-bc44-3630" type="rule"/>
+            <infoLink id="a7c0-cf2b-f8cd-061b" name="Master-crafted" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="10.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="b6e5-70ca-8084-765d" name="Nostraman Chainglaive" page="0" hidden="true" collective="false" import="true" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2732-8ccb-cc97-ee5d" type="equalTo"/>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ae54-92c7-3e66-59f7" type="instanceOf"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7588-821d-3ca1-a9af" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="617e-647f-5fbb-a625" name="Nostraman Chainglaive" publicationId="ca571888--pubN67459" page="57" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
+                <characteristic name="Strength" typeId="537472656e67746823232344415441232323">1</characteristic>
+                <characteristic name="AP" typeId="415023232344415441232323">3</characteristic>
+                <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Two-handed, Rending</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="10.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="0af7-8801-c1c2-da77" name="Legatine Axe" hidden="false" collective="false" import="true" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c52d-5459-0d1f-8a9e" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6afb-2140-ca86-b3fb" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="863d-fe96-fc7b-3042" name="Legatine Axe" publicationId="ca571888--pubN89821" page="231" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
+                <characteristic name="Strength" typeId="537472656e67746823232344415441232323">As User</characteristic>
+                <characteristic name="AP" typeId="415023232344415441232323">2</characteristic>
+                <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Specialist Weapon, Cutting Strike</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="5b03-ed05-4ae8-ba8a" name="Cutting Strike" publicationId="ca571888--pubN89821" page="231" hidden="false">
+              <description>Any To Hit roll result of a 6 with this weapon wounds automatically</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="pts" typeId="points" value="20.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="4a8a-4994-c863-7723" name="Chainaxe" hidden="true" collective="false" import="true" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3d14-4976-b582-a736" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <infoLinks>
+            <infoLink id="e70e-63ac-7311-3e90" name="Chainaxe" hidden="false" targetId="b514-a3d8-7223-e73b" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="578d-7cff-6547-dda5" name="Blade of Perdition" hidden="false" collective="false" import="true" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="59f6-638d-8c1d-75dd" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0ad8-8dd2-5f8b-9d64" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="3da3-19ee-9ce2-4f10" name="Blade of Perdition" publicationId="ca571888--pubN89821" page="259" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
+                <characteristic name="Strength" typeId="537472656e67746823232344415441232323">User</characteristic>
+                <characteristic name="AP" typeId="415023232344415441232323">2</characteristic>
+                <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Master-crafted, Two-handed, Deathfire</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="9f52-62ae-eaf7-3a8d" name="Deathfire" publicationId="ca571888--pubN89821" page="259" hidden="false">
+              <description>Any model successfully wounded by a weapon with this type suffers two wounds for each hit instead of one. Roll to save against each wound separately. Wounds caused in excess of a given model&apos;s remaining Wounds do not spill over to other models.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="pts" typeId="points" value="20.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="ab65-9553-571f-7d2b" name="Aether-rune armour" hidden="false" collective="false" import="true" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a1c-44d8-4d14-c203" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="07f5-e544-1eed-e70d" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="27a0-d850-feba-60c6" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="6b65-8c68-a99d-4a66" name="Aether-rune armour" publicationId="ca571888--pubN92115" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
+              <characteristics>
+                <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Aether-rune armour counts as a suit of Artificer armour, granting a +2 armour save. In addition, it increases the wearer&apos;s Wounds characteristic by 1 and allows any Deny the Witch rolls taken for the wearer or the unit they have joined to be re-rolled.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="1a19-7818-d2a8-ed53" name="Aether-fire Cannon" hidden="false" collective="false" import="true" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="476c-3cc9-7506-2a80" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <profiles>
+            <profile id="67ac-3b00-6a44-a834" name="Aether-fire Cannon" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="52616e676523232344415441232323">36</characteristic>
+                <characteristic name="Strength" typeId="537472656e67746823232344415441232323">7</characteristic>
+                <characteristic name="AP" typeId="415023232344415441232323">2</characteristic>
+                <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 1, Blast(3&quot;), Soul Blaze, Gets Hot</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="4b46-ad31-0cdf-57f3" name="New InfoLink" hidden="false" targetId="acb1-64c4-ef54-3a55" type="rule"/>
+            <infoLink id="f305-4abd-4eda-65ab" name="New InfoLink" hidden="false" targetId="f4fd-d519-4769-5510" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="5bc2-ceb4-2e34-7004" name="Calibanite War Blade" hidden="false" collective="false" import="true" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1445-c8d0-6c21-9c6a" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7252-254f-2165-a459" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="caff-7735-d354-a115" name="Calibanite war blade" publicationId="ca571888--pubN89821" page="267" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
+                <characteristic name="Strength" typeId="537472656e67746823232344415441232323">+1</characteristic>
+                <characteristic name="AP" typeId="415023232344415441232323">3</characteristic>
+                <characteristic name="Type" typeId="5479706523232344415441232323">Melee</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="10.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="d491-f3be-c649-cc6b" name="Raven&apos;s Talons" page="0" hidden="false" collective="false" import="true" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b8d-2642-cc86-8114" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="50ed-2ebb-cfe1-eda6" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="69f1-410a-fe0d-310e" name="Raven&apos;s Talons" publicationId="ca571888--pubN67459" page="105" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
+                <characteristic name="Strength" typeId="537472656e67746823232344415441232323">User</characteristic>
+                <characteristic name="AP" typeId="415023232344415441232323">3</characteristic>
+                <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Shred, Master-crafted, Rending, Specialist Weapon</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="ad7d-b3bc-2e18-4998" name="Master-crafted" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule"/>
+            <infoLink id="a68e-5e4a-45d3-ec81" name="Rending" hidden="false" targetId="8269-2cd6-9236-16e7" type="rule"/>
+            <infoLink id="40e3-9ede-bd90-1f08" name="Shred" hidden="false" targetId="89da-0cb5-bee4-8ec2" type="rule"/>
+            <infoLink id="1262-714b-ed4e-5580" name="Specialist Weapon" hidden="false" targetId="7ee3-d437-bc44-3630" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="10.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="afcc-4a3d-3a71-1172" name="Arcane Litanies" hidden="false" collective="false" import="true" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="476c-3cc9-7506-2a80" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <profiles>
+            <profile id="69f2-5f4f-8200-982d" name="Arcane Litanies" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
+              <characteristics>
+                <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">The bearer of Arcane Litanies may ignore the first failed Perils of the Warp test they are subject to.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="0ad6-d6d9-58ec-feaa" name="Burning Lore" page="0" hidden="false" collective="false" import="true" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4997-fb0a-fb78-aca8" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="fd5b-4851-4677-f49b" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="1e2b-39bf-d00b-ea7e" name="Burning Lore" publicationId="ca571888--pubN67459" page="73" hidden="false">
+              <description>Upgrade turns the model into a Level 1 Psyker with access to the Biomancy or Telepathy discipline.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="pts" typeId="points" value="30.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="b432-5750-528f-98f3" name="Chem-munitions" page="0" hidden="false" collective="false" import="true" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0f9b-69d0-8106-dc52" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d350-6d04-ec96-aae0" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="da85-e576-d09b-2f5c" name="Chem-munitions" publicationId="ca571888--pubN67459" page="38" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
+              <characteristics>
+                <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">All flame weapons (flamers, Heavy flamers, hand flamers, combi-flamers, or Flamestorm Cannons) in a unit or on a vehicle may be upgraded to Chem-munitions.  All eligible weapons must be upgraded. Weapons with this rule gain both Shred and Gets Hot special rules. </characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="c624-e809-3fd3-15bc" name="Teleportation Transponder" publicationId="ca571888--pubN67459" page="97" hidden="true" collective="false" import="true" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ccb3-6eea-535f-86a5" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2732-8ccb-cc97-ee5d" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d9a9-2e78-77e3-9d67" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="ee79-8ae2-4dc0-e236" name="Deep Strike" hidden="false" targetId="d219-2314-4834-c054" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="10.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="ddc3-e5d1-c9aa-5fba" name="Frost Blade" hidden="false" collective="false" import="true">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a1c-44d8-4d14-c203" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f9ac-e1c7-b577-9d8f" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9001-8ebf-272b-f66c" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="9435-b3aa-6ea4-f998" name="Frost Axe" hidden="false" collective="false" import="true" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a1c-44d8-4d14-c203" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9c1a-e94b-d456-3759" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="c3f1-b850-58b6-6eed" name="Frost Axe" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
+                    <characteristic name="Strength" typeId="537472656e67746823232344415441232323">+2</characteristic>
+                    <characteristic name="AP" typeId="415023232344415441232323">2</characteristic>
+                    <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Unwieldy, Specialist Weapon</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink id="9944-0910-99c6-760d" name="Unwieldy" hidden="false" targetId="5eea-958c-d623-c3c9" type="rule"/>
+                <infoLink id="66fa-f62e-b9b7-9daf" name="New InfoLink" hidden="false" targetId="7ee3-d437-bc44-3630" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="4dba-8812-cdc6-6172" name="Frost Blade" hidden="false" collective="false" import="true" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a1c-44d8-4d14-c203" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3bce-ade6-89cb-d35e" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="61d0-28ad-2d0e-a3fd" name="Frost Blade" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
+                    <characteristic name="Strength" typeId="537472656e67746823232344415441232323">+1</characteristic>
+                    <characteristic name="AP" typeId="415023232344415441232323">3</characteristic>
+                    <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Specialist Weapon</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink id="df43-4750-f915-44a8" name="Specialist Weapon" hidden="false" targetId="7ee3-d437-bc44-3630" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="0e82-ee75-815e-bb42" name="Frost Claw" hidden="false" collective="false" import="true" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a1c-44d8-4d14-c203" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="af12-b178-f023-ead5" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="8c10-704e-6b42-0e6a" name="Frost Claw" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
+                    <characteristic name="Strength" typeId="537472656e67746823232344415441232323">+1</characteristic>
+                    <characteristic name="AP" typeId="415023232344415441232323">3</characteristic>
+                    <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Specialist Weapon, Shred</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink id="84c5-6f28-8b5d-9ea8" name="Specialist Weapon" hidden="false" targetId="7ee3-d437-bc44-3630" type="rule"/>
+                <infoLink id="c314-32e8-eed8-ccc9" name="New InfoLink" hidden="false" targetId="89da-0cb5-bee4-8ec2" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="20d9-aac6-cf49-54c7" name="Great Frost Blade" hidden="false" collective="false" import="true" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a1c-44d8-4d14-c203" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="95d5-1020-05c4-1f85" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="0be3-f0f7-c138-c4ad" name="Great Frost Blade" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
+                    <characteristic name="Strength" typeId="537472656e67746823232344415441232323">+1</characteristic>
+                    <characteristic name="AP" typeId="415023232344415441232323">2</characteristic>
+                    <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Reaping Blow, Master-crafted, Two-handed</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules>
+                <rule id="2082-91fd-732e-bccc" name="Reaping Blow" publicationId="0e6e-8c19-c436-39c4" page="23" hidden="false">
+                  <description>Models using a weapon with this special rule fight at -1 Initiative in assault.  Additionally, if the wielder is in base contact with morme than on enemy model at the Initiative step in which they fight, they gain 1 Attack.</description>
+                </rule>
+              </rules>
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="1114-bee3-f372-1b0a" name="Caedere Weapons" hidden="false" collective="false" import="true">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3d14-4976-b582-a736" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="23da-1855-e98a-528e" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="0af4-ed58-bf18-5ba4" name="Barb-hook Lash" page="0" hidden="false" collective="false" import="true" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3d14-4976-b582-a736" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c36c-3278-35cc-14bc" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="6468-c5fa-f915-f8bd" name="Barb-hook Lash" publicationId="ca571888--pubN67459" page="21" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
+                    <characteristic name="Strength" typeId="537472656e67746823232344415441232323">User</characteristic>
+                    <characteristic name="AP" typeId="415023232344415441232323">5</characteristic>
+                    <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Specialist Weapon, Fleshbane</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="points" value="15.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="5c0c-0f0d-1f1b-d314" name="Meteor Hammer" page="0" hidden="false" collective="false" import="true" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3d14-4976-b582-a736" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2baa-9d7a-dcbb-fe36" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="8393-11cb-3e3b-9b5d" name="Meteor Hammer" publicationId="ca571888--pubN67459" page="21" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
+                    <characteristic name="Strength" typeId="537472656e67746823232344415441232323">+2</characteristic>
+                    <characteristic name="AP" typeId="415023232344415441232323">5</characteristic>
+                    <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Specialist Weapon, Two-handed, Concussive, +1 Initiative</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="points" value="15.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="de1e-fcff-6d20-f439" name="Twin Falax Blades" page="0" hidden="false" collective="false" import="true" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3d14-4976-b582-a736" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5470-2efd-7d53-5824" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="d763-8745-9528-e871" name="Twin Falax Blades" publicationId="ca571888--pubN67459" page="21" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
+                    <characteristic name="Strength" typeId="537472656e67746823232344415441232323">User</characteristic>
+                    <characteristic name="AP" typeId="415023232344415441232323">5</characteristic>
+                    <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Specialist Weapon, 1 Attack, Rending</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="points" value="15.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="77ee-34cc-e6ac-4ca7" name="Excoriator Chainaxe" page="0" hidden="false" collective="false" import="true" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3d14-4976-b582-a736" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="79ba-3d8a-3bc6-be23" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="9968-fb6e-5d9c-74c3" name="Excoriator Chainaxe" publicationId="ca571888--pubN67459" page="21" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
+                    <characteristic name="Strength" typeId="537472656e67746823232344415441232323">1</characteristic>
+                    <characteristic name="AP" typeId="415023232344415441232323">3</characteristic>
+                    <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Specialist Weapon, Two-handed, Shred, Unwieldy</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="points" value="15.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="8001-53aa-f47f-9939" name="Rites of War" hidden="false" collective="false" import="true">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dd19-c2d1-2aad-c6f6" type="max"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="1cfb-ee69-719e-3013" name="New CategoryLink" hidden="false" targetId="3c78-d89e-b99b-5ccf" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="418d-9dbf-183c-75cc" name="Sky Hunter Phalanx" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="42c4-2f07-0832-0aef" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="0090-7ef6-cdf9-79ce" name="The Reaping" hidden="false" collective="false" import="true" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0f9b-69d0-8106-dc52" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7a5f-4e86-e093-5eea" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="607f-5517-b4b7-6e46" name="Head of the Gorgon" hidden="false" collective="false" import="true" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b7d6-8217-4fe9-45d4" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9e7e-4ee0-4791-3884" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="f819-ca3a-2adf-6065" name="Horror Cult" hidden="false" collective="false" import="true" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2732-8ccb-cc97-ee5d" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="16c1-e18e-d991-ed20" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="8584-d69f-affc-b67e" name="The Hammer of Olympia" hidden="false" collective="false" import="true" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1660-f879-3beb-0c0b" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f21e-90d3-61e6-26af" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="e691-ca90-8d84-e998" name="3rd Company Elite" hidden="false" collective="false" import="true" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a28-2fed-0e5c-e9e2" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4a5b-e649-097b-2305" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="2210-b6b1-7933-6195" name="Ravenwing Protocol" hidden="false" collective="false" import="true" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1445-c8d0-6c21-9c6a" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="02a7-6c58-f23d-b593" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="4adf-bcb8-7df3-fcae" name="Legion Breacher Company" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6392-b373-e6de-f774" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="efd6-c161-db9c-d837" name="Legion Destroyer Company" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4f12-f759-58d6-571e" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="6e6d-6838-22e6-e3a5" name="Covenant of Fire" hidden="false" collective="false" import="true" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e2d7-e297-5b99-cbac" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c752-9baf-80c0-e617" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="948d-71e8-6673-6add" name="Orbital Assault" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="efea-849d-9829-59bf" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+  </sharedSelectionEntryGroups>
+  <sharedRules>
+    <rule id="438f-70e3-53e6-46fe" name="Agent of the Warmaster" hidden="false"/>
+    <rule id="e9ac-e04c-6b2b-b90b" name="Agent of the Emperor" hidden="false"/>
+    <rule id="fdf7-02a8-bf82-6c11" name="Chosen Warriors" publicationId="ca571888--pubN82424" page="80" hidden="false">
+      <description>All models may issue and accept challenges as if Characters.  This does not confer any of the other special rules associated with Characters.</description>
+    </rule>
+    <rule id="8578-50de-d1fb-da80" name="Banestrike" hidden="false">
+      <description>Gains AP3 on rolls of 6 to wound</description>
+    </rule>
+    <rule id="f546-a57f-5c5e-aed8" name="Support Officer" publicationId="ca571888--pubN89821" page="234" hidden="false">
+      <description>May not be used as a compulsory HQ choice for the army unless specifically exempted by a particular Legiones Astartes rule or Rite of War.</description>
+    </rule>
+    <rule id="46bd-edb5-d2b5-42be" name="Inertial Guidance System" publicationId="ca571888--pubN82424" page="61" hidden="false">
+      <description>Should a Drop Pod scatter on top of impassable terrain or another model, then reduce the scatter distance by theminimum required to avoid the obstacle. Note that some Drop Pods are considerably larger than the more common Drop Pod and so will need a larger space in which to land successfully.</description>
+    </rule>
+    <rule id="782b-fe56-c2e2-76a3" name="Drop Pod Assault" publicationId="ca571888--pubN82424" page="" hidden="false">
+      <description>At the beginning of the controlling player’s first player turn, they must choose half of their Drop Pod units (rounding up) to make a Drop Pod Assault. These units arrive on their controlling player’s first player turn.
+The arrival of the remaining Drop Pods in the player’s force is rolled for as usual for the mission. A unit that Deep Strikes via Drop Pod may not assault in the turn it arrives.
+
+Legion Drop Pod: Once a Drop Pod lands, all passengers must disembark, doors are automatically opened to their full extent as soon as it is deployed. LA:AODAL P46
+Dreadnought Drop pod: The controlling player may choose to disembark or not. Doors are automatically opened to their full extent as soon as it is deployed. LA:AODAL P47
+Dreadclaw: After it has landed treat as a flyer in Hover mode. LA:AODAL P55
+Kharybdis: After it has landed treat as a flyer in Hover mode. LA:AODAL P75</description>
+    </rule>
+    <rule id="fb2f-6a13-3268-d621" name="Dreadnought Talon" publicationId="ca571888--pubN67536" page="4" hidden="false">
+      <description>When first deployed on the battlefield (either at the start of the game or when arriving via Reserves later on), the Dreadnoughts must be placed within 6&quot; of each other, but afterwards operate independently and are not treated as a vehicle squadron but operate independently as individual units for the purposes of taking any actions, as well for determining Victory points in missions which make use of Victory points for destroying units.</description>
+    </rule>
+    <rule id="6eef-be21-4016-bfe3" name="Immobile" publicationId="ca571888--pubN82424" page="46" hidden="false">
+      <description>Once it has been deployed, a Drop Pod cannot move and counts as a vehicle that has suffered an irreparable Immobilised result (although no Hull Point loss is suffered).</description>
+    </rule>
+    <rule id="cf7d-85ff-dfca-8b39" name="Reaping Blow" publicationId="ca571888--pubN67459" page="70" hidden="false">
+      <description>Models using a weapon with this special rule fight at -1 Initiative in assault.  Additionally, if the wielder is in base contact with morme than on enemy model at the Initiative step in which they fight, they gain 1 Attack.</description>
+    </rule>
+    <rule id="a4e8-8d27-18a5-4a96" name="Machine Spirit" publicationId="ca571888--pubN82424" page="239" hidden="false">
+      <description>Confers the Power of the Machine Spirit special rule.
+
+In a turn in which the vehicle neither moves Flat Out nor uses smoke launchers, the vehicle can fire one more weapon at its full Ballistic Skill than normally permitted. In addition, this weapon can be fired at a different target unit to any other weapons, subject to the normal rules for shooting.</description>
+    </rule>
+    <rule id="0ab8-c3dc-fe69-c2f6" name="Grav-backwash" publicationId="ca571888--pubN82424" page="59" hidden="false">
+      <description>Unless the Speeder has become immobilised, attackers suffer a -2 To Hit in Assault.</description>
+    </rule>
+    <rule id="5c68-573a-b2b6-3634" name="Psy-shock" publicationId="ca571888--pubN103311" page="" hidden="false">
+      <description>If a unit containing at least one Daemon or Psyker (i.e., a model with the Psyker, Brotherhood of Psykers/Sorcerers, Psychic Pilot, Daemon or Daemon of the Ruinstorm special rule) is hit by a weapon with this Psi-shock special rule, one randomly determinded Psyker or Daemon model in the unit suffered Perils of the Warp in addition to any other damage.</description>
+    </rule>
+  </sharedRules>
+  <sharedProfiles>
+    <profile id="0999-730e-6f17-dcc7" name="Cameleoline" page="0" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
+      <characteristics>
+        <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Confers Stealth</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="0cc3-b3b0-0880-9366" name="Bolter with Banestrike Rounds" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="52616e676523232344415441232323">18&quot;</characteristic>
+        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">4</characteristic>
+        <characteristic name="AP" typeId="415023232344415441232323">5</characteristic>
+        <characteristic name="Type" typeId="5479706523232344415441232323">Rapid Fire, Banestrike</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="d706-b010-f97a-ff5e" name="Autocannon: Sabot" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="52616e676523232344415441232323">36&quot;</characteristic>
+        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">8</characteristic>
+        <characteristic name="AP" typeId="415023232344415441232323">2</characteristic>
+        <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 1, Sunder</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="ab48-8dc9-50b7-0fa9" name="Bio-Corrosive Rounds" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="52616e676523232344415441232323">15&quot;</characteristic>
+        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">*</characteristic>
+        <characteristic name="AP" typeId="415023232344415441232323">6</characteristic>
+        <characteristic name="Type" typeId="5479706523232344415441232323">Salvo 3/4, Poison (4+)</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="764e-da44-1175-5ac6" name="Psyk-Out Grenade (Thrown)" publicationId="0e6e-8c19-c436-39c4" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="52616e676523232344415441232323">8</characteristic>
+        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">2</characteristic>
+        <characteristic name="AP" typeId="415023232344415441232323">-</characteristic>
+        <characteristic name="Type" typeId="5479706523232344415441232323">Assault 1, Blast, Psi-Shock</characteristic>
+      </characteristics>
+    </profile>
+  </sharedProfiles>
+</catalogue>

--- a/The Horus Heresy.gst
+++ b/The Horus Heresy.gst
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<gameSystem id="ca571888-56a9-c58e-ddaf-54f4713538bc" name="Warhammer 30,000 - The Horus Heresy" revision="117" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
+<gameSystem id="ca571888-56a9-c58e-ddaf-54f4713538bc" name="Warhammer 30,000 - The Horus Heresy" revision="118" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
   <publications>
     <publication id="ca571888--pubN65537" name="Forgeworld Horus Heresy Series"/>
     <publication id="ca571888--pubN66489" name="HH:MT"/>
@@ -6446,6 +6446,21 @@ Command Benefits:
           </costs>
         </selectionEntry>
         <selectionEntry id="0267-083e-86de-3c0f" name="Breaching Charge" publicationId="ca571888--pubN99753" hidden="false" collective="false" import="true" type="upgrade">
+          <profiles>
+            <profile id="e110-b880-2490-0e12" name="Breacher Charge" publicationId="ca571888--pubN82424" page="86" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="52616e676523232344415441232323">Special</characteristic>
+                <characteristic name="Strength" typeId="537472656e67746823232344415441232323">8</characteristic>
+                <characteristic name="AP" typeId="415023232344415441232323">2</characteristic>
+                <characteristic name="Type" typeId="5479706523232344415441232323">Melee, One Use, Blast, Wrecker</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="1613-e573-baea-c0cf" name="Breacher Charge" publicationId="ca571888--pubN66500" page="233" hidden="false">
+              <description>May be used in assault isntead of the carrying model&apos;s normal attacks or weapons.  The model makes a single attack.  Place the Blast template anywhere in base contact with the attacking model so it covers the enemy.  The template may not cover friendly models.  Roll to hit against the majority Weapon Skill of the enemy (buildings, emplacements, and stationary vehicles are hit automatically).  On a hit, the template remains where it was placed.  On a miss, roll a scatter die and flip the template in the direction indicated (always flips).</description>
+            </rule>
+          </rules>
           <costs>
             <cost name="pts" typeId="points" value="0.0"/>
           </costs>


### PR DESCRIPTION

Bit of a clean up of some duplication of Multimelta and a few other bits. Also fixed some issues with Tech Marines Thralls and their weapons.

Just a couple of tweeks to slim down the file. Breaching charges were replicated a couple of times, but were also included in the GST though without the info.

#1680 Ally Issues Fix for Allys from the Questoris, Daemon and Eldar lists. All were missing something. All fixed now.

Fixed reference page for Chaff launchers

Major project...
#1682 Mournival Units

Need to bear with me on this one. This is another Fanmade one from the AUS 30K / Mournival guys.
These files will cause no conflicts with the other files, as they have been kept sepparate.
I have added in all the units from the Mournival 3.0 digital copy for Marines. I will continue to add in the other units, and then finally get on to the revised units from the FAQ. Though i am unsure how i will be doing this, as there are 2 options. The short way is just make a set of "Revised selections" as a category on this file. that mean that you can select an option such as
Iron Warriors: Iron Havocs unit cost reduction. And that will be charged at -25pts

In the case of terminators getting the option for Volkite Chargers, I can have an option of
Exchange Combi-bolter for Volkite Charger. That will be charged at 2pts a time.

All these options will have the weaponry linked within them for profiles and rules, so they will still go on the summery at the bottom.

Anyway hope you enjoy.