### PR TITLE
Quick Fixes and more Custom Char stuff

### DIFF
--- a/(HH) Mornival Units.cat
+++ b/(HH) Mornival Units.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="9f87-b468-2001-5e3b" name="Mornival Units Legion Astartes (Fanmade)" revision="15" battleScribeVersion="2.03" authorName="Aus30K / Mourival Events" authorContact="" authorUrl="https://www.facebook.com/groups/190699548351507/" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="121" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="9f87-b468-2001-5e3b" name="Mornival Units Legion Astartes (Fanmade)" revision="16" battleScribeVersion="2.03" authorName="Aus30K / Mourival Events" authorContact="" authorUrl="https://www.facebook.com/groups/190699548351507/" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="122" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="0e6e-8c19-c436-39c4" name="Mournival Events 3.0 Digital Version"/>
     <publication id="cf75-540e-e446-ecd5" name="Mournival Events FAQ and Experimental Errata v3.1"/>
@@ -9,6 +9,19 @@
     <categoryEntry id="c821-d9f2-5684-64fa" name="# Restiction" hidden="false">
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="33e5-3aed-8c8c-2c8c" type="max"/>
+      </constraints>
+    </categoryEntry>
+    <categoryEntry id="05c9-9e0d-c2e5-d62f" name="Centurion or Delegatus" hidden="false">
+      <modifiers>
+        <modifier type="set" field="2df5-cae6-6838-f7a8" value="1.0">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3907-f781-c7be-4fcb" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2df5-cae6-6838-f7a8" type="min"/>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="af99-c3fa-5d72-13a3" type="max"/>
       </constraints>
     </categoryEntry>
   </categoryEntries>
@@ -391,7 +404,7 @@ Example 4: In a 2000 point army, a Daemon Lord is the Warlord (doesn’t count a
     <selectionEntry id="eee6-afda-09e8-053e" name="Mornival Rules" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0a20-2700-4e88-21e9" type="min"/>
-        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1461-57bb-af1f-d005" type="max"/>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1461-57bb-af1f-d005" type="max"/>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9cab-1ca5-8f4e-5c4d" type="max"/>
       </constraints>
       <categoryLinks>
@@ -404,13 +417,16 @@ Example 4: In a 2000 point army, a Daemon Lord is the Warlord (doesn’t count a
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2091-b9d7-8292-a025" type="max"/>
           </constraints>
           <categoryLinks>
-            <categoryLink id="6a52-8849-e6a9-09b2" name="New CategoryLink" hidden="false" targetId="dbe0-716f-797c-66f7" primary="true"/>
+            <categoryLink id="582b-67f6-9f4e-11b7" name="Mournival Rules" hidden="false" targetId="dbe0-716f-797c-66f7" primary="false"/>
           </categoryLinks>
         </entryLink>
         <entryLink id="b780-fecf-a9d1-27b2" name="Additional Psychic Disciplines" hidden="false" collective="false" import="true" targetId="be86-7cb9-6f78-eb14" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4f40-25d6-5055-63b0" type="min"/>
           </constraints>
+          <categoryLinks>
+            <categoryLink id="6d25-d65e-8980-737e" name="Mournival Rules" hidden="false" targetId="dbe0-716f-797c-66f7" primary="false"/>
+          </categoryLinks>
         </entryLink>
       </entryLinks>
       <costs>
@@ -1012,9 +1028,19 @@ If a Rogue Psyker who is the army’s Warlord becomes possessed, they are still 
         <selectionEntryGroup id="e2af-bc46-d607-621b" name="Any Model my exhange their Bolt Gun for:" hidden="false" collective="false" import="true">
           <entryLinks>
             <entryLink id="87ad-fde5-dbed-e2cc" name="Combat Shield" hidden="false" collective="false" import="true" targetId="e4b12fd7-ca72-5279-a63c-36223abdd186" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c759-a1b7-104a-826b" type="max"/>
-              </constraints>
+              <modifiers>
+                <modifier type="increment" field="maxSelections" value="1.0">
+                  <repeats>
+                    <repeat field="selections" scope="f171-3359-26b3-ea3e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+                <modifier type="decrement" field="maxSelections" value="1.0">
+                  <repeats>
+                    <repeat field="selections" scope="f171-3359-26b3-ea3e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f137-9146-769d-2bc3" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+                <modifier type="decrement" field="maxSelections" value="1.0"/>
+              </modifiers>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
@@ -1037,6 +1063,60 @@ If a Rogue Psyker who is the army’s Warlord becomes possessed, they are still 
           </constraints>
           <entryLinks>
             <entryLink id="e8db-1a4a-d00d-1bee" name="Alpha Legion: Banestrike" hidden="false" collective="false" import="true" targetId="ba94-773c-bf08-b5a7" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="d7dc-f454-0005-b112" name="Frost Weapons" hidden="false" collective="false" import="true">
+          <modifiers>
+            <modifier type="decrement" field="dc48-6936-ae73-75e0" value="1.0">
+              <repeats>
+                <repeat field="selections" scope="f171-3359-26b3-ea3e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="51c6-8978-4a5b-51ba" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+            <modifier type="increment" field="bc68-9761-b8bb-687c" value="1.0">
+              <repeats>
+                <repeat field="selections" scope="f171-3359-26b3-ea3e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+            <modifier type="increment" field="dc48-6936-ae73-75e0" value="1.0">
+              <repeats>
+                <repeat field="selections" scope="f171-3359-26b3-ea3e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+            <modifier type="decrement" field="bc68-9761-b8bb-687c" value="1.0">
+              <repeats>
+                <repeat field="selections" scope="f171-3359-26b3-ea3e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="51c6-8978-4a5b-51ba" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dc48-6936-ae73-75e0" type="min"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bc68-9761-b8bb-687c" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="3ef1-963b-ec3e-8f63" name="Frost Axe" hidden="false" collective="false" import="true" targetId="5a40-b58d-ed9b-62cd" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="points" value="0.0"/>
+                <modifier type="set" field="c752-0f32-add2-9251" value="10.0"/>
+              </modifiers>
+            </entryLink>
+            <entryLink id="2bef-ba36-449e-83b2" name="Frost Blade" hidden="false" collective="false" import="true" targetId="6e02-488e-39f9-47b4" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="points" value="0.0"/>
+                <modifier type="set" field="6d88-acb1-1f6f-a79e" value="10.0"/>
+              </modifiers>
+            </entryLink>
+            <entryLink id="b4bc-7f2b-adbf-85af" name="Frost Claw" hidden="false" collective="false" import="true" targetId="63ef-e326-2f90-961d" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="points" value="0.0"/>
+                <modifier type="set" field="1d20-59c1-b66d-6e92" value="10.0"/>
+              </modifiers>
+            </entryLink>
+            <entryLink id="e87f-41d5-68ee-0464" name="Frost Maul" hidden="false" collective="false" import="true" targetId="9543-d500-7629-8cc9" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="points" value="0.0"/>
+                <modifier type="set" field="9912-107c-2133-2c10" value="10.0"/>
+              </modifiers>
+            </entryLink>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
@@ -8774,6 +8854,7 @@ Hunter: Shot Gun, Chainblade, +1A and Acute Senses</description>
                     <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ba6-dda6-d587-3da7" type="equalTo"/>
                     <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c904-7d1f-f3ce-d04b" type="equalTo"/>
                     <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe66-602f-7cc1-57e9" type="equalTo"/>
+                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4daf-59a4-9046-1bb2" type="equalTo"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
@@ -9071,6 +9152,9 @@ Hunter: Shot Gun, Chainblade, +1A and Acute Senses</description>
               </selectionEntryGroups>
             </selectionEntryGroup>
           </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="533d-a19c-aa38-731b" name="Special Rules, Skills, Specialisation Advances" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
@@ -9515,7 +9599,7 @@ A Unit may not use Counter Attack special rule if it used Reaction Fire.</descri
                 </selectionEntry>
               </selectionEntries>
             </selectionEntryGroup>
-            <selectionEntryGroup id="1354-60df-eaba-e752" name="Legion Special Rules and Wargear" hidden="false" collective="false" import="true">
+            <selectionEntryGroup id="1354-60df-eaba-e752" name="Legion Special Rules" hidden="false" collective="false" import="true">
               <selectionEntries>
                 <selectionEntry id="da50-bd06-8a9d-84c9" name="Monster Hunter" hidden="true" collective="false" import="true" type="upgrade">
                   <modifiers>
@@ -9843,6 +9927,8 @@ A Unit may not use Counter Attack special rule if it used Reaction Fire.</descri
                           <conditions>
                             <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c91-a83b-8ca5-e5db" type="greaterThan"/>
                             <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6b1a-361b-37cc-f1a6" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c6d8-4c85-119c-4528" type="equalTo"/>
+                            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a511-1645-ac77-af33" type="greaterThan"/>
                           </conditions>
                         </conditionGroup>
                       </conditionGroups>
@@ -10037,29 +10123,6 @@ A Unit may not use Counter Attack special rule if it used Reaction Fire.</descri
                     <cost name="pts" typeId="points" value="5.0"/>
                   </costs>
                 </selectionEntry>
-                <selectionEntry id="be65-e1fb-2074-7990" name="Cortex Controller" hidden="true" collective="false" import="true" type="upgrade">
-                  <modifiers>
-                    <modifier type="set" field="hidden" value="false">
-                      <conditionGroups>
-                        <conditionGroup type="or">
-                          <conditions>
-                            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="83c2-692c-6560-3d68" type="greaterThan"/>
-                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7b57-e309-ea7e-4f7c" type="equalTo"/>
-                          </conditions>
-                        </conditionGroup>
-                      </conditionGroups>
-                    </modifier>
-                  </modifiers>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7a50-17f0-b887-16e4" type="max"/>
-                  </constraints>
-                  <entryLinks>
-                    <entryLink id="80c1-e69f-75f5-66db" name="Cortex Controller" hidden="false" collective="false" import="true" targetId="a4ee-573b-f9fd-0507" type="selectionEntry"/>
-                  </entryLinks>
-                  <costs>
-                    <cost name="pts" typeId="points" value="15.0"/>
-                  </costs>
-                </selectionEntry>
                 <selectionEntry id="d27f-420c-c300-4dac" name="Feel No Pain (5+)" hidden="true" collective="false" import="true" type="upgrade">
                   <modifiers>
                     <modifier type="set" field="hidden" value="false">
@@ -10084,6 +10147,18 @@ A Unit may not use Counter Attack special rule if it used Reaction Fire.</descri
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="4223-6925-e21c-250d" name="Feel No Pain (+1 or 6+)" hidden="true" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a511-1645-ac77-af33" type="greaterThan"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c6d8-4c85-119c-4528" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="851b-df4e-e24c-0e06" type="max"/>
                   </constraints>
@@ -10271,67 +10346,6 @@ A Unit may not use Counter Attack special rule if it used Reaction Fire.</descri
                     <cost name="pts" typeId="points" value="20.0"/>
                   </costs>
                 </selectionEntry>
-                <selectionEntry id="6b29-57d3-916a-622e" name="Mantle of the Elder Drake" hidden="true" collective="false" import="true" type="upgrade">
-                  <modifiers>
-                    <modifier type="set" field="hidden" value="false">
-                      <conditionGroups>
-                        <conditionGroup type="or">
-                          <conditions>
-                            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c29-e6cd-2167-ce90" type="greaterThan"/>
-                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="94d2-bcc2-f284-9fff" type="equalTo"/>
-                          </conditions>
-                        </conditionGroup>
-                      </conditionGroups>
-                    </modifier>
-                  </modifiers>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7e12-4218-3289-31dd" type="max"/>
-                  </constraints>
-                  <infoLinks>
-                    <infoLink id="81ab-327e-8ee9-dc85" name="Mantle of the Elder Drake" hidden="false" targetId="959ff616-ce22-b9ee-1ee6-2496b305e880" type="profile"/>
-                    <infoLink id="99de-6db4-5270-5627" name="Eternal Warrior" hidden="false" targetId="3e0b-be9f-b7eb-8c5e" type="rule"/>
-                  </infoLinks>
-                  <costs>
-                    <cost name="pts" typeId="points" value="20.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="b9a2-96f3-345f-f257" name="Molecular Acid Shells" hidden="true" collective="false" import="true" type="upgrade">
-                  <modifiers>
-                    <modifier type="set" field="hidden" value="false">
-                      <conditionGroups>
-                        <conditionGroup type="and">
-                          <conditions>
-                            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e6fb-0e54-0be1-9ed1" type="equalTo"/>
-                          </conditions>
-                          <conditionGroups>
-                            <conditionGroup type="or">
-                              <conditions>
-                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5baa-7812-3569-ed65" type="equalTo"/>
-                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a161-76b3-9ef1-da7b" type="equalTo"/>
-                              </conditions>
-                            </conditionGroup>
-                          </conditionGroups>
-                        </conditionGroup>
-                      </conditionGroups>
-                    </modifier>
-                  </modifiers>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a526-74d6-4545-d51b" type="max"/>
-                  </constraints>
-                  <profiles>
-                    <profile id="e6c0-7c4e-5672-e235" name="Molecular acid shells" publicationId="ca571888--pubN89821" page="267" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
-                      <characteristics>
-                        <characteristic name="Range" typeId="52616e676523232344415441232323">36&quot;</characteristic>
-                        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">2</characteristic>
-                        <characteristic name="AP" typeId="415023232344415441232323">D6</characteristic>
-                        <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 3, Poison (2)</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                  <costs>
-                    <cost name="pts" typeId="points" value="10.0"/>
-                  </costs>
-                </selectionEntry>
                 <selectionEntry id="7efb-8c25-8bd5-854e" name="Fatal Strike (does not confer)" hidden="true" collective="false" import="true" type="upgrade">
                   <modifiers>
                     <modifier type="set" field="hidden" value="false">
@@ -10455,6 +10469,30 @@ A Unit may not use Counter Attack special rule if it used Reaction Fire.</descri
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="6256-381a-0567-2a80" name="Infiltrate" hidden="true" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="aed9-5236-b67f-742c" value="1.0">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a100-ce0a-8c52-2079" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a100-ce0a-8c52-2079" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="699a-1d0d-ee0e-d4f5" type="max"/>
+                    <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aed9-5236-b67f-742c" type="min"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="48e7-ef20-04cc-b41c" name="Infiltrate" hidden="false" targetId="34c7-8b61-a5b8-a301" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -10618,25 +10656,6 @@ A Unit may not use Counter Attack special rule if it used Reaction Fire.</descri
                   </selectionEntries>
                 </selectionEntryGroup>
               </selectionEntryGroups>
-              <entryLinks>
-                <entryLink id="6320-c74d-1f5e-c5d5" name="Stasis Shells (grenade launcher)" hidden="true" collective="false" import="true" targetId="f118-45b2-9b94-d7f3" type="selectionEntry">
-                  <modifiers>
-                    <modifier type="set" field="hidden" value="false">
-                      <conditionGroups>
-                        <conditionGroup type="and">
-                          <conditions>
-                            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e6fb-0e54-0be1-9ed1" type="equalTo"/>
-                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e4e8-96ed-f463-3639" type="equalTo"/>
-                          </conditions>
-                        </conditionGroup>
-                      </conditionGroups>
-                    </modifier>
-                  </modifiers>
-                  <costs>
-                    <cost name="pts" typeId="points" value="10.0"/>
-                  </costs>
-                </entryLink>
-              </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="4ab2-fe75-95b3-c51b" name="Specialisation Upgrades" hidden="false" collective="false" import="true">
               <selectionEntries>
@@ -10673,6 +10692,9 @@ A Unit may not use Counter Attack special rule if it used Reaction Fire.</descri
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aa84-b089-26f3-ca08" type="max"/>
                     <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b616-16bb-c1da-a6ab" type="min"/>
                   </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="0.0"/>
+                  </costs>
                 </selectionEntry>
                 <selectionEntry id="d20c-79be-5792-de79" name="Librarian Psychic Mastery Level 2" hidden="true" collective="false" import="true" type="upgrade">
                   <modifiers>
@@ -10692,6 +10714,9 @@ A Unit may not use Counter Attack special rule if it used Reaction Fire.</descri
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="83e5-0b17-bd51-a464" type="max"/>
                     <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f40f-0d7e-bf7d-9524" type="min"/>
                   </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="0.0"/>
+                  </costs>
                 </selectionEntry>
                 <selectionEntry id="e913-5e73-2a9c-3e33" name="Librarian Psychic Mastery Level 3" hidden="true" collective="false" import="true" type="upgrade">
                   <modifiers>
@@ -10710,12 +10735,18 @@ A Unit may not use Counter Attack special rule if it used Reaction Fire.</descri
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2337-6bfe-6519-1c8d" type="max"/>
                     <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ee29-d8cc-d444-1800" type="min"/>
                   </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="0.0"/>
+                  </costs>
                 </selectionEntry>
               </selectionEntries>
             </selectionEntryGroup>
           </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
-        <selectionEntry id="598d-1f92-a88f-7013" name="Weapons" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="598d-1f92-a88f-7013" name="Weapons, Ammo, Wargear" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7c83-ddc8-ee27-c3b0" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="011e-504c-743f-ead6" type="max"/>
@@ -10723,7 +10754,7 @@ A Unit may not use Counter Attack special rule if it used Reaction Fire.</descri
           <selectionEntryGroups>
             <selectionEntryGroup id="00e4-6f83-9412-147a" name="Basic Weapon (0-1)" hidden="false" collective="false" import="true">
               <modifiers>
-                <modifier type="set" field="3dac-5bc6-5a21-8432" value="0.0">
+                <modifier type="set" field="hidden" value="true">
                   <conditionGroups>
                     <conditionGroup type="or">
                       <conditions>
@@ -10734,14 +10765,23 @@ A Unit may not use Counter Attack special rule if it used Reaction Fire.</descri
                     </conditionGroup>
                   </conditionGroups>
                 </modifier>
-                <modifier type="set" field="hidden" value="true">
+                <modifier type="set" field="3dac-5bc6-5a21-8432" value="0.0">
                   <conditionGroups>
                     <conditionGroup type="or">
-                      <conditions>
-                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="84ea-ada4-abe0-f064" type="equalTo"/>
-                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3afd-ac93-1a99-4de9" type="equalTo"/>
-                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a6cc-561c-56f9-a051" type="equalTo"/>
-                      </conditions>
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3afd-ac93-1a99-4de9" type="equalTo"/>
+                            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cf2e-9aed-ccc5-5696" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="84ea-ada4-abe0-f064" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a6cc-561c-56f9-a051" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
                     </conditionGroup>
                   </conditionGroups>
                 </modifier>
@@ -10782,9 +10822,14 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                 <selectionEntry id="87d9-68c1-4217-d0b4" name="Second Lightning Claw" hidden="true" collective="false" import="true" type="upgrade">
                   <modifiers>
                     <modifier type="set" field="af02-a8e5-b6a9-b5c4" value="1.0">
-                      <conditions>
-                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="26db-484d-3757-03c8" type="equalTo"/>
-                      </conditions>
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63ef-e326-2f90-961d" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="26db-484d-3757-03c8" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
                     </modifier>
                     <modifier type="set" field="hidden" value="true">
                       <conditionGroups>
@@ -10794,6 +10839,7 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                             <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="75c9-e5dd-17e0-c27e" type="equalTo"/>
                             <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a2d0-d202-f0ce-d081" type="equalTo"/>
                             <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c94-33f2-87e2-3fd0" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="af34-c67e-eef6-024d" type="equalTo"/>
                           </conditions>
                         </conditionGroup>
                       </conditionGroups>
@@ -10819,6 +10865,9 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                       </conditions>
                     </modifier>
                   </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="faca-74b6-2c28-8163" type="max"/>
+                  </constraints>
                   <infoLinks>
                     <infoLink id="a6a6-ea52-babd-2001" name="Heavy Bolter" hidden="false" targetId="271e-6286-86cc-06dd" type="profile">
                       <modifiers>
@@ -10829,6 +10878,156 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="7a70-d2d4-4283-d48f" name="Cacophany" hidden="false" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="74c0-fb49-35d8-28ac" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="df8c-2024-8c45-20a4" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="3b2f-e8c6-60b3-af10" name="The Cacophany" hidden="false" targetId="4b00440b-c5d3-ed3e-2feb-cf67688c11fa" type="profile"/>
+                    <infoLink id="1953-beb7-53a7-831c" name="Bio-psychic Shock" hidden="false" targetId="6c4eb82b-10b1-6aee-f83f-c6abab94fdcb" type="rule"/>
+                    <infoLink id="6818-716e-e293-36fe" name="Gets Hot" hidden="false" targetId="f4fd-d519-4769-5510" type="rule"/>
+                    <infoLink id="e884-a268-af30-a8c4" name="Pinning" hidden="false" targetId="f624-f475-e5ec-0dfa" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="15.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="505a-9b5f-3f44-6510" name="Second Frost Claw" hidden="true" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="a76f-5535-4578-de9c" value="1.0">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63ef-e326-2f90-961d" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="26db-484d-3757-03c8" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="aabc-93f7-1ae0-6bfe" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="75c9-e5dd-17e0-c27e" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a2d0-d202-f0ce-d081" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c94-33f2-87e2-3fd0" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="af34-c67e-eef6-024d" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a76f-5535-4578-de9c" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="6977-2369-bd8b-3818" name="Lightning Claw" hidden="false" targetId="3cec-4483-3f2e-fbc2" type="profile"/>
+                    <infoLink id="1771-7c3c-b2e0-89fe" name="Shred" hidden="false" targetId="89da-0cb5-bee4-8ec2" type="rule"/>
+                    <infoLink id="75b1-b38f-05ef-bb1e" name="Specialist Weapon" hidden="false" targetId="7ee3-d437-bc44-3630" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="a100-ce0a-8c52-2079" name="Volkite Charger + Infiltrate#" page="0" hidden="false" collective="false" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0468-fa17-fc14-f87b" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="ba7e-cf54-b66f-8a50" name="Volkite Charger" hidden="false" targetId="c440-1f53-4d20-5cab" type="profile"/>
+                    <infoLink id="4c32-1952-d0c5-d642" name="Deflagrate" hidden="false" targetId="b46a-a3ec-91a5-5001" type="rule"/>
+                  </infoLinks>
+                  <categoryLinks>
+                    <categoryLink id="039b-ef8c-af6d-def2" name="# Restiction" hidden="false" targetId="c821-d9f2-5684-64fa" primary="false"/>
+                  </categoryLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="b8b2-9995-5f27-f0d5" name="Pyroclast Flame Projector" hidden="false" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c29-e6cd-2167-ce90" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="244a-e3be-886e-4caa" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="7c13-4010-df88-3faa" name="Pyroclast Flame Projector (Dispersed)" hidden="false" targetId="25d4e463-b5ce-5327-e7b4-29882b6178e9" type="profile"/>
+                    <infoLink id="1b49-1ad2-5bbc-2e27" name="Pyroclast Flame Projector (Focused)" hidden="false" targetId="41ec0da6-5bd8-5a56-6254-64df6d3d7d6b" type="profile"/>
+                    <infoLink id="ab41-ea25-706d-81cf" name="Pyroclast Flame Projector" hidden="false" targetId="814767ab-606a-0a0c-fd65-3822a3b57902" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="0286-0026-2967-56fe" name="Second Ravens Talon" hidden="true" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="4ff6-22ea-8340-e5e7" value="1.0">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6435afdc-d8b1-09a1-a82a-9d4d7af1c869" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6435afdc-d8b1-09a1-a82a-9d4d7af1c869" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="af34-c67e-eef6-024d" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ff6-22ea-8340-e5e7" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="57ec-5b37-c997-23c3" name="Shred" hidden="false" targetId="89da-0cb5-bee4-8ec2" type="rule"/>
+                    <infoLink id="1a08-212b-0eec-0e59" name="Specialist Weapon" hidden="false" targetId="7ee3-d437-bc44-3630" type="rule"/>
+                    <infoLink id="8bdc-cda2-6075-3353" name="Raven&apos;s Talons" hidden="false" targetId="5e57-5878-9c79-4841" type="profile"/>
+                    <infoLink id="fdbf-bb81-d4c3-e1a8" name="Rending" hidden="false" targetId="8269-2cd6-9236-16e7" type="rule"/>
+                    <infoLink id="8d32-0a0f-f57a-6384" name="Master-crafted" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="4c6f-73b8-2d83-3ec9" name="Xenos Deathlock" hidden="false" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbf2-d8be-0406-b8d6" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2936-a9c0-b680-c575" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="fe24-0e00-d3d2-ba4c" name="Xenos Deathlock" hidden="false" targetId="4b0d-ac88-d973-df29" type="profile"/>
+                    <infoLink id="bff9-f5b6-093c-4c99" name="Deathlock" hidden="false" targetId="64ff-f3fd-77e9-0591" type="rule"/>
+                    <infoLink id="7427-2296-c85a-ee9a" name="Lethal Exposure" hidden="false" targetId="8268-9d62-4b53-9eaa" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -10981,6 +11180,36 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                   <categoryLinks>
                     <categoryLink id="d28a-b12f-be00-8fa9" name="# Restiction" hidden="false" targetId="c821-d9f2-5684-64fa" primary="false"/>
                   </categoryLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="337a-b6d6-c057-d4ee" name="Vigil Pattern Storm Shield" hidden="false" collective="false" import="true" targetId="e92b-34de-9f52-5c3a" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b26e-ba33-ff55-3fd6" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ba6-dda6-d587-3da7" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="28d4-97c4-3355-1b98" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                </entryLink>
+                <entryLink id="f214-2faa-a39d-fcbd" name="Dragonscale Storm Shield" hidden="false" collective="false" import="true" targetId="15662370-7d13-ed80-50aa-02aa0368c309" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="bcd5-d819-b259-cb3f" name="Pariah Bolter" hidden="false" collective="false" import="true" targetId="10c0-d162-c4f2-33c1" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="d996-2d50-bd96-dd65" name="Pariah Flamer" hidden="false" collective="false" import="true" targetId="f631-f1ad-3d62-ba74" type="selectionEntry">
                   <costs>
                     <cost name="pts" typeId="points" value="10.0"/>
                   </costs>
@@ -11167,6 +11396,37 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                 <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b621-1ae6-1095-053a" type="min"/>
                 <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0208-01c3-b3fb-6608" type="max"/>
               </constraints>
+              <selectionEntries>
+                <selectionEntry id="e839-b419-e947-8eb1" name="Fulcrum Hand-cannon" hidden="false" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="09b8-26b3-b27d-621a" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9b72-212e-0382-acfa" type="max"/>
+                  </constraints>
+                  <profiles>
+                    <profile id="2fa3-118c-da85-9c60" name="Fulcrum Hand-cannon" publicationId="839b6f2a--pubN94234" page="110" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+                      <characteristics>
+                        <characteristic name="Range" typeId="52616e676523232344415441232323">18&quot;</characteristic>
+                        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">4</characteristic>
+                        <characteristic name="AP" typeId="415023232344415441232323">4</characteristic>
+                        <characteristic name="Type" typeId="5479706523232344415441232323">Pistol, Rending, Concussive</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <infoLinks>
+                    <infoLink id="e0d5-be40-1b5a-876c" name="Rending" hidden="false" targetId="8269-2cd6-9236-16e7" type="rule"/>
+                    <infoLink id="9af6-3038-7a75-6423" name="Concussive" hidden="false" targetId="9d85-46f7-f5e6-a5f7" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
               <entryLinks>
                 <entryLink id="4f3b-ed60-93fd-65e1" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="6026-d507-935a-7200" type="selectionEntry"/>
                 <entryLink id="673d-762a-5539-2175" name="Hand Flamer" hidden="false" collective="false" import="true" targetId="5eb2-7950-9270-ceb5" type="selectionEntry">
@@ -11192,11 +11452,29 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                     <cost name="pts" typeId="points" value="15.0"/>
                   </costs>
                 </entryLink>
+                <entryLink id="d1a7-372f-3422-8580" name="Inferno Pistol" hidden="false" collective="false" import="true" targetId="e851-30d5-6ac4-a213" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="15.0"/>
+                  </costs>
+                </entryLink>
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="b7b2-c071-101d-3fbd" name="Melee Weapon Options (Select 1)" hidden="false" collective="false" import="true">
               <selectionEntries>
                 <selectionEntry id="1caf-6535-71b3-b268" name="Heavy Chainsword" hidden="false" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="af34-c67e-eef6-024d" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="285c-a3f4-c732-9ff8" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="15662370-7d13-ed80-50aa-02aa0368c309" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5c8d-0ac9-9ac5-2b29" type="max"/>
                   </constraints>
@@ -11206,6 +11484,133 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="111b-4007-1a7d-6572" name="Charnabal Broadsword" hidden="true" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="af34-c67e-eef6-024d" type="equalTo"/>
+                            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="74c0-fb49-35d8-28ac" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="285c-a3f4-c732-9ff8" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="97e2-6b7b-0389-ce50" type="max"/>
+                  </constraints>
+                  <profiles>
+                    <profile id="896a-68ba-27c9-072b" name="Charnabal Broadsword" publicationId="839b6f2a--pubN94234" page="35" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+                      <characteristics>
+                        <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
+                        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">1</characteristic>
+                        <characteristic name="AP" typeId="415023232344415441232323">5</characteristic>
+                        <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Rending, Two-handed, Duellist&apos;s Edge</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <infoLinks>
+                    <infoLink id="ad6b-c238-1139-ae9d" name="Rending" hidden="false" targetId="8269-2cd6-9236-16e7" type="rule"/>
+                    <infoLink id="f943-7010-639a-8e6a" name="Two-Handed" hidden="false" targetId="b11c-0ef4-af6b-d96f" type="rule"/>
+                    <infoLink id="7330-0999-d816-f068" name="Duelist&apos;s Edge" hidden="false" targetId="1a79-befa-05cf-ab0d" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="9008-3785-87b9-74bb" name="Nostraman Chainglaive" hidden="true" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="285c-a3f4-c732-9ff8" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="af34-c67e-eef6-024d" type="equalTo"/>
+                            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cf56-aabc-9977-728d" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                  <infoLinks>
+                    <infoLink id="e795-66b4-5e51-b192" name="Nostraman Chainglaive" hidden="false" targetId="422beb22-1aef-aba9-7c68-7ba770c48584" type="profile"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="44d0-df45-b2c5-1d60" name="Axe-rake" hidden="false" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="edd3-79ac-eb75-34b7" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <profiles>
+                    <profile id="0e77-d8ee-f582-7dd2" name="Axe-rake" publicationId="839b6f2a--pubN94234" page="75" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+                      <modifiers>
+                        <modifier type="set" field="415023232344415441232323" value="3">
+                          <conditions>
+                            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="dace-8f0f-e696-8179" type="equalTo"/>
+                          </conditions>
+                        </modifier>
+                      </modifiers>
+                      <characteristics>
+                        <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
+                        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">+1</characteristic>
+                        <characteristic name="AP" typeId="415023232344415441232323">6</characteristic>
+                        <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Grapple</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <rules>
+                    <rule id="d028-79f8-5e1c-61b6" name="Grapple" publicationId="839b6f2a--pubN94234" page="75" hidden="false">
+                      <modifiers>
+                        <modifier type="set" field="description" value="A model equipped with a weapon with this special rule adds +1 to their Initiative for the purpose of making Sweeping Advances.">
+                          <conditions>
+                            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="dace-8f0f-e696-8179" type="equalTo"/>
+                          </conditions>
+                        </modifier>
+                      </modifiers>
+                      <description>Enemies attempting to fall back after losing an assault suffer -1 penalty.</description>
+                    </rule>
+                  </rules>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="ccc0-6519-9285-833f" name="Halo Blade" hidden="false" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbf2-d8be-0406-b8d6" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1134-f329-4681-3f79" type="max"/>
+                  </constraints>
+                  <profiles>
+                    <profile id="0930-44c9-23c3-6cbd" name="Halo Blade" publicationId="ca571888--pubN89821" page="225" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+                      <characteristics>
+                        <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
+                        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">3</characteristic>
+                        <characteristic name="AP" typeId="415023232344415441232323">3</characteristic>
+                        <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Specialist Weapon, Two-handed</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <infoLinks>
+                    <infoLink id="dd7c-e5b9-f12e-1934" name="Specialist Weapon" hidden="false" targetId="7ee3-d437-bc44-3630" type="rule"/>
+                    <infoLink id="be6c-2ee9-a083-f67a" name="Two-Handed" hidden="false" targetId="b11c-0ef4-af6b-d96f" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="25.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -11338,7 +11743,7 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                     </modifier>
                   </modifiers>
                   <costs>
-                    <cost name="pts" typeId="points" value="20.0"/>
+                    <cost name="pts" typeId="points" value="15.0"/>
                   </costs>
                 </entryLink>
                 <entryLink id="06b6-3968-1b16-998a" name="Cthonian Culling Blade" hidden="false" collective="false" import="true" targetId="e3f4-e57f-f343-a42a" type="selectionEntry">
@@ -11358,7 +11763,7 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                     </modifier>
                   </modifiers>
                   <costs>
-                    <cost name="pts" typeId="points" value="20.0"/>
+                    <cost name="pts" typeId="points" value="15.0"/>
                   </costs>
                 </entryLink>
                 <entryLink id="4f9e-1cb1-25d7-874b" name="Terranic Greatsword" hidden="false" collective="false" import="true" targetId="4cf4-a0ff-a71f-3666" type="selectionEntry">
@@ -11373,6 +11778,7 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                             <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="75c9-e5dd-17e0-c27e" type="equalTo"/>
                             <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="631d-c6b6-1f7d-a4b7" type="equalTo"/>
                             <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="af34-c67e-eef6-024d" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="285c-a3f4-c732-9ff8" type="equalTo"/>
                           </conditions>
                         </conditionGroup>
                       </conditionGroups>
@@ -11380,6 +11786,998 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                   </modifiers>
                   <costs>
                     <cost name="pts" typeId="points" value="20.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="0de7-2efc-98dc-0511" name="Phoenix Spear" hidden="false" collective="false" import="true" targetId="30834ca2-20b0-cb5a-c7db-f76092533a64" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c94-33f2-87e2-3fd0" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="aabc-93f7-1ae0-6bfe" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a2d0-d202-f0ce-d081" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="75c9-e5dd-17e0-c27e" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="631d-c6b6-1f7d-a4b7" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="af34-c67e-eef6-024d" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="285c-a3f4-c732-9ff8" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                  <costs>
+                    <cost name="pts" typeId="points" value="20.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="f788-ddf1-1014-d725" name="Power Glaive" hidden="false" collective="false" import="true" targetId="2767-2afe-31ac-5cca" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="285c-a3f4-c732-9ff8" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="af34-c67e-eef6-024d" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                  <costs>
+                    <cost name="pts" typeId="points" value="20.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="98ae-73ca-8340-666d" name="Frost Axe" hidden="false" collective="false" import="true" targetId="5a40-b58d-ed9b-62cd" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="15.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="61fc-174f-d2a4-91f4" name="Frost Blade" hidden="false" collective="false" import="true" targetId="6e02-488e-39f9-47b4" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="d48f-5a2d-5516-20a4" name="Frost Claw" hidden="false" collective="false" import="true" targetId="63ef-e326-2f90-961d" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="20.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="1cc2-dd74-4c2a-90d7" name="Frost Maul" hidden="false" collective="false" import="true" targetId="9543-d500-7629-8cc9" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="25c9-9107-fa2c-ad08" name="Great Frost Blade" hidden="false" collective="false" import="true" targetId="00fc-86df-116d-d3de" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="25.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="322f-0177-8461-df88" name="Solarite Power Gauntlet" hidden="false" collective="false" import="true" targetId="9756-a335-ec78-d580" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c94-33f2-87e2-3fd0" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a2d0-d202-f0ce-d081" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="aabc-93f7-1ae0-6bfe" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                  <costs>
+                    <cost name="pts" typeId="points" value="30.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="2997-8290-3437-0f06" name="Nostraman Chainglaive" hidden="false" collective="false" import="true" targetId="c31253d0-d1b9-35ac-6435-f1a06611e356" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="15.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="4790-110b-a66a-85e1" name="Blade of Perdition" hidden="false" collective="false" import="true" targetId="e5be-2b36-334f-e2e8" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a2d0-d202-f0ce-d081" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="631d-c6b6-1f7d-a4b7" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="aabc-93f7-1ae0-6bfe" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="75c9-e5dd-17e0-c27e" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c94-33f2-87e2-3fd0" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="af34-c67e-eef6-024d" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                  <costs>
+                    <cost name="pts" typeId="points" value="30.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="19ba-743e-b7b9-3f6b" name="Chainaxe" hidden="false" collective="false" import="true" targetId="a3a3-3a90-0c2a-cd81" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="points" value="0.0">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a511-1645-ac77-af33" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cf2e-9aed-ccc5-5696" type="equalTo"/>
+                            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a511-1645-ac77-af33" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="0e5e-083f-62c8-49bd" name="Barb-hook Lash" hidden="false" collective="false" import="true" targetId="ca97e7b7-6f10-cd1c-17be-8d56aa708770" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a511-1645-ac77-af33" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="174f-557e-087e-c048" name="Excoriator Chainaxe" hidden="false" collective="false" import="true" targetId="c668914a-edb4-6b51-13b1-b1b4542eed6f" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a511-1645-ac77-af33" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="af34-c67e-eef6-024d" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="285c-a3f4-c732-9ff8" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="51ba-7d1f-28aa-a1c3" name="Meteor Hammer" hidden="false" collective="false" import="true" targetId="19aadb8a-b814-c2c0-0198-223c038c1950" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a511-1645-ac77-af33" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="af34-c67e-eef6-024d" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="285c-a3f4-c732-9ff8" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="830d-8b34-41cb-e81e" name="Twin Falax Blades" hidden="false" collective="false" import="true" targetId="4b74a48f-4b50-01c0-53b2-f88c01fc0306" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a511-1645-ac77-af33" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="82a8-16f1-899f-81b5" name="Legatine Axe" hidden="false" collective="false" import="true" targetId="f2b4-83cd-492c-d495" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="25.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="18c5-f58e-7572-bc9f" name="Power Scythe" hidden="false" collective="false" import="true" targetId="479f576b-b28d-801e-b928-d82431d554b9" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a2d0-d202-f0ce-d081" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="631d-c6b6-1f7d-a4b7" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="aabc-93f7-1ae0-6bfe" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="75c9-e5dd-17e0-c27e" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c94-33f2-87e2-3fd0" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="af34-c67e-eef6-024d" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                  <costs>
+                    <cost name="pts" typeId="points" value="20.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="654f-adce-1aa2-dae5" name="Tainted Weapon" hidden="false" collective="false" import="true" targetId="2acd15a3-57b3-6c4e-1199-0fa706a5b3d8" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="8acb-b45a-1858-1d5a" name="Raven&apos;s Talons" hidden="false" collective="false" import="true" targetId="6435afdc-d8b1-09a1-a82a-9d4d7af1c869" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c94-33f2-87e2-3fd0" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a2d0-d202-f0ce-d081" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="aabc-93f7-1ae0-6bfe" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                  <costs>
+                    <cost name="pts" typeId="points" value="25.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="cbff-0bff-a3f9-427c" name="Legion Ammo" hidden="false" collective="false" import="true">
+              <selectionEntries>
+                <selectionEntry id="445e-d91b-7b12-688f" name="Iron Warriors: Shrapnel Bolts - Custom Char (All Bolt Weapons)" hidden="false" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="74c0-fb49-35d8-28ac" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7aa0-cfd4-fcea-6785" type="max"/>
+                  </constraints>
+                  <rules>
+                    <rule id="6d64-09ae-e3b7-3481" name="Shrapnel Bolts" publicationId="839b6f2a--pubN94234" page="81" hidden="false">
+                      <description>All Bolt Weapons carried by this custom character gain Pinning and reduce AP value to 5.</description>
+                    </rule>
+                  </rules>
+                  <infoLinks>
+                    <infoLink id="8427-b32a-25bf-a480" name="Pinning" hidden="false" targetId="f624-f475-e5ec-0dfa" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="2383-f247-c2e6-fdda" name="Molecular Acid Shells" hidden="true" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e6fb-0e54-0be1-9ed1" type="equalTo"/>
+                          </conditions>
+                          <conditionGroups>
+                            <conditionGroup type="or">
+                              <conditions>
+                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5baa-7812-3569-ed65" type="equalTo"/>
+                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a161-76b3-9ef1-da7b" type="equalTo"/>
+                              </conditions>
+                            </conditionGroup>
+                          </conditionGroups>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="65dc-9826-6c6d-ba65" type="max"/>
+                  </constraints>
+                  <profiles>
+                    <profile id="4c48-e41c-9876-0509" name="Molecular acid shells" publicationId="ca571888--pubN89821" page="267" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+                      <characteristics>
+                        <characteristic name="Range" typeId="52616e676523232344415441232323">36&quot;</characteristic>
+                        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">2</characteristic>
+                        <characteristic name="AP" typeId="415023232344415441232323">D6</characteristic>
+                        <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 3, Poison (2)</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <entryLinks>
+                <entryLink id="d392-ad5e-f0a7-5fb8" name="Alpha Legion: Banestrike" hidden="false" collective="false" import="true" targetId="ba94-773c-bf08-b5a7" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a6cc-561c-56f9-a051" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3afd-ac93-1a99-4de9" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="84ea-ada4-abe0-f064" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7fec-f66c-6e16-496c" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="b82d-b594-9379-e883" name="Blood Angels: Hammer Bolts" hidden="false" collective="false" import="true" targetId="b3ba-3185-8a11-19fc" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0a9-a794-02a1-ff48" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bd39-70f8-0bf1-ee2b" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d533-1276-39ec-2ba4" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e4e8-96ed-f463-3639" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ebbf-7ab7-06c5-e830" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bf07-7189-7297-52b2" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="95c8-bc8c-fda3-1ac3" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="56f3-894c-80e1-ba8b" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="90e4-6253-a964-4f46" name="Dark Angels: Acid Bolts" hidden="false" collective="false" import="true" targetId="c06d-81b7-4e3b-1db6" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="99e4-7895-2ea5-0de8" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="cbc1-5298-1ef7-fd0a" name="Death Guard: Toxin Bolts" hidden="false" collective="false" import="true" targetId="608e-55e6-821d-4587" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditionGroups>
+                            <conditionGroup type="or">
+                              <conditions>
+                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a6cc-561c-56f9-a051" type="equalTo"/>
+                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3afd-ac93-1a99-4de9" type="equalTo"/>
+                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="84ea-ada4-abe0-f064" type="equalTo"/>
+                              </conditions>
+                            </conditionGroup>
+                            <conditionGroup type="and">
+                              <conditions>
+                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0a9-a794-02a1-ff48" type="equalTo"/>
+                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bd39-70f8-0bf1-ee2b" type="equalTo"/>
+                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d533-1276-39ec-2ba4" type="equalTo"/>
+                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e4e8-96ed-f463-3639" type="equalTo"/>
+                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ebbf-7ab7-06c5-e830" type="equalTo"/>
+                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bf07-7189-7297-52b2" type="equalTo"/>
+                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="95c8-bc8c-fda3-1ac3" type="equalTo"/>
+                              </conditions>
+                            </conditionGroup>
+                          </conditionGroups>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1be6-b2f0-08df-0059" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="bfe5-be1d-559e-9782" name="Emperors Children: Rapture Bolts" hidden="false" collective="false" import="true" targetId="3681-f734-e12c-8ce4" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eeb4-7484-c6c2-d3de" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="2e70-6332-1a78-fb1e" name="Imperial Fists: Artisan Bolts" hidden="false" collective="false" import="true" targetId="3e8b-910f-a654-3ca7" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0a9-a794-02a1-ff48" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bd39-70f8-0bf1-ee2b" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d533-1276-39ec-2ba4" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e4e8-96ed-f463-3639" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ebbf-7ab7-06c5-e830" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bf07-7189-7297-52b2" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="95c8-bc8c-fda3-1ac3" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="50d6-da19-f64b-3e59" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="6369-e295-a1b3-7ac7" name="Iron Hands: Splinter Bolts" hidden="false" collective="false" import="true" targetId="70dc-bb19-6bf5-ade4" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditionGroups>
+                            <conditionGroup type="or">
+                              <conditions>
+                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a6cc-561c-56f9-a051" type="equalTo"/>
+                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3afd-ac93-1a99-4de9" type="equalTo"/>
+                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="84ea-ada4-abe0-f064" type="equalTo"/>
+                              </conditions>
+                            </conditionGroup>
+                            <conditionGroup type="and">
+                              <conditions>
+                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0a9-a794-02a1-ff48" type="equalTo"/>
+                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bd39-70f8-0bf1-ee2b" type="equalTo"/>
+                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d533-1276-39ec-2ba4" type="equalTo"/>
+                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e4e8-96ed-f463-3639" type="equalTo"/>
+                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ebbf-7ab7-06c5-e830" type="equalTo"/>
+                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bf07-7189-7297-52b2" type="equalTo"/>
+                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="95c8-bc8c-fda3-1ac3" type="equalTo"/>
+                              </conditions>
+                            </conditionGroup>
+                          </conditionGroups>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6fd2-ecb5-1058-26a5" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="74e8-695d-cc2b-8ba3" name="Night Lords: Kraken Light Bolts" hidden="false" collective="false" import="true" targetId="1b8b-372e-f757-d474" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0a9-a794-02a1-ff48" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bd39-70f8-0bf1-ee2b" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d533-1276-39ec-2ba4" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e4e8-96ed-f463-3639" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ebbf-7ab7-06c5-e830" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bf07-7189-7297-52b2" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="95c8-bc8c-fda3-1ac3" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a3c3-c4a0-2c92-7068" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="4e35-197e-2f8f-8fae" name="Raven Guard: Scorpius Light" hidden="false" collective="false" import="true" targetId="422a-7ab4-ff43-7e2d" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0a9-a794-02a1-ff48" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bd39-70f8-0bf1-ee2b" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d533-1276-39ec-2ba4" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e4e8-96ed-f463-3639" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ebbf-7ab7-06c5-e830" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bf07-7189-7297-52b2" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="95c8-bc8c-fda3-1ac3" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3b1e-ac58-a1b0-9fa6" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="8d7b-675b-116d-c1e8" name="Salamanders: Pyre bolts" hidden="false" collective="false" import="true" targetId="9a57-8f0b-966b-4797" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0a9-a794-02a1-ff48" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bd39-70f8-0bf1-ee2b" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d533-1276-39ec-2ba4" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e4e8-96ed-f463-3639" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ebbf-7ab7-06c5-e830" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bf07-7189-7297-52b2" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="95c8-bc8c-fda3-1ac3" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="92b5-0255-a343-fe5c" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="5d4e-64e3-55ae-6bc3" name="Sons of Horus: Banestrike" hidden="false" collective="false" import="true" targetId="413e-0bb7-815e-c3be" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0a9-a794-02a1-ff48" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bd39-70f8-0bf1-ee2b" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d533-1276-39ec-2ba4" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e4e8-96ed-f463-3639" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ebbf-7ab7-06c5-e830" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bf07-7189-7297-52b2" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="95c8-bc8c-fda3-1ac3" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9d56-b690-4852-e92f" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="14a8-7ca3-9cc7-334f" name="Thousand Sons: Asphyx Light Shells" hidden="false" collective="false" import="true" targetId="63f3-9b22-bb21-7f18" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditionGroups>
+                            <conditionGroup type="or">
+                              <conditions>
+                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a6cc-561c-56f9-a051" type="equalTo"/>
+                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3afd-ac93-1a99-4de9" type="equalTo"/>
+                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="84ea-ada4-abe0-f064" type="equalTo"/>
+                              </conditions>
+                            </conditionGroup>
+                            <conditionGroup type="and">
+                              <conditions>
+                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0a9-a794-02a1-ff48" type="equalTo"/>
+                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bd39-70f8-0bf1-ee2b" type="equalTo"/>
+                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d533-1276-39ec-2ba4" type="equalTo"/>
+                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e4e8-96ed-f463-3639" type="equalTo"/>
+                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ebbf-7ab7-06c5-e830" type="equalTo"/>
+                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bf07-7189-7297-52b2" type="equalTo"/>
+                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="95c8-bc8c-fda3-1ac3" type="equalTo"/>
+                              </conditions>
+                            </conditionGroup>
+                          </conditionGroups>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5121-efcf-79fd-cdd4" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="bb56-505a-af44-f11f" name="Ultramarines: Banestrike" hidden="false" collective="false" import="true" targetId="7f11-e52c-6719-a716" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0a9-a794-02a1-ff48" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bd39-70f8-0bf1-ee2b" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d533-1276-39ec-2ba4" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e4e8-96ed-f463-3639" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ebbf-7ab7-06c5-e830" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bf07-7189-7297-52b2" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="95c8-bc8c-fda3-1ac3" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="80cd-5471-6019-c8c3" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="edeb-f5d7-1feb-7cb2" name="White Scars: Hyper Velocity Bolts" hidden="false" collective="false" import="true" targetId="d3fe-f8d5-271f-8fdc" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditionGroups>
+                            <conditionGroup type="or">
+                              <conditions>
+                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a6cc-561c-56f9-a051" type="equalTo"/>
+                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3afd-ac93-1a99-4de9" type="equalTo"/>
+                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="84ea-ada4-abe0-f064" type="equalTo"/>
+                              </conditions>
+                            </conditionGroup>
+                            <conditionGroup type="and">
+                              <conditions>
+                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0a9-a794-02a1-ff48" type="equalTo"/>
+                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bd39-70f8-0bf1-ee2b" type="equalTo"/>
+                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d533-1276-39ec-2ba4" type="equalTo"/>
+                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e4e8-96ed-f463-3639" type="equalTo"/>
+                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ebbf-7ab7-06c5-e830" type="equalTo"/>
+                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bf07-7189-7297-52b2" type="equalTo"/>
+                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="95c8-bc8c-fda3-1ac3" type="equalTo"/>
+                              </conditions>
+                            </conditionGroup>
+                          </conditionGroups>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b16c-70f5-73c6-ff24" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="8a48-7ae2-f0c5-8119" name="Word Bearers: Hex-bolts" hidden="false" collective="false" import="true" targetId="e63d-3a4b-c2d9-6d0f" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="94e2-c591-2882-e84c" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="9988-cfe3-c751-d0e0" name="Stasis Shells (grenade launcher)" hidden="true" collective="false" import="true" targetId="f118-45b2-9b94-d7f3" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e6fb-0e54-0be1-9ed1" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e4e8-96ed-f463-3639" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="073e-74a4-882c-7c36" name="Chem-munitions" hidden="false" collective="false" import="true" targetId="86e70545-ed1a-7cf4-5a3d-d60662a6b3be" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="points" value="0.0"/>
+                  </modifiers>
+                </entryLink>
+                <entryLink id="4448-59f1-f43e-f769" name="Asphyx Shells" hidden="false" collective="false" import="true" targetId="1dd8-eef0-af1d-e067" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a406-45de-cccf-799a" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="de02-43fb-71c5-28d1" name="Archaeotech Pistol Ammo" hidden="false" collective="false" import="true">
+              <entryLinks>
+                <entryLink id="e58c-2355-ea72-0b5d" name="Manstopper Rounds (Indepentant Characters Only)" hidden="true" collective="false" import="true" targetId="0438-d18f-d8f7-a37f" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6d66-7dbf-a1fe-0398" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="281f-5224-336f-1fda" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2847-ad40-01df-9504" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="bbae-c8bb-86f3-eef0" name="Splintex rounds (Indepentant Characters Only)" hidden="true" collective="false" import="true" targetId="669a-f9b1-622f-1447" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6d66-7dbf-a1fe-0398" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="281f-5224-336f-1fda" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2104-4fba-d5b6-a1bc" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="5f85-79f9-2cf3-7fa9" name="Wargear" hidden="false" collective="false" import="true">
+              <selectionEntries>
+                <selectionEntry id="197c-a30c-b107-d542" name="Digital Lasers" hidden="true" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="74c0-fb49-35d8-28ac" type="greaterThan"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2c04-aa6b-b2ba-d266" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="1203-eed4-f09b-2c81" name="Cortex Controller" hidden="true" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="83c2-692c-6560-3d68" type="greaterThan"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7b57-e309-ea7e-4f7c" type="equalTo"/>
+                            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a5b8-cb5e-952f-3d3e" type="greaterThan"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0a8b-1f1b-6e82-2616" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="84c5-67d8-dff3-496c" name="Cortex Controller" hidden="false" collective="false" import="true" targetId="a4ee-573b-f9fd-0507" type="selectionEntry"/>
+                  </entryLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="15.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="5f3d-215c-61fd-3cd6" name="Mantle of the Elder Drake" hidden="true" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c29-e6cd-2167-ce90" type="greaterThan"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="94d2-bcc2-f284-9fff" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="50ea-0c23-0e6b-5d7f" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="aa12-d677-6b0e-8193" name="Mantle of the Elder Drake" hidden="false" targetId="959ff616-ce22-b9ee-1ee6-2496b305e880" type="profile"/>
+                    <infoLink id="4dd8-c6db-8137-cb24" name="Eternal Warrior" hidden="false" targetId="3e0b-be9f-b7eb-8c5e" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="20.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="dd0e-2191-5797-61c9" name="Sonic Shrieker" hidden="false" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="74c0-fb49-35d8-28ac" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1028-2936-b113-b7c1" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="6be3-2137-73b0-5653" name="Sonic Shrieker" hidden="false" targetId="580dd5a9-f85d-c9f3-eeff-e72d970ad9e5" type="profile"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="99e0-549f-d0a0-8c26" name="Teleportation Transponder" publicationId="839b6f2a--pubN94234" page="97" hidden="true" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditionGroups>
+                            <conditionGroup type="or">
+                              <conditions>
+                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b26e-ba33-ff55-3fd6" type="equalTo"/>
+                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ba6-dda6-d587-3da7" type="equalTo"/>
+                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="28d4-97c4-3355-1b98" type="equalTo"/>
+                              </conditions>
+                            </conditionGroup>
+                            <conditionGroup type="or">
+                              <conditions>
+                                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9f2f-6f6f-1978-5623" type="equalTo"/>
+                                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cf56-aabc-9977-728d" type="equalTo"/>
+                                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cf2e-9aed-ccc5-5696" type="equalTo"/>
+                              </conditions>
+                            </conditionGroup>
+                          </conditionGroups>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="469a-e956-e4f6-1faa" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="7517-59e8-6285-8d01" name="Deep Strike" hidden="false" targetId="d219-2314-4834-c054" type="rule"/>
+                  </infoLinks>
+                  <categoryLinks>
+                    <categoryLink id="6eea-fd88-8cc3-205e" name="Deep Strike" hidden="false" targetId="2d6f-e613-ab10-e55a" primary="false"/>
+                  </categoryLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="01ca-3af7-a1c9-8f9a" name="Teleportation Transponders for Terminators Squads (Per Unit)" publicationId="839b6f2a--pubN94234" page="97" hidden="true" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cf2e-9aed-ccc5-5696" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="99e0-549f-d0a0-8c26" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                  <infoLinks>
+                    <infoLink id="7ff2-cd6e-916c-f518" name="Deep Strike" hidden="false" targetId="d219-2314-4834-c054" type="rule"/>
+                  </infoLinks>
+                  <categoryLinks>
+                    <categoryLink id="8398-ab1b-176f-4570" name="Deep Strike" hidden="false" targetId="2d6f-e613-ab10-e55a" primary="false"/>
+                  </categoryLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="15.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="0852-dd5c-f130-1555" name="Runic Matrix" hidden="true" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9f2f-6f6f-1978-5623" type="greaterThan"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f70f-92fd-ae0e-031a" type="equalTo"/>
+                          </conditions>
+                          <conditionGroups>
+                            <conditionGroup type="or">
+                              <conditions>
+                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b26e-ba33-ff55-3fd6" type="equalTo"/>
+                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ba6-dda6-d587-3da7" type="equalTo"/>
+                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="28d4-97c4-3355-1b98" type="equalTo"/>
+                              </conditions>
+                            </conditionGroup>
+                          </conditionGroups>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1f47-5ef9-aa9a-8f66" type="max"/>
+                  </constraints>
+                  <rules>
+                    <rule id="4c18-1e73-0be1-559c" name="Runic Matrix" hidden="false">
+                      <description>The Runic matrix allows the Psyker to re-roll a single Deny the Witch test per turn, but their controlling player may not utilise more than four Warp Charge dice to manifest any single use of a psychic power for a model equipped with a Runic matrix.</description>
+                    </rule>
+                  </rules>
+                  <costs>
+                    <cost name="pts" typeId="points" value="20.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <entryLinks>
+                <entryLink id="2ca5-99a4-5fef-ba02" name="Cyber-hawk" hidden="false" collective="false" import="true" targetId="3736-b417-3bbd-72a4" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="25.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="5b25-9ff6-5199-2d1b" name="Fenrisian Wolf" hidden="false" collective="false" import="true" targetId="80f2-5957-9f22-df1b" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cb47-a51a-9399-b049" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="64c8-6472-c2da-5f75" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="fafc-db32-7f43-f128" name="Cyber-familiar" hidden="false" collective="false" import="true" targetId="955bce92-a604-419f-0f2e-de6ce81af313" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="e987-1227-c4f2-fbc6" name="Nuncio-vox" hidden="false" collective="false" import="true" targetId="b4ea-a586-86a9-02eb" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="34fa-286c-521b-2899" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="f946-54b1-3be9-a1af" name="Arcane Litanies" hidden="false" collective="false" import="true" targetId="173c-8101-bdb9-1584" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ab74-5ebd-93e8-d743" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="f976-18d2-5fd0-04c2" name="Artificer Weapons" hidden="false" collective="false" import="true" targetId="927bb13b-06a2-ab05-743f-74b859c1eee2" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="d9c1-27b0-cc73-b6d6" name="Cameleoline" hidden="false" collective="false" import="true" targetId="0d86175b-00bf-8a27-6964-d6eec7f81169" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b26e-ba33-ff55-3fd6" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ba6-dda6-d587-3da7" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="28d4-97c4-3355-1b98" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a6cc-561c-56f9-a051" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3afd-ac93-1a99-4de9" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="84ea-ada4-abe0-f064" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="5c39-2fc8-1c2b-17dc" name="Infravisor" hidden="false" collective="false" import="true" targetId="4d465f07-675f-0f55-c8cb-ca43c5e2adba" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
                   </costs>
                 </entryLink>
               </entryLinks>
@@ -11401,6 +12799,9 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
               </modifiers>
             </entryLink>
           </entryLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -11600,63 +13001,6 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="e954-a474-cb44-9768" name="May Take:" hidden="false" collective="false" import="true">
-          <entryLinks>
-            <entryLink id="9b7c-86e9-6bfa-a862" name="Grenade Harness" hidden="true" collective="false" import="true" targetId="d054f965-5059-139b-029b-61b60c1af93d" type="selectionEntry">
-              <modifiers>
-                <modifier type="set" field="hidden" value="false">
-                  <conditionGroups>
-                    <conditionGroup type="or">
-                      <conditions>
-                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b26e-ba33-ff55-3fd6" type="equalTo"/>
-                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ba6-dda6-d587-3da7" type="equalTo"/>
-                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c904-7d1f-f3ce-d04b" type="equalTo"/>
-                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="28d4-97c4-3355-1b98" type="equalTo"/>
-                      </conditions>
-                    </conditionGroup>
-                  </conditionGroups>
-                </modifier>
-              </modifiers>
-              <costs>
-                <cost name="pts" typeId="points" value="5.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="4a41-4d56-6c08-2d8e" name="Manstopper Rounds (Indepentant Characters Only)" hidden="true" collective="false" import="true" targetId="0438-d18f-d8f7-a37f" type="selectionEntry">
-              <modifiers>
-                <modifier type="set" field="hidden" value="false">
-                  <conditionGroups>
-                    <conditionGroup type="and">
-                      <conditions>
-                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6d66-7dbf-a1fe-0398" type="equalTo"/>
-                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="281f-5224-336f-1fda" type="equalTo"/>
-                      </conditions>
-                    </conditionGroup>
-                  </conditionGroups>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e235-85d6-05d9-88e7" type="max"/>
-              </constraints>
-            </entryLink>
-            <entryLink id="de93-548c-7284-aefb" name="Splintex rounds (Indepentant Characters Only)" hidden="true" collective="false" import="true" targetId="669a-f9b1-622f-1447" type="selectionEntry">
-              <modifiers>
-                <modifier type="set" field="hidden" value="false">
-                  <conditionGroups>
-                    <conditionGroup type="and">
-                      <conditions>
-                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6d66-7dbf-a1fe-0398" type="equalTo"/>
-                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="281f-5224-336f-1fda" type="equalTo"/>
-                      </conditions>
-                    </conditionGroup>
-                  </conditionGroups>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9643-0611-f653-6ee6" type="max"/>
-              </constraints>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
         <selectionEntryGroup id="85cb-acb3-e445-7f58" name="Warlord Traits (0-1)" hidden="true" collective="false" import="true">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
@@ -11751,7 +13095,14 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                 </selectionEntry>
               </selectionEntries>
             </selectionEntryGroup>
-            <selectionEntryGroup id="a3b3-6cd7-a7dd-986f" name="Space Wolf Traits" hidden="false" collective="false" import="true">
+            <selectionEntryGroup id="a3b3-6cd7-a7dd-986f" name="Space Wolf Traits" hidden="true" collective="false" import="true">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <conditions>
+                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6b1a-361b-37cc-f1a6" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <selectionEntries>
                 <selectionEntry id="bb41-14ae-63db-1a62" name="Get of the Wyrm" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
@@ -12137,11 +13488,19 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
           </constraints>
           <selectionEntries>
             <selectionEntry id="d2a8-fe6d-b793-225b" name="Delegatus" hidden="false" collective="false" import="true" type="upgrade">
+              <modifiers>
+                <modifier type="add" field="category" value="a5b5-33d4-9941-d832">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c91-a83b-8ca5-e5db" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cbf3-c953-970b-bc62" type="max"/>
               </constraints>
               <categoryLinks>
                 <categoryLink id="be3a-2afc-f1ea-306b" name="Compulsory HQ" hidden="false" targetId="becd-7a6d-e80f-878e" primary="false"/>
+                <categoryLink id="59e6-8bc1-9cdd-37ae" name="Centurion or Delegatus" hidden="false" targetId="05c9-9e0d-c2e5-d62f" primary="false"/>
               </categoryLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -12237,6 +13596,7 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                   </constraints>
                   <categoryLinks>
                     <categoryLink id="dfc1-8e43-9e51-2704" name="Compulsory HQ" hidden="false" targetId="becd-7a6d-e80f-878e" primary="false"/>
+                    <categoryLink id="3787-5e0f-30c8-8b89" name="Wolf Lord/Claw Leader" hidden="false" targetId="a5b5-33d4-9941-d832" primary="false"/>
                   </categoryLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="0.0"/>
@@ -12255,6 +13615,7 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                   </constraints>
                   <categoryLinks>
                     <categoryLink id="3a16-67ad-9267-8ac7" name="Compulsory HQ" hidden="false" targetId="becd-7a6d-e80f-878e" primary="false"/>
+                    <categoryLink id="f769-9f42-4d2f-57ec" name="Wolf Lord/Claw Leader" hidden="false" targetId="a5b5-33d4-9941-d832" primary="false"/>
                   </categoryLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="0.0"/>
@@ -12425,8 +13786,16 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="aabc-93f7-1ae0-6bfe" name="Master of Signal*#" hidden="false" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="bc61-975a-8f22-dbfb" value="1.0">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0208-9207-7481-6ed1" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d496-3e4c-a42d-47df" type="max"/>
+                    <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bc61-975a-8f22-dbfb" type="min"/>
                   </constraints>
                   <categoryLinks>
                     <categoryLink id="6b3a-2e0f-07a6-d6c0" name="# Restiction" hidden="false" targetId="c821-d9f2-5684-64fa" primary="false"/>
@@ -12473,8 +13842,16 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="af34-c67e-eef6-024d" name="Herald*" hidden="false" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="5d34-3da5-6946-9840" value="1.0">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ae76-0da4-f0cd-2a24" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5ad4-e5f0-da0e-ded0" type="max"/>
+                    <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5d34-3da5-6946-9840" type="min"/>
                   </constraints>
                   <costs>
                     <cost name="pts" typeId="points" value="0.0"/>
@@ -12484,6 +13861,29 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d02e-ab38-daa9-4a8f" type="max"/>
                   </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="0ad9-c4ca-88be-afec" name="Centurion" hidden="true" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3907-f781-c7be-4fcb" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="add" field="category" value="a5b5-33d4-9941-d832">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c91-a83b-8ca5-e5db" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c53d-3a45-9f61-7746" type="max"/>
+                  </constraints>
+                  <categoryLinks>
+                    <categoryLink id="64eb-a9be-6599-a421" name="Centurion or Delegatus" hidden="false" targetId="05c9-9e0d-c2e5-d62f" primary="false"/>
+                  </categoryLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="0.0"/>
                   </costs>
@@ -12525,7 +13925,14 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
             <entryLink id="1430-f1b2-65dd-0eb7" name="Refractor Field" hidden="false" collective="false" import="true" targetId="40e37f6e-a984-4232-4dc4-807ed9028f62" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="cb47-a51a-9399-b049" name="Unit Type (0-1)" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="cb47-a51a-9399-b049" name="Mobility / Unit Type (0-1)" hidden="false" collective="false" import="true">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3aaa-366b-7265-5402" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2905-674d-d690-d7f8" type="max"/>
           </constraints>
@@ -12672,20 +14079,6 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
           </selectionEntries>
         </selectionEntryGroup>
         <selectionEntryGroup id="dcbf-c7f3-7217-68a1" name="Grenades (0+)" hidden="false" collective="false" import="true">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditionGroups>
-                <conditionGroup type="or">
-                  <conditions>
-                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b26e-ba33-ff55-3fd6" type="equalTo"/>
-                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ba6-dda6-d587-3da7" type="equalTo"/>
-                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c904-7d1f-f3ce-d04b" type="equalTo"/>
-                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="28d4-97c4-3355-1b98" type="equalTo"/>
-                  </conditions>
-                </conditionGroup>
-              </conditionGroups>
-            </modifier>
-          </modifiers>
           <selectionEntries>
             <selectionEntry id="6f39-b5d8-65e6-be42" name="Frag and Krak Grenades" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
@@ -12699,6 +14092,18 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                         <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4616-2173-0435-fd8a" type="equalTo"/>
                         <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7582-f288-ad5d-69b2" type="equalTo"/>
                         <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cb28-1750-23ab-be51" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+                <modifier type="set" field="hidden" value="true">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b26e-ba33-ff55-3fd6" type="equalTo"/>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ba6-dda6-d587-3da7" type="equalTo"/>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c904-7d1f-f3ce-d04b" type="equalTo"/>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="28d4-97c4-3355-1b98" type="equalTo"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
@@ -12718,20 +14123,138 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
+            <selectionEntry id="e576-ea66-2e8b-1370" name="Shroud Bombs" hidden="false" collective="false" import="true" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="09b8-26b3-b27d-621a" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="67a7-bda4-6e78-0e8e" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="ce6a-67c6-5243-b30d" name="Shroud Bomb" hidden="false" targetId="17f3-89d3-0f42-1c09" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="cbb7-6939-acc5-13b6" name="Rad Grenades" page="0" hidden="false" collective="false" import="true" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b66f-2c54-e1a3-57c7" type="equalTo"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3ff3-644e-6e21-bbc6" type="equalTo"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fdee-96d0-9948-daa1" type="equalTo"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cba6-2d9f-b041-e96e" type="equalTo"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbf2-d8be-0406-b8d6" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+                <modifier type="set" field="points" value="5.0">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3ff3-644e-6e21-bbc6" type="atLeast"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="dc6d-dbdd-d0cd-0d83" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="acd3-a79b-d15b-9ae6" name="Rad Grenades" hidden="false" targetId="6176-c8fa-7b50-26a2" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </selectionEntry>
           </selectionEntries>
           <entryLinks>
             <entryLink id="fe03-91c9-7917-05d1" name="Melta Bombs" hidden="false" collective="false" import="true" targetId="4c62-8983-4a1b-d1c6" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9311-3c42-349a-b51a" type="equalTo"/>
+                      </conditions>
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b26e-ba33-ff55-3fd6" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ba6-dda6-d587-3da7" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c904-7d1f-f3ce-d04b" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="28d4-97c4-3355-1b98" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
               </costs>
             </entryLink>
             <entryLink id="28fd-d410-51c5-51f4" name="Breaching Charge" hidden="false" collective="false" import="true" targetId="0267-083e-86de-3c0f" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b26e-ba33-ff55-3fd6" type="equalTo"/>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ba6-dda6-d587-3da7" type="equalTo"/>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c904-7d1f-f3ce-d04b" type="equalTo"/>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="28d4-97c4-3355-1b98" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e246-722b-3076-b1ae" type="max"/>
               </constraints>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
               </costs>
+            </entryLink>
+            <entryLink id="19bc-1c90-f2a0-19d7" name="Grenade Harness" hidden="true" collective="false" import="true" targetId="d054f965-5059-139b-029b-61b60c1af93d" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b26e-ba33-ff55-3fd6" type="equalTo"/>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ba6-dda6-d587-3da7" type="equalTo"/>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c904-7d1f-f3ce-d04b" type="equalTo"/>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="28d4-97c4-3355-1b98" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="f96d-1d3c-187c-9b10" name="Venom Spheres" hidden="false" collective="false" import="true" targetId="2ef05d79-5317-0bda-7758-44e83a42270b" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b26e-ba33-ff55-3fd6" type="equalTo"/>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ba6-dda6-d587-3da7" type="equalTo"/>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="28d4-97c4-3355-1b98" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
@@ -12818,418 +14341,6 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="98e0-1be6-78ff-f53f" name="Legion Ammo" hidden="false" collective="false" import="true">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditionGroups>
-                <conditionGroup type="and">
-                  <conditions>
-                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0a9-a794-02a1-ff48" type="equalTo"/>
-                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6026-d507-935a-7200" type="equalTo"/>
-                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bd39-70f8-0bf1-ee2b" type="equalTo"/>
-                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d533-1276-39ec-2ba4" type="equalTo"/>
-                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e4e8-96ed-f463-3639" type="equalTo"/>
-                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ebbf-7ab7-06c5-e830" type="equalTo"/>
-                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bf07-7189-7297-52b2" type="equalTo"/>
-                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="95c8-bc8c-fda3-1ac3" type="equalTo"/>
-                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="30c2c848-c1d3-e61f-6632-a91bcee1fdc4" type="equalTo"/>
-                  </conditions>
-                </conditionGroup>
-              </conditionGroups>
-            </modifier>
-          </modifiers>
-          <entryLinks>
-            <entryLink id="bb89-132e-839d-ff05" name="Alpha Legion: Banestrike" hidden="false" collective="false" import="true" targetId="ba94-773c-bf08-b5a7" type="selectionEntry">
-              <modifiers>
-                <modifier type="set" field="hidden" value="true">
-                  <conditionGroups>
-                    <conditionGroup type="or">
-                      <conditions>
-                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a6cc-561c-56f9-a051" type="equalTo"/>
-                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3afd-ac93-1a99-4de9" type="equalTo"/>
-                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="84ea-ada4-abe0-f064" type="equalTo"/>
-                      </conditions>
-                    </conditionGroup>
-                  </conditionGroups>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7892-5296-3732-834d" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="pts" typeId="points" value="5.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="d2ac-6091-02d9-68c5" name="Blood Angels: Hammer Bolts" hidden="false" collective="false" import="true" targetId="b3ba-3185-8a11-19fc" type="selectionEntry">
-              <modifiers>
-                <modifier type="set" field="hidden" value="true">
-                  <conditionGroups>
-                    <conditionGroup type="and">
-                      <conditions>
-                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0a9-a794-02a1-ff48" type="equalTo"/>
-                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bd39-70f8-0bf1-ee2b" type="equalTo"/>
-                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d533-1276-39ec-2ba4" type="equalTo"/>
-                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e4e8-96ed-f463-3639" type="equalTo"/>
-                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ebbf-7ab7-06c5-e830" type="equalTo"/>
-                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bf07-7189-7297-52b2" type="equalTo"/>
-                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="95c8-bc8c-fda3-1ac3" type="equalTo"/>
-                      </conditions>
-                    </conditionGroup>
-                  </conditionGroups>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1bbe-9a6c-384a-4a67" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="pts" typeId="points" value="5.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="a8d9-67ad-7374-b323" name="Dark Angels: Acid Bolts" hidden="false" collective="false" import="true" targetId="c06d-81b7-4e3b-1db6" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="25f9-4025-8ef4-b2bf" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="pts" typeId="points" value="5.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="144a-03d4-7c85-e7ab" name="Death Guard: Toxin Bolts" hidden="false" collective="false" import="true" targetId="608e-55e6-821d-4587" type="selectionEntry">
-              <modifiers>
-                <modifier type="set" field="hidden" value="true">
-                  <conditionGroups>
-                    <conditionGroup type="or">
-                      <conditionGroups>
-                        <conditionGroup type="or">
-                          <conditions>
-                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a6cc-561c-56f9-a051" type="equalTo"/>
-                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3afd-ac93-1a99-4de9" type="equalTo"/>
-                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="84ea-ada4-abe0-f064" type="equalTo"/>
-                          </conditions>
-                        </conditionGroup>
-                        <conditionGroup type="and">
-                          <conditions>
-                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0a9-a794-02a1-ff48" type="equalTo"/>
-                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bd39-70f8-0bf1-ee2b" type="equalTo"/>
-                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d533-1276-39ec-2ba4" type="equalTo"/>
-                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e4e8-96ed-f463-3639" type="equalTo"/>
-                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ebbf-7ab7-06c5-e830" type="equalTo"/>
-                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bf07-7189-7297-52b2" type="equalTo"/>
-                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="95c8-bc8c-fda3-1ac3" type="equalTo"/>
-                          </conditions>
-                        </conditionGroup>
-                      </conditionGroups>
-                    </conditionGroup>
-                  </conditionGroups>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="92b9-2ab2-9ed3-24cc" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="pts" typeId="points" value="5.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="56d0-bbe2-0a40-ae23" name="Emperors Children: Rapture Bolts" hidden="false" collective="false" import="true" targetId="3681-f734-e12c-8ce4" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2382-d589-fae5-4cbb" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="pts" typeId="points" value="5.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="f829-fdad-fa64-5ac0" name="Imperial Fists: Artisan Bolts" hidden="false" collective="false" import="true" targetId="3e8b-910f-a654-3ca7" type="selectionEntry">
-              <modifiers>
-                <modifier type="set" field="hidden" value="true">
-                  <conditionGroups>
-                    <conditionGroup type="and">
-                      <conditions>
-                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0a9-a794-02a1-ff48" type="equalTo"/>
-                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bd39-70f8-0bf1-ee2b" type="equalTo"/>
-                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d533-1276-39ec-2ba4" type="equalTo"/>
-                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e4e8-96ed-f463-3639" type="equalTo"/>
-                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ebbf-7ab7-06c5-e830" type="equalTo"/>
-                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bf07-7189-7297-52b2" type="equalTo"/>
-                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="95c8-bc8c-fda3-1ac3" type="equalTo"/>
-                      </conditions>
-                    </conditionGroup>
-                  </conditionGroups>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9fcc-d630-324e-2b65" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="pts" typeId="points" value="5.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="3dc6-668f-78f7-9c64" name="Iron Hands: Splinter Bolts" hidden="false" collective="false" import="true" targetId="70dc-bb19-6bf5-ade4" type="selectionEntry">
-              <modifiers>
-                <modifier type="set" field="hidden" value="true">
-                  <conditionGroups>
-                    <conditionGroup type="or">
-                      <conditionGroups>
-                        <conditionGroup type="or">
-                          <conditions>
-                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a6cc-561c-56f9-a051" type="equalTo"/>
-                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3afd-ac93-1a99-4de9" type="equalTo"/>
-                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="84ea-ada4-abe0-f064" type="equalTo"/>
-                          </conditions>
-                        </conditionGroup>
-                        <conditionGroup type="and">
-                          <conditions>
-                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0a9-a794-02a1-ff48" type="equalTo"/>
-                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bd39-70f8-0bf1-ee2b" type="equalTo"/>
-                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d533-1276-39ec-2ba4" type="equalTo"/>
-                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e4e8-96ed-f463-3639" type="equalTo"/>
-                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ebbf-7ab7-06c5-e830" type="equalTo"/>
-                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bf07-7189-7297-52b2" type="equalTo"/>
-                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="95c8-bc8c-fda3-1ac3" type="equalTo"/>
-                          </conditions>
-                        </conditionGroup>
-                      </conditionGroups>
-                    </conditionGroup>
-                  </conditionGroups>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6553-919f-911b-00cd" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="pts" typeId="points" value="5.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="5632-0772-3384-bff8" name="Iron Warriors: Shrapnel Bolts" hidden="false" collective="false" import="true" targetId="1f83-fc1b-6a63-d1c4" type="selectionEntry">
-              <modifiers>
-                <modifier type="set" field="hidden" value="true">
-                  <conditionGroups>
-                    <conditionGroup type="and">
-                      <conditions>
-                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0a9-a794-02a1-ff48" type="equalTo"/>
-                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bd39-70f8-0bf1-ee2b" type="equalTo"/>
-                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d533-1276-39ec-2ba4" type="equalTo"/>
-                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e4e8-96ed-f463-3639" type="equalTo"/>
-                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ebbf-7ab7-06c5-e830" type="equalTo"/>
-                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bf07-7189-7297-52b2" type="equalTo"/>
-                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="95c8-bc8c-fda3-1ac3" type="equalTo"/>
-                      </conditions>
-                    </conditionGroup>
-                  </conditionGroups>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e8bd-6679-565d-564f" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="pts" typeId="points" value="5.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="1962-54c9-5c3f-4233" name="Night Lords: Kraken Light Bolts" hidden="false" collective="false" import="true" targetId="1b8b-372e-f757-d474" type="selectionEntry">
-              <modifiers>
-                <modifier type="set" field="hidden" value="true">
-                  <conditionGroups>
-                    <conditionGroup type="and">
-                      <conditions>
-                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0a9-a794-02a1-ff48" type="equalTo"/>
-                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bd39-70f8-0bf1-ee2b" type="equalTo"/>
-                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d533-1276-39ec-2ba4" type="equalTo"/>
-                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e4e8-96ed-f463-3639" type="equalTo"/>
-                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ebbf-7ab7-06c5-e830" type="equalTo"/>
-                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bf07-7189-7297-52b2" type="equalTo"/>
-                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="95c8-bc8c-fda3-1ac3" type="equalTo"/>
-                      </conditions>
-                    </conditionGroup>
-                  </conditionGroups>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="02ba-d791-4a3c-aa2a" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="pts" typeId="points" value="5.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="bc23-ff49-1bbf-65ba" name="Raven Guard: Scorpius Light" hidden="false" collective="false" import="true" targetId="422a-7ab4-ff43-7e2d" type="selectionEntry">
-              <modifiers>
-                <modifier type="set" field="hidden" value="true">
-                  <conditionGroups>
-                    <conditionGroup type="and">
-                      <conditions>
-                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0a9-a794-02a1-ff48" type="equalTo"/>
-                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bd39-70f8-0bf1-ee2b" type="equalTo"/>
-                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d533-1276-39ec-2ba4" type="equalTo"/>
-                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e4e8-96ed-f463-3639" type="equalTo"/>
-                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ebbf-7ab7-06c5-e830" type="equalTo"/>
-                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bf07-7189-7297-52b2" type="equalTo"/>
-                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="95c8-bc8c-fda3-1ac3" type="equalTo"/>
-                      </conditions>
-                    </conditionGroup>
-                  </conditionGroups>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b918-3a99-a77f-fd4f" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="pts" typeId="points" value="5.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="913e-ed65-f69c-9674" name="Salamanders: Pyre bolts" hidden="false" collective="false" import="true" targetId="9a57-8f0b-966b-4797" type="selectionEntry">
-              <modifiers>
-                <modifier type="set" field="hidden" value="true">
-                  <conditionGroups>
-                    <conditionGroup type="and">
-                      <conditions>
-                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0a9-a794-02a1-ff48" type="equalTo"/>
-                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bd39-70f8-0bf1-ee2b" type="equalTo"/>
-                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d533-1276-39ec-2ba4" type="equalTo"/>
-                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e4e8-96ed-f463-3639" type="equalTo"/>
-                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ebbf-7ab7-06c5-e830" type="equalTo"/>
-                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bf07-7189-7297-52b2" type="equalTo"/>
-                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="95c8-bc8c-fda3-1ac3" type="equalTo"/>
-                      </conditions>
-                    </conditionGroup>
-                  </conditionGroups>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="192c-e2d1-b4ed-2756" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="pts" typeId="points" value="5.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="0ff3-9fd7-f7e5-0e73" name="Sons of Horus: Banestrike" hidden="false" collective="false" import="true" targetId="413e-0bb7-815e-c3be" type="selectionEntry">
-              <modifiers>
-                <modifier type="set" field="hidden" value="true">
-                  <conditionGroups>
-                    <conditionGroup type="and">
-                      <conditions>
-                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0a9-a794-02a1-ff48" type="equalTo"/>
-                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bd39-70f8-0bf1-ee2b" type="equalTo"/>
-                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d533-1276-39ec-2ba4" type="equalTo"/>
-                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e4e8-96ed-f463-3639" type="equalTo"/>
-                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ebbf-7ab7-06c5-e830" type="equalTo"/>
-                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bf07-7189-7297-52b2" type="equalTo"/>
-                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="95c8-bc8c-fda3-1ac3" type="equalTo"/>
-                      </conditions>
-                    </conditionGroup>
-                  </conditionGroups>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1eb3-b2c2-8425-993f" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="pts" typeId="points" value="5.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="ca03-60e9-38a2-db5e" name="Thousand Sons: Asphyx Light Shells" hidden="false" collective="false" import="true" targetId="63f3-9b22-bb21-7f18" type="selectionEntry">
-              <modifiers>
-                <modifier type="set" field="hidden" value="true">
-                  <conditionGroups>
-                    <conditionGroup type="or">
-                      <conditionGroups>
-                        <conditionGroup type="or">
-                          <conditions>
-                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a6cc-561c-56f9-a051" type="equalTo"/>
-                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3afd-ac93-1a99-4de9" type="equalTo"/>
-                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="84ea-ada4-abe0-f064" type="equalTo"/>
-                          </conditions>
-                        </conditionGroup>
-                        <conditionGroup type="and">
-                          <conditions>
-                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0a9-a794-02a1-ff48" type="equalTo"/>
-                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bd39-70f8-0bf1-ee2b" type="equalTo"/>
-                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d533-1276-39ec-2ba4" type="equalTo"/>
-                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e4e8-96ed-f463-3639" type="equalTo"/>
-                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ebbf-7ab7-06c5-e830" type="equalTo"/>
-                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bf07-7189-7297-52b2" type="equalTo"/>
-                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="95c8-bc8c-fda3-1ac3" type="equalTo"/>
-                          </conditions>
-                        </conditionGroup>
-                      </conditionGroups>
-                    </conditionGroup>
-                  </conditionGroups>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a173-b325-ef4d-f86b" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="pts" typeId="points" value="5.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="cd89-2739-eb3a-96cb" name="Ultramarines: Banestrike" hidden="false" collective="false" import="true" targetId="7f11-e52c-6719-a716" type="selectionEntry">
-              <modifiers>
-                <modifier type="set" field="hidden" value="true">
-                  <conditionGroups>
-                    <conditionGroup type="and">
-                      <conditions>
-                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0a9-a794-02a1-ff48" type="equalTo"/>
-                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bd39-70f8-0bf1-ee2b" type="equalTo"/>
-                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d533-1276-39ec-2ba4" type="equalTo"/>
-                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e4e8-96ed-f463-3639" type="equalTo"/>
-                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ebbf-7ab7-06c5-e830" type="equalTo"/>
-                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bf07-7189-7297-52b2" type="equalTo"/>
-                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="95c8-bc8c-fda3-1ac3" type="equalTo"/>
-                      </conditions>
-                    </conditionGroup>
-                  </conditionGroups>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e126-7c15-c583-6eb3" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="pts" typeId="points" value="5.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="7cf4-4586-26b6-cf0a" name="White Scars: Hyper Velocity Bolts" hidden="false" collective="false" import="true" targetId="d3fe-f8d5-271f-8fdc" type="selectionEntry">
-              <modifiers>
-                <modifier type="set" field="hidden" value="true">
-                  <conditionGroups>
-                    <conditionGroup type="or">
-                      <conditionGroups>
-                        <conditionGroup type="or">
-                          <conditions>
-                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a6cc-561c-56f9-a051" type="equalTo"/>
-                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3afd-ac93-1a99-4de9" type="equalTo"/>
-                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="84ea-ada4-abe0-f064" type="equalTo"/>
-                          </conditions>
-                        </conditionGroup>
-                        <conditionGroup type="and">
-                          <conditions>
-                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0a9-a794-02a1-ff48" type="equalTo"/>
-                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bd39-70f8-0bf1-ee2b" type="equalTo"/>
-                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d533-1276-39ec-2ba4" type="equalTo"/>
-                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e4e8-96ed-f463-3639" type="equalTo"/>
-                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ebbf-7ab7-06c5-e830" type="equalTo"/>
-                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bf07-7189-7297-52b2" type="equalTo"/>
-                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="95c8-bc8c-fda3-1ac3" type="equalTo"/>
-                          </conditions>
-                        </conditionGroup>
-                      </conditionGroups>
-                    </conditionGroup>
-                  </conditionGroups>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b473-60e5-d1af-8419" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="pts" typeId="points" value="5.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="2342-11c0-bc83-d272" name="Word Bearers: Hex-bolts" hidden="false" collective="false" import="true" targetId="e63d-3a4b-c2d9-6d0f" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="39ba-dabd-0800-0177" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="pts" typeId="points" value="5.0"/>
-              </costs>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
@@ -13278,6 +14389,16 @@ The Centurion/Delegatus may take Terminator Armour as normal. If he does then th
             <modifier type="add" field="category" value="a5b5-33d4-9941-d832">
               <conditions>
                 <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c91-a83b-8ca5-e5db" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="d751-622e-c1e4-28e9" value="0.0">
+              <conditions>
+                <condition field="selections" scope="bfae-d4db-e184-7134" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3907-f781-c7be-4fcb" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="69c2-0f6f-143f-d25a" value="0.0">
+              <conditions>
+                <condition field="selections" scope="bfae-d4db-e184-7134" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3907-f781-c7be-4fcb" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -14209,6 +15330,18 @@ Void Shield Harness</description>
           </costs>
         </selectionEntry>
         <selectionEntry id="ea69-747a-a648-daae" name="Herald" publicationId="ca571888--pubN82424" page="18" hidden="false" collective="false" import="true" type="unit">
+          <modifiers>
+            <modifier type="set" field="838b-feef-eab5-cfa1" value="0.0">
+              <conditions>
+                <condition field="selections" scope="bfae-d4db-e184-7134" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ae76-0da4-f0cd-2a24" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="b14b-5e63-11a8-6681" value="0.0">
+              <conditions>
+                <condition field="selections" scope="bfae-d4db-e184-7134" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ae76-0da4-f0cd-2a24" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b14b-5e63-11a8-6681" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="838b-feef-eab5-cfa1" type="max"/>
@@ -14948,6 +16081,18 @@ Void Shield Harness</description>
           </costs>
         </selectionEntry>
         <selectionEntry id="6817-44ed-9e65-d5e1" name="Master of Signal" publicationId="ca571888--pubN82424" page="18" hidden="false" collective="false" import="true" type="unit">
+          <modifiers>
+            <modifier type="set" field="f234-1f54-4fbe-ca23" value="0.0">
+              <conditions>
+                <condition field="selections" scope="bfae-d4db-e184-7134" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0208-9207-7481-6ed1" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="8ee6-e268-5a0e-2cdc" value="0.0">
+              <conditions>
+                <condition field="selections" scope="bfae-d4db-e184-7134" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0208-9207-7481-6ed1" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f234-1f54-4fbe-ca23" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8ee6-e268-5a0e-2cdc" type="max"/>
@@ -17006,7 +18151,67 @@ cognis-signum.</description>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
+        <selectionEntryGroup id="fc04-12b5-8358-b214" name="Custom Character Replacement" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cca7-76a3-de0b-c897" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="ae76-0da4-f0cd-2a24" name="Herald" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0839-7a62-d951-cb3c" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="0208-9207-7481-6ed1" name="Master of Signal" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8755-a3af-02c5-5d86" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <entryLinks>
+            <entryLink id="a0a9-274e-83d1-e718" name="Centurion or Delegatus" hidden="false" collective="false" import="true" targetId="3907-f781-c7be-4fcb" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
       </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9543-d500-7629-8cc9" name="Frost Maul" hidden="true" collective="false" import="true" type="upgrade">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c91-a83b-8ca5-e5db" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dc97-da49-8c15-1e5b" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9912-107c-2133-2c10" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="13a4-ab2d-57d9-bf2d" name="Frost Maul" page="" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
+            <characteristic name="Strength" typeId="537472656e67746823232344415441232323">+3</characteristic>
+            <characteristic name="AP" typeId="415023232344415441232323">4</characteristic>
+            <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Concussive, Specialist Weapon</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="8727-1d0e-01c7-7ca4" name="Concussive" hidden="false" targetId="9d85-46f7-f5e6-a5f7" type="rule"/>
+        <infoLink id="377a-b274-41e4-6196" name="Specialist Weapon" hidden="false" targetId="7ee3-d437-bc44-3630" type="rule"/>
+      </infoLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>


### PR DESCRIPTION
Quick fix for Blackshield Marauder units (they weren't tagged as compulsory
Added some rules lines to Cadre weapons for World Eaters that were missing such as Two-Handed or Rending...
Added some rules lines to Raven's Talons and Pair of Ravens Talons as they were missing all the special rules for them.
Fixed restrictions on Cameleoline for Ravanguard for Centurions. Previously it was only preventing you from taking it when you had terminator armour. It should have also prevented it when using jump packs, bikes or jetbikes.

Mournival Custom Char stuff. Added in all the remaining Legion Equipment. So this just leaves the biggest and hardest chunk left to go, and that is the Specialisation stuff. This will no doubt take a few weeks to implement fully..
