### PR TITLE
Hidden issues Part 1

### DIFF
--- a/(HH) Mornival Units.cat
+++ b/(HH) Mornival Units.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="9f87-b468-2001-5e3b" name="Mornival Units (Fanmade)" revision="2" battleScribeVersion="2.03" authorName="Aus30K / Mourival Events" authorContact="" authorUrl="https://www.facebook.com/groups/190699548351507/" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="2" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="9f87-b468-2001-5e3b" name="Mornival Units (Fanmade)" revision="3" battleScribeVersion="2.03" authorName="Aus30K / Mourival Events" authorContact="" authorUrl="https://www.facebook.com/groups/190699548351507/" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="2" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="0e6e-8c19-c436-39c4" name="Mournival Events 3.0 Digital Version"/>
     <publication id="cf75-540e-e446-ecd5" name="Mournival Events FAQ and Experimental Errata v3.1"/>
@@ -9888,7 +9888,7 @@ Hunter: Shot Gun, Chainblade, +1A and Acute Senses</description>
                     <modifier type="set" field="ccce-cd4b-c78d-16d1" value="2.0"/>
                   </modifiers>
                   <costs>
-                    <cost name="pts" typeId="points" value="5.0"/>
+                    <cost name="pts" typeId="points" value="10.0"/>
                   </costs>
                 </entryLink>
                 <entryLink id="f019-cd7b-4dcc-45d7" name="Volkite Serpenta" hidden="false" collective="false" import="true" targetId="ae27-c659-fffd-1561" type="selectionEntry">
@@ -10053,7 +10053,7 @@ Hunter: Shot Gun, Chainblade, +1A and Acute Senses</description>
                 <modifier type="set" field="ccce-cd4b-c78d-16d1" value="18.0"/>
               </modifiers>
               <costs>
-                <cost name="pts" typeId="points" value="5.0"/>
+                <cost name="pts" typeId="points" value="10.0"/>
               </costs>
             </entryLink>
             <entryLink id="3330-b7f8-acaa-b1f0" name="Hand Flamer" hidden="false" collective="false" import="true" targetId="8a98-53c5-6fab-b3a7" type="selectionEntry">


### PR DESCRIPTION
Mournival FAQ fix

Salamander Infernus squads pay additional pts for Inferno pistol upgrade / exchange from plasma pistols..

Hidden Fixes pt1

Fixed a few "Hidden" validation issues.
Also removed a load of surplus data of entry links having "Set pts to X" as separate lines to the entry link. These were mainly relics of previous version of the data editor, where you couldn't assign costs to entry links.

Also reworked a bunch of Centurion weapon options they they are no longer nested entries, but instead are selectable on a flat list, with hidden flags added to each.

Also fixed a major unreported issue of many things not getting the option to take inferno pistols for salamanders that should have had the option. It seems that when the blood angels one was added, they all were, however, the salamanders were left out. Also unnested many of those entries as well.