### PR TITLE
Toxi contemptors and Speeder squads

### DIFF
--- a/(HH) Mornival Units.cat
+++ b/(HH) Mornival Units.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="9f87-b468-2001-5e3b" name="Mornival Units Legion Astartes (Fanmade)" revision="16" battleScribeVersion="2.03" authorName="Aus30K / Mourival Events" authorContact="" authorUrl="https://www.facebook.com/groups/190699548351507/" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="122" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="9f87-b468-2001-5e3b" name="Mornival Units Legion Astartes (Fanmade)" revision="17" battleScribeVersion="2.03" authorName="Aus30K / Mourival Events" authorContact="" authorUrl="https://www.facebook.com/groups/190699548351507/" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="123" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="0e6e-8c19-c436-39c4" name="Mournival Events 3.0 Digital Version"/>
     <publication id="cf75-540e-e446-ecd5" name="Mournival Events FAQ and Experimental Errata v3.1"/>
@@ -3553,7 +3553,7 @@ All models with psychic powers suffer a penalty to roll to manifest psychic powe
                 <entryLink id="8788-8870-dc36-2af4" name="Shrapnel Bolts" hidden="false" collective="false" import="true" targetId="f785888f-6dfa-08f4-054f-29b1a0e4f20c" type="selectionEntry"/>
                 <entryLink id="cb38-570a-d3f1-01f6" name="Molecular Acid Shells" hidden="false" collective="false" import="true" targetId="413a-6252-82be-9f41" type="selectionEntry"/>
                 <entryLink id="7322-2f47-f77e-a2b4" name="Chem-munitions" hidden="false" collective="false" import="true" targetId="86e70545-ed1a-7cf4-5a3d-d60662a6b3be" type="selectionEntry"/>
-                <entryLink id="669b-7b30-aab5-0bab" name="Basilica Administratum" hidden="false" collective="false" import="true" targetId="e10f-7b90-ecd3-80a5" type="selectionEntry"/>
+                <entryLink id="669b-7b30-aab5-0bab" name="Blessed Autosimulacra" hidden="false" collective="false" import="true" targetId="a15bdf56-4ffe-fe04-ff77-3d533ab99dfa" type="selectionEntry"/>
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="284d-e597-a9e6-44c8" name="May be equipped with one of the following:" hidden="false" collective="false" import="true">
@@ -7502,7 +7502,7 @@ Hunter: Shot Gun, Chainblade, +1A and Acute Senses</description>
             </selectionEntryGroup>
             <selectionEntryGroup id="8c4a-ce51-7649-b719" name="Legion-specific upgrade" hidden="false" collective="false" import="true">
               <entryLinks>
-                <entryLink id="6731-c9da-3e41-3848" name="Basilica Administratum" hidden="false" collective="false" import="true" targetId="e10f-7b90-ecd3-80a5" type="selectionEntry"/>
+                <entryLink id="6731-c9da-3e41-3848" name="Blessed Autosimulacra" hidden="false" collective="false" import="true" targetId="a15bdf56-4ffe-fe04-ff77-3d533ab99dfa" type="selectionEntry"/>
                 <entryLink id="c2e6-c6c2-754f-bcdc" name="Chem-munitions" hidden="false" collective="false" import="true" targetId="86e70545-ed1a-7cf4-5a3d-d60662a6b3be" type="selectionEntry"/>
                 <entryLink id="aebd-85ba-ab63-d0d9" name="Shrapnel Bolts" hidden="false" collective="false" import="true" targetId="f785888f-6dfa-08f4-054f-29b1a0e4f20c" type="selectionEntry"/>
               </entryLinks>
@@ -7623,7 +7623,7 @@ Hunter: Shot Gun, Chainblade, +1A and Acute Senses</description>
             </selectionEntryGroup>
             <selectionEntryGroup id="95dd-d7df-4ee1-e1c1" name="Legion-specific upgrade" hidden="false" collective="false" import="true">
               <entryLinks>
-                <entryLink id="6f46-72ee-cf43-a163" name="Basilica Administratum" hidden="false" collective="false" import="true" targetId="e10f-7b90-ecd3-80a5" type="selectionEntry"/>
+                <entryLink id="6f46-72ee-cf43-a163" name="Blessed Autosimulacra" hidden="false" collective="false" import="true" targetId="a15bdf56-4ffe-fe04-ff77-3d533ab99dfa" type="selectionEntry"/>
                 <entryLink id="753c-a62d-f784-e1f8" name="Chem-munitions" hidden="false" collective="false" import="true" targetId="86e70545-ed1a-7cf4-5a3d-d60662a6b3be" type="selectionEntry"/>
                 <entryLink id="1fc0-8b58-ca4f-3008" name="Shrapnel Bolts" hidden="false" collective="false" import="true" targetId="f785888f-6dfa-08f4-054f-29b1a0e4f20c" type="selectionEntry"/>
               </entryLinks>
@@ -7737,7 +7737,7 @@ Hunter: Shot Gun, Chainblade, +1A and Acute Senses</description>
             </selectionEntryGroup>
             <selectionEntryGroup id="76ad-118f-6af7-d63c" name="Legion-specific upgrade" hidden="false" collective="false" import="true">
               <entryLinks>
-                <entryLink id="cfd2-7c37-81e9-9a5a" name="Basilica Administratum" hidden="false" collective="false" import="true" targetId="e10f-7b90-ecd3-80a5" type="selectionEntry"/>
+                <entryLink id="cfd2-7c37-81e9-9a5a" name="Blessed Autosimulacra" hidden="false" collective="false" import="true" targetId="a15bdf56-4ffe-fe04-ff77-3d533ab99dfa" type="selectionEntry"/>
                 <entryLink id="5f49-47f9-7bad-ec44" name="Chem-munitions" hidden="false" collective="false" import="true" targetId="86e70545-ed1a-7cf4-5a3d-d60662a6b3be" type="selectionEntry"/>
                 <entryLink id="646d-49da-185d-8c9c" name="Shrapnel Bolts" hidden="false" collective="false" import="true" targetId="f785888f-6dfa-08f4-054f-29b1a0e4f20c" type="selectionEntry"/>
               </entryLinks>
@@ -16814,6 +16814,9 @@ cognis-signum.</description>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
+                  <entryLinks>
+                    <entryLink id="d5e6-ff3f-886e-68e9" name="Blessed Autosimulacra" hidden="false" collective="false" import="true" targetId="a15bdf56-4ffe-fe04-ff77-3d533ab99dfa" type="selectionEntry"/>
+                  </entryLinks>
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <costs>


### PR DESCRIPTION
Toxiferno Cannons on Contemptors
Toxiferno Cannons on Contemptors were incorrectly showing hidden when selected. Same issue as the Melta Bomb one was.

Fix to Landspeeder squads
Landspeeder squads where accidentally linked to Basilica Administratum rather than Blessed Autosimulacra as an upgrade