### PR TITLE
Mournival (Mech, Militia & Talons)

### DIFF
--- a/(HH) Imperialis Militia and Cults Army List.cat
+++ b/(HH) Imperialis Militia and Cults Army List.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="90aa-c2c8-ffb0-496e" name="Imperialis Militia and Cults Army List" revision="100" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="99" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="90aa-c2c8-ffb0-496e" name="Imperialis Militia and Cults Army List" revision="101" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="120" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="90aa-c2c8-pubN65537" name="Crusade Imperialis"/>
     <publication id="90aa-c2c8-pubN65563" name="AoDRB"/>
@@ -102,6 +102,23 @@ A wound cannot be re-allocated onto a gun model from a successful Look Out, Sir 
     <categoryEntry id="25d0-388c-dd16-af9a" name="Flying Monstrous Creature" hidden="false"/>
     <categoryEntry id="7fdd-2a97-d0e9-6524" name="Cybernetica Cortex" hidden="false"/>
     <categoryEntry id="37f2-7398-84ee-6fdf" name="Lorica Thallax" hidden="false"/>
+    <categoryEntry id="632b-24e7-f308-28f8" name="Bike" hidden="false">
+      <constraints>
+        <constraint field="selections" scope="parent" value="-1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b725-164a-8f15-6939" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="5e88-a3ee-976d-86e1" name="Relentless" hidden="false" targetId="3c7d-a1fa-c68b-caad" type="rule"/>
+        <infoLink id="234a-a7db-d03a-3adc" name="Hammer of Wrath" hidden="false" targetId="6f66-b417-6004-0916" type="rule"/>
+        <infoLink id="9073-f452-dca0-0407" name="Jink" hidden="false" targetId="d3e5-b43d-a89c-3bd8" type="rule"/>
+        <infoLink id="28fd-8dfa-58a4-3aca" name="Very Bulky" hidden="false" targetId="abc9-8566-bb61-4b7c" type="rule"/>
+      </infoLinks>
+    </categoryEntry>
+    <categoryEntry id="a54c-aa0e-4092-1b9a" name="Cavalry" page="" hidden="false">
+      <infoLinks>
+        <infoLink id="9fd8-3c90-9424-97d3" name="Fleet" hidden="false" targetId="69e5-fc02-1f9d-63c2" type="rule"/>
+        <infoLink id="05df-6769-b04f-fa9e" name="Hammer of Wrath" hidden="false" targetId="6f66-b417-6004-0916" type="rule"/>
+      </infoLinks>
+    </categoryEntry>
   </categoryEntries>
   <forceEntries>
     <forceEntry id="6329-878c-da3f-aa5e" name="Fan Made - Centurion" page="https://ia801902.us.archive.org/12/items/CENTURION1.1/CENTURION%201.1.pdf" hidden="false">
@@ -204,6 +221,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="d8b5-c04a-817f-3c7e" type="max"/>
           </constraints>
         </categoryLink>
+        <categoryLink id="e35f-1e1c-fc6c-f1fe" name="Mournival Rules" hidden="false" targetId="dbe0-716f-797c-66f7" primary="false"/>
       </categoryLinks>
     </forceEntry>
     <forceEntry id="80a2-7d5f-396f-352e" name="Armies of Dark Compliance" hidden="false">
@@ -255,6 +273,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="9bcf-e1db-16a8-8f68" type="max"/>
           </constraints>
         </categoryLink>
+        <categoryLink id="4e2c-70ad-4dd1-1c1e" name="Mournival Rules" hidden="false" targetId="dbe0-716f-797c-66f7" primary="false"/>
       </categoryLinks>
     </forceEntry>
     <forceEntry id="98db-b4ba-fbcd-3239" name=" Crusade" hidden="false">
@@ -317,6 +336,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="995f-3c8e-6690-e0be" type="max"/>
           </constraints>
         </categoryLink>
+        <categoryLink id="06e0-fd6c-814c-b905" name="Mournival Rules" hidden="false" targetId="dbe0-716f-797c-66f7" primary="false"/>
       </categoryLinks>
     </forceEntry>
     <forceEntry id="657a-bc81-4ae3-8a5b" name="Allied Detachment" hidden="false">
@@ -371,6 +391,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="3873-4bf0-2e6e-51de" type="max"/>
           </constraints>
         </categoryLink>
+        <categoryLink id="ea32-ebdf-a9e0-1feb" name="Mournival Rules" hidden="false" targetId="dbe0-716f-797c-66f7" primary="false"/>
       </categoryLinks>
     </forceEntry>
     <forceEntry id="089f-7e79-bde1-90dd" name=" Zone Mortalis - Attacker" hidden="false">
@@ -408,6 +429,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="1b51-ce52-4d7a-c446" type="max"/>
           </constraints>
         </categoryLink>
+        <categoryLink id="6e3c-278f-1fe5-df94" name="Mournival Rules" hidden="false" targetId="dbe0-716f-797c-66f7" primary="false"/>
       </categoryLinks>
     </forceEntry>
     <forceEntry id="7b39-af6b-52e1-b4d7" name=" Zone Mortalis - Defender" hidden="false">
@@ -441,6 +463,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="9fcc-124f-4a07-bf97" type="max"/>
           </constraints>
         </categoryLink>
+        <categoryLink id="64a7-0135-65c0-7fa2" name="Mournival Rules" hidden="false" targetId="dbe0-716f-797c-66f7" primary="false"/>
       </categoryLinks>
     </forceEntry>
     <forceEntry id="7e48-c376-8ffe-8ae7" name=" Zone Mortalis - Combatant" hidden="false">
@@ -478,6 +501,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="fdc6-f699-aeb3-f756" type="max"/>
           </constraints>
         </categoryLink>
+        <categoryLink id="9cdd-504a-8562-88b3" name="Mournival Rules" hidden="false" targetId="dbe0-716f-797c-66f7" primary="false"/>
       </categoryLinks>
     </forceEntry>
     <forceEntry id="d1ef-61e1-3d67-5a19" name="Optional - Onslaught" hidden="false">
@@ -522,6 +546,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="591e-77a0-8c09-b4b5" type="max"/>
           </constraints>
         </categoryLink>
+        <categoryLink id="bde2-af12-3fb7-5510" name="Mournival Rules" hidden="false" targetId="dbe0-716f-797c-66f7" primary="false"/>
       </categoryLinks>
     </forceEntry>
     <forceEntry id="3a6f-6d67-a8b2-e911" name="Optional - Castellan" hidden="false">
@@ -571,6 +596,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="13c4-57aa-ad88-303c" type="max"/>
           </constraints>
         </categoryLink>
+        <categoryLink id="3754-c399-0058-9cfc" name="Mournival Rules" hidden="false" targetId="dbe0-716f-797c-66f7" primary="false"/>
       </categoryLinks>
     </forceEntry>
     <forceEntry id="f715-cdf4-0c5e-213a" name="Optional - Leviathan" hidden="false">
@@ -628,6 +654,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="c25f-1d0e-8826-021c" type="max"/>
           </constraints>
         </categoryLink>
+        <categoryLink id="fbdc-d038-8a86-98da" name="Mournival Rules" hidden="false" targetId="dbe0-716f-797c-66f7" primary="false"/>
       </categoryLinks>
     </forceEntry>
     <forceEntry id="8666-c0df-4dfa-08f1" name=" Strategic Raid - Garrison" hidden="false">
@@ -675,6 +702,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="b210-4caa-2fae-d5e5" type="max"/>
           </constraints>
         </categoryLink>
+        <categoryLink id="39e3-532c-0241-bd1a" name="Mournival Rules" hidden="false" targetId="dbe0-716f-797c-66f7" primary="false"/>
       </categoryLinks>
     </forceEntry>
   </forceEntries>
@@ -684,6 +712,27 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <categoryLink id="b9e8-93cb-b89e-24a1" name="New CategoryLink" hidden="false" targetId="5297-7e0f-fa0b-3537" primary="true"/>
         <categoryLink id="9420-adca-b388-9142" name="New CategoryLink" hidden="false" targetId="c1d8-4cbf-e883-4e44" primary="false"/>
       </categoryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5a9e-6c6d-c357-0f70" name="Mournival Rules" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6cda-a9c1-63bf-c14d" type="min"/>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6fa5-84ab-120d-eca8" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="85d6-b968-20a1-233f" type="max"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="a3f8-0cf8-e2af-9f3c" name="Mournival Rules" hidden="false" targetId="dbe0-716f-797c-66f7" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="9e37-8b0c-2c91-602b" name="Mornival Rules Active" hidden="false" collective="false" import="true" targetId="c859-6b16-c533-7e97" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b35e-5cb0-9679-b942" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0dca-fb38-49a3-d4c1" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
@@ -803,7 +852,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <categoryLink id="cea8-0318-73b4-c3a4" name="New CategoryLink" hidden="false" targetId="8a8c-ed20-7427-ddff" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="450e-3771-b9c4-d45a" name="Imperialis Militia Grenadier Squad" hidden="false" collective="false" import="true" targetId="f299-898a-b637-0aa2" type="selectionEntry">
+    <entryLink id="450e-3771-b9c4-d45a" name="Grenadier Squad, Imperialis Militia" hidden="false" collective="false" import="true" targetId="f299-898a-b637-0aa2" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditionGroups>
@@ -1011,7 +1060,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <categoryLink id="209c-eaf9-4bf5-08f9" name="New CategoryLink" hidden="false" targetId="8a8c-ed20-7427-ddff" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="4e4e-f6f4-33e0-f927" name="Imperialis Militia Grenadier Squad" hidden="true" collective="false" import="true" targetId="f299-898a-b637-0aa2" type="selectionEntry">
+    <entryLink id="4e4e-f6f4-33e0-f927" name="Grenadier Squad, Imperialis Militia" hidden="true" collective="false" import="true" targetId="f299-898a-b637-0aa2" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
@@ -1116,6 +1165,30 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
     <entryLink id="20c2-dc1e-b6e8-983b" name="Questoris Knight Warden" hidden="false" collective="false" import="true" targetId="f4f1-dad6-0596-ca5a" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="b8a6-3834-26a1-3780" name="New CategoryLink" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="bf29-1737-feca-6c29" name="Militia Land Speeder Squadron" hidden="true" collective="false" import="true" targetId="7617-bc44-a31d-b389" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c859-6b16-c533-7e97" type="greaterThan"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="17a8-5eb7-d15a-9138" name="New CategoryLink" hidden="false" targetId="466173742041747461636b23232344415441232323" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="4589-2034-b7aa-dad6" name="Militia Mounted Squadron" hidden="true" collective="false" import="true" targetId="222a-94eb-eda4-afe1" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c859-6b16-c533-7e97" type="greaterThan"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="fbf2-9e88-52a2-c014" name="New CategoryLink" hidden="false" targetId="466173742041747461636b23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
   </entryLinks>
@@ -2275,6 +2348,26 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
                 <condition field="selections" scope="90d3-fb2c-d7c2-6482" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9a69-a0b1-a2be-9e00" type="equalTo"/>
               </conditions>
             </modifier>
+            <modifier type="set" field="556e6974205479706523232344415441232323" value="Bike (Character)">
+              <conditions>
+                <condition field="selections" scope="90d3-fb2c-d7c2-6482" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7fbb-1bb9-0360-d6e1" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="556e6974205479706523232344415441232323" value="Cavalry (Character)">
+              <conditions>
+                <condition field="selections" scope="90d3-fb2c-d7c2-6482" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="875a-e56c-84b6-2b18" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="5423232344415441232323" value="1">
+              <conditions>
+                <condition field="selections" scope="90d3-fb2c-d7c2-6482" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7fbb-1bb9-0360-d6e1" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="5723232344415441232323" value="1">
+              <conditions>
+                <condition field="selections" scope="90d3-fb2c-d7c2-6482" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="875a-e56c-84b6-2b18" type="equalTo"/>
+              </conditions>
+            </modifier>
           </modifiers>
           <characteristics>
             <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry (Character)</characteristic>
@@ -2348,6 +2441,28 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
               </constraints>
               <profiles>
                 <profile id="f020-df3c-3ae2-b268" name="Alpha Psyker" publicationId="90aa-c2c8-pubN73486" page="191" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+                  <modifiers>
+                    <modifier type="set" field="556e6974205479706523232344415441232323" value="Bike (Character)">
+                      <conditions>
+                        <condition field="selections" scope="90d3-fb2c-d7c2-6482" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7fbb-1bb9-0360-d6e1" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="set" field="556e6974205479706523232344415441232323" value="Cavalry (Character)">
+                      <conditions>
+                        <condition field="selections" scope="90d3-fb2c-d7c2-6482" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="875a-e56c-84b6-2b18" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="5423232344415441232323" value="1">
+                      <conditions>
+                        <condition field="selections" scope="90d3-fb2c-d7c2-6482" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7fbb-1bb9-0360-d6e1" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="5723232344415441232323" value="1">
+                      <conditions>
+                        <condition field="selections" scope="90d3-fb2c-d7c2-6482" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="875a-e56c-84b6-2b18" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
                   <characteristics>
                     <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry (Character)</characteristic>
                     <characteristic name="WS" typeId="575323232344415441232323">3</characteristic>
@@ -2404,6 +2519,30 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
               <modifiers>
                 <modifier type="set" field="hidden" value="false"/>
               </modifiers>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="a9f2-dd1b-aeb3-c22e" name="Mounted Force" hidden="true" collective="false" import="true">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="222a-94eb-eda4-afe1" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bb0e-9b64-5cd9-a3f5" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="d5f8-7437-b276-e578" name="Outriders (Bikes)" hidden="false" collective="false" import="true" targetId="7fbb-1bb9-0360-d6e1" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="3b41-b9de-146d-0ce6" name="Riders (Cavalry)" hidden="false" collective="false" import="true" targetId="875a-e56c-84b6-2b18" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="points" value="4.0"/>
+              </costs>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
@@ -2629,7 +2768,7 @@ D3     Mutation
                 <entryLink id="b6d0-caa9-7637-7c64" name="May exchange heavy bolter for:" hidden="false" collective="false" import="true" targetId="4be5-eee6-ab84-8558" type="selectionEntryGroup"/>
                 <entryLink id="4a38-5b1d-9136-e02e" hidden="false" collective="false" import="true" targetId="bbe6-a89e-c49e-15c6" type="selectionEntryGroup"/>
                 <entryLink id="b6a2-680c-039a-e24d" hidden="false" collective="false" import="true" targetId="e218-c4f7-0220-e158" type="selectionEntryGroup"/>
-                <entryLink id="c829-a856-a5c7-fd50" hidden="false" collective="false" import="true" targetId="525c-a63f-e928-d7d5" type="selectionEntryGroup"/>
+                <entryLink id="c829-a856-a5c7-fd50" name="May take a pair of sponsons:" hidden="false" collective="false" import="true" targetId="525c-a63f-e928-d7d5" type="selectionEntryGroup"/>
               </entryLinks>
               <costs>
                 <cost name="pts" typeId="points" value="140.0"/>
@@ -2843,6 +2982,28 @@ D3     Mutation
           </constraints>
           <profiles>
             <profile id="1693-d1f1-afc3-4eb8" name="Medicae Orderly" publicationId="90aa-c2c8-pubN73486" page="199" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+              <modifiers>
+                <modifier type="set" field="556e6974205479706523232344415441232323" value="Cavalry (Character)">
+                  <conditions>
+                    <condition field="selections" scope="2111-1bc6-317a-5314" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="875a-e56c-84b6-2b18" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="5723232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="2111-1bc6-317a-5314" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="875a-e56c-84b6-2b18" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="556e6974205479706523232344415441232323" value="Bike (Character)">
+                  <conditions>
+                    <condition field="selections" scope="2111-1bc6-317a-5314" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7fbb-1bb9-0360-d6e1" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="5423232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="2111-1bc6-317a-5314" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7fbb-1bb9-0360-d6e1" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry (Character)</characteristic>
                 <characteristic name="WS" typeId="575323232344415441232323">3</characteristic>
@@ -2857,6 +3018,32 @@ D3     Mutation
               </characteristics>
             </profile>
           </profiles>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="dec6-e0b8-a173-b08f" name="Mounted Force" hidden="true" collective="false" import="true">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="222a-94eb-eda4-afe1" type="greaterThan"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8254-a742-1955-b741" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="db32-a6b4-a8ec-b20c" name="Outriders (Bikes)" hidden="false" collective="false" import="true" targetId="7fbb-1bb9-0360-d6e1" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="5688-4e5f-d92a-3956" name="Riders (Cavalry)" hidden="false" collective="false" import="true" targetId="875a-e56c-84b6-2b18" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="4.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
           <entryLinks>
             <entryLink id="8e46-07b0-979b-8a35" name="Laspistol" hidden="false" collective="false" import="true" targetId="8f9a-ab5e-56a1-18d2" type="selectionEntry"/>
             <entryLink id="d926-ace1-0a77-a9c0" name="Medi-Pack" hidden="false" collective="false" import="true" targetId="0c10-40cd-a0d5-f562" type="selectionEntry"/>
@@ -4201,6 +4388,28 @@ D3     Mutation
           </constraints>
           <profiles>
             <profile id="891c-78dd-db0d-659f" name="Discipline Master" publicationId="90aa-c2c8-pubN73486" page="190" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+              <modifiers>
+                <modifier type="set" field="556e6974205479706523232344415441232323" value="Bike (Character)">
+                  <conditions>
+                    <condition field="selections" scope="8ef3-b699-2981-1b1a" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7fbb-1bb9-0360-d6e1" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="556e6974205479706523232344415441232323" value="Cavalry (Character)">
+                  <conditions>
+                    <condition field="selections" scope="8ef3-b699-2981-1b1a" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="875a-e56c-84b6-2b18" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="5723232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="8ef3-b699-2981-1b1a" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="875a-e56c-84b6-2b18" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="5423232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="8ef3-b699-2981-1b1a" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7fbb-1bb9-0360-d6e1" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry (Character)</characteristic>
                 <characteristic name="WS" typeId="575323232344415441232323">4</characteristic>
@@ -4362,6 +4571,30 @@ D3     Mutation
                   </costs>
                 </selectionEntry>
               </selectionEntries>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="a500-24a4-0c58-511b" name="Mounted Force" hidden="true" collective="false" import="true">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="222a-94eb-eda4-afe1" type="greaterThan"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2a84-3857-0448-0182" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="0fed-e571-41e9-c63c" name="Outriders (Bikes)" hidden="false" collective="false" import="true" targetId="7fbb-1bb9-0360-d6e1" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="6da8-74e3-8ffe-eb94" name="Riders (Cavalry)" hidden="false" collective="false" import="true" targetId="875a-e56c-84b6-2b18" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="4.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks>
@@ -4724,6 +4957,28 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
       </constraints>
       <profiles>
         <profile id="3627-ea71-a4fd-23a6" name="Force Commander" publicationId="90aa-c2c8-pubN73486" page="187" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+          <modifiers>
+            <modifier type="set" field="556e6974205479706523232344415441232323" value="Cavalry (Character)">
+              <conditions>
+                <condition field="selections" scope="343f-b1ae-c962-4f62" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="875a-e56c-84b6-2b18" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="556e6974205479706523232344415441232323" value="Bike (Character)">
+              <conditions>
+                <condition field="selections" scope="343f-b1ae-c962-4f62" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7fbb-1bb9-0360-d6e1" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="5723232344415441232323" value="1">
+              <conditions>
+                <condition field="selections" scope="343f-b1ae-c962-4f62" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="875a-e56c-84b6-2b18" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="5423232344415441232323" value="1">
+              <conditions>
+                <condition field="selections" scope="343f-b1ae-c962-4f62" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7fbb-1bb9-0360-d6e1" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
           <characteristics>
             <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry (Character)</characteristic>
             <characteristic name="WS" typeId="575323232344415441232323">4</characteristic>
@@ -5170,6 +5425,30 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
+        <selectionEntryGroup id="b05e-2d3f-3ade-c230" name="Mounted Force" hidden="true" collective="false" import="true">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="222a-94eb-eda4-afe1" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="342a-d6d6-d52b-d1b4" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="0531-1688-d509-97b7" name="Outriders (Bikes)" hidden="false" collective="false" import="true" targetId="7fbb-1bb9-0360-d6e1" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="9fdc-834c-9c54-118b" name="Riders (Cavalry)" hidden="false" collective="false" import="true" targetId="875a-e56c-84b6-2b18" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="points" value="4.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
         <entryLink id="2c60-a021-ccf6-8386" name="The Muster of Worlds" hidden="false" collective="false" import="true" targetId="cbce-55d8-bc66-b3a9" type="selectionEntry"/>
@@ -5197,13 +5476,35 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
         <categoryLink id="d07a-7a4d-c270-e223" name="New CategoryLink" hidden="false" targetId="8a8c-ed20-7427-ddff" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="68a8-a846-69bc-b994" name="Militia Bodyguard" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="68a8-a846-69bc-b994" name="Militia Bodyguard" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2547-9376-5924-2874" type="min"/>
             <constraint field="selections" scope="parent" value="7.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6691-87f3-18ea-53c5" type="max"/>
           </constraints>
           <profiles>
             <profile id="db25-fc9e-26d8-7f82" name="Militia Bodyguard" publicationId="90aa-c2c8-pubN73486" page="192" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+              <modifiers>
+                <modifier type="set" field="556e6974205479706523232344415441232323" value="Bike">
+                  <conditions>
+                    <condition field="selections" scope="ee8f-fcde-88df-7261" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7fbb-1bb9-0360-d6e1" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="556e6974205479706523232344415441232323" value="Cavalry">
+                  <conditions>
+                    <condition field="selections" scope="ee8f-fcde-88df-7261" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="875a-e56c-84b6-2b18" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="5723232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="ee8f-fcde-88df-7261" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="875a-e56c-84b6-2b18" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="5423232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="ee8f-fcde-88df-7261" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7fbb-1bb9-0360-d6e1" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry</characteristic>
                 <characteristic name="WS" typeId="575323232344415441232323">3</characteristic>
@@ -5225,13 +5526,35 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
             <cost name="pts" typeId="points" value="5.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="fcf9-e928-e7fc-6a40" name="Platoon Commander" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="fcf9-e928-e7fc-6a40" name="Platoon Commander" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f3bc-b646-ea5d-2bc5" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2a0d-3574-a6e2-fa96" type="max"/>
           </constraints>
           <profiles>
             <profile id="f241-1206-39f8-66e3" name="Platoon Commander" publicationId="90aa-c2c8-pubN73486" page="192" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+              <modifiers>
+                <modifier type="set" field="556e6974205479706523232344415441232323" value="Bike (Character)">
+                  <conditions>
+                    <condition field="selections" scope="ee8f-fcde-88df-7261" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7fbb-1bb9-0360-d6e1" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="556e6974205479706523232344415441232323" value="Cavalry (Character)">
+                  <conditions>
+                    <condition field="selections" scope="ee8f-fcde-88df-7261" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="875a-e56c-84b6-2b18" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="5723232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="ee8f-fcde-88df-7261" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="875a-e56c-84b6-2b18" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="5423232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="ee8f-fcde-88df-7261" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7fbb-1bb9-0360-d6e1" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry (Character)</characteristic>
                 <characteristic name="WS" typeId="575323232344415441232323">4</characteristic>
@@ -5458,13 +5781,35 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
             <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="a4ec-b949-4938-b0c6" name="Vox Operator" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="a4ec-b949-4938-b0c6" name="Vox Operator" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c982-c631-e160-512b" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0559-b275-73a5-97bb" type="min"/>
           </constraints>
           <profiles>
             <profile id="ceb0-3378-6fe7-3533" name="Vox Operator" publicationId="90aa-c2c8-pubN73486" page="192" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+              <modifiers>
+                <modifier type="set" field="556e6974205479706523232344415441232323" value="Cavalry">
+                  <conditions>
+                    <condition field="selections" scope="ee8f-fcde-88df-7261" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="875a-e56c-84b6-2b18" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="556e6974205479706523232344415441232323" value="Bike">
+                  <conditions>
+                    <condition field="selections" scope="ee8f-fcde-88df-7261" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7fbb-1bb9-0360-d6e1" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="5723232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="ee8f-fcde-88df-7261" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="875a-e56c-84b6-2b18" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="5423232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="ee8f-fcde-88df-7261" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7fbb-1bb9-0360-d6e1" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry</characteristic>
                 <characteristic name="WS" typeId="575323232344415441232323">3</characteristic>
@@ -5500,13 +5845,35 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
             <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="a5be-7900-a68f-5055" name="Platoon Standard Bearer" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="a5be-7900-a68f-5055" name="Platoon Standard Bearer" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6478-0c99-4480-47c4" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c917-ed37-e645-dcdd" type="min"/>
           </constraints>
           <profiles>
             <profile id="24be-7aba-151a-17cf" name="Platoon Standard Bearer" publicationId="90aa-c2c8-pubN73486" page="192" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+              <modifiers>
+                <modifier type="set" field="556e6974205479706523232344415441232323" value="Bike">
+                  <conditions>
+                    <condition field="selections" scope="ee8f-fcde-88df-7261" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7fbb-1bb9-0360-d6e1" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="556e6974205479706523232344415441232323" value="Cavalry">
+                  <conditions>
+                    <condition field="selections" scope="ee8f-fcde-88df-7261" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="875a-e56c-84b6-2b18" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="5723232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="ee8f-fcde-88df-7261" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="875a-e56c-84b6-2b18" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="5423232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="ee8f-fcde-88df-7261" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7fbb-1bb9-0360-d6e1" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry</characteristic>
                 <characteristic name="WS" typeId="575323232344415441232323">3</characteristic>
@@ -5575,6 +5942,13 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
           </selectionEntries>
         </selectionEntryGroup>
         <selectionEntryGroup id="8082-5ec3-3bb2-b709" name="Dedicated Transport" hidden="false" collective="false" import="true">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="ee8f-fcde-88df-7261" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2917-ac81-176d-3780" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3ef0-bf2a-3454-2e56" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c6ee-1bdb-803c-9609" type="max"/>
@@ -5686,6 +6060,38 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
               </costs>
             </selectionEntry>
           </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="2917-ac81-176d-3780" name="Mounted Force" hidden="true" collective="false" import="true">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="222a-94eb-eda4-afe1" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cb67-3bd3-b52d-11c9" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="fdbe-a11d-daca-5c6f" name="Outriders (Bikes)" hidden="false" collective="false" import="true" targetId="7fbb-1bb9-0360-d6e1" type="selectionEntry">
+              <modifiers>
+                <modifier type="increment" field="points" value="5.0">
+                  <repeats>
+                    <repeat field="selections" scope="ee8f-fcde-88df-7261" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+            </entryLink>
+            <entryLink id="36ee-03ec-59c3-1bb2" name="Riders (Cavalry)" hidden="false" collective="false" import="true" targetId="875a-e56c-84b6-2b18" type="selectionEntry">
+              <modifiers>
+                <modifier type="increment" field="points" value="4.0">
+                  <repeats>
+                    <repeat field="selections" scope="ee8f-fcde-88df-7261" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+            </entryLink>
+          </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
@@ -6222,6 +6628,28 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
           </constraints>
           <profiles>
             <profile id="7584-1482-cee0-6c48" name="Grenadier" publicationId="90aa-c2c8-pubN73486" page="195" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+              <modifiers>
+                <modifier type="set" field="556e6974205479706523232344415441232323" value="Cavalry">
+                  <conditions>
+                    <condition field="selections" scope="f299-898a-b637-0aa2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="875a-e56c-84b6-2b18" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="556e6974205479706523232344415441232323" value="Bike">
+                  <conditions>
+                    <condition field="selections" scope="f299-898a-b637-0aa2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7fbb-1bb9-0360-d6e1" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="5723232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="f299-898a-b637-0aa2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="875a-e56c-84b6-2b18" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="5423232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="f299-898a-b637-0aa2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7fbb-1bb9-0360-d6e1" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry</characteristic>
                 <characteristic name="WS" typeId="575323232344415441232323">3</characteristic>
@@ -6250,6 +6678,28 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
           </constraints>
           <profiles>
             <profile id="8684-f5f1-6c0f-d399" name="Grenadier Sergeant" publicationId="90aa-c2c8-pubN73486" page="195" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+              <modifiers>
+                <modifier type="set" field="556e6974205479706523232344415441232323" value="Bike (Character)">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7fbb-1bb9-0360-d6e1" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="556e6974205479706523232344415441232323" value="Cavalry (Character)">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="875a-e56c-84b6-2b18" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="5723232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="875a-e56c-84b6-2b18" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="5423232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="f299-898a-b637-0aa2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7fbb-1bb9-0360-d6e1" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry (Character)</characteristic>
                 <characteristic name="WS" typeId="575323232344415441232323">3</characteristic>
@@ -6550,6 +7000,13 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
           </selectionEntries>
         </selectionEntryGroup>
         <selectionEntryGroup id="7b61-5fdd-cf5c-8c7b" name="Dedicated Transport" hidden="false" collective="false" import="true">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="f299-898a-b637-0aa2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3976-de26-0726-03aa" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="63de-cef1-4974-861f" type="max"/>
           </constraints>
@@ -6895,6 +7352,38 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
+        <selectionEntryGroup id="3976-de26-0726-03aa" name="Mounted Force" hidden="true" collective="false" import="true">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="222a-94eb-eda4-afe1" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="99d0-920a-47c9-b6d9" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="6d65-40f8-bcd8-b907" name="Outriders (Bikes)" hidden="false" collective="false" import="true" targetId="7fbb-1bb9-0360-d6e1" type="selectionEntry">
+              <modifiers>
+                <modifier type="increment" field="points" value="5.0">
+                  <repeats>
+                    <repeat field="selections" scope="f299-898a-b637-0aa2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+            </entryLink>
+            <entryLink id="1b54-374c-eb31-eedb" name="Riders (Cavalry)" hidden="false" collective="false" import="true" targetId="875a-e56c-84b6-2b18" type="selectionEntry">
+              <modifiers>
+                <modifier type="increment" field="points" value="4.0">
+                  <repeats>
+                    <repeat field="selections" scope="f299-898a-b637-0aa2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
         <entryLink id="3d11-0d9d-0dbb-4ae8" name="Provenance" hidden="false" collective="false" import="true" targetId="9d50-7127-dc55-d542" type="selectionEntryGroup"/>
@@ -6933,13 +7422,35 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
         <categoryLink id="0c29-6662-4f23-3d41" name="New CategoryLink" hidden="false" targetId="8a8c-ed20-7427-ddff" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="3b8d-1a44-5054-bf06" name="Recon Auxiliaries" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="3b8d-1a44-5054-bf06" name="Recon Auxiliaries" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4938-8a44-5c91-8dfe" type="min"/>
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b564-0bcb-ec4d-b609" type="max"/>
           </constraints>
           <profiles>
             <profile id="eb2b-06ae-944c-f22f" name="Recon Auxiliary" publicationId="90aa-c2c8-pubN73486" page="197" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+              <modifiers>
+                <modifier type="increment" field="5723232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="a05b-1aaf-314c-cbba" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="875a-e56c-84b6-2b18" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="556e6974205479706523232344415441232323" value="Bike">
+                  <conditions>
+                    <condition field="selections" scope="a05b-1aaf-314c-cbba" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7fbb-1bb9-0360-d6e1" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="5423232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="a05b-1aaf-314c-cbba" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7fbb-1bb9-0360-d6e1" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="556e6974205479706523232344415441232323" value="Cavalry">
+                  <conditions>
+                    <condition field="selections" scope="a05b-1aaf-314c-cbba" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="875a-e56c-84b6-2b18" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry</characteristic>
                 <characteristic name="WS" typeId="575323232344415441232323">3</characteristic>
@@ -6958,13 +7469,35 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
             <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="6acc-9e13-506e-15d9" name="Recon Sergeant" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="6acc-9e13-506e-15d9" name="Recon Sergeant" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ae25-3062-4a99-da55" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c72c-ce19-b260-cf7b" type="max"/>
           </constraints>
           <profiles>
             <profile id="46c2-414b-6147-1608" name="Recon Sergeant" publicationId="90aa-c2c8-pubN73486" page="197" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+              <modifiers>
+                <modifier type="set" field="556e6974205479706523232344415441232323" value="Cavalry (Character)">
+                  <conditions>
+                    <condition field="selections" scope="a05b-1aaf-314c-cbba" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="875a-e56c-84b6-2b18" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="556e6974205479706523232344415441232323" value="Bike (Character)">
+                  <conditions>
+                    <condition field="selections" scope="a05b-1aaf-314c-cbba" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7fbb-1bb9-0360-d6e1" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="5723232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="a05b-1aaf-314c-cbba" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="875a-e56c-84b6-2b18" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="5423232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="a05b-1aaf-314c-cbba" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7fbb-1bb9-0360-d6e1" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry (Character)</characteristic>
                 <characteristic name="WS" typeId="575323232344415441232323">3</characteristic>
@@ -7093,6 +7626,38 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
+        <selectionEntryGroup id="cf82-7eac-704a-80e5" name="Mounted Force" hidden="true" collective="false" import="true">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="222a-94eb-eda4-afe1" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f1ad-8e60-7461-bad9" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="2e08-be2c-5ed6-2286" name="Outriders (Bikes)" hidden="false" collective="false" import="true" targetId="7fbb-1bb9-0360-d6e1" type="selectionEntry">
+              <modifiers>
+                <modifier type="increment" field="points" value="5.0">
+                  <repeats>
+                    <repeat field="selections" scope="a05b-1aaf-314c-cbba" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+            </entryLink>
+            <entryLink id="f010-9ce2-87a4-160a" name="Riders (Cavalry)" hidden="false" collective="false" import="true" targetId="875a-e56c-84b6-2b18" type="selectionEntry">
+              <modifiers>
+                <modifier type="increment" field="points" value="4.0">
+                  <repeats>
+                    <repeat field="selections" scope="a05b-1aaf-314c-cbba" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
         <entryLink id="8435-e675-5e5b-2d48" name="Provenance" hidden="false" collective="false" import="true" targetId="9d50-7127-dc55-d542" type="selectionEntryGroup"/>
@@ -7110,33 +7675,39 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
       </costs>
     </selectionEntry>
     <selectionEntry id="c542-ddd4-6b6b-f761" name="Infantry Squad, Imperialis Militia" hidden="false" collective="false" import="true" type="unit">
-      <profiles>
-        <profile id="4e87-0dba-72a2-5836" name="Militia Auxiliary" publicationId="90aa-c2c8-pubN73486" page="193" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
-          <characteristics>
-            <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry</characteristic>
-            <characteristic name="WS" typeId="575323232344415441232323">3</characteristic>
-            <characteristic name="BS" typeId="425323232344415441232323">3</characteristic>
-            <characteristic name="S" typeId="5323232344415441232323">3</characteristic>
-            <characteristic name="T" typeId="5423232344415441232323">3</characteristic>
-            <characteristic name="W" typeId="5723232344415441232323">1</characteristic>
-            <characteristic name="I" typeId="4923232344415441232323">3</characteristic>
-            <characteristic name="A" typeId="4123232344415441232323">1</characteristic>
-            <characteristic name="LD" typeId="4c4423232344415441232323">6</characteristic>
-            <characteristic name="Save" typeId="5361766523232344415441232323">5+</characteristic>
-          </characteristics>
-        </profile>
-      </profiles>
       <categoryLinks>
         <categoryLink id="28c8-6342-6ce7-b142" name="New CategoryLink" hidden="false" targetId="8a8c-ed20-7427-ddff" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="3039-df71-608f-a04b" name="Sergeant" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="3039-df71-608f-a04b" name="Sergeant" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c40d-2f89-1068-f0a9" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4be5-9a62-9d82-127e" type="max"/>
           </constraints>
           <profiles>
             <profile id="e91c-bcc4-05cc-efad" name="Sergeant" publicationId="90aa-c2c8-pubN73486" page="193" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+              <modifiers>
+                <modifier type="set" field="556e6974205479706523232344415441232323" value="Bike (Character)">
+                  <conditions>
+                    <condition field="selections" scope="c542-ddd4-6b6b-f761" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7fbb-1bb9-0360-d6e1" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="556e6974205479706523232344415441232323" value="Cavalry (Character)">
+                  <conditions>
+                    <condition field="selections" scope="c542-ddd4-6b6b-f761" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="875a-e56c-84b6-2b18" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="5723232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="c542-ddd4-6b6b-f761" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="875a-e56c-84b6-2b18" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="5423232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="c542-ddd4-6b6b-f761" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7fbb-1bb9-0360-d6e1" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry (Character)</characteristic>
                 <characteristic name="WS" typeId="575323232344415441232323">3</characteristic>
@@ -7154,7 +7725,7 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
           <selectionEntryGroups>
             <selectionEntryGroup id="2487-e8a8-d774-a32e" name="May take:" hidden="false" collective="false" import="true">
               <entryLinks>
-                <entryLink id="fbeb-1bba-ab7f-d17b" name="New EntryLink" hidden="false" collective="false" import="true" targetId="af29-a6cf-7b05-c362" type="selectionEntry"/>
+                <entryLink id="fbeb-1bba-ab7f-d17b" name="Melta Bombs" hidden="false" collective="false" import="true" targetId="af29-a6cf-7b05-c362" type="selectionEntry"/>
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="f9f4-bf7a-53a3-f794" name="May exchange close combat weapon for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="76a3-6ba8-c225-a219">
@@ -7306,13 +7877,35 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
             <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="1884-69d1-90e1-0688" name="Militia Auxiliaries" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="1884-69d1-90e1-0688" name="Militia Auxiliaries" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d408-f627-3be9-2e88" type="min"/>
             <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5f78-f6c8-9768-b123" type="max"/>
           </constraints>
           <profiles>
             <profile id="1abd-8245-ddf0-c387" name="Militia Auxiliaries" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+              <modifiers>
+                <modifier type="set" field="556e6974205479706523232344415441232323" value="Bike">
+                  <conditions>
+                    <condition field="selections" scope="c542-ddd4-6b6b-f761" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7fbb-1bb9-0360-d6e1" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="5723232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="c542-ddd4-6b6b-f761" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="875a-e56c-84b6-2b18" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="5423232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="c542-ddd4-6b6b-f761" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7fbb-1bb9-0360-d6e1" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="556e6974205479706523232344415441232323" value="Cavalry">
+                  <conditions>
+                    <condition field="selections" scope="c542-ddd4-6b6b-f761" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="875a-e56c-84b6-2b18" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry</characteristic>
                 <characteristic name="WS" typeId="575323232344415441232323">3</characteristic>
@@ -7440,6 +8033,13 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
           </selectionEntries>
         </selectionEntryGroup>
         <selectionEntryGroup id="2641-cb73-68a9-5d0d" name="Dedicated Transport" hidden="false" collective="false" import="true">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="c542-ddd4-6b6b-f761" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6ecf-1b6e-9bcb-f93b" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="bf93-7672-f903-ef68" type="max"/>
           </constraints>
@@ -7461,6 +8061,38 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
               </costs>
             </selectionEntry>
           </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="6ecf-1b6e-9bcb-f93b" name="Mounted Force" hidden="true" collective="false" import="true">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="222a-94eb-eda4-afe1" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ca5f-aa65-e11c-ec39" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="67f9-a9e3-175e-ef72" name="Outriders (Bikes)" hidden="false" collective="false" import="true" targetId="7fbb-1bb9-0360-d6e1" type="selectionEntry">
+              <modifiers>
+                <modifier type="increment" field="points" value="5.0">
+                  <repeats>
+                    <repeat field="selections" scope="c542-ddd4-6b6b-f761" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+            </entryLink>
+            <entryLink id="b6ae-aa48-3575-8016" name="Riders (Cavalry)" hidden="false" collective="false" import="true" targetId="875a-e56c-84b6-2b18" type="selectionEntry">
+              <modifiers>
+                <modifier type="increment" field="points" value="4.0">
+                  <repeats>
+                    <repeat field="selections" scope="c542-ddd4-6b6b-f761" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+            </entryLink>
+          </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
@@ -7904,13 +8536,9 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="85bc-31a7-8fb5-fc70" type="max"/>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b0c3-2af2-ab9c-4db7" type="min"/>
       </constraints>
-      <profiles>
-        <profile id="7fa8-e34e-1dc4-2b61" name="Carapace Armour" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
-          <characteristics>
-            <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">4+ Armor Save</characteristic>
-          </characteristics>
-        </profile>
-      </profiles>
+      <infoLinks>
+        <infoLink id="1c02-9e86-42b8-bbd6" name="Carapace Armour" hidden="false" targetId="338e-f7af-1bb7-06bf" type="profile"/>
+      </infoLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
@@ -8277,6 +8905,567 @@ This rule, while similar in function to the Drop Pod Assault special rule, does 
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
+    </selectionEntry>
+    <selectionEntry id="7617-bc44-a31d-b389" name="Militia Land Speeder Squadron" hidden="false" collective="false" import="true" type="unit">
+      <categoryLinks>
+        <categoryLink id="0697-a6b3-7d0f-c2e3" name="Vehicle" hidden="false" targetId="53bd-99e7-aba0-e79f" primary="false"/>
+        <categoryLink id="f4f3-25e6-b62d-fab8" name="Skimmer" hidden="false" targetId="9480-d3f6-fff1-7b35" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="e72f-2216-1627-ab26" name="Militia Land Speeder" hidden="false" collective="false" import="true" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4906-a386-840d-56dc" type="min"/>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e22-173c-2ed1-4eef" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="31d1-7c35-afc5-a417" name="Militia Land Speeder" hidden="false" typeId="56656869636c6523232344415441232323" typeName="Vehicle">
+              <characteristics>
+                <characteristic name="BS" typeId="425323232344415441232323">3</characteristic>
+                <characteristic name="Front" typeId="46726f6e7423232344415441232323">10</characteristic>
+                <characteristic name="Side" typeId="5369646523232344415441232323">10</characteristic>
+                <characteristic name="Rear" typeId="5265617223232344415441232323">10</characteristic>
+                <characteristic name="HP" typeId="485023232344415441232323">2</characteristic>
+                <characteristic name="Type" typeId="5479706523232344415441232323">Vehicle (Fast, Skimmer), Open-Topped</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="f380-4b53-5304-cc9e" name="Scout" hidden="false" targetId="9b30-1da3-eb8d-ce7a" type="rule"/>
+          </infoLinks>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="06d1-34fb-fcea-a9e3" name="Any Land Speeder may be equipped with one of the following:" hidden="false" collective="false" import="true">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="39be-1bd5-01a1-5fa2" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="2fe3-9edf-8b7d-4fd0" name="Meltagun" hidden="false" collective="false" import="true" targetId="a22d-ceac-5063-54e1" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="15.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="e823-002e-2c82-2ea5" name="Hunter-killer missile" hidden="false" collective="false" import="true" targetId="7aa1-96c8-c1f9-eb05" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="f2c4-e2a2-08a2-c9f3" name="Plasma gun" hidden="false" collective="false" import="true" targetId="0f13-bded-1c10-bc38" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="15.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="6882-bc40-4350-4f05" name="Any Land Speeder may exchange its Multi-laser for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="ed02-1618-2a40-8420">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1451-f64d-03e7-e3d4" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d2f7-0382-2eba-92c0" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="ed02-1618-2a40-8420" name="Multi-Laser" hidden="false" collective="false" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2fd4-c0ca-45a2-a793" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="bb98-0cfd-d872-1212" name="Multi-laser" hidden="false" targetId="92be-1bfc-f355-f214" type="profile"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="2497-6743-26fe-34f1" name="Plasma Cannon" hidden="false" collective="false" import="true" type="upgrade">
+                  <infoLinks>
+                    <infoLink id="2815-bbfa-517f-d132" name="Plasma Cannon" hidden="false" targetId="13df-d6b0-3f33-bf9b" type="profile"/>
+                    <infoLink id="4cea-e55a-f4c0-cbd4" name="Gets Hot" hidden="false" targetId="f4fd-d519-4769-5510" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="15.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <entryLinks>
+                <entryLink id="cf33-909f-c7ce-d765" name="Heavy Flamer" hidden="false" collective="false" import="true" targetId="ead9-305c-a7e7-323e" type="selectionEntry"/>
+                <entryLink id="eecc-5e7f-b91d-5389" name="Multi-melta" hidden="false" collective="false" import="true" targetId="d1c0-746f-2b39-5f17" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="fb82-bd41-05e5-5533" name="Lascannon" hidden="false" collective="false" import="true" targetId="8036-b730-d533-e31f" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="20.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="38c7-bf98-c02c-6d8c" name="Searchlight" hidden="false" collective="false" import="true" targetId="7b19-0e33-9c8d-e56a" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="40.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="222a-94eb-eda4-afe1" name="Militia Mounted Squadron" hidden="false" collective="false" import="true" type="unit">
+      <infoLinks>
+        <infoLink id="49e8-2bd8-6093-8a19" name="Scout" hidden="false" targetId="9b30-1da3-eb8d-ce7a" type="rule"/>
+      </infoLinks>
+      <selectionEntries>
+        <selectionEntry id="1caa-7aea-4f42-4d5a" name="Rider Sergeant" hidden="false" collective="false" import="true" type="model">
+          <modifiers>
+            <modifier type="set" field="name" value="Outrider Sergeant">
+              <conditions>
+                <condition field="selections" scope="222a-94eb-eda4-afe1" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8630-9a32-45c6-6be7" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9d23-1f28-9d5d-b1ba" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5ef8-1075-f009-41b4" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="2eb0-34c4-148f-14a7" name="Rider Sergeant" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+              <modifiers>
+                <modifier type="set" field="556e6974205479706523232344415441232323" value="Bike (Character)">
+                  <conditions>
+                    <condition field="selections" scope="222a-94eb-eda4-afe1" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8630-9a32-45c6-6be7" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="name" value="Outrider Sergeant">
+                  <conditions>
+                    <condition field="selections" scope="222a-94eb-eda4-afe1" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8630-9a32-45c6-6be7" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="5361766523232344415441232323" value="4+">
+                  <conditions>
+                    <condition field="selections" scope="222a-94eb-eda4-afe1" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="59de-2acc-79e5-90f1" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <characteristics>
+                <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Cavalry (Character)</characteristic>
+                <characteristic name="WS" typeId="575323232344415441232323">3</characteristic>
+                <characteristic name="BS" typeId="425323232344415441232323">3</characteristic>
+                <characteristic name="S" typeId="5323232344415441232323">3</characteristic>
+                <characteristic name="T" typeId="5423232344415441232323">3</characteristic>
+                <characteristic name="W" typeId="5723232344415441232323">2</characteristic>
+                <characteristic name="I" typeId="4923232344415441232323">3</characteristic>
+                <characteristic name="A" typeId="4123232344415441232323">2</characteristic>
+                <characteristic name="LD" typeId="4c4423232344415441232323">8</characteristic>
+                <characteristic name="Save" typeId="5361766523232344415441232323">5+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+        </selectionEntry>
+        <selectionEntry id="73a0-e777-08a1-5b92" name="Rider/Outrider" hidden="false" collective="false" import="true" type="model">
+          <modifiers>
+            <modifier type="set" field="name" value="Outrider">
+              <conditions>
+                <condition field="selections" scope="222a-94eb-eda4-afe1" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8630-9a32-45c6-6be7" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6b08-1d0f-ef34-b225" type="min"/>
+            <constraint field="selections" scope="parent" value="14.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d305-bbcc-ef3a-c2cd" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="bc6f-3519-0f50-3986" name="Rider" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+              <modifiers>
+                <modifier type="set" field="5361766523232344415441232323" value="4+">
+                  <conditions>
+                    <condition field="selections" scope="222a-94eb-eda4-afe1" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="59de-2acc-79e5-90f1" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="name" value="Outrider">
+                  <conditions>
+                    <condition field="selections" scope="222a-94eb-eda4-afe1" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8630-9a32-45c6-6be7" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="556e6974205479706523232344415441232323" value="Bike">
+                  <conditions>
+                    <condition field="selections" scope="222a-94eb-eda4-afe1" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8630-9a32-45c6-6be7" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <characteristics>
+                <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Cavalry</characteristic>
+                <characteristic name="WS" typeId="575323232344415441232323">3</characteristic>
+                <characteristic name="BS" typeId="425323232344415441232323">3</characteristic>
+                <characteristic name="S" typeId="5323232344415441232323">3</characteristic>
+                <characteristic name="T" typeId="5423232344415441232323">3</characteristic>
+                <characteristic name="W" typeId="5723232344415441232323">2</characteristic>
+                <characteristic name="I" typeId="4923232344415441232323">3</characteristic>
+                <characteristic name="A" typeId="4123232344415441232323">1</characteristic>
+                <characteristic name="LD" typeId="4c4423232344415441232323">7</characteristic>
+                <characteristic name="Save" typeId="5361766523232344415441232323">5+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="10.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="4ca5-c1ef-1574-0bb8" name="Riders on Mounts or Outriders on Bikes" hidden="false" collective="false" import="true" defaultSelectionEntryId="6819-9690-ae5a-84b9">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fea5-d7ab-4f82-a0b7" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="303e-bb3f-03ed-186e" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="6819-9690-ae5a-84b9" name="Riders (Cavalry)" hidden="false" collective="false" import="true" type="upgrade">
+              <categoryLinks>
+                <categoryLink id="9702-4a39-13e7-38a5" name="Cavalry" hidden="false" targetId="a54c-aa0e-4092-1b9a" primary="false"/>
+              </categoryLinks>
+            </selectionEntry>
+            <selectionEntry id="8630-9a32-45c6-6be7" name="Outriders (Bikes)" hidden="false" collective="false" import="true" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="points" value="1.0">
+                  <repeats>
+                    <repeat field="selections" scope="222a-94eb-eda4-afe1" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <categoryLinks>
+                <categoryLink id="172e-bda1-e20a-4690" name="Bike" hidden="false" targetId="632b-24e7-f308-28f8" primary="false"/>
+              </categoryLinks>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="d8a9-a369-b8ad-ac74" name="The entire Squadron may take:" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9919-e21a-a2ad-68b1" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="59de-2acc-79e5-90f1" name="Carapace Armour" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3b2b-c983-2285-d5aa" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="1d22-ae27-528e-d288" name="Carapace Armour" hidden="false" targetId="338e-f7af-1bb7-06bf" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="20.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="8c65-6959-651a-df09" name="Krak Grenades" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3fbf-af50-b12f-4ac1" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="e0bc-999c-64f7-3189" name="Krak Grenade (Assault)" hidden="false" targetId="ba14-6731-7c9d-ef15" type="profile"/>
+                <infoLink id="7bbe-021b-8b26-16e6" name="Krak Grenade (Shooting)" hidden="false" targetId="d9f7-775b-1047-f335" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="1498-8fd3-7a09-8b51" name="The Sergeant may take melta bombs" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a189-9ba7-e0a2-45bf" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="d5b1-0ce8-b7da-9c40" name="Melta Bombs" hidden="false" collective="false" import="true" targetId="af29-a6cf-7b05-c362" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="e4e3-7b2f-b987-5600" name="Unit may take:" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="95d7-a3c1-6bc8-364e" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="bf90-3dce-07bf-776a" name="Vexilla" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0e23-6a5d-991a-63c3" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="188d-fbe7-1c05-cb5f" hidden="false" targetId="19fd-ec02-c740-1fea" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <entryLinks>
+            <entryLink id="0ca5-c925-8b59-b17a" name="Nuncio-vox" hidden="false" collective="false" import="true" targetId="b4ea-a586-86a9-02eb" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="d2a3-6954-2d72-e7ec" name="The entire Squadron may replace its Close Combat Weapons with one of the following:" hidden="false" collective="false" import="true" defaultSelectionEntryId="ca63-8582-f31a-1dc2">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e7fc-57c4-8420-8a1c" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b794-8ca6-fd20-1f17" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="5e6a-e4bc-c10e-3695" name="Augmented Weapons" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="35b5-5653-3c63-443e" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="ae7c-8579-035f-b233" hidden="false" targetId="4c65-b01f-1491-555a" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="15.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="ca63-8582-f31a-1dc2" name="Close Combat Weapons" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f28e-587e-e329-3a2b" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="c6e2-9fcb-3625-d217" name="Close Combat Weapon" hidden="false" targetId="0466-931b-dd0b-34e9" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="5160-afc1-a3e1-9fd3" name="Riding Lances" hidden="false" collective="false" import="true" type="upgrade">
+              <profiles>
+                <profile id="ba0b-6835-c84f-2f29" name="Riding Lances" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
+                    <characteristic name="Strength" typeId="537472656e67746823232344415441232323">+1</characteristic>
+                    <characteristic name="AP" typeId="415023232344415441232323">3</characteristic>
+                    <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Specialist Weapon, Charge!, One use only</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules>
+                <rule id="9efa-4752-aaca-5dd3" name="Charge!" hidden="false">
+                  <description>Some weapons such as electro-barb tipped lances are used by riders to devastating effect. Such weapons are accurate and deadly on the charge, however in the whirl of ongoing melee such weapons are either broken or too cumbersome to use.
+A model may only use this weapon if it has successfully charged that player turn. When striking with this weapon,</description>
+                </rule>
+              </rules>
+              <infoLinks>
+                <infoLink id="870f-99ca-c357-ca0e" name="One Use Only/One Shot Only" hidden="false" targetId="3789-00ab-3f47-eb36" type="rule"/>
+                <infoLink id="989f-bb1c-b75d-0cfa" name="Specialist Weapon" hidden="false" targetId="7ee3-d437-bc44-3630" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="35.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="6e29-e119-80f1-175f" name="The entire squadron may replace its Auxilia Pistols with one of the following:" hidden="false" collective="false" import="true" defaultSelectionEntryId="3ffe-6963-2374-e9cc">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ace-fd29-48de-4e49" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7544-db76-c879-586d" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="3ffe-6963-2374-e9cc" name="Auxilia Pistols" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6be2-fee4-5159-8640" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="c435-cd74-e2d7-1934" hidden="false" targetId="fc06-74ac-5c24-65b8" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="62eb-3178-15d4-719f" name="Auxilia Rifles" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e8ce-6a0e-2f84-1523" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="b8bd-6877-a8fa-d9ae" name="Auxilia Rifle" hidden="false" targetId="0055-6283-b0d1-8e41" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="81a5-2634-bff7-8365" name="Close Combat Weapons" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="58d0-205f-817a-d86a" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="a01f-74d1-a30d-7853" name="Close Combat Weapon" hidden="false" targetId="0466-931b-dd0b-34e9" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="c35e-181f-149b-d59f" name="Lascarbines" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9581-8591-9130-181d" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="1e9b-eb46-ef61-aa78" hidden="false" targetId="a7ca-04d9-b34d-d8cc" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="ddad-2813-04a2-4f55" name="Autoguns" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="82cf-656d-77c3-f584" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="9e3f-d100-605d-1361" hidden="false" targetId="537a-63f4-d939-c7f2" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="9c77-0f2a-7173-2182" name="Shotguns" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="166f-bc0d-3716-38e2" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="33e1-7404-8ff7-d289" name="Shotgun" hidden="false" targetId="07cb-70d7-15c3-5117" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="d43e-d906-964d-f33c" name="Laspistols" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e604-4848-161f-8672" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="c3c4-0d45-1395-7dc3" name="Laspistol" hidden="false" targetId="f2b7-768f-a270-de64" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="0195-81ff-47d1-31ca" name="One model may take one of the following:" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a94d-b572-5705-65b4" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="5e2a-a5a0-f4b8-96d7" name="Flamer" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3207-ef49-68e2-8801" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="5cf5-8d35-fe15-129e" name="Flamer" hidden="false" targetId="3a71-7de1-1948-3655" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="bfd6-c8ca-3f1e-7894" name="Grenade Launcher" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d54d-0b80-53e0-2dc3" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="29e2-604c-6f73-199a" name="Grenade Launcher (Frag)" hidden="false" targetId="ace0-cde1-8b6a-4357" type="profile"/>
+                <infoLink id="b97e-45d0-a05d-c3b7" name="Grenade Launcher (Krak)" hidden="false" targetId="b42c-34d8-7fda-ffa0" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="6020-311d-00ff-9e49" name="Meltagun" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b5d6-8045-0a7f-d49b" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="d798-2ee0-ea91-288e" name="Meltagun" hidden="false" targetId="8ae4-74e5-7700-3804" type="profile"/>
+                <infoLink id="07db-5e4a-d03e-6927" name="Melta" hidden="false" targetId="21c0-62ff-3ed2-17a7" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="a41d-34d9-7522-caff" name="The Sergeant may exhange their Auxilia Pistol and/or Close Combat weapon for one of the following:" hidden="false" collective="false" import="true">
+          <selectionEntries>
+            <selectionEntry id="8329-d81e-52c4-287f" name="Blast Pistol" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="508b-fffc-a023-c040" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="0fcc-8aab-5d96-bc21" hidden="false" targetId="035e-17b5-4110-4726" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="3915-a985-228e-b31b" name="Bolt Pistol" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="248d-d454-0ba9-f343" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="9bcc-933d-3138-9eb0" name="Bolt Pistol" hidden="false" targetId="ec83-0776-ef74-9cc2" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="2.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="418a-9aa4-732e-8497" name="Hand Flamer" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="60c1-17fc-f21e-a8d9" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="176a-a15a-dd36-85d7" name="Hand Flamer" hidden="false" targetId="ea8a-04f6-ae7c-f351" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <entryLinks>
+            <entryLink id="8fc1-1628-a1ad-d477" name="Power Axe" hidden="false" collective="false" import="true" targetId="7b92-ab87-86a1-ab2e" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="df2f-d94c-0701-bcb2" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="b674-272e-697e-8a44" name="Power Lance" hidden="false" collective="false" import="true" targetId="233d-238b-6940-2740" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a805-59e7-994c-78e1" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="bc04-8ff3-92be-58db" name="Power Maul" hidden="false" collective="false" import="true" targetId="e8a2-42e8-82a7-8dd9" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7666-6909-5c0c-ca88" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="995a-1911-2478-95bf" name="Power Sword" hidden="false" collective="false" import="true" targetId="3e90-5ca1-8abe-0275" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="76e7-7543-97a3-b9e2" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="1c2f-f0fa-85e0-a5e3" name="Provenance" hidden="false" collective="false" import="true" targetId="9d50-7127-dc55-d542" type="selectionEntryGroup"/>
+        <entryLink id="9f56-6a8b-6885-c801" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="4980-c798-0374-d36c" type="selectionEntry"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7fbb-1bb9-0360-d6e1" name="Outriders (Bikes)" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="8e89-ff43-87d1-c86c" name="Bike" hidden="false" targetId="632b-24e7-f308-28f8" primary="false"/>
+      </categoryLinks>
+    </selectionEntry>
+    <selectionEntry id="875a-e56c-84b6-2b18" name="Riders (Cavalry)" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="4e6d-6e31-390b-23bb" name="Cavalry" hidden="false" targetId="a54c-aa0e-4092-1b9a" primary="false"/>
+      </categoryLinks>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>

--- a/(HH) Mechanicum - Taghmata Army List.cat
+++ b/(HH) Mechanicum - Taghmata Army List.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="cf03-f607-41dc-7545" name="Mechanicum: Taghmata Army List" revision="93" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="92" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="cf03-f607-41dc-7545" name="Mechanicum: Taghmata Army List" revision="94" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="120" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="cf03-f607-pubN65537" name="Horus Heresy: Taghmata Army List"/>
     <publication id="cf03-f607-pubN65563" name="AoDRB"/>
@@ -275,6 +275,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="b7b6-2edc-e201-f37a" type="max"/>
           </constraints>
         </categoryLink>
+        <categoryLink id="4444-60c3-3472-db7d" name="Mournival Rules" hidden="false" targetId="dbe0-716f-797c-66f7" primary="false"/>
       </categoryLinks>
     </forceEntry>
     <forceEntry id="0cb5-a583-e14f-2231" name=" Matrix of Ruin" hidden="false">
@@ -337,6 +338,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="6218-fb5a-3709-4308" type="max"/>
           </constraints>
         </categoryLink>
+        <categoryLink id="b68c-aba7-3a8a-35eb" name="Mournival Rules" hidden="false" targetId="dbe0-716f-797c-66f7" primary="false"/>
       </categoryLinks>
     </forceEntry>
     <forceEntry id="98db-b4ba-fbcd-3239" name=" Crusade" hidden="false">
@@ -465,6 +467,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="13f4-4597-0a96-036b" type="max"/>
           </constraints>
         </categoryLink>
+        <categoryLink id="44e7-ee6f-19e3-11f8" name="Mournival Rules" hidden="false" targetId="dbe0-716f-797c-66f7" primary="false"/>
       </categoryLinks>
     </forceEntry>
     <forceEntry id="657a-bc81-4ae3-8a5b" name="Allied Detachment" hidden="false">
@@ -519,6 +522,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="9df4-eae6-77e1-6b86" type="max"/>
           </constraints>
         </categoryLink>
+        <categoryLink id="f918-5041-51eb-d541" name="Mournival Rules" hidden="false" targetId="dbe0-716f-797c-66f7" primary="false"/>
       </categoryLinks>
     </forceEntry>
     <forceEntry id="089f-7e79-bde1-90dd" name=" Zone Mortalis - Attacker" hidden="false">
@@ -556,6 +560,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="4cfc-1ed0-d6ad-a294" type="max"/>
           </constraints>
         </categoryLink>
+        <categoryLink id="6279-d5af-6cde-41e9" name="Mournival Rules" hidden="false" targetId="dbe0-716f-797c-66f7" primary="false"/>
       </categoryLinks>
     </forceEntry>
     <forceEntry id="7b39-af6b-52e1-b4d7" name=" Zone Mortalis - Defender" hidden="false">
@@ -589,6 +594,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="6ad3-949c-76f3-15f0" type="max"/>
           </constraints>
         </categoryLink>
+        <categoryLink id="5f45-c44a-9087-4af2" name="Mournival Rules" hidden="false" targetId="dbe0-716f-797c-66f7" primary="false"/>
       </categoryLinks>
     </forceEntry>
     <forceEntry id="7e48-c376-8ffe-8ae7" name=" Zone Mortalis - Combatant" hidden="false">
@@ -626,6 +632,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="ffd3-d6be-c420-bbe4" type="max"/>
           </constraints>
         </categoryLink>
+        <categoryLink id="4eee-7c91-c9b8-c7e7" name="Mournival Rules" hidden="false" targetId="dbe0-716f-797c-66f7" primary="false"/>
       </categoryLinks>
     </forceEntry>
     <forceEntry id="d1ef-61e1-3d67-5a19" name="Optional - Onslaught" hidden="false">
@@ -671,6 +678,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="d196-af4e-70d0-16bf" type="max"/>
           </constraints>
         </categoryLink>
+        <categoryLink id="763d-3144-e199-2567" name="Mournival Rules" hidden="false" targetId="dbe0-716f-797c-66f7" primary="false"/>
       </categoryLinks>
     </forceEntry>
     <forceEntry id="3a6f-6d67-a8b2-e911" name="Optional - Castellan" hidden="false">
@@ -721,6 +729,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="6901-86ef-2ad5-eba5" type="max"/>
           </constraints>
         </categoryLink>
+        <categoryLink id="7abd-d4d1-970c-f242" name="Mournival Rules" hidden="false" targetId="dbe0-716f-797c-66f7" primary="false"/>
       </categoryLinks>
     </forceEntry>
     <forceEntry id="f715-cdf4-0c5e-213a" name="Optional - Leviathan" hidden="false">
@@ -780,6 +789,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="d894-367a-b1d4-660b" type="max"/>
           </constraints>
         </categoryLink>
+        <categoryLink id="6835-a523-c8f4-439a" name="Mournival Rules" hidden="false" targetId="dbe0-716f-797c-66f7" primary="false"/>
       </categoryLinks>
     </forceEntry>
     <forceEntry id="8666-c0df-4dfa-08f1" name=" Strategic Raid - Garrison" hidden="false">
@@ -828,6 +838,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="f60d-bc9c-115f-f35f" type="max"/>
           </constraints>
         </categoryLink>
+        <categoryLink id="6cd4-1528-1f87-ee92" name="Mournival Rules" hidden="false" targetId="dbe0-716f-797c-66f7" primary="false"/>
       </categoryLinks>
     </forceEntry>
   </forceEntries>
@@ -865,6 +876,27 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="30.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b0d5-66d5-abe1-10df" name="Mournival Rules" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9810-cd6a-ee9a-2d03" type="min"/>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="24b6-638c-5ff0-f85d" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9708-0b67-1fe8-029d" type="max"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="6bf5-c891-6b22-0819" name="Mournival Rules" hidden="false" targetId="dbe0-716f-797c-66f7" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="f986-d225-70b5-6838" name="Mornival Rules Active" hidden="false" collective="false" import="true" targetId="c859-6b16-c533-7e97" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7831-2ea2-54e5-c411" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7c9b-b61f-d477-0981" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
   </selectionEntries>
@@ -1599,6 +1631,47 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
     <entryLink id="0669-3ea9-3eea-1990" name="Questoris Knight Warden" hidden="false" collective="false" import="true" targetId="f4f1-dad6-0596-ca5a" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="c00b-70ed-d783-78de" name="New CategoryLink" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="bfcd-5e4c-9e99-e3d1" name="Triaros Guardian" hidden="true" collective="false" import="true" targetId="e688-c102-11a4-7271" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c859-6b16-c533-7e97" type="greaterThan"/>
+              </conditions>
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0199-0faf-34c8-fbee" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d76d-0097-d56b-e6bf" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="1895-6f20-7048-64a1" name="New CategoryLink" hidden="false" targetId="466173742041747461636b23232344415441232323" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="efcb-3b0d-f2e2-157f" name="Myrmidon Reductors" hidden="true" collective="false" import="true" targetId="4e71-ad77-8060-a757" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c859-6b16-c533-7e97" type="greaterThan"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0199-0faf-34c8-fbee" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="a1f9-199b-9a44-5dcf" name="New CategoryLink" hidden="false" targetId="456c6974657323232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
   </entryLinks>
@@ -3782,7 +3855,7 @@ Reduces transport capacity to 8.</description>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
       </constraints>
       <infoLinks>
-        <infoLink id="0457fffb-df7e-8c75-a919-6fa5754ae7a8" hidden="false" targetId="9c9de857-ac5e-11ff-ead6-1df8480d3f28" type="profile"/>
+        <infoLink id="0457fffb-df7e-8c75-a919-6fa5754ae7a8" name="Volkite Charger" hidden="false" targetId="9c9de857-ac5e-11ff-ead6-1df8480d3f28" type="profile"/>
         <infoLink id="7c62e21b-119d-9283-b2c4-b75427503e32" name="Deflagrate" hidden="false" targetId="b46a-a3ec-91a5-5001" type="rule"/>
       </infoLinks>
       <costs>
@@ -4302,7 +4375,7 @@ Reduces transport capacity to 8.</description>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="f2a5-f499-58e1-21e8" name="Volkite Sentinel" hidden="false" collective="true" import="true" type="upgrade">
+    <selectionEntry id="f2a5-f499-58e1-21e8" name="Volkite Sentinels" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e2f1-877a-ee4c-ee34" type="min"/>
         <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c350-273e-e4b2-8b59" type="max"/>
@@ -4314,13 +4387,9 @@ Reduces transport capacity to 8.</description>
           </characteristics>
         </profile>
       </profiles>
-      <entryLinks>
-        <entryLink id="4837-d363-41ea-9338" name="New EntryLink" hidden="false" collective="false" import="true" targetId="2075c6c6-b54d-2d3e-fce9-0543efa392f8" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7cdc-2b79-c9cf-b9f5" type="min"/>
-          </constraints>
-        </entryLink>
-      </entryLinks>
+      <infoLinks>
+        <infoLink id="bb26-bf44-e4f3-c09d" name="Volkite Charger" hidden="false" targetId="9c9de857-ac5e-11ff-ead6-1df8480d3f28" type="profile"/>
+      </infoLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
@@ -12825,6 +12894,268 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
         <cost name="pts" typeId="points" value="355.0"/>
       </costs>
     </selectionEntry>
+    <selectionEntry id="e688-c102-11a4-7271" name="Triaros Guardian" page="" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5cbe-71ff-c07e-445d" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="7914-3f0d-db8d-0867" name="Triaros Guardian" page="" hidden="false" typeId="56656869636c6523232344415441232323" typeName="Vehicle">
+          <characteristics>
+            <characteristic name="BS" typeId="425323232344415441232323">4</characteristic>
+            <characteristic name="Front" typeId="46726f6e7423232344415441232323">14</characteristic>
+            <characteristic name="Side" typeId="5369646523232344415441232323">12</characteristic>
+            <characteristic name="Rear" typeId="5265617223232344415441232323">12</characteristic>
+            <characteristic name="HP" typeId="485023232344415441232323">3</characteristic>
+            <characteristic name="Type" typeId="5479706523232344415441232323">Tank</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="faf6-50cc-8923-08b4" name="Galvanic Traction Drive" hidden="false" targetId="6e59-4afd-8668-f066" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="8727-565f-71f8-2f36" name="Vehicle" hidden="false" targetId="53bd-99e7-aba0-e79f" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="b233-69b4-4888-6024" name="Void Shield Projector" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ba5e-5934-0e98-ec63" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c19a-e048-8c42-241c" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="22ab-ec51-29a9-e95f" name="Void Shield Projector" hidden="false">
+              <description>All models within 6” of the vehicle are protected by a Void Shield. Any shooting attacks from outside this area strike the Void Shield before hitting the targeted unit. The Void Shield is AV12 with a single Hull Point. Each additional Void Shield increases the number of Hull Points by one.</description>
+            </rule>
+          </rules>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="f1c7-1e47-4e22-4a81" name="Psyarkana" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6425-0222-2d59-4699" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="2819-76ac-f538-4930" name="Armatus Necrotechnica" hidden="false" collective="false" import="true" targetId="e78c-d1a1-c20f-dae8" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false"/>
+              </modifiers>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="6adc-6ca3-1eac-28c9" name="Any Guardian may be equipped with" hidden="false" collective="false" import="true">
+          <entryLinks>
+            <entryLink id="f424-1b30-493c-cfcb" name="Extra Armour" hidden="false" collective="false" import="true" targetId="d00f-81d6-1749-9499" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="b239-7867-6aa2-ddc1" name="Blessed Autosimulacra" hidden="false" collective="false" import="true" targetId="fb66-11c0-3cb4-aac3" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="points" value="15.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="05c0-5455-4e7b-b33c" name="Smoke Launchers" hidden="false" collective="false" import="true" targetId="8d58-8392-abdd-c6f1" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="36a3-8324-b193-dbc9" name="Hunter-killer Missile" hidden="false" collective="false" import="true" targetId="287b-b205-0926-5822" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="5d13-8da2-1ae9-48da" name="Flare Shield" hidden="false" collective="false" import="true" targetId="776e-2ea5-2be8-fee3" type="selectionEntry"/>
+        <entryLink id="664b-33cd-dfc8-68ee" name="Shock Ram" hidden="false" collective="false" import="true" targetId="0a18-686c-1dfb-4b71" type="selectionEntry"/>
+        <entryLink id="583f-5650-5056-3048" name="Twin-Linked Mauler Bolt Cannon" hidden="false" collective="false" import="true" targetId="48e5-e3dc-433e-d5a6" type="selectionEntry"/>
+        <entryLink id="ed3f-c6a9-6702-1ea1" name="Volkite Sentinel" hidden="false" collective="false" import="true" targetId="f2a5-f499-58e1-21e8" type="selectionEntry"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="135.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4e71-ad77-8060-a757" name="Myrmidon Reductors" publicationId="cf03-f607-pubN76979" page="220" hidden="false" collective="false" import="true" type="unit">
+      <infoLinks>
+        <infoLink id="fa0b-66ca-6a74-f059" name="Wrecker" hidden="false" targetId="fe2f-3220-3fef-b177" type="rule"/>
+        <infoLink id="909d-d273-e431-fdc2" name="Lumbering Advance" hidden="false" targetId="797e55b1-251e-6606-9cb3-64661b0b18a3" type="rule"/>
+        <infoLink id="d7f1-b193-c768-469c" name="New InfoLink" hidden="false" targetId="3c7d-a1fa-c68b-caad" type="rule"/>
+        <infoLink id="fde4-177e-bd8c-5e0f" name="New InfoLink" hidden="false" targetId="7be5-30af-1a02-0a89" type="rule"/>
+        <infoLink id="3ff0-15e4-8a6f-df64" name="New InfoLink" hidden="false" targetId="38d5-b6eb-bda8-2497" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="2172-1939-f5d8-30e7" name="Infantry" hidden="false" targetId="f74d-4679-75a6-1252" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="03d7-68b2-8ccc-ee83" name="Myrmidon Reductors" page="0" hidden="false" collective="false" import="true" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="63d1-77c3-0519-a952" type="min"/>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9f38-b25e-4efc-bfbd" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="9ac0-1a71-5cd1-886e" name="Myrmidon Secutors" publicationId="cf03-f607-pubN76979" page="220" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+              <characteristics>
+                <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry</characteristic>
+                <characteristic name="WS" typeId="575323232344415441232323">4</characteristic>
+                <characteristic name="BS" typeId="425323232344415441232323">5</characteristic>
+                <characteristic name="S" typeId="5323232344415441232323">4</characteristic>
+                <characteristic name="T" typeId="5423232344415441232323">5</characteristic>
+                <characteristic name="W" typeId="5723232344415441232323">2</characteristic>
+                <characteristic name="I" typeId="4923232344415441232323">2</characteristic>
+                <characteristic name="A" typeId="4123232344415441232323">2</characteristic>
+                <characteristic name="LD" typeId="4c4423232344415441232323">9</characteristic>
+                <characteristic name="Save" typeId="5361766523232344415441232323">3+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="40.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="8561-f7fe-13e5-444b" name="Myrmidon Lord" page="0" hidden="false" collective="false" import="true" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="de08-4019-55fa-c21a" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="09e7-e74f-eaa2-02a4" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="767b-2080-8b5c-1c7a" name="Myrmidon Lord" publicationId="cf03-f607-pubN76979" page="220" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+              <characteristics>
+                <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry (Character)</characteristic>
+                <characteristic name="WS" typeId="575323232344415441232323">4</characteristic>
+                <characteristic name="BS" typeId="425323232344415441232323">5</characteristic>
+                <characteristic name="S" typeId="5323232344415441232323">4</characteristic>
+                <characteristic name="T" typeId="5423232344415441232323">5</characteristic>
+                <characteristic name="W" typeId="5723232344415441232323">2</characteristic>
+                <characteristic name="I" typeId="4923232344415441232323">2</characteristic>
+                <characteristic name="A" typeId="4123232344415441232323">3</characteristic>
+                <characteristic name="LD" typeId="4c4423232344415441232323">10</characteristic>
+                <characteristic name="Save" typeId="5361766523232344415441232323">3+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+        </selectionEntry>
+        <selectionEntry id="85de-458b-429e-9789" name="Power Fist" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e6b2-f5e6-a3d9-9692" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ff32-bf23-d0e1-cd4f" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="0d3d-3d28-735b-8a1d" name="Power Fist" hidden="false" targetId="4ddd-399c-d71c-4ac1" type="profile"/>
+            <infoLink id="2a0a-2e23-31f0-3a0e" name="Specialist Weapon" hidden="false" targetId="7ee3-d437-bc44-3630" type="rule"/>
+            <infoLink id="b5b3-6e10-e9ef-7a6d" name="Unwieldy" hidden="false" targetId="5eea-958c-d623-c3c9" type="rule"/>
+          </infoLinks>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="cc88-98d0-4729-463f" name="Any model may exchange Multi Melta for a:" hidden="false" collective="false" import="true" defaultSelectionEntryId="902b-aa1a-5570-b204">
+          <modifiers>
+            <modifier type="increment" field="958a-bb6f-36d9-b2d7" value="1.0">
+              <repeats>
+                <repeat field="selections" scope="4e71-ad77-8060-a757" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+            <modifier type="increment" field="0621-3c1d-60f5-a0e2" value="1.0">
+              <repeats>
+                <repeat field="selections" scope="4e71-ad77-8060-a757" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0621-3c1d-60f5-a0e2" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="958a-bb6f-36d9-b2d7" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="5218-1e0c-ef09-ba61" name="Missile Launcher (Frag and Krak Missiles)" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a12e-dbed-5dec-8ed1" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="81e6-4b86-a62e-4a31" name="Krak Missile" hidden="false" targetId="1e33-d8ec-f833-b584" type="profile"/>
+                <infoLink id="ddd2-1998-2fb7-fe32" name="Frag Missile" hidden="false" targetId="40e6-c95c-7c8d-cf02" type="profile"/>
+              </infoLinks>
+            </selectionEntry>
+          </selectionEntries>
+          <entryLinks>
+            <entryLink id="902b-aa1a-5570-b204" name="Multi-melta" hidden="false" collective="false" import="true" targetId="d1c0-746f-2b39-5f17" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ffd8-4329-1342-e749" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="4931-0cdc-1f1b-7b52" name="Any model with a Missile Launcher may be equipped with:" hidden="false" collective="false" import="true">
+          <selectionEntries>
+            <selectionEntry id="d283-6f39-0fb4-435d" name="Rad Missiles" hidden="false" collective="false" import="true" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="558e-ba6f-26de-af82" value="1.0">
+                  <repeats>
+                    <repeat field="selections" scope="4e71-ad77-8060-a757" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5218-1e0c-ef09-ba61" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="558e-ba6f-26de-af82" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="4ff3-39d2-edaa-388a" name="Rad Missile" hidden="false" targetId="fd99-1d8e-87fa-e8e8" type="profile"/>
+                <infoLink id="4f9e-beb1-57aa-6761" name="Rad-phage" hidden="false" targetId="eefe-09e4-17aa-deb2" type="rule"/>
+                <infoLink id="caf6-192f-3862-3bc2" name="Fleshbane" hidden="false" targetId="4575-0a0a-caaf-e4bf" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="6463-868f-3bb4-0789" name="Phosphex Missiles" hidden="false" collective="false" import="true" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="a239-9b47-428c-e5a7" value="1.0">
+                  <repeats>
+                    <repeat field="selections" scope="4e71-ad77-8060-a757" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5218-1e0c-ef09-ba61" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a239-9b47-428c-e5a7" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="67b4-a043-1dde-a936" name="Phosphex Missiles" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="52616e676523232344415441232323">24&quot;</characteristic>
+                    <characteristic name="Strength" typeId="537472656e67746823232344415441232323">(3+)</characteristic>
+                    <characteristic name="AP" typeId="415023232344415441232323">3</characteristic>
+                    <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 1, Blast, Crawling Fire, Lingering Death</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink id="6591-8f06-a48b-1008" name="Crawling Fire" hidden="false" targetId="91ee-e6c7-272f-49e0" type="rule"/>
+                <infoLink id="baa4-54cb-973d-e7db" name="Lingering Death" hidden="false" targetId="3a2e-7a7b-1de3-78c0" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="3d22-eb9b-0a11-5145" hidden="false" collective="false" import="true" targetId="bb6538b0-0f23-8a43-9752-dd356ba76e46" type="selectionEntry"/>
+        <entryLink id="488f-b109-29ec-b73b" name="Frag and Krak Grenades" hidden="false" collective="false" import="true" targetId="0a53-b471-df87-7b83" type="selectionEntry"/>
+        <entryLink id="fda8-8e40-baf2-1d0e" name="Infravisor" hidden="false" collective="false" import="true" targetId="f921-3533-183e-c741" type="selectionEntry"/>
+        <entryLink id="ca13-7c45-250b-0b90" name="Refractor Field" hidden="false" collective="false" import="true" targetId="40e37f6e-a984-4232-4dc4-807ed9028f62" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="points" value="0.0"/>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e9eb-51b3-59c2-c051" type="min"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="55.0"/>
+      </costs>
+    </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup id="d696-042d-2afa-b026" name="Heavy Bolter or Heavy Flamer" hidden="false" collective="false" import="true">
@@ -13029,10 +13360,10 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
     </selectionEntryGroup>
     <selectionEntryGroup id="4e41-e567-a14d-8e3a" name="Triaros/Karacnos optionals:" hidden="false" collective="false" import="true">
       <entryLinks>
-        <entryLink id="36ab-ebde-d1c5-3d30" name="New EntryLink" hidden="false" collective="false" import="true" targetId="d00f-81d6-1749-9499" type="selectionEntry"/>
+        <entryLink id="36ab-ebde-d1c5-3d30" name="Extra Armour" hidden="false" collective="false" import="true" targetId="d00f-81d6-1749-9499" type="selectionEntry"/>
         <entryLink id="0331-2746-380f-6ca8" name="Blessed Autosimulacra" hidden="false" collective="false" import="true" targetId="fb66-11c0-3cb4-aac3" type="selectionEntry"/>
-        <entryLink id="6025-3bae-68c7-aa19" name="New EntryLink" hidden="false" collective="false" import="true" targetId="8d58-8392-abdd-c6f1" type="selectionEntry"/>
-        <entryLink id="4537-9bc4-624b-0f1e" name="New EntryLink" hidden="false" collective="false" import="true" targetId="287b-b205-0926-5822" type="selectionEntry"/>
+        <entryLink id="6025-3bae-68c7-aa19" name="Smoke Launchers" hidden="false" collective="false" import="true" targetId="8d58-8392-abdd-c6f1" type="selectionEntry"/>
+        <entryLink id="4537-9bc4-624b-0f1e" name="Hunter-killer Missile" hidden="false" collective="false" import="true" targetId="287b-b205-0926-5822" type="selectionEntry"/>
       </entryLinks>
     </selectionEntryGroup>
     <selectionEntryGroup id="7722-2a80-cea6-fc30" name="Allegiance" hidden="false" collective="false" import="true">

--- a/(HH) Talons of the Emperor Army List.cat
+++ b/(HH) Talons of the Emperor Army List.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="a30a-7522-3343-553a" name="Talons of the Emperor" revision="101" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="100" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="a30a-7522-3343-553a" name="Talons of the Emperor" revision="101" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="120" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="a30a-7522-pubN65537" name="HH7 / HH8"/>
     <publication id="a30a-7522-pubN69988" name="Forgeworld.co.uk"/>
@@ -71,6 +71,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="0cb0-bf5d-1691-4560" type="max"/>
           </constraints>
         </categoryLink>
+        <categoryLink id="1551-86a0-a987-6cf3" name="Mournival Rules" hidden="false" targetId="dbe0-716f-797c-66f7" primary="false"/>
       </categoryLinks>
     </forceEntry>
     <forceEntry id="657a-bc81-4ae3-8a5b" name="Allied Detachment" hidden="false">
@@ -125,6 +126,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="ccf1-aa52-1f31-43f4" type="max"/>
           </constraints>
         </categoryLink>
+        <categoryLink id="1f93-7724-bb58-090f" name="Mournival Rules" hidden="false" targetId="dbe0-716f-797c-66f7" primary="false"/>
       </categoryLinks>
     </forceEntry>
     <forceEntry id="089f-7e79-bde1-90dd" name=" Zone Mortalis - Attacker" hidden="false">
@@ -162,6 +164,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="ce41-ed42-0a0a-f6db" type="max"/>
           </constraints>
         </categoryLink>
+        <categoryLink id="9acb-dbaf-382f-42cd" name="Mournival Rules" hidden="false" targetId="dbe0-716f-797c-66f7" primary="false"/>
       </categoryLinks>
     </forceEntry>
     <forceEntry id="7b39-af6b-52e1-b4d7" name=" Zone Mortalis - Defender" hidden="false">
@@ -195,6 +198,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="7643-97fa-727f-b8b6" type="max"/>
           </constraints>
         </categoryLink>
+        <categoryLink id="e71d-d101-c736-075c" name="Mournival Rules" hidden="false" targetId="dbe0-716f-797c-66f7" primary="false"/>
       </categoryLinks>
     </forceEntry>
     <forceEntry id="7e48-c376-8ffe-8ae7" name=" Zone Mortalis - Combatant" hidden="false">
@@ -232,6 +236,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="15fd-8026-0b00-4c23" type="max"/>
           </constraints>
         </categoryLink>
+        <categoryLink id="7da7-5612-3d00-7202" name="Mournival Rules" hidden="false" targetId="dbe0-716f-797c-66f7" primary="false"/>
       </categoryLinks>
     </forceEntry>
     <forceEntry id="d1ef-61e1-3d67-5a19" name="Optional - Onslaught" hidden="false">
@@ -276,6 +281,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="8b7b-7d03-bf24-f894" type="max"/>
           </constraints>
         </categoryLink>
+        <categoryLink id="642d-98e0-7a4d-29ba" name="Mournival Rules" hidden="false" targetId="dbe0-716f-797c-66f7" primary="false"/>
       </categoryLinks>
     </forceEntry>
     <forceEntry id="3a6f-6d67-a8b2-e911" name="Optional - Castellan" hidden="false">
@@ -325,6 +331,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="87f3-2bed-8a7d-d3ba" type="max"/>
           </constraints>
         </categoryLink>
+        <categoryLink id="3c2a-3fcb-1c75-8340" name="Mournival Rules" hidden="false" targetId="dbe0-716f-797c-66f7" primary="false"/>
       </categoryLinks>
     </forceEntry>
     <forceEntry id="f715-cdf4-0c5e-213a" name="Optional - Leviathan" hidden="false">
@@ -382,6 +389,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="8642-b9b6-73bf-31c4" type="max"/>
           </constraints>
         </categoryLink>
+        <categoryLink id="4d97-7651-ecd8-68ca" name="Mournival Rules" hidden="false" targetId="dbe0-716f-797c-66f7" primary="false"/>
       </categoryLinks>
     </forceEntry>
     <forceEntry id="8666-c0df-4dfa-08f1" name=" Strategic Raid - Garrison" hidden="false">
@@ -429,9 +437,30 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="7b48-0020-e262-162d" type="max"/>
           </constraints>
         </categoryLink>
+        <categoryLink id="defb-6067-82a7-eb34" name="Mournival Rules" hidden="false" targetId="dbe0-716f-797c-66f7" primary="false"/>
       </categoryLinks>
     </forceEntry>
   </forceEntries>
+  <selectionEntries>
+    <selectionEntry id="105d-6676-7d6f-3272" name="Mournival Rules" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2b4e-09b5-c0bf-d9fd" type="min"/>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c2b8-54ba-b368-acef" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a5c6-985b-c9ec-8a66" type="max"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="a3c3-d0aa-8f4b-2b5a" name="Mournival Rules" hidden="false" targetId="dbe0-716f-797c-66f7" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="3537-4069-5118-192d" name="Mornival Rules Active" hidden="false" collective="false" import="true" targetId="c859-6b16-c533-7e97" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9c83-73fd-5721-0438" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="15ce-5046-79da-2b2f" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+    </selectionEntry>
+  </selectionEntries>
   <entryLinks>
     <entryLink id="55a4-3c7c-28ec-878f" name="New EntryLink" hidden="false" collective="false" import="true" targetId="dab7-cef6-7603-3be2" type="selectionEntry">
       <categoryLinks>
@@ -493,7 +522,7 @@
         <categoryLink id="69f7-13e8-abc8-7e8f-486561767920537570706f727423232344415441232323" hidden="false" targetId="486561767920537570706f727423232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="7066-ede9-5077-68d6" name="New EntryLink" hidden="false" collective="false" import="true" targetId="5e4a-d122-6e76-2634" type="selectionEntry">
+    <entryLink id="7066-ede9-5077-68d6" name="Legio Custodes Shield Captain" hidden="false" collective="false" import="true" targetId="5e4a-d122-6e76-2634" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="7066-ede9-5077-68d6-485123232344415441232323" hidden="false" targetId="485123232344415441232323" primary="true"/>
       </categoryLinks>
@@ -568,7 +597,7 @@
         <categoryLink id="5e81-c325-81e7-585b-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="1b5c-a6b3-188c-511b" name="New EntryLink" hidden="false" collective="false" import="true" targetId="6140-dc64-5896-957f" type="selectionEntry">
+    <entryLink id="1b5c-a6b3-188c-511b" name="Manufactorum" hidden="false" collective="false" import="true" targetId="6140-dc64-5896-957f" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="1b5c-a6b3-188c-511b-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
@@ -697,6 +726,18 @@
     <entryLink id="fc2e-6abd-ccd7-57a7" name="Questoris Knight Warden" hidden="false" collective="false" import="true" targetId="f4f1-dad6-0596-ca5a" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="f706-2be5-1626-2be5" name="New CategoryLink" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="6642-27ca-60ac-4ec0" name="Legio Custodes Talon Master" hidden="true" collective="false" import="true" targetId="01e5-960d-a7b8-87fe" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c859-6b16-c533-7e97" type="greaterThan"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="f535-e7b9-097b-5969" name="New CategoryLink" hidden="false" targetId="485123232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
   </entryLinks>
@@ -1232,12 +1273,12 @@
     </selectionEntry>
     <selectionEntry id="5e4a-d122-6e76-2634" name="Legio Custodes Shield Captain" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
-        <infoLink id="05ad-f44a-ac4d-887c" name="New InfoLink" hidden="false" targetId="38d5-b6eb-bda8-2497" type="rule"/>
-        <infoLink id="2a42-1169-edd2-9b91" name="New InfoLink" hidden="false" targetId="2b06-29a6-641a-b22e" type="rule"/>
-        <infoLink id="0d6e-ed17-adc9-b0f4" name="New InfoLink" hidden="false" targetId="0900-71d5-1937-aa96" type="rule"/>
-        <infoLink id="4cb0-8b03-42d7-66ef" name="New InfoLink" hidden="false" targetId="4771-b711-0e74-3aee" type="rule"/>
-        <infoLink id="43ce-ceac-a79d-6cb0" name="New InfoLink" hidden="false" targetId="a080-af1b-fb2e-4860" type="rule"/>
-        <infoLink id="edde-e47b-187c-c952" name="New InfoLink" hidden="false" targetId="3ad4-1c37-d60b-1a4e" type="rule"/>
+        <infoLink id="05ad-f44a-ac4d-887c" name="Bulky" hidden="false" targetId="38d5-b6eb-bda8-2497" type="rule"/>
+        <infoLink id="2a42-1169-edd2-9b91" name="Crusader" hidden="false" targetId="2b06-29a6-641a-b22e" type="rule"/>
+        <infoLink id="0d6e-ed17-adc9-b0f4" name="Counter-attack" hidden="false" targetId="0900-71d5-1937-aa96" type="rule"/>
+        <infoLink id="4cb0-8b03-42d7-66ef" name="Precision Shots" hidden="false" targetId="4771-b711-0e74-3aee" type="rule"/>
+        <infoLink id="43ce-ceac-a79d-6cb0" name="Precision Strikes" hidden="false" targetId="a080-af1b-fb2e-4860" type="rule"/>
+        <infoLink id="edde-e47b-187c-c952" name="Independent Character" hidden="false" targetId="3ad4-1c37-d60b-1a4e" type="rule"/>
         <infoLink id="9fc5-e569-4415-3a56" name="Shield Captain" hidden="false" targetId="943e-ce67-f8bb-fed8" type="profile"/>
       </infoLinks>
       <selectionEntries>
@@ -1271,52 +1312,52 @@
         <selectionEntryGroup id="8e20-b55f-d272-d847" name="May Be Equipped with any of the Following:" hidden="false" collective="false" import="true">
           <entryLinks>
             <entryLink id="ee42-5914-fd38-2da5" name="Arae-Shrikes" hidden="false" collective="false" import="true" targetId="be4a-0e91-0f1f-4c1d" type="selectionEntry">
-              <modifiers>
-                <modifier type="set" field="points" value="10"/>
-              </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1c76-f822-3bd7-2926" type="max"/>
               </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
             </entryLink>
             <entryLink id="970f-2368-d143-5d63" name="Praesidium Shield" hidden="false" collective="false" import="true" targetId="a521-ee67-6936-d9b2" type="selectionEntry">
-              <modifiers>
-                <modifier type="set" field="points" value="15"/>
-              </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bdf7-a7f4-3ce2-4ee5" type="max"/>
               </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="15.0"/>
+              </costs>
             </entryLink>
             <entryLink id="1441-8bce-071d-e567" name="Teleportation Transponders" hidden="false" collective="false" import="true" targetId="81f8-eb55-e1fd-c90a" type="selectionEntry">
-              <modifiers>
-                <modifier type="set" field="points" value="10"/>
-              </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="12de-51f8-f572-f2d9" type="max"/>
               </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
             </entryLink>
             <entryLink id="ab00-cdde-e3ad-e31b" name="Archaeotech Pistol" hidden="false" collective="false" import="true" targetId="5f1c-b6c2-0caa-f462" type="selectionEntry">
-              <modifiers>
-                <modifier type="set" field="points" value="10"/>
-              </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a355-7f53-78b9-65f3" type="max"/>
               </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
             </entryLink>
-            <entryLink id="a7dc-30d2-3c72-b5ef" name="New EntryLink" hidden="false" collective="false" import="true" targetId="648a-e853-bb44-9cee" type="selectionEntry">
-              <modifiers>
-                <modifier type="set" field="points" value="5"/>
-              </modifiers>
+            <entryLink id="a7dc-30d2-3c72-b5ef" name="Melta bombs" hidden="false" collective="false" import="true" targetId="648a-e853-bb44-9cee" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0a2c-11f7-a42e-e603" type="max"/>
               </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
             </entryLink>
             <entryLink id="acd0-ba73-b55c-b957" name="Digital Lasers" hidden="false" collective="false" import="true" targetId="155f-54a6-8ca9-27f5" type="selectionEntry">
-              <modifiers>
-                <modifier type="set" field="points" value="15"/>
-              </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2bdc-a796-2543-bdb6" type="max"/>
               </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="15.0"/>
+              </costs>
             </entryLink>
             <entryLink id="d645-5984-1d62-e22c" name="Teleportation Transponders" hidden="false" collective="false" import="true" targetId="7d72-4429-d25c-54f3" type="selectionEntry"/>
           </entryLinks>
@@ -1345,7 +1386,7 @@
             </selectionEntry>
           </selectionEntries>
           <entryLinks>
-            <entryLink id="83e8-a29e-d4ed-b441" name="New EntryLink" hidden="false" collective="false" import="true" targetId="dc9c-fe1d-8c26-fb07" type="selectionEntry">
+            <entryLink id="83e8-a29e-d4ed-b441" name="Guardian Spear" hidden="false" collective="false" import="true" targetId="dc9c-fe1d-8c26-fb07" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="points" value="0.0"/>
               </modifiers>
@@ -1366,7 +1407,7 @@
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1414-7551-fe7f-8564" type="max"/>
               </constraints>
             </entryLink>
-            <entryLink id="3ac7-3389-c2f2-7870" name="New EntryLink" hidden="false" collective="false" import="true" targetId="cb99-fafa-3e9d-035e" type="selectionEntry">
+            <entryLink id="3ac7-3389-c2f2-7870" name="Solerite Power Talon" hidden="false" collective="false" import="true" targetId="cb99-fafa-3e9d-035e" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="points" value="10"/>
               </modifiers>
@@ -1382,7 +1423,7 @@
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="71d4-21a1-2137-d756" type="max"/>
               </constraints>
             </entryLink>
-            <entryLink id="ccbc-9db0-427b-231f" name="New EntryLink" hidden="false" collective="false" import="true" targetId="0179-aa55-899c-aa0b" type="selectionEntry">
+            <entryLink id="ccbc-9db0-427b-231f" name="Adrasite Spear" hidden="false" collective="false" import="true" targetId="0179-aa55-899c-aa0b" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="points" value="10"/>
               </modifiers>
@@ -1390,7 +1431,7 @@
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="db10-563a-a5ae-cf49" type="max"/>
               </constraints>
             </entryLink>
-            <entryLink id="a934-0f3f-2933-009c" name="New EntryLink" hidden="false" collective="false" import="true" targetId="5111-6e79-1a9b-007a" type="selectionEntry">
+            <entryLink id="a934-0f3f-2933-009c" name="Paragon Spear" hidden="false" collective="false" import="true" targetId="5111-6e79-1a9b-007a" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="points" value="25"/>
               </modifiers>
@@ -1425,31 +1466,31 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="91c4-8ce3-80fb-a334" name="New EntryLink" hidden="false" collective="false" import="true" targetId="a502-5799-a2f4-310b" type="selectionEntry">
+        <entryLink id="91c4-8ce3-80fb-a334" name="Legio Custodes" hidden="false" collective="false" import="true" targetId="a502-5799-a2f4-310b" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a0c9-9eb8-7f96-154c" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d443-c257-8c2e-4de2" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="2005-c815-d8a1-e391" name="New EntryLink" hidden="false" collective="false" import="true" targetId="81d2-94da-550c-1dd3" type="selectionEntry">
+        <entryLink id="2005-c815-d8a1-e391" name="Close Combat Weapon" hidden="false" collective="false" import="true" targetId="81d2-94da-550c-1dd3" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4143-01f4-69bb-e824" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="779b-acdc-8a84-2372" type="min"/>
           </constraints>
         </entryLink>
-        <entryLink id="ba60-287b-d5b3-c6f5" name="New EntryLink" hidden="false" collective="false" import="true" targetId="2c5a-1976-04e4-e277" type="selectionEntry">
+        <entryLink id="ba60-287b-d5b3-c6f5" name="Custodian Armour" hidden="false" collective="false" import="true" targetId="2c5a-1976-04e4-e277" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6c51-8c37-273d-8828" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2033-385d-a605-94b7" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="4c8d-b7c1-87ee-7ece" name="New EntryLink" hidden="false" collective="false" import="true" targetId="c60c-dfd9-c5b8-50d1" type="selectionEntry">
+        <entryLink id="4c8d-b7c1-87ee-7ece" name="Iron Halo" hidden="false" collective="false" import="true" targetId="c60c-dfd9-c5b8-50d1" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d6a3-771f-8fa3-8405" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2a4b-2b5d-f187-ae27" type="min"/>
           </constraints>
         </entryLink>
-        <entryLink id="71d9-af3f-67af-35f6" name="New EntryLink" hidden="false" collective="false" import="true" targetId="42e2-2cc0-6353-4d47" type="selectionEntry">
+        <entryLink id="71d9-af3f-67af-35f6" name="Plasma + Krak Grenades" hidden="false" collective="false" import="true" targetId="42e2-2cc0-6353-4d47" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="08f4-da3d-8842-545a" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7541-15b2-b5db-11ad" type="min"/>
@@ -2164,7 +2205,7 @@
                 <selectionEntry id="5962-87f8-4be7-24fc" name="Twin-Linked Adrathic Destructor" hidden="false" collective="false" import="true" type="upgrade">
                   <infoLinks>
                     <infoLink id="8cd0-50e9-9723-80a5" name="New InfoLink" hidden="false" targetId="10a8-8d89-0bec-3e21" type="rule"/>
-                    <infoLink id="53c8-8183-eb97-d22d" name="New InfoLink" hidden="false" targetId="0351-af54-349e-1fd3" type="profile"/>
+                    <infoLink id="53c8-8183-eb97-d22d" name="Twin-Linked Adrathic Destructor" hidden="false" targetId="78c8-6feb-ba8b-6427" type="profile"/>
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="15.0"/>
@@ -2182,7 +2223,7 @@
             </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks>
-            <entryLink id="81f4-74ee-e023-55a7" name="New EntryLink" hidden="false" collective="false" import="true" targetId="6e95-2ae6-4dd8-c24b" type="selectionEntry">
+            <entryLink id="81f4-74ee-e023-55a7" name="Aquilon Pattern Terminator Armor" hidden="false" collective="false" import="true" targetId="6e95-2ae6-4dd8-c24b" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aa22-7607-2bfb-d11a" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="36e0-6760-af35-1b55" type="min"/>
@@ -2569,7 +2610,7 @@
                   </constraints>
                   <infoLinks>
                     <infoLink id="c5fd-4ad9-8b4f-607d" name="Twin-linked" hidden="false" targetId="10a8-8d89-0bec-3e21" type="rule"/>
-                    <infoLink id="24f6-a21f-ed1e-91c2" name="Adrathic Destructor" hidden="false" targetId="0351-af54-349e-1fd3" type="profile"/>
+                    <infoLink id="24f6-a21f-ed1e-91c2" name="Twin-Linked Adrathic Destructor" hidden="false" targetId="78c8-6feb-ba8b-6427" type="profile"/>
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="15.0"/>
@@ -2842,7 +2883,7 @@
           <selectionEntryGroups>
             <selectionEntryGroup id="bb0b-f2d4-657b-e065" name="May take any of the Following:" hidden="false" collective="false" import="true">
               <entryLinks>
-                <entryLink id="5454-ce80-d153-c1f2" name="New EntryLink" hidden="false" collective="false" import="true" targetId="7a9d-499d-e939-23a3" type="selectionEntryGroup">
+                <entryLink id="5454-ce80-d153-c1f2" name="Power Weapon" hidden="false" collective="false" import="true" targetId="7a9d-499d-e939-23a3" type="selectionEntryGroup">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="39f8-6717-5def-c777" type="max"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="88b9-9ce5-7ebc-e288" type="max"/>
@@ -2864,7 +2905,7 @@
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1776-5434-ccbc-cfc7" type="max"/>
                   </constraints>
                 </entryLink>
-                <entryLink id="d758-53e4-a24e-bfcb" name="New EntryLink" hidden="false" collective="false" import="true" targetId="a598-a02a-d502-adf4" type="selectionEntry">
+                <entryLink id="d758-53e4-a24e-bfcb" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="a598-a02a-d502-adf4" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="points" value="15"/>
                   </modifiers>
@@ -2872,7 +2913,7 @@
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f6ec-c76f-ee3b-69fd" type="max"/>
                   </constraints>
                 </entryLink>
-                <entryLink id="9b6e-ad8a-3efc-e0d6" name="New EntryLink" hidden="false" collective="false" import="true" targetId="af7d-23e9-3a57-57aa" type="selectionEntry">
+                <entryLink id="9b6e-ad8a-3efc-e0d6" name="Hand Flamer" hidden="false" collective="false" import="true" targetId="af7d-23e9-3a57-57aa" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="points" value="5"/>
                   </modifiers>
@@ -2971,7 +3012,7 @@
               <selectionEntryGroups>
                 <selectionEntryGroup id="d518-3b65-35de-853c" name="One in Three may be equipped with the Following:" hidden="false" collective="false" import="true">
                   <modifiers>
-                    <modifier type="increment" field="9fa7-c308-e918-173d" value="1">
+                    <modifier type="increment" field="9fa7-c308-e918-173d" value="1.0">
                       <conditions>
                         <condition field="selections" scope="17c2-d576-4704-9d48" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6f86-521d-ead0-c631" type="equalTo"/>
                       </conditions>
@@ -3005,6 +3046,23 @@
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
+                  <entryLinks>
+                    <entryLink id="127b-0e59-fb1f-a0f2" name="Toxiferran Flamer" hidden="true" collective="false" import="true" targetId="60f6-183e-98a3-d6d8" type="selectionEntry">
+                      <modifiers>
+                        <modifier type="set" field="hidden" value="false">
+                          <conditions>
+                            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c859-6b16-c533-7e97" type="equalTo"/>
+                          </conditions>
+                        </modifier>
+                      </modifiers>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dc46-0062-445a-f903" type="max"/>
+                      </constraints>
+                      <costs>
+                        <cost name="pts" typeId="points" value="20.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <costs>
@@ -3400,14 +3458,14 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8d54-2241-cfcc-6c7a" type="min"/>
           </constraints>
           <entryLinks>
-            <entryLink id="cd3a-da95-d9ab-493c" name="New EntryLink" hidden="false" collective="false" import="true" targetId="cf19-156c-1aa3-daa0" type="selectionEntry">
+            <entryLink id="cd3a-da95-d9ab-493c" name="Flamer" hidden="false" collective="false" import="true" targetId="cf19-156c-1aa3-daa0" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9f75-f84c-44ae-1fd5" type="max"/>
               </constraints>
             </entryLink>
-            <entryLink id="fb31-6183-9d08-ee69" name="New EntryLink" hidden="false" collective="false" import="true" targetId="4f36-1f24-0152-73d0" type="selectionEntry">
+            <entryLink id="fb31-6183-9d08-ee69" name="Grenade Launcher" hidden="false" collective="false" import="true" targetId="4f36-1f24-0152-73d0" type="selectionEntry">
               <modifiers>
-                <modifier type="increment" field="points" value="5">
+                <modifier type="increment" field="points" value="5.0">
                   <repeats>
                     <repeat field="selections" scope="08a1-0907-5ed0-2a6c" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b08a-cc0a-fcde-a695" repeats="1" roundUp="false"/>
                     <repeat field="selections" scope="08a1-0907-5ed0-2a6c" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ac71-e300-0442-d8de" repeats="1" roundUp="false"/>
@@ -3417,6 +3475,25 @@
               </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="003a-c53c-7b69-302b" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="9bf5-3ad5-5637-07ab" name="Toxiferran Flamer" hidden="true" collective="false" import="true" targetId="60f6-183e-98a3-d6d8" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c859-6b16-c533-7e97" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="points" value="5.0">
+                  <repeats>
+                    <repeat field="selections" scope="08a1-0907-5ed0-2a6c" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b08a-cc0a-fcde-a695" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="08a1-0907-5ed0-2a6c" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ac71-e300-0442-d8de" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="08a1-0907-5ed0-2a6c" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c9fc-4070-c8d4-a1fd" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="94a9-de2a-17a2-2099" type="max"/>
               </constraints>
             </entryLink>
           </entryLinks>
@@ -4925,6 +5002,368 @@ decided.</description>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
+    <selectionEntry id="01e5-960d-a7b8-87fe" name="Legio Custodes Talon Master" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="324c-4138-3540-2c9a" name="Legio Custodes Talon Master" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+          <characteristics>
+            <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry (Character)</characteristic>
+            <characteristic name="WS" typeId="575323232344415441232323">5</characteristic>
+            <characteristic name="BS" typeId="425323232344415441232323">5</characteristic>
+            <characteristic name="S" typeId="5323232344415441232323">5</characteristic>
+            <characteristic name="T" typeId="5423232344415441232323">5</characteristic>
+            <characteristic name="W" typeId="5723232344415441232323">3</characteristic>
+            <characteristic name="I" typeId="4923232344415441232323">5</characteristic>
+            <characteristic name="A" typeId="4123232344415441232323">3</characteristic>
+            <characteristic name="LD" typeId="4c4423232344415441232323">10</characteristic>
+            <characteristic name="Save" typeId="5361766523232344415441232323">2)</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="1b1e-b0d9-1369-7b55" name="Bulky" hidden="false" targetId="38d5-b6eb-bda8-2497" type="rule"/>
+        <infoLink id="fc07-fb38-4659-8c47" name="Counter-attack" hidden="false" targetId="0900-71d5-1937-aa96" type="rule"/>
+        <infoLink id="6775-a789-34bc-52fb" name="Crusader" hidden="false" targetId="2b06-29a6-641a-b22e" type="rule"/>
+        <infoLink id="21e7-50d6-db65-8530" name="Independent Character" hidden="false" targetId="3ad4-1c37-d60b-1a4e" type="rule"/>
+      </infoLinks>
+      <selectionEntries>
+        <selectionEntry id="3e91-98e0-1de1-31b8" name="Master-crafted Boltgun" hidden="false" collective="false" import="true" type="upgrade">
+          <profiles>
+            <profile id="bad6-8b78-be39-c1e2" name="Boltgun" publicationId="ca571888--pubN106502" page="177" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="52616e676523232344415441232323">24&quot;</characteristic>
+                <characteristic name="Strength" typeId="537472656e67746823232344415441232323">4</characteristic>
+                <characteristic name="AP" typeId="415023232344415441232323">5</characteristic>
+                <characteristic name="Type" typeId="5479706523232344415441232323">Rapid Fire, Master-crafted</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="8014-8e39-6473-56b8" name="Master-crafted" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="7773-3256-efd2-b776" name="Talon Master in Custodian Armour may select one of the following:" hidden="false" collective="false" import="true">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="01e5-960d-a7b8-87fe" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="53b4-cf3a-a65a-4aab" type="equalTo"/>
+                    <condition field="selections" scope="01e5-960d-a7b8-87fe" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e625-77f2-7829-e6be" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="set" field="15c2-9d20-e499-fd1a" value="0.0">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="01e5-960d-a7b8-87fe" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="53b4-cf3a-a65a-4aab" type="equalTo"/>
+                    <condition field="selections" scope="01e5-960d-a7b8-87fe" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e625-77f2-7829-e6be" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="15c2-9d20-e499-fd1a" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="c1a7-718e-9b6a-7622" name="Archaeotech Pistol" hidden="false" collective="false" import="true" targetId="5f1c-b6c2-0caa-f462" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0395-4c4f-7ee0-ae53" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="20.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="afb3-14d2-1f1f-0280" name="Praesidium Shield" hidden="false" collective="false" import="true" targetId="a521-ee67-6936-d9b2" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="744f-2509-afcb-a2b7" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="35.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="ff52-6bc4-b970-2102" name="Armour" hidden="false" collective="false" import="true" defaultSelectionEntryId="e305-af38-d77e-bf26">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="359b-7420-78e9-63cc" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a824-720d-37ea-5fd1" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="e305-af38-d77e-bf26" name="Custodian Armour" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7160-d7e9-97ba-2de0" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="2748-eaf7-4a5b-1d99" name="Custodian Armour" hidden="false" targetId="f07e-858e-d637-e858" type="profile"/>
+                <infoLink id="1af3-d725-c46f-c1f9" name="Move Through Cover" hidden="false" targetId="6d06-5ea0-9a17-ca97" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="53b4-cf3a-a65a-4aab" name="Aquilon Pattern Terminator Armor" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8468-e5ba-1676-3afe" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="a58d-316d-b9a1-1e8c" name="Aquillon Pattern Terminator Armour" hidden="false" targetId="0a62-df1f-aed7-fc07" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="15.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="ccef-7656-9080-4713" name="The Talon Master must be equipped with one of the following:" hidden="false" collective="false" import="true">
+          <selectionEntries>
+            <selectionEntry id="e625-77f2-7829-e6be" name="Pair of Solarite Power Talons" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2fdf-623e-7db8-b3ac" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="5c76-a0d4-8c0f-eda6" name="Solerite Power Talons" hidden="false" targetId="2ddd-f96f-86df-50ba" type="profile"/>
+                <infoLink id="52ef-46d9-1c17-4e38" name="Master-crafted" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule"/>
+                <infoLink id="0f17-a973-21fa-9a4d" name="Shred" hidden="false" targetId="89da-0cb5-bee4-8ec2" type="rule"/>
+                <infoLink id="111e-d85a-864a-9a3d" name="Specialist Weapon" hidden="false" targetId="7ee3-d437-bc44-3630" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="20.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="d5f8-1a3e-b0c9-95c8" name="Twin-Linked Adrathic Destructor" hidden="true" collective="false" import="true" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <conditions>
+                    <condition field="selections" scope="01e5-960d-a7b8-87fe" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="53b4-cf3a-a65a-4aab" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c169-3022-d26b-a167" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="2527-86b3-7ff1-640a" name="Twin-linked" hidden="false" targetId="10a8-8d89-0bec-3e21" type="rule"/>
+                <infoLink id="df5d-df5d-92b0-deec" name="Twin-Linked Adrathic Destructor" hidden="false" targetId="78c8-6feb-ba8b-6427" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="15.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <entryLinks>
+            <entryLink id="cd19-11fe-3b6c-9873" name="Guardian Spear" hidden="false" collective="false" import="true" targetId="dc9c-fe1d-8c26-fb07" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="points" value="0.0"/>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c59c-d385-9414-12b9" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="f33d-7cdb-8c0d-9dbc" name="Sentinel Warblade" hidden="false" collective="false" import="true" targetId="0caf-31e2-cd7b-a4dd" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9893-1a5e-7136-1433" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="cf7e-a58e-7c5b-1d12" name="Solerite Power Gauntlet" hidden="false" collective="false" import="true" targetId="8ba6-041a-ff23-98f6" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c14c-6d6c-160b-a34e" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="30.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="f3a4-1e6f-84ee-aba2" name="Solerite Power Talon" hidden="false" collective="false" import="true" targetId="cb99-fafa-3e9d-035e" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="903e-b879-e38c-64fb" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="15.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="5fbd-f5c0-ec60-4e35" name="Adrasite Spear" hidden="false" collective="false" import="true" targetId="0179-aa55-899c-aa0b" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="58de-d1b0-0d44-b4ca" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="77ef-24d4-1357-5fbd" name="Pyrithite Spear" hidden="false" collective="false" import="true" targetId="4af1-fc20-e881-7ad9" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9a73-bc66-ac70-9b52" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="15.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="3f9f-10bd-651d-6bd9" name="Paragon Spear" hidden="false" collective="false" import="true" targetId="5111-6e79-1a9b-007a" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6fa6-65d8-24ac-7eb6" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="30.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="4033-024e-624d-c673" name="Infernus Firepike" hidden="true" collective="false" import="true" targetId="af24-638f-cd0d-5d2d" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <conditions>
+                    <condition field="selections" scope="01e5-960d-a7b8-87fe" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="53b4-cf3a-a65a-4aab" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e65a-2134-57c0-51a3" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="fa7d-c4a9-7227-b6de" name="Lastrum Storm Bolter" hidden="true" collective="false" import="true" targetId="2693-afa7-96a3-150a" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <conditions>
+                    <condition field="selections" scope="01e5-960d-a7b8-87fe" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="53b4-cf3a-a65a-4aab" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="03fc-6882-52ba-9670" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="899d-b93f-a5d4-6310" name="The Talon Master may be equipped with any of the following:" hidden="false" collective="false" import="true">
+          <entryLinks>
+            <entryLink id="03ef-12c7-855e-a1fc" name="Arae-Shrikes" hidden="false" collective="false" import="true" targetId="be4a-0e91-0f1f-4c1d" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="17c0-8663-3003-0fdd" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="57cc-d0a8-32da-4287" name="Teleportation Transponders" hidden="false" collective="false" import="true" targetId="81f8-eb55-e1fd-c90a" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="88ef-0950-2908-5884" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="5bff-8cea-0dd6-5f0a" name="Melta bombs" hidden="false" collective="false" import="true" targetId="648a-e853-bb44-9cee" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8249-f2b6-a234-936f" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="b3b0-58c0-fa06-a937" name="Digital Lasers" hidden="false" collective="false" import="true" targetId="155f-54a6-8ca9-27f5" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d35f-e238-3a84-56f5" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="15.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="5290-343e-d330-f5cb" name="Teleportation Transponders" hidden="false" collective="false" import="true" targetId="7d72-4429-d25c-54f3" type="selectionEntry"/>
+            <entryLink id="9903-60b2-e734-5708" name="Teleportation Transponders" hidden="false" collective="false" import="true" targetId="7d72-4429-d25c-54f3" type="selectionEntry"/>
+            <entryLink id="bf5d-f50d-a374-14cb" name="Iron Halo" hidden="false" collective="false" import="true" targetId="c60c-dfd9-c5b8-50d1" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f2f5-e304-034f-87a7" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="15.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="35cf-936f-e2e4-47dc" name="Psyarkana" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="889f-b035-433e-0222" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="1ee4-148f-d1e7-08ae" name="Icon of the Blazing Sun" hidden="false" collective="false" import="true" targetId="b2fe-de24-0c45-9b4d" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false"/>
+              </modifiers>
+            </entryLink>
+            <entryLink id="d328-79b4-a919-1e65" name="Psi-resonant Pentacles" hidden="false" collective="false" import="true" targetId="199f-821c-598a-c660" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <conditions>
+                    <condition field="selections" scope="01e5-960d-a7b8-87fe" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c60c-dfd9-c5b8-50d1" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="5e53-ae92-e43f-c8a5" name="Terminal Lucidity Injectors" hidden="false" collective="false" import="true" targetId="66e2-6760-fb6a-edc3" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false"/>
+              </modifiers>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="a8f5-e837-0cfa-b0f3" name="Plasma + Krak Grenades" hidden="false" collective="false" import="true" targetId="42e2-2cc0-6353-4d47" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="30dd-3f09-eead-9f2b" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5e4e-8937-9c72-f335" type="min"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="b9b1-e70e-d3ff-e7fc" name="Legio Custodes" hidden="false" collective="false" import="true" targetId="a502-5799-a2f4-310b" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7fb8-b20b-41f1-58c4" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cede-f4d6-2589-ce45" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="1168-e6a2-1ddf-00f5" name="Nuncio-Vox" hidden="false" collective="false" import="true" targetId="e8f5-fd9d-1891-93d3" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5a49-4ead-568d-eec8" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6d66-f236-b17c-6fa6" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="135.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="60f6-183e-98a3-d6d8" name="Toxiferran Flamer" page="" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="fda8-6313-5312-aad5" name="Toxiferran Flamer" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="52616e676523232344415441232323">Template</characteristic>
+            <characteristic name="Strength" typeId="537472656e67746823232344415441232323">4</characteristic>
+            <characteristic name="AP" typeId="415023232344415441232323">5</characteristic>
+            <characteristic name="Type" typeId="5479706523232344415441232323">Assault 1, Poisoned (3+), Tainted</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="8b3d-5702-8b36-c04f" name="Tainted" page="" hidden="false">
+          <description>Any successful wound dealt by a weapon with this special rule removes the effects of any psychic blessing which is active on the target unit. In addition, any To Wound roll of a 6 with this weapon is resolved at AP2.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="f58f-bf77-d11f-6d5b" name="Poisoned" hidden="false" targetId="a5ff-1cb1-bee4-d809" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup id="986b-441b-bff6-b09f" name="Wargear" hidden="false" collective="false" import="true">
@@ -5406,10 +5845,10 @@ decided.</description>
         </selectionEntry>
         <selectionEntry id="cb99-fafa-3e9d-035e" name="Solerite Power Talon" publicationId="a30a-7522-pubN95872" hidden="false" collective="false" import="true" type="upgrade">
           <infoLinks>
-            <infoLink id="0a47-ac3f-ef01-762c" name="New InfoLink" hidden="false" targetId="2ddd-f96f-86df-50ba" type="profile"/>
-            <infoLink id="0a8e-9b6e-e9af-ba25" name="New InfoLink" hidden="false" targetId="7ee3-d437-bc44-3630" type="rule"/>
-            <infoLink id="2020-646b-57a9-fc44" name="New InfoLink" hidden="false" targetId="89da-0cb5-bee4-8ec2" type="rule"/>
-            <infoLink id="a96f-ccc2-5460-e292" name="New InfoLink" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule"/>
+            <infoLink id="0a47-ac3f-ef01-762c" name="Solerite Power Talons" hidden="false" targetId="2ddd-f96f-86df-50ba" type="profile"/>
+            <infoLink id="0a8e-9b6e-e9af-ba25" name="Specialist Weapon" hidden="false" targetId="7ee3-d437-bc44-3630" type="rule"/>
+            <infoLink id="2020-646b-57a9-fc44" name="Shred" hidden="false" targetId="89da-0cb5-bee4-8ec2" type="rule"/>
+            <infoLink id="a96f-ccc2-5460-e292" name="Master-crafted" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule"/>
           </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="0.0"/>
@@ -6841,6 +7280,14 @@ Overawe(+1 to the total score to determine the result of an assault)</descriptio
         <characteristic name="A" typeId="4123232344415441232323">2</characteristic>
         <characteristic name="LD" typeId="4c4423232344415441232323">9</characteristic>
         <characteristic name="Save" typeId="5361766523232344415441232323">3+</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="78c8-6feb-ba8b-6427" name="Twin-Linked Adrathic Destructor" publicationId="a30a-7522-pubN95872" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="52616e676523232344415441232323">12&quot;</characteristic>
+        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">5</characteristic>
+        <characteristic name="AP" typeId="415023232344415441232323">2</characteristic>
+        <characteristic name="Type" typeId="5479706523232344415441232323">Assault 1, Instant Death, Gets Hot, Armourbane, Twin-Linked</characteristic>
       </characteristics>
     </profile>
   </sharedProfiles>


### PR DESCRIPTION
Mournival additions.

Talons : Added the additional HQ choice and options of Toxi Flamers to Seekers and Pursuers.
Militia : Added the additional units from Mournival (Militia Mounted Squadron & Militia Land Speeder)
Mech : Added the additional units from Mournival (Myrmidon Reductor & Triaros Guardian)