### PR TITLE
More Mournival Custom Characters

### DIFF
--- a/(HH) Mornival Units.cat
+++ b/(HH) Mornival Units.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="9f87-b468-2001-5e3b" name="Mornival Units Legion Astartes (Fanmade)" revision="17" battleScribeVersion="2.03" authorName="Aus30K / Mourival Events" authorContact="" authorUrl="https://www.facebook.com/groups/190699548351507/" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="123" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="9f87-b468-2001-5e3b" name="Mornival Units Legion Astartes (Fanmade)" revision="18" battleScribeVersion="2.03" authorName="Aus30K / Mourival Events" authorContact="" authorUrl="https://www.facebook.com/groups/190699548351507/" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="123" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="0e6e-8c19-c436-39c4" name="Mournival Events 3.0 Digital Version"/>
     <publication id="cf75-540e-e446-ecd5" name="Mournival Events FAQ and Experimental Errata v3.1"/>
@@ -9578,7 +9578,7 @@ A Unit may not use Counter Attack special rule if it used Reaction Fire.</descri
                   </constraints>
                   <rules>
                     <rule id="af00-0fc1-0969-9b8d" name="Split Attacks" hidden="false">
-                      <description>Attacks can be split between Melee weapons, declared before rolling to hit</description>
+                      <description>Attacks can be split between Melee weapons, declared before rolling to hit. This also allows the character to replace the option for a basic weapon with an additional melee weapon.</description>
                     </rule>
                   </rules>
                   <costs>
@@ -9597,9 +9597,43 @@ A Unit may not use Counter Attack special rule if it used Reaction Fire.</descri
                     <cost name="pts" typeId="points" value="5.0"/>
                   </costs>
                 </selectionEntry>
+                <selectionEntry id="2241-f7c0-d1e3-20cd" name="Master of the Legion" page="0" hidden="false" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d2a8-fe6d-b793-225b" type="equalTo"/>
+                            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbf2-d8be-0406-b8d6" type="atLeast"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                    <modifier type="set" field="d32c-1e22-8773-1c93" value="1.0">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d2a8-fe6d-b793-225b" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="set" field="14be-d676-6d97-f200" value="1.0">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d2a8-fe6d-b793-225b" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="14be-d676-6d97-f200" type="max"/>
+                    <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d32c-1e22-8773-1c93" type="min"/>
+                  </constraints>
+                  <categoryLinks>
+                    <categoryLink id="a6e4-8113-791d-9c0a" name="New CategoryLink" hidden="false" targetId="600a-fe5d-71ba-e067" primary="false"/>
+                  </categoryLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </selectionEntry>
               </selectionEntries>
             </selectionEntryGroup>
-            <selectionEntryGroup id="1354-60df-eaba-e752" name="Legion Special Rules" hidden="false" collective="false" import="true">
+            <selectionEntryGroup id="1354-60df-eaba-e752" name="Specialisation &amp; Legion Special Rules" hidden="false" collective="false" import="true">
               <selectionEntries>
                 <selectionEntry id="da50-bd06-8a9d-84c9" name="Monster Hunter" hidden="true" collective="false" import="true" type="upgrade">
                   <modifiers>
@@ -9636,6 +9670,7 @@ A Unit may not use Counter Attack special rule if it used Reaction Fire.</descri
                           <conditions>
                             <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e6fb-0e54-0be1-9ed1" type="greaterThan"/>
                             <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f6e-f509-60ae-6a10" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7336-2cf5-3705-2ee2" type="equalTo"/>
                           </conditions>
                         </conditionGroup>
                       </conditionGroups>
@@ -9818,30 +9853,6 @@ A Unit may not use Counter Attack special rule if it used Reaction Fire.</descri
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="5.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="b758-bb01-9ba4-66fb" name="+1 Psychic Mastery Lvl" hidden="true" collective="false" import="true" type="upgrade">
-                  <modifiers>
-                    <modifier type="set" field="hidden" value="false">
-                      <conditionGroups>
-                        <conditionGroup type="or">
-                          <conditions>
-                            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5c66-2306-9285-8809" type="greaterThan"/>
-                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6800-8a1d-e8f4-136d" type="equalTo"/>
-                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0ec9-9f8e-b18a-f11b" type="equalTo"/>
-                            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fc29-3cdf-838d-e6b7" type="greaterThan"/>
-                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d96c-42af-e242-f7d8" type="equalTo"/>
-                            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d97b-d19f-4972-8e7f" type="greaterThan"/>
-                          </conditions>
-                        </conditionGroup>
-                      </conditionGroups>
-                    </modifier>
-                  </modifiers>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d9fb-0826-7093-b5ee" type="max"/>
-                  </constraints>
-                  <costs>
-                    <cost name="pts" typeId="points" value="25.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="a22e-7b4c-b921-f425" name="Infiltrate" hidden="true" collective="false" import="true" type="upgrade">
@@ -10495,6 +10506,377 @@ A Unit may not use Counter Attack special rule if it used Reaction Fire.</descri
                     <cost name="pts" typeId="points" value="0.0"/>
                   </costs>
                 </selectionEntry>
+                <selectionEntry id="ffd8-715a-abfd-953a" name="Must issue/accept Challenges" hidden="true" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7336-2cf5-3705-2ee2" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="set" field="e322-33e7-c5a8-b416" value="1.0">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7336-2cf5-3705-2ee2" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e322-33e7-c5a8-b416" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0982-3f86-751e-9df2" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="5d3b-5556-b92d-8299" name="Fear" hidden="true" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4131-d89f-489f-2f48" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="set" field="5e9d-1bf3-b6c6-7c99" value="1.0">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4131-d89f-489f-2f48" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aee2-c664-65c6-f081" type="max"/>
+                    <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5e9d-1bf3-b6c6-7c99" type="min"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="8064-1fb5-eeed-4744" name="Fear" hidden="false" targetId="52ff-4074-570b-4ea1" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="6ce1-3d16-ccbe-db5e" name="Zealot" hidden="true" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4131-d89f-489f-2f48" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d34c-cdbc-9899-8c6f" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="f13a-9f7c-dc1d-b5f6" name="Zealot" hidden="false" targetId="e300-69f2-111a-ed55" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="20.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="6545-567d-6293-274e" name="Art of Destruction" hidden="true" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2832-4cb2-3a2c-5683" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="set" field="b607-f189-d719-872b" value="1.0">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2832-4cb2-3a2c-5683" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="12fd-4365-a383-a4a5" type="max"/>
+                    <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b607-f189-d719-872b" type="min"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="1b1d-6082-63f2-60c7" name="Art of Destruction" hidden="false" targetId="31071b30-b643-a675-cca2-cf1ca6fd5e09" type="rule"/>
+                    <infoLink id="89a5-02b7-81f0-b39f" name="Tank Hunters" hidden="false" targetId="5d88-bcf6-e410-6e01" type="rule"/>
+                    <infoLink id="a879-3dc7-bd19-6c96" name="Wrecker" hidden="false" targetId="fe2f-3220-3fef-b177" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="9ad6-3658-0c12-d502" name="Scout + Acute Senses" hidden="true" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="9526-3e3e-1fc2-f548" value="1.0">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a2d0-d202-f0ce-d081" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a2d0-d202-f0ce-d081" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9526-3e3e-1fc2-f548" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="82c7-53e0-6a38-48fc" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="e7aa-2247-2a11-7f5c" name="Scout" hidden="false" targetId="9b30-1da3-eb8d-ce7a" type="rule"/>
+                    <infoLink id="b432-1551-f9f6-f773" name="Acute Senses" hidden="false" targetId="e15d-1437-cfb2-b8dd" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="cb78-f713-c3f2-9eaa" name="Stealth + Shroud Bombs" hidden="true" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a2d0-d202-f0ce-d081" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="931c-5c28-edb0-9851" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="37be-7023-7707-9c1d" name="Acute Senses" hidden="false" targetId="e15d-1437-cfb2-b8dd" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="6869-6916-cdfb-992f" name="Sniper" hidden="true" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a2d0-d202-f0ce-d081" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0ebc-9475-7434-ff33" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="afd8-083c-21a7-739f" name="Sniper" hidden="false" targetId="3919-29f5-0c68-3ecb" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="b233-96b5-7aa8-fa3a" name="Sabotage!" hidden="true" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a2d0-d202-f0ce-d081" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="39c6-abb4-6752-c831" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="a3f7-4c88-e7eb-c8d5" name="Sabatoge!" hidden="false" targetId="54eaabc9-d89a-048a-fc05-e5f184ccdd19" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="5c6c-fb30-8115-f309" name="Infiltrate + Move Through Cover" hidden="true" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a2d0-d202-f0ce-d081" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="65e1-835b-3882-bf21" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="83e2-4f8d-aebc-7521" name="Infiltrate" hidden="false" targetId="34c7-8b61-a5b8-a301" type="rule"/>
+                    <infoLink id="b686-771e-1ac0-6951" name="Move Through Cover" hidden="false" targetId="6d06-5ea0-9a17-ca97" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="0ee4-35b6-4658-df01" name="Marked For Death" hidden="true" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a2d0-d202-f0ce-d081" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d14f-ab3e-7719-aa6a" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="eaf5-7537-f6ad-0c62" name="Marked for Death" hidden="false" targetId="8e27-703d-8305-4072" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="8ec6-01a2-a384-fc01" name="Master of Cybernetica" hidden="false" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe8b-2145-2541-9062" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2f6e-94fd-90b1-8849" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="2ab1-fa95-7ecd-95a8" name="Master of Cybernetica" hidden="false" targetId="302e-aa30-ec50-139d" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="c967-e4c7-0c68-82e0" name="Fallen Honour" hidden="true" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="af34-c67e-eef6-024d" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="set" field="fdd3-1167-6ed3-5c70" value="1.0">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="af34-c67e-eef6-024d" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fdd3-1167-6ed3-5c70" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dd78-a7fb-18ac-2277" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="cc87-4a6e-adf6-df09" name="Fallen Honour" hidden="false" targetId="dab7-1f8d-ea88-517f" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="cbea-12f3-6fd6-399f" name="Fearless" hidden="true" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0f8d-5060-0530-d1f9" type="equalTo"/>
+                          </conditions>
+                          <conditionGroups>
+                            <conditionGroup type="and">
+                              <conditions>
+                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="af34-c67e-eef6-024d" type="equalTo"/>
+                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="78b4-c0fc-c692-8b34" type="equalTo"/>
+                              </conditions>
+                            </conditionGroup>
+                          </conditionGroups>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="40c7-f00f-281f-21bb" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="cf24-c4fb-ef18-23f7" name="Fearless" hidden="false" targetId="dc70-e199-5525-e78c" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="59b1-7156-98c3-8015" name="Model + unit gain Deep Strike" hidden="true" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="19c7-fd12-c4d6-44ce" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="set" field="48c6-d1ce-4387-1fda" value="1.0">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="19c7-fd12-c4d6-44ce" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="48c6-d1ce-4387-1fda" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="be4d-00a0-00e5-3900" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="182e-5ea1-8f37-d2d5" name="-1VP if removed from play" hidden="true" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="26a6-7250-f7b3-d0cd" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="set" field="f092-84c5-89aa-d899" value="1.0">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="26a6-7250-f7b3-d0cd" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f092-84c5-89aa-d899" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="80cf-bdae-5328-7262" type="max"/>
+                  </constraints>
+                  <rules>
+                    <rule id="2912-407b-838b-ec93" name="-1VP if removed from play" hidden="false">
+                      <description>This model is worth an additional Victory point to the enemy if slain in any mission where Victory points are being used.</description>
+                    </rule>
+                  </rules>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="a28b-4fd2-7335-f4e3" name="Shatter Defences" hidden="true" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="26a6-7250-f7b3-d0cd" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8171-db3e-62d0-84c4" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="e901-4966-3e9e-a920" name="Shatter Defences" hidden="false" targetId="5bedfd75-556c-7837-0212-513cabe5b830" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="9f7e-e17f-0160-2e3b" name="Battlesmith" hidden="true" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fcb3-10fd-341f-986e" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="26a6-7250-f7b3-d0cd" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                    <modifier type="set" field="c6fd-27d5-0d16-f4af" value="1.0">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fcb3-10fd-341f-986e" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e1b7-db82-8ec5-36d6" type="max"/>
+                    <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c6fd-27d5-0d16-f4af" type="min"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="26f5-bde8-8cc8-3fda" name="Battlesmith" hidden="false" targetId="9edbc777-7d2b-011b-7488-335b14870be5" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </selectionEntry>
               </selectionEntries>
               <selectionEntryGroups>
                 <selectionEntryGroup id="ed55-b08c-3024-f8bd" name="Blackshields" hidden="true" collective="false" import="true">
@@ -10656,8 +11038,40 @@ A Unit may not use Counter Attack special rule if it used Reaction Fire.</descri
                   </selectionEntries>
                 </selectionEntryGroup>
               </selectionEntryGroups>
+              <entryLinks>
+                <entryLink id="873b-ff72-9f0f-bab1" name="Unlock Phosphex Medusa (Mourn)" hidden="true" collective="false" import="true" targetId="cdfa-cd0f-26aa-a872" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2832-4cb2-3a2c-5683" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="802d-ee17-1e33-0808" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="0083-0ddb-d970-1d4c" name="Unlock Phosphex Mortars (Mourn)" hidden="true" collective="false" import="true" targetId="a68c-3ff3-7697-f59e" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2832-4cb2-3a2c-5683" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="820f-0343-9454-b8a6" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
             </selectionEntryGroup>
-            <selectionEntryGroup id="4ab2-fe75-95b3-c51b" name="Specialisation Upgrades" hidden="false" collective="false" import="true">
+            <selectionEntryGroup id="4ab2-fe75-95b3-c51b" name="Psychic Upgrades" hidden="false" collective="false" import="true">
               <selectionEntries>
                 <selectionEntry id="9497-c4be-baa5-4b20" name="Psychic Mastery 1 (Sanctic Daemonology)" hidden="true" collective="false" import="true" type="upgrade">
                   <modifiers>
@@ -10737,6 +11151,30 @@ A Unit may not use Counter Attack special rule if it used Reaction Fire.</descri
                   </constraints>
                   <costs>
                     <cost name="pts" typeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="b758-bb01-9ba4-66fb" name="+1 Psychic Mastery Lvl" hidden="true" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5c66-2306-9285-8809" type="greaterThan"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6800-8a1d-e8f4-136d" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0ec9-9f8e-b18a-f11b" type="equalTo"/>
+                            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fc29-3cdf-838d-e6b7" type="greaterThan"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d96c-42af-e242-f7d8" type="equalTo"/>
+                            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d97b-d19f-4972-8e7f" type="greaterThan"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f4c1-4d3b-66bf-0eb8" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="25.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -10939,7 +11377,14 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                     <cost name="pts" typeId="points" value="10.0"/>
                   </costs>
                 </selectionEntry>
-                <selectionEntry id="a100-ce0a-8c52-2079" name="Volkite Charger + Infiltrate#" page="0" hidden="false" collective="false" import="true" type="upgrade">
+                <selectionEntry id="a100-ce0a-8c52-2079" name="Volkite Charger + Infiltrate#" page="0" hidden="true" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cf56-aabc-9977-728d" type="greaterThan"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0468-fa17-fc14-f87b" type="max"/>
                   </constraints>
@@ -11025,6 +11470,81 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                     <infoLink id="fe24-0e00-d3d2-ba4c" name="Xenos Deathlock" hidden="false" targetId="4b0d-ac88-d973-df29" type="profile"/>
                     <infoLink id="bff9-f5b6-093c-4c99" name="Deathlock" hidden="false" targetId="64ff-f3fd-77e9-0591" type="rule"/>
                     <infoLink id="7427-2296-c85a-ee9a" name="Lethal Exposure" hidden="false" targetId="8268-9d62-4b53-9eaa" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="f663-14f0-9a4a-26bb" name="Shotgun + Ammo" hidden="true" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a2d0-d202-f0ce-d081" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <profiles>
+                    <profile id="4230-b169-13bf-56e0" name="Shotgun + Ammo" publicationId="ca571888--pubN106502" page="" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+                      <characteristics>
+                        <characteristic name="Range" typeId="52616e676523232344415441232323">12&quot;</characteristic>
+                        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">4</characteristic>
+                        <characteristic name="AP" typeId="415023232344415441232323">4</characteristic>
+                        <characteristic name="Type" typeId="5479706523232344415441232323">Assault 2</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="3aaf-bfa2-35f6-3651" name="Sniper Rifle + Marksman" hidden="true" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a2d0-d202-f0ce-d081" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <rules>
+                    <rule id="f30e-9125-b10f-7c37" name="Marksman" hidden="false">
+                      <description>All attacks are Precision Shots (excluding Snap Shots). If the target unit suffers any casualties from such shots, that unit suffers a Pinning test.</description>
+                    </rule>
+                  </rules>
+                  <infoLinks>
+                    <infoLink id="7b8f-ec61-3122-385a" name="Sniper Rifle" hidden="false" targetId="45a4-5982-7f8b-fb33" type="profile"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="581e-0212-3f66-7cbc" name="Exhange Basic Weapon for 2nd Melee Weapon" hidden="true" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="944f-ed74-4224-443f" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c6e4-a7f3-a657-bf26" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="78b4-c0fc-c692-8b34" name="Legion Banner" hidden="true" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="af34-c67e-eef6-024d" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="daad-e5e8-f1f4-447e" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="52d9-4151-8edd-20b9" name="Legion Standard" hidden="false" targetId="352f5f7a-45e0-0416-e7cd-1cb8f985b0ac" type="profile"/>
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="10.0"/>
@@ -11351,6 +11871,20 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                     <cost name="pts" typeId="points" value="20.0"/>
                   </costs>
                 </entryLink>
+                <entryLink id="5bab-058b-6747-45d0" name="Scatterbolt Launcher" hidden="false" collective="false" import="true" targetId="080e-3f21-4626-603f" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a6cc-561c-56f9-a051" type="equalTo"/>
+                            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5c66-2306-9285-8809" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                </entryLink>
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="e258-b20c-bf4a-0d12" name="Pistol Option (Select 1)" hidden="false" collective="false" import="true">
@@ -11459,7 +11993,23 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
-            <selectionEntryGroup id="b7b2-c071-101d-3fbd" name="Melee Weapon Options (Select 1)" hidden="false" collective="false" import="true">
+            <selectionEntryGroup id="b7b2-c071-101d-3fbd" name="Melee Weapon Options (Select 1)" hidden="false" collective="false" import="true" defaultSelectionEntryId="f9ff-3ef1-be99-60d6">
+              <modifiers>
+                <modifier type="set" field="edba-1583-719c-f564" value="2.0">
+                  <conditions>
+                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="581e-0212-3f66-7cbc" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="47a1-7c84-5ac9-11e0" value="2.0">
+                  <conditions>
+                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="581e-0212-3f66-7cbc" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="47a1-7c84-5ac9-11e0" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="edba-1583-719c-f564" type="max"/>
+              </constraints>
               <selectionEntries>
                 <selectionEntry id="1caf-6535-71b3-b268" name="Heavy Chainsword" hidden="false" collective="false" import="true" type="upgrade">
                   <modifiers>
@@ -11614,6 +12164,51 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                   </costs>
                 </selectionEntry>
               </selectionEntries>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="1376-adf0-fde4-a69b" name="Crozius" hidden="true" collective="false" import="true">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4131-d89f-489f-2f48" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="32fb-761d-29c8-8cfd" type="max"/>
+                    <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="5586-7ce5-0774-0db2" type="min"/>
+                  </constraints>
+                  <selectionEntries>
+                    <selectionEntry id="6e57-4446-0f34-03e3" name="Power Lance" hidden="false" collective="false" import="true" type="upgrade">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="246b-3405-e1d1-a519" type="max"/>
+                      </constraints>
+                      <infoLinks>
+                        <infoLink id="6648-ebb2-e17e-ac24" name="Power Lance" hidden="false" targetId="fdd4-9bf3-da9d-5479" type="profile"/>
+                      </infoLinks>
+                      <costs>
+                        <cost name="pts" typeId="points" value="15.0"/>
+                      </costs>
+                    </selectionEntry>
+                  </selectionEntries>
+                  <entryLinks>
+                    <entryLink id="2c32-0ba1-f49c-ea97" name="Power Axe" hidden="false" collective="false" import="true" targetId="9cf8-dd8c-592d-52ab" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="points" value="15.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="b3eb-fa80-050d-3a39" name="Power Sword" hidden="false" collective="false" import="true" targetId="98bb-edb9-27a1-8a52" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="points" value="15.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="bb85-6716-ec90-4776" name="Power Maul" hidden="false" collective="false" import="true" targetId="f009-d100-6fae-b8f7" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="points" value="15.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
               <entryLinks>
                 <entryLink id="f9ff-3ef1-be99-60d6" name="Chainsword/Combat Blade" hidden="false" collective="false" import="true" targetId="4b1e-680b-1d39-e4f1" type="selectionEntry"/>
                 <entryLink id="9752-4920-d9f4-1714" name="Charnabal Sabre" hidden="false" collective="false" import="true" targetId="3f38d321-12f2-5f34-726f-08b9e03eb50a" type="selectionEntry">
@@ -12027,9 +12622,26 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                     <cost name="pts" typeId="points" value="25.0"/>
                   </costs>
                 </entryLink>
+                <entryLink id="9ae7-8358-d962-4dce" name="Empyreal Lances" hidden="false" collective="false" import="true" targetId="516c-071e-3cc9-2578" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7336-2cf5-3705-2ee2" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4eb4-2eeb-0a76-dd81" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                  <costs>
+                    <cost name="pts" typeId="points" value="25.0"/>
+                  </costs>
+                </entryLink>
               </entryLinks>
             </selectionEntryGroup>
-            <selectionEntryGroup id="cbff-0bff-a3f9-427c" name="Legion Ammo" hidden="false" collective="false" import="true">
+            <selectionEntryGroup id="cbff-0bff-a3f9-427c" name="Ammo" hidden="false" collective="false" import="true">
               <selectionEntries>
                 <selectionEntry id="445e-d91b-7b12-688f" name="Iron Warriors: Shrapnel Bolts - Custom Char (All Bolt Weapons)" hidden="false" collective="false" import="true" type="upgrade">
                   <modifiers>
@@ -12089,6 +12701,26 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                   </profiles>
                   <costs>
                     <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="a3c9-1990-74a0-0442" name="Special Issue Ammunition" hidden="true" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a2d0-d202-f0ce-d081" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a275-7d16-f3bd-d8e0" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="b3a7-dc92-9b2e-4eb4" name="Kraken Bolt Shells" hidden="false" targetId="dae18398-f03c-63ac-5477-470244e1e687" type="profile"/>
+                    <infoLink id="9111-e124-893e-e7c3" name="Scorpius Bolt Shells" hidden="false" targetId="067e9186-0fba-6430-507f-4fbaaecd0d17" type="profile"/>
+                    <infoLink id="95c5-8ac0-43f5-233e" name="Tempest Bolt Shells" hidden="false" targetId="345c9b22-c89e-3234-d710-9b9262a1fd38" type="profile"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -12487,10 +13119,6 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                     <cost name="pts" typeId="points" value="5.0"/>
                   </costs>
                 </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-            <selectionEntryGroup id="de02-43fb-71c5-28d1" name="Archaeotech Pistol Ammo" hidden="false" collective="false" import="true">
-              <entryLinks>
                 <entryLink id="e58c-2355-ea72-0b5d" name="Manstopper Rounds (Indepentant Characters Only)" hidden="true" collective="false" import="true" targetId="0438-d18f-d8f7-a37f" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="hidden" value="false">
@@ -12505,7 +13133,7 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                     </modifier>
                   </modifiers>
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2847-ad40-01df-9504" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9e96-ad7c-7b20-abb8" type="max"/>
                   </constraints>
                 </entryLink>
                 <entryLink id="bbae-c8bb-86f3-eef0" name="Splintex rounds (Indepentant Characters Only)" hidden="true" collective="false" import="true" targetId="669a-f9b1-622f-1447" type="selectionEntry">
@@ -12522,7 +13150,7 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                     </modifier>
                   </modifiers>
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2104-4fba-d5b6-a1bc" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="63f5-f434-8fe9-5866" type="max"/>
                   </constraints>
                 </entryLink>
               </entryLinks>
@@ -12531,17 +13159,36 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
               <selectionEntries>
                 <selectionEntry id="197c-a30c-b107-d542" name="Digital Lasers" hidden="true" collective="false" import="true" type="upgrade">
                   <modifiers>
+                    <modifier type="set" field="points" value="10.0">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7336-2cf5-3705-2ee2" type="equalTo"/>
+                            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="74c0-fb49-35d8-28ac" type="greaterThan"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="19c7-fd12-c4d6-44ce" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
                     <modifier type="set" field="hidden" value="false">
-                      <conditions>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="74c0-fb49-35d8-28ac" type="greaterThan"/>
-                      </conditions>
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="74c0-fb49-35d8-28ac" type="greaterThan"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d2a8-fe6d-b793-225b" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7336-2cf5-3705-2ee2" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="19c7-fd12-c4d6-44ce" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fcb3-10fd-341f-986e" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
                     </modifier>
                   </modifiers>
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2c04-aa6b-b2ba-d266" type="max"/>
                   </constraints>
                   <costs>
-                    <cost name="pts" typeId="points" value="10.0"/>
+                    <cost name="pts" typeId="points" value="15.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="1203-eed4-f09b-2c81" name="Cortex Controller" hidden="true" collective="false" import="true" type="upgrade">
@@ -12553,13 +13200,25 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                             <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="83c2-692c-6560-3d68" type="greaterThan"/>
                             <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7b57-e309-ea7e-4f7c" type="equalTo"/>
                             <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a5b8-cb5e-952f-3d3e" type="greaterThan"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe8b-2145-2541-9062" type="equalTo"/>
                           </conditions>
                         </conditionGroup>
                       </conditionGroups>
                     </modifier>
+                    <modifier type="set" field="points" value="10.0">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe8b-2145-2541-9062" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="set" field="ee0a-c5ff-8a82-08d7" value="1.0">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe8b-2145-2541-9062" type="equalTo"/>
+                      </conditions>
+                    </modifier>
                   </modifiers>
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0a8b-1f1b-6e82-2616" type="max"/>
+                    <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ee0a-c5ff-8a82-08d7" type="min"/>
                   </constraints>
                   <entryLinks>
                     <entryLink id="84c5-67d8-dff3-496c" name="Cortex Controller" hidden="false" collective="false" import="true" targetId="a4ee-573b-f9fd-0507" type="selectionEntry"/>
@@ -12705,7 +13364,195 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                     <cost name="pts" typeId="points" value="20.0"/>
                   </costs>
                 </selectionEntry>
+                <selectionEntry id="4c2d-4442-b4e9-2069" name="Master-crafted (Delegatus)" hidden="false" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="c01c-ce24-9ab3-5e43" value="1.0">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d2a8-fe6d-b793-225b" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d2a8-fe6d-b793-225b" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0f82-7b43-9a68-3c40" type="min"/>
+                    <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c01c-ce24-9ab3-5e43" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="12e4-b229-d480-9787" name="Master-crafted" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="990c-75b4-5347-1b17" name="Master-crafted one weapon (Champion)" hidden="false" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="a3dd-7521-5b14-e375" value="1.0">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7336-2cf5-3705-2ee2" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7336-2cf5-3705-2ee2" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a3dd-7521-5b14-e375" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b699-9d46-474b-fdcd" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="a074-5b97-d644-2f71" name="Master-crafted" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="5d52-4258-1b84-6ccb" name="Suspensor Web" hidden="true" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a2d0-d202-f0ce-d081" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="38b8-62cf-bc29-0077" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="b724-786f-c2cd-71ae" name="Suspensor Web" hidden="false" targetId="3d78-f901-8afc-00ff" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="8eed-07ab-2697-6716" name="Cortex Designator" hidden="true" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe8b-2145-2541-9062" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="045f-04a7-be45-9fe7" type="max"/>
+                    <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6ad4-8ed1-6674-adbc" type="min"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="8dee-21d6-9344-2dc1" name="Cortex Designator" hidden="false" targetId="a544-0b30-4b15-43ff" type="profile"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="9003-41e0-26df-7757" name="Master-crafted one weapon (Iron Father)" hidden="false" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fcb3-10fd-341f-986e" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3967-11d8-5938-b397" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="ddc4-9fad-5414-d056" name="Master-crafted" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </selectionEntry>
               </selectionEntries>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="cee6-7e1c-bfbc-6843" name="Banner Type (0-1)" hidden="true" collective="false" import="true">
+                  <modifiers>
+                    <modifier type="set" field="200c-732d-8177-2f36" value="1.0">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="af34-c67e-eef6-024d" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="af34-c67e-eef6-024d" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="200c-732d-8177-2f36" type="max"/>
+                  </constraints>
+                  <selectionEntries>
+                    <selectionEntry id="7a3e-1596-a1e8-6f41" name="Dark Banner" hidden="true" collective="false" import="true" type="upgrade">
+                      <modifiers>
+                        <modifier type="set" field="hidden" value="false">
+                          <conditions>
+                            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" childId="dbf2-d8be-0406-b8d6" type="equalTo"/>
+                          </conditions>
+                        </modifier>
+                      </modifiers>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4667-4e95-44f8-cd8c" type="max"/>
+                      </constraints>
+                      <infoLinks>
+                        <infoLink id="b5e8-36f5-5136-3472" name="Dark Banner" hidden="false" targetId="2032-1710-8e3f-3acc" type="profile"/>
+                      </infoLinks>
+                      <costs>
+                        <cost name="pts" typeId="points" value="10.0"/>
+                      </costs>
+                    </selectionEntry>
+                    <selectionEntry id="3025-fcfd-db2d-7bc0" name="Banner of the Aquila" hidden="true" collective="false" import="true" type="upgrade">
+                      <modifiers>
+                        <modifier type="set" field="hidden" value="false">
+                          <conditionGroups>
+                            <conditionGroup type="and">
+                              <conditions>
+                                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" childId="dbf2-d8be-0406-b8d6" type="equalTo"/>
+                                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="25b6-d93f-bbd2-95a9" type="equalTo"/>
+                              </conditions>
+                            </conditionGroup>
+                          </conditionGroups>
+                        </modifier>
+                      </modifiers>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f885-9fbe-847b-cd20" type="max"/>
+                      </constraints>
+                      <infoLinks>
+                        <infoLink id="6c48-abd7-377d-476c" name="Banner of the Aquila" hidden="false" targetId="1f2f-ade8-ebc6-e020" type="profile"/>
+                      </infoLinks>
+                      <costs>
+                        <cost name="pts" typeId="points" value="10.0"/>
+                      </costs>
+                    </selectionEntry>
+                    <selectionEntry id="ef1b-0175-81b4-489e" name="Banner of the Eye" hidden="true" collective="false" import="true" type="upgrade">
+                      <modifiers>
+                        <modifier type="set" field="hidden" value="false">
+                          <conditionGroups>
+                            <conditionGroup type="and">
+                              <conditions>
+                                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" childId="dbf2-d8be-0406-b8d6" type="equalTo"/>
+                                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="08ff-9734-7fbc-cb73" type="equalTo"/>
+                              </conditions>
+                            </conditionGroup>
+                          </conditionGroups>
+                        </modifier>
+                      </modifiers>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1271-e99d-89f3-0532" type="max"/>
+                      </constraints>
+                      <infoLinks>
+                        <infoLink id="0f9c-9622-a5e2-11bb" name="Banner of the Eye" hidden="false" targetId="c9db-d1fb-fdc2-d524" type="profile"/>
+                      </infoLinks>
+                      <costs>
+                        <cost name="pts" typeId="points" value="10.0"/>
+                      </costs>
+                    </selectionEntry>
+                  </selectionEntries>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
               <entryLinks>
                 <entryLink id="2ca5-99a4-5fef-ba02" name="Cyber-hawk" hidden="false" collective="false" import="true" targetId="3736-b417-3bbd-72a4" type="selectionEntry">
                   <costs>
@@ -12732,9 +13579,14 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                 <entryLink id="e987-1227-c4f2-fbc6" name="Nuncio-vox" hidden="false" collective="false" import="true" targetId="b4ea-a586-86a9-02eb" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="hidden" value="true">
-                      <conditions>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="34fa-286c-521b-2899" type="equalTo"/>
-                      </conditions>
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2832-4cb2-3a2c-5683" type="equalTo"/>
+                            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="34fa-286c-521b-2899" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
                     </modifier>
                   </modifiers>
                   <costs>
@@ -12778,6 +13630,35 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                 <entryLink id="5c39-2fc8-1c2b-17dc" name="Infravisor" hidden="false" collective="false" import="true" targetId="4d465f07-675f-0f55-c8cb-ca43c5e2adba" type="selectionEntry">
                   <costs>
                     <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="058c-8c7f-36ec-6c32" name="Phosphex Bombs" hidden="true" collective="false" import="true" targetId="1de1f2d9-0857-67bf-d191-297d0f9f60bc" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2832-4cb2-3a2c-5683" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="fbbf-0b34-64cc-874d" name="Servo-arm" hidden="false" collective="false" import="true" targetId="4c4b-b3ad-f37b-0dcf" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fcb3-10fd-341f-986e" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="26a6-7250-f7b3-d0cd" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
                   </costs>
                 </entryLink>
               </entryLinks>
@@ -13494,10 +14375,573 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                     <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c91-a83b-8ca5-e5db" type="equalTo"/>
                   </conditions>
                 </modifier>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dbf2-d8be-0406-b8d6" type="atLeast"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="cbf3-c953-970b-bc62" value="1.0">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7336-2cf5-3705-2ee2" type="equalTo"/>
+                          </conditions>
+                          <conditionGroups>
+                            <conditionGroup type="or">
+                              <conditionGroups>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9ae7-8358-d962-4dce" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="197c-a30c-b107-d542" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e943-48be-e93c-faed" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="197c-a30c-b107-d542" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e943-48be-e93c-faed" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9ae7-8358-d962-4dce" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                              </conditionGroups>
+                            </conditionGroup>
+                          </conditionGroups>
+                        </conditionGroup>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4131-d89f-489f-2f48" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1376-adf0-fde4-a69b" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6ce1-3d16-ccbe-db5e" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2832-4cb2-3a2c-5683" type="equalTo"/>
+                          </conditions>
+                          <conditionGroups>
+                            <conditionGroup type="or">
+                              <conditionGroups>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a68c-3ff3-7697-f59e" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1de1f2d9-0857-67bf-d191-297d0f9f60bc" type="atLeast"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a68c-3ff3-7697-f59e" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cdfa-cd0f-26aa-a872" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a68c-3ff3-7697-f59e" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b4ea-a586-86a9-02eb" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cdfa-cd0f-26aa-a872" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b4ea-a586-86a9-02eb" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1de1f2d9-0857-67bf-d191-297d0f9f60bc" type="atLeast"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b4ea-a586-86a9-02eb" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cdfa-cd0f-26aa-a872" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1de1f2d9-0857-67bf-d191-297d0f9f60bc" type="atLeast"/>
+                                  </conditions>
+                                </conditionGroup>
+                              </conditionGroups>
+                            </conditionGroup>
+                          </conditionGroups>
+                        </conditionGroup>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a2d0-d202-f0ce-d081" type="equalTo"/>
+                          </conditions>
+                          <conditionGroups>
+                            <conditionGroup type="or">
+                              <conditionGroups>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6869-6916-cdfb-992f" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a95-0e58-99ce-d282" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6869-6916-cdfb-992f" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5c6c-fb30-8115-f309" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0ee4-35b6-4658-df01" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c347-ce4a-f9f6-48ec" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a95-0e58-99ce-d282" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5d52-4258-1b84-6ccb" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a95-0e58-99ce-d282" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c347-ce4a-f9f6-48ec" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a3c9-1990-74a0-0442" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6869-6916-cdfb-992f" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a3c9-1990-74a0-0442" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a95-0e58-99ce-d282" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a3c9-1990-74a0-0442" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3aaf-bfa2-35f6-3651" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5c6c-fb30-8115-f309" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cb78-f713-c3f2-9eaa" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5c6c-fb30-8115-f309" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0ee4-35b6-4658-df01" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cb78-f713-c3f2-9eaa" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a3c9-1990-74a0-0442" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b233-96b5-7aa8-fa3a" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3aaf-bfa2-35f6-3651" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a95-0e58-99ce-d282" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3aaf-bfa2-35f6-3651" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cb78-f713-c3f2-9eaa" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0ee4-35b6-4658-df01" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b233-96b5-7aa8-fa3a" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5d52-4258-1b84-6ccb" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c347-ce4a-f9f6-48ec" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5d52-4258-1b84-6ccb" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5c6c-fb30-8115-f309" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f663-14f0-9a4a-26bb" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f663-14f0-9a4a-26bb" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b233-96b5-7aa8-fa3a" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a3c9-1990-74a0-0442" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5d52-4258-1b84-6ccb" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b233-96b5-7aa8-fa3a" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0ee4-35b6-4658-df01" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3aaf-bfa2-35f6-3651" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5c6c-fb30-8115-f309" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5d52-4258-1b84-6ccb" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0ee4-35b6-4658-df01" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6869-6916-cdfb-992f" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3aaf-bfa2-35f6-3651" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5d52-4258-1b84-6ccb" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3aaf-bfa2-35f6-3651" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cb78-f713-c3f2-9eaa" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5d52-4258-1b84-6ccb" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c347-ce4a-f9f6-48ec" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f663-14f0-9a4a-26bb" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b233-96b5-7aa8-fa3a" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a3c9-1990-74a0-0442" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c347-ce4a-f9f6-48ec" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cb78-f713-c3f2-9eaa" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a3c9-1990-74a0-0442" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5c6c-fb30-8115-f309" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3aaf-bfa2-35f6-3651" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cb78-f713-c3f2-9eaa" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b233-96b5-7aa8-fa3a" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5c6c-fb30-8115-f309" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0ee4-35b6-4658-df01" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a95-0e58-99ce-d282" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cb78-f713-c3f2-9eaa" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6869-6916-cdfb-992f" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0ee4-35b6-4658-df01" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6869-6916-cdfb-992f" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a3c9-1990-74a0-0442" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0ee4-35b6-4658-df01" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5c6c-fb30-8115-f309" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c347-ce4a-f9f6-48ec" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cb78-f713-c3f2-9eaa" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f663-14f0-9a4a-26bb" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cb78-f713-c3f2-9eaa" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a95-0e58-99ce-d282" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6869-6916-cdfb-992f" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5d52-4258-1b84-6ccb" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b233-96b5-7aa8-fa3a" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c347-ce4a-f9f6-48ec" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f663-14f0-9a4a-26bb" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5d52-4258-1b84-6ccb" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b233-96b5-7aa8-fa3a" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6869-6916-cdfb-992f" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b233-96b5-7aa8-fa3a" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cb78-f713-c3f2-9eaa" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6869-6916-cdfb-992f" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f663-14f0-9a4a-26bb" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a3c9-1990-74a0-0442" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c347-ce4a-f9f6-48ec" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5d52-4258-1b84-6ccb" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5c6c-fb30-8115-f309" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0ee4-35b6-4658-df01" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3aaf-bfa2-35f6-3651" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6869-6916-cdfb-992f" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c347-ce4a-f9f6-48ec" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f663-14f0-9a4a-26bb" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a3c9-1990-74a0-0442" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a95-0e58-99ce-d282" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f663-14f0-9a4a-26bb" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5c6c-fb30-8115-f309" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a95-0e58-99ce-d282" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0ee4-35b6-4658-df01" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f663-14f0-9a4a-26bb" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a95-0e58-99ce-d282" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b233-96b5-7aa8-fa3a" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c347-ce4a-f9f6-48ec" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3aaf-bfa2-35f6-3651" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                              </conditionGroups>
+                            </conditionGroup>
+                          </conditionGroups>
+                        </conditionGroup>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe8b-2145-2541-9062" type="equalTo"/>
+                          </conditions>
+                          <conditionGroups>
+                            <conditionGroup type="or">
+                              <conditionGroups>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8ec6-01a2-a384-fc01" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8eed-07ab-2697-6716" type="atLeast"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7842-fd45-8c6e-f0ff" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8ec6-01a2-a384-fc01" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8eed-07ab-2697-6716" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7842-fd45-8c6e-f0ff" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                              </conditionGroups>
+                            </conditionGroup>
+                          </conditionGroups>
+                        </conditionGroup>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="af34-c67e-eef6-024d" type="equalTo"/>
+                          </conditions>
+                          <conditionGroups>
+                            <conditionGroup type="or">
+                              <conditionGroups>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cbea-12f3-6fd6-399f" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cee6-7e1c-bfbc-6843" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cee6-7e1c-bfbc-6843" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="78b4-c0fc-c692-8b34" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                              </conditionGroups>
+                            </conditionGroup>
+                          </conditionGroups>
+                        </conditionGroup>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="19c7-fd12-c4d6-44ce" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4eba-d895-16c1-d22e" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="197c-a30c-b107-d542" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="26a6-7250-f7b3-d0cd" type="equalTo"/>
+                          </conditions>
+                          <conditionGroups>
+                            <conditionGroup type="or">
+                              <conditionGroups>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a28b-4fd2-7335-f4e3" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4c4b-b3ad-f37b-0dcf" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9f7e-e17f-0160-2e3b" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a28b-4fd2-7335-f4e3" type="atLeast"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4c4b-b3ad-f37b-0dcf" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9f7e-e17f-0160-2e3b" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                              </conditionGroups>
+                            </conditionGroup>
+                          </conditionGroups>
+                        </conditionGroup>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fcb3-10fd-341f-986e" type="equalTo"/>
+                          </conditions>
+                          <conditionGroups>
+                            <conditionGroup type="or">
+                              <conditionGroups>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9003-41e0-26df-7757" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4c4b-b3ad-f37b-0dcf" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="197c-a30c-b107-d542" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9003-41e0-26df-7757" type="atLeast"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4c4b-b3ad-f37b-0dcf" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="197c-a30c-b107-d542" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                              </conditionGroups>
+                            </conditionGroup>
+                          </conditionGroups>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+                <modifier type="decrement" field="cbf3-c953-970b-bc62" value="1.0">
+                  <conditions>
+                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9058-210e-7313-1e07" type="equalTo"/>
+                  </conditions>
+                </modifier>
               </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cbf3-c953-970b-bc62" type="max"/>
               </constraints>
+              <rules>
+                <rule id="883d-974f-af43-f77f" name="Custom Delegatus" hidden="false">
+                  <description>Custom Delegatus
+Master of the Legion (Location: Specialisation &amp; Legion Special Rules, Cost 5pts, Mandatory)
+Master crafting (Location: Wargear, Cost 10pts, Not Mandatory)
+Digital lasers (Location: Wargear, Cost 15pts, Not Mandatory)
+Corpus Mymir^ (Location: Psyarkana, Cost 30pts, Not Mandatory)
+The Everchanging Axiom^ (Location: Psyarkana, Cost 60pts, Not Mandatory)</description>
+                </rule>
+              </rules>
               <categoryLinks>
                 <categoryLink id="be3a-2afc-f1ea-306b" name="Compulsory HQ" hidden="false" targetId="becd-7a6d-e80f-878e" primary="false"/>
                 <categoryLink id="59e6-8bc1-9cdd-37ae" name="Centurion or Delegatus" hidden="false" targetId="05c9-9e0d-c2e5-d62f" primary="false"/>
@@ -13517,6 +14961,16 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a10d-11f1-76b8-5e3a" type="max"/>
                   </constraints>
+                  <rules>
+                    <rule id="1bea-9fc7-5331-1420" name="Custom Champion" hidden="false">
+                      <description>Custom Delegatus
+Must issue/accept Challenges (Location: Specialisation &amp; Legion Special Rules, Cost 0pts, Mandatory)
+Master crafting (Location: Wargear, Cost 5pts, Mandatory)
+Precision Strikes (Location: Specialisation &amp; Legion Special Rules, Cost 5pts, Not Mandatory)
+Digital lasers (Location: Wargear, Cost 10pts, Not Mandatory)
+Empyreal Lance^ (Location: Melee, Cost 25pts, Not Mandatory)</description>
+                    </rule>
+                  </rules>
                   <categoryLinks>
                     <categoryLink id="5a29-17a0-298a-8958" name="Compulsory HQ" hidden="false" targetId="becd-7a6d-e80f-878e" primary="false"/>
                   </categoryLinks>
@@ -13535,6 +14989,14 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8d25-b22e-3505-6097" type="max"/>
                   </constraints>
+                  <rules>
+                    <rule id="bf87-b371-33a1-8020" name="Custom Chaplain" hidden="false">
+                      <description>Custom Chaplain
+Fear (Location: Specialisation &amp; Legion Special Rules, Cost 5pts, Mandatory)
+Zealot (Location: Specialisation &amp; Legion Special Rules, Cost 20pts,, Not Mandatory)
+Crozius Arcanum (Location: Melee, Cost 15pts, Not Mandatory)</description>
+                    </rule>
+                  </rules>
                   <categoryLinks>
                     <categoryLink id="d399-8738-c16b-c5ad" name="Compulsory HQ" hidden="false" targetId="becd-7a6d-e80f-878e" primary="false"/>
                   </categoryLinks>
@@ -13546,6 +15008,16 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="31f4-41e6-167e-e3b7" type="max"/>
                   </constraints>
+                  <rules>
+                    <rule id="7667-0221-5d03-4b5c" name="Custom Siege Breaker" hidden="false">
+                      <description>Custom Siege Breaker
+Art of Destuction (Location: Specialisation &amp; Legion Special Rules, Cost 10pts, Mandatory)
+Unlock Phosphex Mortars (Location: Specialisation &amp; Legion Special Rules, Cost 10pts, Not Mandatory)
+Unlock Phosphex Medusa (Location: Specialisation &amp; Legion Special Rules, Cost 10pts, Not Mandatory)
+Nuncio Vox (Location: Wargear, Cost 10pts, Not Mandatory)
+Phosphex Bombs (Max 3) (Location: Wargear, Cost 10pts each, Not Mandatory)</description>
+                    </rule>
+                  </rules>
                   <categoryLinks>
                     <categoryLink id="fd8e-1090-e180-144f" name="Compulsory HQ" hidden="false" targetId="becd-7a6d-e80f-878e" primary="false"/>
                   </categoryLinks>
@@ -13557,6 +15029,24 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1e24-a9b4-07cb-f871" type="max"/>
                   </constraints>
+                  <rules>
+                    <rule id="7142-3724-56a4-1a8d" name="Custom Vigilator" hidden="false">
+                      <description>Custom Vigilator
+Unlocks Recon Company Rite of War
+Scout + Acute Senses (Location: Specialisation &amp; Legion Special Rules, Cost 5pts, Mandatory)
+Stealth + Shroud Bombs (Location: Specialisation &amp; Legion Special Rules &amp; Grenades, Cost 5pts, Not Mandatory)
+Sniper (Location: Specialisation &amp; Legion Special Rules, Cost 5pts, Not Mandatory)
+Sabotage (Location: Specialisation &amp; Legion Special Rules, Cost 5pts, Not Mandatory)
+Special Ammunition (Location: Ammo, Cost 5pts, Not Mandatory)
+Suspensor Web (Location: Wargear, Cost 5pts, Not Mandatory)
+Infiltrate + Move Through Cover (Location: Specialisation &amp; Legion Special Rules, Cost 5pts, Not Mandatory)
+Marked For Death (Location: Specialisation &amp; Legion Special Rules, Cost 5pts, Not Mandatory)
+Psyk-out Grenades  (Location: Grenades, Cost 5pts, Not Mandatory)
+Jump Pack (Location: Unit Type, Cost 10pts, Not Mandatory)
+Shot Gun + Ammo (Location: Basic, Cost 5pts, Not Mandatory)
+Sniper Rifle + Expert Marksman (Location: Basic, Cost 5pts, Not Mandatory)</description>
+                    </rule>
+                  </rules>
                   <categoryLinks>
                     <categoryLink id="446c-4cdd-1adc-384c" name="# Restiction" hidden="false" targetId="c821-d9f2-5684-64fa" primary="false"/>
                     <categoryLink id="7774-872a-d3f2-92ca" name="Compulsory HQ" hidden="false" targetId="becd-7a6d-e80f-878e" primary="false"/>
@@ -13576,6 +15066,15 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="867e-b770-ac62-2ed2" type="max"/>
                   </constraints>
+                  <rules>
+                    <rule id="d76d-6c58-fbfe-87ab" name="Custom " hidden="false">
+                      <description>Custom 
+ (Location: Specialisation &amp; Legion Special Rules, Cost pts, Mandatory)
+ (Location: Wargear, Cost pts, Not Mandatory)
+ (Location: Melee, Cost pts each, Not Mandatory)
+ (Location: Basic, Cost pts each, Not Mandatory)</description>
+                    </rule>
+                  </rules>
                   <categoryLinks>
                     <categoryLink id="6fed-1018-9760-7e6d" name="# Restiction" hidden="false" targetId="c821-d9f2-5684-64fa" primary="false"/>
                   </categoryLinks>
@@ -13594,6 +15093,15 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aa00-8233-2ce5-b1ba" type="max"/>
                   </constraints>
+                  <rules>
+                    <rule id="8b90-f39d-87fe-71b1" name="Custom " hidden="false">
+                      <description>Custom 
+ (Location: Specialisation &amp; Legion Special Rules, Cost pts, Mandatory)
+ (Location: Wargear, Cost pts, Not Mandatory)
+ (Location: Melee, Cost pts each, Not Mandatory)
+ (Location: Basic, Cost pts each, Not Mandatory)</description>
+                    </rule>
+                  </rules>
                   <categoryLinks>
                     <categoryLink id="dfc1-8e43-9e51-2704" name="Compulsory HQ" hidden="false" targetId="becd-7a6d-e80f-878e" primary="false"/>
                     <categoryLink id="3787-5e0f-30c8-8b89" name="Wolf Lord/Claw Leader" hidden="false" targetId="a5b5-33d4-9941-d832" primary="false"/>
@@ -13613,6 +15121,15 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="74a4-b42c-cdd5-4792" type="max"/>
                   </constraints>
+                  <rules>
+                    <rule id="2baf-29f1-14b7-c3a3" name="Custom " hidden="false">
+                      <description>Custom 
+ (Location: Specialisation &amp; Legion Special Rules, Cost pts, Mandatory)
+ (Location: Wargear, Cost pts, Not Mandatory)
+ (Location: Melee, Cost pts each, Not Mandatory)
+ (Location: Basic, Cost pts each, Not Mandatory)</description>
+                    </rule>
+                  </rules>
                   <categoryLinks>
                     <categoryLink id="3a16-67ad-9267-8ac7" name="Compulsory HQ" hidden="false" targetId="becd-7a6d-e80f-878e" primary="false"/>
                     <categoryLink id="f769-9f42-4d2f-57ec" name="Wolf Lord/Claw Leader" hidden="false" targetId="a5b5-33d4-9941-d832" primary="false"/>
@@ -13632,6 +15149,20 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="94ae-435b-705f-7def" type="max"/>
                   </constraints>
+                  <rules>
+                    <rule id="f3cc-1ab1-044c-b58b" name="Custom Iron Father" hidden="false">
+                      <description>Custom 
+Battlesmith (Location: Specialisation &amp; Legion Special Rules, Cost 10pts, Mandatory)
+Master crafting
+Servo Arm (No Jump Pack)
+Digital lasers
+
+ (Location: Specialisation &amp; Legion Special Rules, Cost pts, Mandatory)
+ (Location: Wargear, Cost pts, Not Mandatory)
+ (Location: Melee, Cost pts each, Not Mandatory)
+ (Location: Basic, Cost pts each, Not Mandatory)</description>
+                    </rule>
+                  </rules>
                   <categoryLinks>
                     <categoryLink id="b73d-fbbf-ee1b-c9a0" name="Compulsory HQ" hidden="false" targetId="becd-7a6d-e80f-878e" primary="false"/>
                   </categoryLinks>
@@ -13650,6 +15181,15 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2578-806c-c068-6e27" type="max"/>
                   </constraints>
+                  <rules>
+                    <rule id="ba46-3c49-340c-43ca" name="Custom Warsmith" hidden="false">
+                      <description>Custom Warsmith
+-1VP if removed from play (Location: Specialisation &amp; Legion Special Rules, Cost 5pts, Mandatory)
+Shatter Defences (Location: Specialisation &amp; Legion Special Rules, Cost 5pts, Not Mandatory)
+Servo Arm (Location: Wargear, Cost 10pts, Not Mandatory)
+Battlesmith (Location: Specialisation &amp; Legion Special Rules, Cost 10pts, Not Mandatory)</description>
+                    </rule>
+                  </rules>
                   <categoryLinks>
                     <categoryLink id="be49-1ee4-793e-a422" name="# Restiction" hidden="false" targetId="c821-d9f2-5684-64fa" primary="false"/>
                     <categoryLink id="8e1f-42c2-45ed-29c0" name="Compulsory HQ" hidden="false" targetId="becd-7a6d-e80f-878e" primary="false"/>
@@ -13662,6 +15202,15 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aa17-492f-5c39-793b" type="max"/>
                   </constraints>
+                  <rules>
+                    <rule id="0159-b8c4-1eee-6683" name="Custom " hidden="false">
+                      <description>Custom 
+ (Location: Specialisation &amp; Legion Special Rules, Cost pts, Mandatory)
+ (Location: Wargear, Cost pts, Not Mandatory)
+ (Location: Melee, Cost pts each, Not Mandatory)
+ (Location: Basic, Cost pts each, Not Mandatory)</description>
+                    </rule>
+                  </rules>
                   <categoryLinks>
                     <categoryLink id="1f0f-4e1b-e0de-0443" name="# Restiction" hidden="false" targetId="c821-d9f2-5684-64fa" primary="false"/>
                   </categoryLinks>
@@ -13673,6 +15222,15 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5160-9a7b-b34e-119f" type="max"/>
                   </constraints>
+                  <rules>
+                    <rule id="af6a-e46b-3fc8-b3b9" name="Custom " hidden="false">
+                      <description>Custom 
+ (Location: Specialisation &amp; Legion Special Rules, Cost pts, Mandatory)
+ (Location: Wargear, Cost pts, Not Mandatory)
+ (Location: Melee, Cost pts each, Not Mandatory)
+ (Location: Basic, Cost pts each, Not Mandatory)</description>
+                    </rule>
+                  </rules>
                   <categoryLinks>
                     <categoryLink id="f3f3-c642-9e01-58d1" name="Compulsory HQ" hidden="false" targetId="becd-7a6d-e80f-878e" primary="false"/>
                   </categoryLinks>
@@ -13691,6 +15249,15 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="640b-b377-b339-29ae" type="max"/>
                   </constraints>
+                  <rules>
+                    <rule id="f293-82f5-5cf0-31bd" name="Custom " hidden="false">
+                      <description>Custom 
+ (Location: Specialisation &amp; Legion Special Rules, Cost pts, Mandatory)
+ (Location: Wargear, Cost pts, Not Mandatory)
+ (Location: Melee, Cost pts each, Not Mandatory)
+ (Location: Basic, Cost pts each, Not Mandatory)</description>
+                    </rule>
+                  </rules>
                   <categoryLinks>
                     <categoryLink id="6492-11dc-b13c-51d0" name="# Restiction" hidden="false" targetId="c821-d9f2-5684-64fa" primary="false"/>
                   </categoryLinks>
@@ -13702,6 +15269,15 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4d0f-7a84-9aad-25e8" type="max"/>
                   </constraints>
+                  <rules>
+                    <rule id="0009-0e8b-1513-93a7" name="Custom " hidden="false">
+                      <description>Custom 
+ (Location: Specialisation &amp; Legion Special Rules, Cost pts, Mandatory)
+ (Location: Wargear, Cost pts, Not Mandatory)
+ (Location: Melee, Cost pts each, Not Mandatory)
+ (Location: Basic, Cost pts each, Not Mandatory)</description>
+                    </rule>
+                  </rules>
                   <categoryLinks>
                     <categoryLink id="57b0-3a96-875e-674a" name="# Restiction" hidden="false" targetId="c821-d9f2-5684-64fa" primary="false"/>
                     <categoryLink id="6c18-d031-36c2-7e2a" name="Compulsory HQ" hidden="false" targetId="becd-7a6d-e80f-878e" primary="false"/>
@@ -13714,6 +15290,15 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e375-da5d-73ff-423d" type="max"/>
                   </constraints>
+                  <rules>
+                    <rule id="96b0-9021-57d5-eb79" name="Custom " hidden="false">
+                      <description>Custom 
+ (Location: Specialisation &amp; Legion Special Rules, Cost pts, Mandatory)
+ (Location: Wargear, Cost pts, Not Mandatory)
+ (Location: Melee, Cost pts each, Not Mandatory)
+ (Location: Basic, Cost pts each, Not Mandatory)</description>
+                    </rule>
+                  </rules>
                   <categoryLinks>
                     <categoryLink id="c77b-98b6-0f66-cdcb" name="Compulsory HQ" hidden="false" targetId="becd-7a6d-e80f-878e" primary="false"/>
                   </categoryLinks>
@@ -13732,6 +15317,15 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7c2d-5c19-c9cc-320b" type="max"/>
                   </constraints>
+                  <rules>
+                    <rule id="4ee9-c6a8-3658-4971" name="Custom " hidden="false">
+                      <description>Custom 
+ (Location: Specialisation &amp; Legion Special Rules, Cost pts, Mandatory)
+ (Location: Wargear, Cost pts, Not Mandatory)
+ (Location: Melee, Cost pts each, Not Mandatory)
+ (Location: Basic, Cost pts each, Not Mandatory)</description>
+                    </rule>
+                  </rules>
                   <costs>
                     <cost name="pts" typeId="points" value="0.0"/>
                   </costs>
@@ -13740,6 +15334,15 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d1bb-5923-2182-6285" type="max"/>
                   </constraints>
+                  <rules>
+                    <rule id="ccd7-fcbd-cce3-2ab2" name="Custom " hidden="false">
+                      <description>Custom 
+ (Location: Specialisation &amp; Legion Special Rules, Cost pts, Mandatory)
+ (Location: Wargear, Cost pts, Not Mandatory)
+ (Location: Melee, Cost pts each, Not Mandatory)
+ (Location: Basic, Cost pts each, Not Mandatory)</description>
+                    </rule>
+                  </rules>
                   <costs>
                     <cost name="pts" typeId="points" value="0.0"/>
                   </costs>
@@ -13748,6 +15351,15 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="feb1-be61-a90c-afb5" type="max"/>
                   </constraints>
+                  <rules>
+                    <rule id="03c1-8832-43a3-4c62" name="Custom " hidden="false">
+                      <description>Custom 
+ (Location: Specialisation &amp; Legion Special Rules, Cost pts, Mandatory)
+ (Location: Wargear, Cost pts, Not Mandatory)
+ (Location: Melee, Cost pts each, Not Mandatory)
+ (Location: Basic, Cost pts each, Not Mandatory)</description>
+                    </rule>
+                  </rules>
                   <costs>
                     <cost name="pts" typeId="points" value="0.0"/>
                   </costs>
@@ -13763,6 +15375,15 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9f55-8009-4dd1-8c4f" type="max"/>
                   </constraints>
+                  <rules>
+                    <rule id="ea92-488a-c43f-0302" name="Custom " hidden="false">
+                      <description>Custom 
+ (Location: Specialisation &amp; Legion Special Rules, Cost pts, Mandatory)
+ (Location: Wargear, Cost pts, Not Mandatory)
+ (Location: Melee, Cost pts each, Not Mandatory)
+ (Location: Basic, Cost pts each, Not Mandatory)</description>
+                    </rule>
+                  </rules>
                   <costs>
                     <cost name="pts" typeId="points" value="0.0"/>
                   </costs>
@@ -13778,6 +15399,15 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="adf0-8bf0-24be-94fc" type="max"/>
                   </constraints>
+                  <rules>
+                    <rule id="f279-e6d9-ca35-0ece" name="Custom " hidden="false">
+                      <description>Custom 
+ (Location: Specialisation &amp; Legion Special Rules, Cost pts, Mandatory)
+ (Location: Wargear, Cost pts, Not Mandatory)
+ (Location: Melee, Cost pts each, Not Mandatory)
+ (Location: Basic, Cost pts each, Not Mandatory)</description>
+                    </rule>
+                  </rules>
                   <categoryLinks>
                     <categoryLink id="fd2b-9755-3d9c-e830" name="Compulsory HQ" hidden="false" targetId="becd-7a6d-e80f-878e" primary="false"/>
                   </categoryLinks>
@@ -13797,6 +15427,15 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d496-3e4c-a42d-47df" type="max"/>
                     <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bc61-975a-8f22-dbfb" type="min"/>
                   </constraints>
+                  <rules>
+                    <rule id="603a-7a64-e06a-3607" name="Custom " hidden="false">
+                      <description>Custom 
+ (Location: Specialisation &amp; Legion Special Rules, Cost pts, Mandatory)
+ (Location: Wargear, Cost pts, Not Mandatory)
+ (Location: Melee, Cost pts each, Not Mandatory)
+ (Location: Basic, Cost pts each, Not Mandatory)</description>
+                    </rule>
+                  </rules>
                   <categoryLinks>
                     <categoryLink id="6b3a-2e0f-07a6-d6c0" name="# Restiction" hidden="false" targetId="c821-d9f2-5684-64fa" primary="false"/>
                   </categoryLinks>
@@ -13808,6 +15447,15 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="be69-1b34-b1be-2170" type="max"/>
                   </constraints>
+                  <rules>
+                    <rule id="8ed4-085e-05b9-ef7a" name="Custom " hidden="false">
+                      <description>Custom 
+ (Location: Specialisation &amp; Legion Special Rules, Cost pts, Mandatory)
+ (Location: Wargear, Cost pts, Not Mandatory)
+ (Location: Melee, Cost pts each, Not Mandatory)
+ (Location: Basic, Cost pts each, Not Mandatory)</description>
+                    </rule>
+                  </rules>
                   <costs>
                     <cost name="pts" typeId="points" value="0.0"/>
                   </costs>
@@ -13816,6 +15464,15 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="69ad-d551-ef7e-affe" type="max"/>
                   </constraints>
+                  <rules>
+                    <rule id="ff99-7ce1-47ed-cc9f" name="Custom Warmonger" hidden="false">
+                      <description>Custom Warmonger
+Model + unit gain Deep Strike (Location: Specialisation &amp; Legion Special Rules, Cost 10pts, Mandatory)
+Digital Lasers (Location: Wargear, Cost 10pts, Not Mandatory)
+Iron Halo (Location: Shields and Fields, Cost 25/10pts depending on if in Termy Armour, Not Mandatory)
+</description>
+                    </rule>
+                  </rules>
                   <categoryLinks>
                     <categoryLink id="d278-74f3-05d0-5843" name="Compulsory HQ" hidden="false" targetId="becd-7a6d-e80f-878e" primary="false"/>
                   </categoryLinks>
@@ -13834,6 +15491,15 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9b32-7897-04f8-4766" type="max"/>
                   </constraints>
+                  <rules>
+                    <rule id="e1b5-bf6f-8322-3015" name="Custom " hidden="false">
+                      <description>Custom 
+ (Location: Specialisation &amp; Legion Special Rules, Cost pts, Mandatory)
+ (Location: Wargear, Cost pts, Not Mandatory)
+ (Location: Melee, Cost pts each, Not Mandatory)
+ (Location: Basic, Cost pts each, Not Mandatory)</description>
+                    </rule>
+                  </rules>
                   <categoryLinks>
                     <categoryLink id="1326-d2f5-882b-9435" name="Compulsory HQ" hidden="false" targetId="becd-7a6d-e80f-878e" primary="false"/>
                   </categoryLinks>
@@ -13853,6 +15519,15 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5ad4-e5f0-da0e-ded0" type="max"/>
                     <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5d34-3da5-6946-9840" type="min"/>
                   </constraints>
+                  <rules>
+                    <rule id="36a2-1aa1-3772-dddc" name="Custom Herald" hidden="false">
+                      <description>Custom 
+Fallen Honour (Location: Specialisation &amp; Legion Special Rules, Cost 5pts, Mandatory)
+Legion Banner (Location: Basic, Cost 10pts, Not Mandatory)
+Banner Type (Location: Wargear, Cost 10pts, Not Mandatory)
+Fearless (Location: Specialisation &amp; Legion Special Rules, Cost 10pts, Not Mandatory) (BS-NOTE: Set to hidden if you take Legion Banner as this gives you fearless anyway)</description>
+                    </rule>
+                  </rules>
                   <costs>
                     <cost name="pts" typeId="points" value="0.0"/>
                   </costs>
@@ -13861,6 +15536,18 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d02e-ab38-daa9-4a8f" type="max"/>
                   </constraints>
+                  <rules>
+                    <rule id="3cc0-89f6-c3b0-d1c6" name="Custom Praevian" hidden="false">
+                      <description>Custom Praevian
+Cortex Controller  (Location: Wargear, Cost 10pts, Mandatory)
+Legion Inductees (Location: Castallax or Vorax, Cost 5pts, Not Mandatory)
+Cortex Designator (Location: Wargear, Cost 10pts, Not Mandatory)
+Master of Cybernetica (Location: Specialisation &amp; Legion Special Rules, Cost 10pts, Not Mandatory)</description>
+                    </rule>
+                  </rules>
+                  <categoryLinks>
+                    <categoryLink id="180b-91ff-8a95-e747" name="Custom Praevian" hidden="false" targetId="3d9f-f376-397f-1d80" primary="false"/>
+                  </categoryLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="0.0"/>
                   </costs>
@@ -13881,6 +15568,15 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c53d-3a45-9f61-7746" type="max"/>
                   </constraints>
+                  <rules>
+                    <rule id="1c0b-8d30-92ad-5522" name="Custom " hidden="false">
+                      <description>Custom 
+ (Location: Specialisation &amp; Legion Special Rules, Cost pts, Mandatory)
+ (Location: Wargear, Cost pts, Not Mandatory)
+ (Location: Melee, Cost pts each, Not Mandatory)
+ (Location: Basic, Cost pts each, Not Mandatory)</description>
+                    </rule>
+                  </rules>
                   <categoryLinks>
                     <categoryLink id="64eb-a9be-6599-a421" name="Centurion or Delegatus" hidden="false" targetId="05c9-9e0d-c2e5-d62f" primary="false"/>
                   </categoryLinks>
@@ -13956,6 +15652,7 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                         <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0d32-4399-cd60-62be" type="equalTo"/>
                         <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe8b-2145-2541-9062" type="equalTo"/>
                         <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="af34-c67e-eef6-024d" type="equalTo"/>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4c4b-b3ad-f37b-0dcf" type="equalTo"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
@@ -14069,11 +15766,23 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
               <categoryLinks>
                 <categoryLink id="356b-2fbf-9890-fbdf" name="New CategoryLink" hidden="false" targetId="1640-3081-13eb-b1cf" primary="false"/>
               </categoryLinks>
-              <entryLinks>
-                <entryLink id="5d52-15b7-1dec-b801" name="Legiones Astartes" hidden="false" collective="false" import="true" targetId="4014-7d86-22e9-5d96" type="selectionEntry"/>
-              </entryLinks>
               <costs>
                 <cost name="pts" typeId="points" value="35.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="c347-ce4a-f9f6-48ec" name="Jump Pack" hidden="true" collective="false" import="true" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <conditions>
+                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a2d0-d202-f0ce-d081" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <categoryLinks>
+                <categoryLink id="7626-582d-4097-94fc" name="Jump Units" hidden="false" targetId="47cf-71bb-d59d-f9de" primary="false"/>
+              </categoryLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -14126,13 +15835,29 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
             <selectionEntry id="e576-ea66-2e8b-1370" name="Shroud Bombs" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="09b8-26b3-b27d-621a" type="equalTo"/>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cb78-f713-c3f2-9eaa" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+                <modifier type="set" field="f0b2-32fe-6f7e-256c" value="1.0">
                   <conditions>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="09b8-26b3-b27d-621a" type="equalTo"/>
+                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cb78-f713-c3f2-9eaa" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="points" value="0.0">
+                  <conditions>
+                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cb78-f713-c3f2-9eaa" type="equalTo"/>
                   </conditions>
                 </modifier>
               </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="67a7-bda4-6e78-0e8e" type="max"/>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f0b2-32fe-6f7e-256c" type="min"/>
               </constraints>
               <infoLinks>
                 <infoLink id="ce6a-67c6-5243-b30d" name="Shroud Bomb" hidden="false" targetId="17f3-89d3-0f42-1c09" type="profile"/>
@@ -14256,9 +15981,21 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                 </modifier>
               </modifiers>
             </entryLink>
+            <entryLink id="0a95-0e58-99ce-d282" name="Psyk-out Grenades" hidden="true" collective="false" import="true" targetId="64f3-dde0-ce54-8812" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <conditions>
+                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a2d0-d202-f0ce-d081" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="4eb4-2eeb-0a76-dd81" name="Psyarkana^" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b96e-f881-a7ff-594d" type="max"/>
+          </constraints>
           <entryLinks>
             <entryLink id="d06f-8935-2bf8-308f" name="Terminal Lucidity Injectors" hidden="false" collective="false" import="true" targetId="66e2-6760-fb6a-edc3" type="selectionEntry">
               <modifiers>
@@ -14339,6 +16076,60 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                 <cost name="pts" typeId="points" value="25.0"/>
               </costs>
             </entryLink>
+            <entryLink id="582c-af14-5581-dfe2" name="Corpus Mymir" hidden="false" collective="false" import="true" targetId="d761-15dd-7631-ba0d" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <conditions>
+                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d2a8-fe6d-b793-225b" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <costs>
+                <cost name="pts" typeId="points" value="30.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="b6d6-884a-f491-70b4" name="The Ever-changing Axiom" hidden="false" collective="false" import="true" targetId="f162-9d1e-ca8d-d5f6" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <conditions>
+                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d2a8-fe6d-b793-225b" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <costs>
+                <cost name="pts" typeId="points" value="60.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="18d2-298c-85bc-ed4a" name="Master of Cybernetica" hidden="true" collective="false" import="true">
+          <modifiers>
+            <modifier type="set" field="78f1-7efe-46a2-a993" value="1.0">
+              <conditions>
+                <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8ec6-01a2-a384-fc01" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8ec6-01a2-a384-fc01" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="1471-5ef0-4e1c-1873" value="1.0">
+              <conditions>
+                <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8ec6-01a2-a384-fc01" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="78f1-7efe-46a2-a993" type="min"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1471-5ef0-4e1c-1873" type="max"/>
+          </constraints>
+          <categoryLinks>
+            <categoryLink id="baf0-8a1d-b0ed-74e9" name="Custom Praevian" hidden="false" targetId="3d9f-f376-397f-1d80" primary="false"/>
+          </categoryLinks>
+          <entryLinks>
+            <entryLink id="b9a6-50d3-b7ba-c95d" name="Castellax Class Battle-Automata Maniple" hidden="false" collective="false" import="true" targetId="f454-429a-6d3f-116f" type="selectionEntry"/>
+            <entryLink id="108f-b8e5-beb0-f739" name="Vorax Class Battle-automata Maniple" hidden="false" collective="false" import="true" targetId="deb3-68a3-5d36-eb3d" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
@@ -15281,6 +17072,7 @@ Void Shield Harness</description>
                   <categoryLinks>
                     <categoryLink id="93b4-6e21-1f33-a990" name="New CategoryLink" hidden="false" targetId="becd-7a6d-e80f-878e" primary="false"/>
                     <categoryLink id="4614-d7f3-e064-767f" name="New CategoryLink" hidden="false" targetId="287a-5939-2a29-9ccf" primary="false"/>
+                    <categoryLink id="0239-b0ff-8220-b73f" name="Master of the Legion" hidden="false" targetId="600a-fe5d-71ba-e067" primary="false"/>
                   </categoryLinks>
                   <selectionEntries>
                     <selectionEntry id="7e64-7351-fffb-f798" name="Master Crafted Weapon" hidden="false" collective="false" import="true" type="upgrade">


### PR DESCRIPTION
Custom Characters are now in a state where all options are available apart from Consul Specialisations and the sub options which are now 10 out of 26 complete.

Delegatus, Champion, Chaplain, Siege Breaker, Vigilator, Praevian, Herald, Warmonger, Warsmith & Iron Father should all be working. Including the ability to make any of the Primary Specialisations also a Delegatus as well so long as they take the mandatory option, and 2 others from their list.