### PR TITLE
Mournival Heavy Destroyer fix, Necron power fix.

### DIFF
--- a/(HH) Mornival Units.cat
+++ b/(HH) Mornival Units.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="9f87-b468-2001-5e3b" name="Mornival Units Legion Astartes (Fanmade)" revision="6" battleScribeVersion="2.03" authorName="Aus30K / Mourival Events" authorContact="" authorUrl="https://www.facebook.com/groups/190699548351507/" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="120" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="9f87-b468-2001-5e3b" name="Mornival Units Legion Astartes (Fanmade)" revision="7" battleScribeVersion="2.03" authorName="Aus30K / Mourival Events" authorContact="" authorUrl="https://www.facebook.com/groups/190699548351507/" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="120" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="0e6e-8c19-c436-39c4" name="Mournival Events 3.0 Digital Version"/>
     <publication id="cf75-540e-e446-ecd5" name="Mournival Events FAQ and Experimental Errata v3.1"/>
@@ -9101,6 +9101,9 @@ Hunter: Shot Gun, Chainblade, +1A and Acute Senses</description>
               <constraints>
                 <constraint field="selections" scope="parent" value="18.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="250d-c49f-9382-f403" type="max"/>
               </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="7.0"/>
+              </costs>
             </entryLink>
             <entryLink id="81ad-cf15-cc95-1a2a" name="Irad-Cleanser" hidden="false" collective="false" import="true" targetId="32e0-80f7-982d-b29a" type="selectionEntry">
               <constraints>

--- a/(HH) Necron Army List.cat
+++ b/(HH) Necron Army List.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="b50f-0671-3aea-cf90" name="Necron Army List (Fanmade)" revision="5" battleScribeVersion="2.03" authorName="Dono Author / Maye Gelt the Battlescribbler" authorContact="Dono (for Content) / Maye Gelt (for Battlescibbling)" authorUrl="http://www.facebook.com/AUS30K" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="4" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="b50f-0671-3aea-cf90" name="Necron Army List (Fanmade)" revision="6" battleScribeVersion="2.03" authorName="Dono Author / Maye Gelt the Battlescribbler" authorContact="Dono (for Content) / Maye Gelt (for Battlescibbling)" authorUrl="http://www.facebook.com/AUS30K" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="120" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="6fc6-dd7c-7a39-b0c8" name="30K Necron Army List (Fanmade)"/>
   </publications>
@@ -7566,10 +7566,10 @@ A Monolith docked at the Ziggurat cannot use its Eternity Gate but can undock an
           <profiles>
             <profile id="42a6-5919-1ae0-6ac3" name="Sky of Falling Stars" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
               <characteristics>
-                <characteristic name="Range" typeId="52616e676523232344415441232323"/>
-                <characteristic name="Strength" typeId="537472656e67746823232344415441232323"/>
-                <characteristic name="AP" typeId="415023232344415441232323"/>
-                <characteristic name="Type" typeId="5479706523232344415441232323"/>
+                <characteristic name="Range" typeId="52616e676523232344415441232323">48&quot;</characteristic>
+                <characteristic name="Strength" typeId="537472656e67746823232344415441232323">7</characteristic>
+                <characteristic name="AP" typeId="415023232344415441232323">3</characteristic>
+                <characteristic name="Type" typeId="5479706523232344415441232323">Apocalyptic Barrage (6)</characteristic>
               </characteristics>
             </profile>
           </profiles>


### PR DESCRIPTION
Heavy Destroyer Heavy Bolter upgrade was wrong cost
Necron "Sky of Falling Stars" Transcendent power had no statline.

