### PR TITLE
#1743 issues

### DIFF
--- a/(HH) Imperialis Militia and Cults Army List.cat
+++ b/(HH) Imperialis Militia and Cults Army List.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="90aa-c2c8-ffb0-496e" name="Imperialis Militia and Cults Army List" revision="104" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="121" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="90aa-c2c8-ffb0-496e" name="Imperialis Militia and Cults Army List" revision="105" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="124" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="90aa-c2c8-pubN65537" name="Crusade Imperialis"/>
     <publication id="90aa-c2c8-pubN65563" name="AoDRB"/>
@@ -1635,6 +1635,13 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
             <characteristic name="Type" typeId="5479706523232344415441232323">Super-heavy Vehicle</characteristic>
           </characteristics>
         </profile>
+        <profile id="db8b-e8af-2466-da5e" name="Gorgon Heavy Transporter, Auxilia" hidden="false" typeId="307d-047f-ca13-706b" typeName="Transport">
+          <characteristics>
+            <characteristic name="Capacity" typeId="8285-4205-b6cd-8473">40</characteristic>
+            <characteristic name="Fire Points" typeId="b270-a7f9-22b2-3702">Although it appears Open-topped, passengers may not fire out of the Auxilia Gorgon Heavy Transporter</characteristic>
+            <characteristic name="Access Points" typeId="d17b-0342-b1dc-b8e7">Although it appears Open-topped, passengers may only embark and disembark from the front ramp access hatch. Up to two units may embark or disembark per turn.</characteristic>
+          </characteristics>
+        </profile>
       </profiles>
       <rules>
         <rule id="9590-7442-e99f-755b" name="Heavy Armoured Prow" publicationId="90aa-c2c8-pubN73486" page="198" hidden="false">
@@ -1929,6 +1936,9 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
           <description>Unit gains Rage and must make Sweeping Advances if able.</description>
         </rule>
       </rules>
+      <infoLinks>
+        <infoLink id="fc19-3fde-3350-2226" name="Rage" hidden="false" targetId="988c-d4d0-9418-1165" type="rule"/>
+      </infoLinks>
       <costs>
         <cost name="pts" typeId="points" value="25.0"/>
       </costs>
@@ -3115,6 +3125,46 @@ D3     Mutation
                     <condition field="selections" scope="2111-1bc6-317a-5314" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7fbb-1bb9-0360-d6e1" type="equalTo"/>
                   </conditions>
                 </modifier>
+                <modifier type="increment" field="4c4423232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="96b4-3842-f492-d7cb" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="5323232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a77a-bcf8-90fd-d9e5" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="4923232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a77a-bcf8-90fd-d9e5" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="5361766523232344415441232323" value="4+">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d18f-6d15-942c-0ac5" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="575323232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8836-1dde-d860-bd88" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="4123232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="02ca-0436-4d29-a606" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2f36-2a1b-4944-4e59" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="5423232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1072-a486-548b-2be7" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="decrement" field="4923232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1072-a486-548b-2be7" type="equalTo"/>
+                  </conditions>
+                </modifier>
               </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry (Character)</characteristic>
@@ -3193,6 +3243,48 @@ D3     Mutation
               </constraints>
               <profiles>
                 <profile id="a3e7-b642-0492-d301" name="Auxilia Crew" publicationId="90aa-c2c8-pubN73486" page="208" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+                  <modifiers>
+                    <modifier type="increment" field="4c4423232344415441232323" value="1">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="96b4-3842-f492-d7cb" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="5323232344415441232323" value="1">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a77a-bcf8-90fd-d9e5" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="4923232344415441232323" value="1">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a77a-bcf8-90fd-d9e5" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="set" field="5361766523232344415441232323" value="6+">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d18f-6d15-942c-0ac5" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="575323232344415441232323" value="1">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8836-1dde-d860-bd88" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="4123232344415441232323" value="1">
+                      <conditions>
+                        <condition field="selections" scope="3119-6513-bb98-1a37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2f36-2a1b-4944-4e59" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="5423232344415441232323" value="1">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1072-a486-548b-2be7" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="decrement" field="4923232344415441232323" value="1">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1072-a486-548b-2be7" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
                   <characteristics>
                     <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry</characteristic>
                     <characteristic name="WS" typeId="575323232344415441232323">3</characteristic>
@@ -3338,6 +3430,9 @@ D3     Mutation
           </characteristics>
         </profile>
       </profiles>
+      <infoLinks>
+        <infoLink id="932d-4781-c054-7148" name="Fast" hidden="false" targetId="f4f1-8772-1a1b-4f50" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="c336-61a6-6f47-52c4" name="New CategoryLink" hidden="false" targetId="8a8c-ed20-7427-ddff" primary="false"/>
         <categoryLink id="8fe6-c586-aee6-6fbc" name="New CategoryLink" hidden="false" targetId="218b-fafd-986d-56ba" primary="false"/>
@@ -3617,6 +3712,68 @@ D3     Mutation
           </constraints>
           <profiles>
             <profile id="8101-9496-5d9a-66e8" name="Ogryn Brutes" publicationId="90aa-c2c8-pubN73486" page="200" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+              <modifiers>
+                <modifier type="increment" field="4c4423232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="96b4-3842-f492-d7cb" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="5323232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a77a-bcf8-90fd-d9e5" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="4923232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a77a-bcf8-90fd-d9e5" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="5361766523232344415441232323" value="3+">
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d18f-6d15-942c-0ac5" type="equalTo"/>
+                        <condition field="selections" scope="0390-b19f-2fd3-a817" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="15f0-640c-1e4a-c4a3" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+                <modifier type="set" field="5361766523232344415441232323" value="4+">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d18f-6d15-942c-0ac5" type="equalTo"/>
+                            <condition field="selections" scope="0390-b19f-2fd3-a817" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="15f0-640c-1e4a-c4a3" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d18f-6d15-942c-0ac5" type="equalTo"/>
+                            <condition field="selections" scope="0390-b19f-2fd3-a817" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="15f0-640c-1e4a-c4a3" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+                <modifier type="increment" field="4123232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8836-1dde-d860-bd88" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="5423232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1072-a486-548b-2be7" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="decrement" field="4923232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1072-a486-548b-2be7" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry</characteristic>
                 <characteristic name="WS" typeId="575323232344415441232323">4</characteristic>
@@ -4225,7 +4382,42 @@ D3     Mutation
                 </modifier>
                 <modifier type="increment" field="5423232344415441232323" value="1">
                   <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1072-a486-548b-2be7" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="5323232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a77a-bcf8-90fd-d9e5" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="5361766523232344415441232323" value="4+">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d18f-6d15-942c-0ac5" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="4923232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a77a-bcf8-90fd-d9e5" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="4c4423232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="96b4-3842-f492-d7cb" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="4123232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="bd53-6efb-ac8d-e3a4" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2f36-2a1b-4944-4e59" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="5423232344415441232323" value="1">
+                  <conditions>
                     <condition field="selections" scope="8ef3-b699-2981-1b1a" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7fbb-1bb9-0360-d6e1" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="decrement" field="4923232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1072-a486-548b-2be7" type="equalTo"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -4797,6 +4989,86 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
                 <condition field="selections" scope="343f-b1ae-c962-4f62" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7fbb-1bb9-0360-d6e1" type="equalTo"/>
               </conditions>
             </modifier>
+            <modifier type="increment" field="4c4423232344415441232323" value="1">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="96b4-3842-f492-d7cb" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="5323232344415441232323" value="1">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a77a-bcf8-90fd-d9e5" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="4923232344415441232323" value="1">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a77a-bcf8-90fd-d9e5" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="5361766523232344415441232323" value="3+">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c3fd-ab0b-5ec7-7679" type="equalTo"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d18f-6d15-942c-0ac5" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d18f-6d15-942c-0ac5" type="equalTo"/>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="42e1-0228-b803-0c71" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="set" field="5361766523232344415441232323" value="2+">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d18f-6d15-942c-0ac5" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c3fd-ab0b-5ec7-7679" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="set" field="5361766523232344415441232323" value="4+">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d18f-6d15-942c-0ac5" type="equalTo"/>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="42e1-0228-b803-0c71" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d18f-6d15-942c-0ac5" type="equalTo"/>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="381f-2529-f25c-8258" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="increment" field="4123232344415441232323" value="1">
+              <conditions>
+                <condition field="selections" scope="343f-b1ae-c962-4f62" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2f36-2a1b-4944-4e59" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="5423232344415441232323" value="1">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1072-a486-548b-2be7" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="decrement" field="4923232344415441232323" value="1">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1072-a486-548b-2be7" type="equalTo"/>
+              </conditions>
+            </modifier>
           </modifiers>
           <characteristics>
             <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry (Character)</characteristic>
@@ -5352,6 +5624,71 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
                     <condition field="selections" scope="ee8f-fcde-88df-7261" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7fbb-1bb9-0360-d6e1" type="equalTo"/>
                   </conditions>
                 </modifier>
+                <modifier type="increment" field="4c4423232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="96b4-3842-f492-d7cb" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="5323232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a77a-bcf8-90fd-d9e5" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="4923232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a77a-bcf8-90fd-d9e5" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="5361766523232344415441232323" value="4+">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d18f-6d15-942c-0ac5" type="equalTo"/>
+                            <condition field="selections" scope="ee8f-fcde-88df-7261" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6230-90a6-5547-3dfc" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d18f-6d15-942c-0ac5" type="equalTo"/>
+                            <condition field="selections" scope="ee8f-fcde-88df-7261" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6230-90a6-5547-3dfc" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+                <modifier type="set" field="5361766523232344415441232323" value="3+">
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d18f-6d15-942c-0ac5" type="equalTo"/>
+                        <condition field="selections" scope="ee8f-fcde-88df-7261" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6230-90a6-5547-3dfc" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+                <modifier type="increment" field="575323232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8836-1dde-d860-bd88" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="4123232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="ee8f-fcde-88df-7261" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2f36-2a1b-4944-4e59" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="5423232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1072-a486-548b-2be7" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="decrement" field="4923232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1072-a486-548b-2be7" type="equalTo"/>
+                  </conditions>
+                </modifier>
               </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry</characteristic>
@@ -5400,6 +5737,66 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
                 <modifier type="increment" field="5423232344415441232323" value="1">
                   <conditions>
                     <condition field="selections" scope="ee8f-fcde-88df-7261" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7fbb-1bb9-0360-d6e1" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="4c4423232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="96b4-3842-f492-d7cb" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="5323232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a77a-bcf8-90fd-d9e5" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="4923232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a77a-bcf8-90fd-d9e5" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="5361766523232344415441232323" value="4+">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d18f-6d15-942c-0ac5" type="equalTo"/>
+                            <condition field="selections" scope="ee8f-fcde-88df-7261" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6230-90a6-5547-3dfc" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d18f-6d15-942c-0ac5" type="equalTo"/>
+                            <condition field="selections" scope="ee8f-fcde-88df-7261" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6230-90a6-5547-3dfc" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+                <modifier type="set" field="5361766523232344415441232323" value="3+">
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d18f-6d15-942c-0ac5" type="equalTo"/>
+                        <condition field="selections" scope="ee8f-fcde-88df-7261" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6230-90a6-5547-3dfc" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+                <modifier type="increment" field="4123232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="ee8f-fcde-88df-7261" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2f36-2a1b-4944-4e59" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="5423232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1072-a486-548b-2be7" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="decrement" field="4923232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1072-a486-548b-2be7" type="equalTo"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -5657,6 +6054,71 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
                     <condition field="selections" scope="ee8f-fcde-88df-7261" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7fbb-1bb9-0360-d6e1" type="equalTo"/>
                   </conditions>
                 </modifier>
+                <modifier type="increment" field="4c4423232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="96b4-3842-f492-d7cb" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="5323232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a77a-bcf8-90fd-d9e5" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="4923232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a77a-bcf8-90fd-d9e5" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="5361766523232344415441232323" value="4+">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d18f-6d15-942c-0ac5" type="equalTo"/>
+                            <condition field="selections" scope="ee8f-fcde-88df-7261" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6230-90a6-5547-3dfc" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d18f-6d15-942c-0ac5" type="equalTo"/>
+                            <condition field="selections" scope="ee8f-fcde-88df-7261" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6230-90a6-5547-3dfc" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+                <modifier type="set" field="5361766523232344415441232323" value="3+">
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d18f-6d15-942c-0ac5" type="equalTo"/>
+                        <condition field="selections" scope="ee8f-fcde-88df-7261" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6230-90a6-5547-3dfc" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+                <modifier type="increment" field="575323232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8836-1dde-d860-bd88" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="4123232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="ee8f-fcde-88df-7261" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2f36-2a1b-4944-4e59" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="5423232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1072-a486-548b-2be7" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="decrement" field="4923232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1072-a486-548b-2be7" type="equalTo"/>
+                  </conditions>
+                </modifier>
               </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry</characteristic>
@@ -5719,6 +6181,71 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
                 <modifier type="increment" field="5423232344415441232323" value="1">
                   <conditions>
                     <condition field="selections" scope="ee8f-fcde-88df-7261" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7fbb-1bb9-0360-d6e1" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="4c4423232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="96b4-3842-f492-d7cb" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="5323232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a77a-bcf8-90fd-d9e5" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="4923232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a77a-bcf8-90fd-d9e5" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="5361766523232344415441232323" value="4+">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d18f-6d15-942c-0ac5" type="equalTo"/>
+                            <condition field="selections" scope="ee8f-fcde-88df-7261" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6230-90a6-5547-3dfc" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d18f-6d15-942c-0ac5" type="equalTo"/>
+                            <condition field="selections" scope="ee8f-fcde-88df-7261" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6230-90a6-5547-3dfc" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+                <modifier type="set" field="5361766523232344415441232323" value="3+">
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d18f-6d15-942c-0ac5" type="equalTo"/>
+                        <condition field="selections" scope="ee8f-fcde-88df-7261" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6230-90a6-5547-3dfc" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+                <modifier type="increment" field="575323232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8836-1dde-d860-bd88" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="4123232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="ee8f-fcde-88df-7261" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2f36-2a1b-4944-4e59" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="5423232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1072-a486-548b-2be7" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="decrement" field="4923232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1072-a486-548b-2be7" type="equalTo"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -6102,6 +6629,48 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
               </constraints>
               <profiles>
                 <profile id="b793-6b33-b15b-77ac" name="Auxiliary" publicationId="90aa-c2c8-pubN73486" page="205" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+                  <modifiers>
+                    <modifier type="increment" field="4c4423232344415441232323" value="1">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="96b4-3842-f492-d7cb" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="5323232344415441232323" value="1">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a77a-bcf8-90fd-d9e5" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="4923232344415441232323" value="1">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a77a-bcf8-90fd-d9e5" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="set" field="5361766523232344415441232323" value="4+">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d18f-6d15-942c-0ac5" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="575323232344415441232323" value="1">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8836-1dde-d860-bd88" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="4123232344415441232323" value="1">
+                      <conditions>
+                        <condition field="selections" scope="0ed3-b2fd-0ca7-588b" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e27e-c832-69b2-1872" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="5423232344415441232323" value="1">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1072-a486-548b-2be7" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="decrement" field="4923232344415441232323" value="1">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1072-a486-548b-2be7" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
                   <characteristics>
                     <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry</characteristic>
                     <characteristic name="WS" typeId="575323232344415441232323">3</characteristic>
@@ -6294,6 +6863,48 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
           </constraints>
           <profiles>
             <profile id="a32a-8240-1255-b99a" name="Militia Fire Team" publicationId="90aa-c2c8-pubN73486" page="196" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+              <modifiers>
+                <modifier type="increment" field="4c4423232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="96b4-3842-f492-d7cb" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="5323232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a77a-bcf8-90fd-d9e5" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="4923232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a77a-bcf8-90fd-d9e5" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="5361766523232344415441232323" value="4+">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d18f-6d15-942c-0ac5" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="575323232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8836-1dde-d860-bd88" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="4123232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="43bb-4acf-c78a-8a35" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2f36-2a1b-4944-4e59" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="5423232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1072-a486-548b-2be7" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="decrement" field="4923232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1072-a486-548b-2be7" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry</characteristic>
                 <characteristic name="WS" typeId="575323232344415441232323">3</characteristic>
@@ -6497,6 +7108,46 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
                     <condition field="selections" scope="f299-898a-b637-0aa2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7fbb-1bb9-0360-d6e1" type="equalTo"/>
                   </conditions>
                 </modifier>
+                <modifier type="increment" field="4c4423232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="96b4-3842-f492-d7cb" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="5323232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a77a-bcf8-90fd-d9e5" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="4923232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a77a-bcf8-90fd-d9e5" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="5361766523232344415441232323" value="3+">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d18f-6d15-942c-0ac5" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="575323232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8836-1dde-d860-bd88" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="4123232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="f299-898a-b637-0aa2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2f36-2a1b-4944-4e59" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="5423232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1072-a486-548b-2be7" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="decrement" field="4923232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1072-a486-548b-2be7" type="equalTo"/>
+                  </conditions>
+                </modifier>
               </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry</characteristic>
@@ -6545,6 +7196,46 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
                 <modifier type="increment" field="5423232344415441232323" value="1">
                   <conditions>
                     <condition field="selections" scope="f299-898a-b637-0aa2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7fbb-1bb9-0360-d6e1" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="4c4423232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="96b4-3842-f492-d7cb" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="5323232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a77a-bcf8-90fd-d9e5" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="4923232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a77a-bcf8-90fd-d9e5" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="5361766523232344415441232323" value="3+">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d18f-6d15-942c-0ac5" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="575323232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8836-1dde-d860-bd88" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="4123232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="f299-898a-b637-0aa2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2f36-2a1b-4944-4e59" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="5423232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1072-a486-548b-2be7" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="decrement" field="4923232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1072-a486-548b-2be7" type="equalTo"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -7327,6 +8018,46 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
                     <condition field="selections" scope="a05b-1aaf-314c-cbba" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="875a-e56c-84b6-2b18" type="equalTo"/>
                   </conditions>
                 </modifier>
+                <modifier type="increment" field="4c4423232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="96b4-3842-f492-d7cb" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="5323232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a77a-bcf8-90fd-d9e5" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="4923232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a77a-bcf8-90fd-d9e5" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="5361766523232344415441232323" value="4+">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d18f-6d15-942c-0ac5" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="575323232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8836-1dde-d860-bd88" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="4123232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="a05b-1aaf-314c-cbba" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2f36-2a1b-4944-4e59" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="5423232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1072-a486-548b-2be7" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="decrement" field="4923232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1072-a486-548b-2be7" type="equalTo"/>
+                  </conditions>
+                </modifier>
               </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry</characteristic>
@@ -7372,6 +8103,46 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
                 <modifier type="increment" field="5423232344415441232323" value="1">
                   <conditions>
                     <condition field="selections" scope="a05b-1aaf-314c-cbba" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7fbb-1bb9-0360-d6e1" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="4c4423232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="96b4-3842-f492-d7cb" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="5323232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a77a-bcf8-90fd-d9e5" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="4923232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a77a-bcf8-90fd-d9e5" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="5361766523232344415441232323" value="4+">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d18f-6d15-942c-0ac5" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="575323232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8836-1dde-d860-bd88" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="4123232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="a05b-1aaf-314c-cbba" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2f36-2a1b-4944-4e59" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="decrement" field="4923232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1072-a486-548b-2be7" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="5423232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1072-a486-548b-2be7" type="equalTo"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -7584,6 +8355,46 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
                     <condition field="selections" scope="c542-ddd4-6b6b-f761" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7fbb-1bb9-0360-d6e1" type="equalTo"/>
                   </conditions>
                 </modifier>
+                <modifier type="increment" field="4c4423232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="96b4-3842-f492-d7cb" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="5323232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a77a-bcf8-90fd-d9e5" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="4923232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a77a-bcf8-90fd-d9e5" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="5361766523232344415441232323" value="4+">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d18f-6d15-942c-0ac5" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="575323232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8836-1dde-d860-bd88" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="4123232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="c542-ddd4-6b6b-f761" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2f36-2a1b-4944-4e59" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="5423232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1072-a486-548b-2be7" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="decrement" field="4923232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1072-a486-548b-2be7" type="equalTo"/>
+                  </conditions>
+                </modifier>
               </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry (Character)</characteristic>
@@ -7780,6 +8591,46 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
                 <modifier type="set" field="556e6974205479706523232344415441232323" value="Cavalry">
                   <conditions>
                     <condition field="selections" scope="c542-ddd4-6b6b-f761" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="875a-e56c-84b6-2b18" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="4c4423232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="96b4-3842-f492-d7cb" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="5323232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a77a-bcf8-90fd-d9e5" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="4923232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a77a-bcf8-90fd-d9e5" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="5361766523232344415441232323" value="4+">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d18f-6d15-942c-0ac5" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="575323232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8836-1dde-d860-bd88" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="4123232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="c542-ddd4-6b6b-f761" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2f36-2a1b-4944-4e59" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="5423232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1072-a486-548b-2be7" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="decrement" field="4923232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1072-a486-548b-2be7" type="equalTo"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -8012,6 +8863,48 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
           </constraints>
           <profiles>
             <profile id="2c2e-3d03-a308-0c6f" name="Levy Auxiliary" publicationId="90aa-c2c8-pubN73486" page="194" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+              <modifiers>
+                <modifier type="increment" field="4c4423232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="96b4-3842-f492-d7cb" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="5323232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a77a-bcf8-90fd-d9e5" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="4923232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a77a-bcf8-90fd-d9e5" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="5361766523232344415441232323" value="5+">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d18f-6d15-942c-0ac5" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="575323232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8836-1dde-d860-bd88" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="4123232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="7689-6fdc-260e-d041" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2f36-2a1b-4944-4e59" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="5423232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1072-a486-548b-2be7" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="decrement" field="4923232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1072-a486-548b-2be7" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry</characteristic>
                 <characteristic name="WS" typeId="575323232344415441232323">2</characteristic>
@@ -8041,6 +8934,48 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
           </constraints>
           <profiles>
             <profile id="09ac-694a-907b-4d0e" name="Custodian" publicationId="90aa-c2c8-pubN73486" page="194" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+              <modifiers>
+                <modifier type="increment" field="4c4423232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="96b4-3842-f492-d7cb" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="5323232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a77a-bcf8-90fd-d9e5" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="4923232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a77a-bcf8-90fd-d9e5" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="5361766523232344415441232323" value="4+">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d18f-6d15-942c-0ac5" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="575323232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8836-1dde-d860-bd88" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="4123232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="7689-6fdc-260e-d041" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2f36-2a1b-4944-4e59" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="5423232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1072-a486-548b-2be7" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="decrement" field="4923232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1072-a486-548b-2be7" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry (Character)</characteristic>
                 <characteristic name="WS" typeId="575323232344415441232323">3</characteristic>
@@ -8917,8 +9852,68 @@ This rule, while similar in function to the Drop Pod Assault special rule, does 
                   </conditions>
                 </modifier>
                 <modifier type="set" field="5361766523232344415441232323" value="4+">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d18f-6d15-942c-0ac5" type="equalTo"/>
+                            <condition field="selections" scope="222a-94eb-eda4-afe1" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="59de-2acc-79e5-90f1" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d18f-6d15-942c-0ac5" type="equalTo"/>
+                            <condition field="selections" scope="222a-94eb-eda4-afe1" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="59de-2acc-79e5-90f1" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+                <modifier type="increment" field="4c4423232344415441232323" value="1">
                   <conditions>
-                    <condition field="selections" scope="222a-94eb-eda4-afe1" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="59de-2acc-79e5-90f1" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="96b4-3842-f492-d7cb" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="5323232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a77a-bcf8-90fd-d9e5" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="4923232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a77a-bcf8-90fd-d9e5" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="5361766523232344415441232323" value="3+">
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d18f-6d15-942c-0ac5" type="equalTo"/>
+                        <condition field="selections" scope="222a-94eb-eda4-afe1" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="59de-2acc-79e5-90f1" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+                <modifier type="increment" field="575323232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8836-1dde-d860-bd88" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="4123232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="222a-94eb-eda4-afe1" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2f36-2a1b-4944-4e59" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="5423232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1072-a486-548b-2be7" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="decrement" field="4923232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1072-a486-548b-2be7" type="equalTo"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -8955,11 +9950,6 @@ This rule, while similar in function to the Drop Pod Assault special rule, does 
           <profiles>
             <profile id="bc6f-3519-0f50-3986" name="Rider" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
               <modifiers>
-                <modifier type="set" field="5361766523232344415441232323" value="4+">
-                  <conditions>
-                    <condition field="selections" scope="222a-94eb-eda4-afe1" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="59de-2acc-79e5-90f1" type="equalTo"/>
-                  </conditions>
-                </modifier>
                 <modifier type="set" field="name" value="Outrider">
                   <conditions>
                     <condition field="selections" scope="222a-94eb-eda4-afe1" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8630-9a32-45c6-6be7" type="equalTo"/>
@@ -8968,6 +9958,71 @@ This rule, while similar in function to the Drop Pod Assault special rule, does 
                 <modifier type="set" field="556e6974205479706523232344415441232323" value="Bike">
                   <conditions>
                     <condition field="selections" scope="222a-94eb-eda4-afe1" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8630-9a32-45c6-6be7" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="4c4423232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="96b4-3842-f492-d7cb" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="5323232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a77a-bcf8-90fd-d9e5" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="4923232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a77a-bcf8-90fd-d9e5" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="5361766523232344415441232323" value="3+">
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d18f-6d15-942c-0ac5" type="equalTo"/>
+                        <condition field="selections" scope="222a-94eb-eda4-afe1" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="59de-2acc-79e5-90f1" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+                <modifier type="set" field="5361766523232344415441232323" value="4+">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d18f-6d15-942c-0ac5" type="equalTo"/>
+                            <condition field="selections" scope="222a-94eb-eda4-afe1" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="59de-2acc-79e5-90f1" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d18f-6d15-942c-0ac5" type="equalTo"/>
+                            <condition field="selections" scope="222a-94eb-eda4-afe1" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="59de-2acc-79e5-90f1" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+                <modifier type="increment" field="575323232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8836-1dde-d860-bd88" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="4123232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="222a-94eb-eda4-afe1" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2f36-2a1b-4944-4e59" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="5423232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1072-a486-548b-2be7" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="decrement" field="4923232344415441232323" value="1">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1072-a486-548b-2be7" type="equalTo"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -9552,7 +10607,7 @@ A model may only use this weapon if it has successfully charged that player turn
         <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9783-04f2-30c3-f02b" type="max"/>
       </constraints>
       <entryLinks>
-        <entryLink id="4460-3009-3f20-d74d" hidden="false" collective="false" import="true" targetId="2512-6bcd-7038-84bd" type="selectionEntry">
+        <entryLink id="4460-3009-3f20-d74d" name="Frenzon Dispensers" hidden="false" collective="false" import="true" targetId="2512-6bcd-7038-84bd" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="points" value="50">
               <conditions>
@@ -9569,7 +10624,7 @@ A model may only use this weapon if it has successfully charged that player turn
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="650a-46f7-d277-df5d" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="2f36-2a1b-4944-4e59" hidden="false" collective="false" import="true" targetId="e27e-c832-69b2-1872" type="selectionEntry">
+        <entryLink id="2f36-2a1b-4944-4e59" name="Blade and Fury" hidden="false" collective="false" import="true" targetId="e27e-c832-69b2-1872" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>

--- a/(HH) Mornival Units.cat
+++ b/(HH) Mornival Units.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="9f87-b468-2001-5e3b" name="Mornival Units Legion Astartes (Fanmade)" revision="19" battleScribeVersion="2.03" authorName="Aus30K / Mourival Events" authorContact="" authorUrl="https://www.facebook.com/groups/190699548351507/" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="123" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="9f87-b468-2001-5e3b" name="Mornival Units Legion Astartes (Fanmade)" revision="20" battleScribeVersion="2.03" authorName="Aus30K / Mourival Events" authorContact="" authorUrl="https://www.facebook.com/groups/190699548351507/" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="124" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="0e6e-8c19-c436-39c4" name="Mournival Events 3.0 Digital Version"/>
     <publication id="cf75-540e-e446-ecd5" name="Mournival Events FAQ and Experimental Errata v3.1"/>
@@ -443,11 +443,13 @@ Example 4: In a 2000 point army, a Daemon Lord is the Warlord (doesn’t count a
     <entryLink id="b403-00fc-857d-0131" name="Vanus Assassin" hidden="false" collective="false" import="true" targetId="6277-fb4b-0461-2f0e" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="da4e-ee54-a6e6-931d" name="Elites" hidden="false" targetId="456c6974657323232344415441232323" primary="true"/>
+        <categoryLink id="c1fd-fcaf-4608-231d" name="Compulsory Elite" hidden="false" targetId="196d-5b83-524b-4bdf" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="f6cd-e40a-1338-4aef" name="Venenum Assassin" hidden="false" collective="false" import="true" targetId="ceb1-cf74-814f-f02a" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="9852-ae19-2636-a18d" name="Elites" hidden="false" targetId="456c6974657323232344415441232323" primary="true"/>
+        <categoryLink id="1eb7-3116-1922-64c5" name="Compulsory Elite" hidden="false" targetId="196d-5b83-524b-4bdf" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="3304-fdfe-b8d2-7a1e" name="Rogue Psyker" hidden="false" collective="false" import="true" targetId="6f91-2969-795c-509b" type="selectionEntry">
@@ -464,12 +466,14 @@ Example 4: In a 2000 point army, a Daemon Lord is the Warlord (doesn’t count a
       <categoryLinks>
         <categoryLink id="cb8c-1883-b35c-a91d" name="Elites" hidden="false" targetId="456c6974657323232344415441232323" primary="true"/>
         <categoryLink id="bfce-2858-8d34-823a" name="Mournival Centurion Unrestricted" hidden="false" targetId="c00c-5a5c-3d86-f5a5" primary="false"/>
+        <categoryLink id="4f15-c466-7b73-403e" name="Compulsory Elite" hidden="false" targetId="196d-5b83-524b-4bdf" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="6c4f-279c-c0ec-7ffd" name="Alpha Legion Sleeper Cell" hidden="false" collective="false" import="true" targetId="5a81-880e-e9ff-b913" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="3b19-64b7-34f0-92dc" name="New CategoryLink" hidden="false" targetId="456c6974657323232344415441232323" primary="true"/>
         <categoryLink id="a448-e686-5b8a-cce3" name="Mournival Centurion Unrestricted" hidden="false" targetId="c00c-5a5c-3d86-f5a5" primary="false"/>
+        <categoryLink id="e676-6aad-6eb7-a155" name="Compulsory Elite" hidden="false" targetId="196d-5b83-524b-4bdf" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="a713-ead7-46d5-1e92" name="Gunnery Centurion" hidden="false" collective="false" import="true" targetId="a38d-bc4d-7016-cf8d" type="selectionEntry">
@@ -481,24 +485,28 @@ Example 4: In a 2000 point army, a Daemon Lord is the Warlord (doesn’t count a
       <categoryLinks>
         <categoryLink id="a2f5-9dd3-4bf2-67e9" name="New CategoryLink" hidden="false" targetId="456c6974657323232344415441232323" primary="true"/>
         <categoryLink id="1188-13dc-738d-2b19" name="Mournival Centurion Restricted Unit" hidden="false" targetId="0617-4e0c-126d-17f3" primary="false"/>
+        <categoryLink id="a3e0-38d5-4473-0e6b" name="Compulsory Elite" hidden="false" targetId="196d-5b83-524b-4bdf" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="1408-6131-1677-6d8d" name="Possessed Astartes Squad, Legion" hidden="false" collective="false" import="true" targetId="491a-9bf1-e9bd-b2f8" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="eac0-de29-5cbd-3a1b" name="New CategoryLink" hidden="false" targetId="456c6974657323232344415441232323" primary="true"/>
         <categoryLink id="b85c-7dc1-f457-fd3c" name="Mournival Centurion Unrestricted" hidden="false" targetId="c00c-5a5c-3d86-f5a5" primary="false"/>
+        <categoryLink id="2e08-bc1b-8fa9-80d4" name="Compulsory Elite" hidden="false" targetId="196d-5b83-524b-4bdf" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="16c3-33ba-d1f5-de9a" name="Independent Techmarines, Legion" hidden="false" collective="false" import="true" targetId="7d04-bb7c-cffb-f005" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="fe0f-ab4a-8a42-76ca" name="New CategoryLink" hidden="false" targetId="456c6974657323232344415441232323" primary="true"/>
         <categoryLink id="f90b-bbe1-5b21-b8a4" name="Mournival Centurion Unrestricted" hidden="false" targetId="c00c-5a5c-3d86-f5a5" primary="false"/>
+        <categoryLink id="2cf9-ef69-a4e3-7513" name="Compulsory Elite" hidden="false" targetId="196d-5b83-524b-4bdf" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="3da3-bf37-f82d-1440" name="Ulfhednar Pack" hidden="false" collective="false" import="true" targetId="ff4e-9474-9ad9-8975" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="9ed4-acac-17f8-a57b" name="Elites" hidden="false" targetId="456c6974657323232344415441232323" primary="true"/>
         <categoryLink id="75e7-88af-e31b-50c0" name="Mournival Centurion Unrestricted" hidden="false" targetId="c00c-5a5c-3d86-f5a5" primary="false"/>
+        <categoryLink id="2d1a-7b68-971c-8671" name="Compulsory Elite" hidden="false" targetId="196d-5b83-524b-4bdf" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="4274-9cd2-c164-6acc" name="Assault Support Squad, Legion" hidden="false" collective="false" import="true" targetId="eefe-b2cd-3f41-7c84" type="selectionEntry">
@@ -597,6 +605,7 @@ Example 4: In a 2000 point army, a Daemon Lord is the Warlord (doesn’t count a
       <categoryLinks>
         <categoryLink id="f51e-d6f8-2b62-52e2" name="New CategoryLink" hidden="false" targetId="456c6974657323232344415441232323" primary="true"/>
         <categoryLink id="1114-7bc4-82d1-b9f2" name="Mournival Centurion Unrestricted" hidden="false" targetId="c00c-5a5c-3d86-f5a5" primary="false"/>
+        <categoryLink id="78f6-e9d7-f729-47f9" name="Compulsory Elite" hidden="false" targetId="196d-5b83-524b-4bdf" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="834d-9c15-11e5-40e4" name="Salamanders Infernus Destroyer Squad" hidden="false" collective="false" import="true" targetId="c74b-38cc-7b44-348c" type="selectionEntry">
@@ -9815,6 +9824,7 @@ A Unit may not use Counter Attack special rule if it used Reaction Fire.</descri
                           <conditions>
                             <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a5b8-cb5e-952f-3d3e" type="greaterThan"/>
                             <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="abb9-6ccb-e01e-e0f5" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0d32-4399-cd60-62be" type="equalTo"/>
                           </conditions>
                         </conditionGroup>
                       </conditionGroups>
@@ -10119,6 +10129,17 @@ A Unit may not use Counter Attack special rule if it used Reaction Fire.</descri
                           <conditions>
                             <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cf56-aabc-9977-728d" type="greaterThan"/>
                             <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2e9e-6f3a-dcc9-1113" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0f8d-5060-0530-d1f9" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                    <modifier type="set" field="points" value="5.0">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cf56-aabc-9977-728d" type="greaterThan"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2e9e-6f3a-dcc9-1113" type="equalTo"/>
                           </conditions>
                         </conditionGroup>
                       </conditionGroups>
@@ -10131,7 +10152,7 @@ A Unit may not use Counter Attack special rule if it used Reaction Fire.</descri
                     <infoLink id="1e3e-1480-f7e8-e89d" name="Preferred Enemy" hidden="false" targetId="4dd2-fcb0-de6a-5b70" type="rule"/>
                   </infoLinks>
                   <costs>
-                    <cost name="pts" typeId="points" value="5.0"/>
+                    <cost name="pts" typeId="points" value="10.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="d27f-420c-c300-4dac" name="Feel No Pain (5+)" hidden="true" collective="false" import="true" type="upgrade">
@@ -10975,6 +10996,145 @@ A Unit may not use Counter Attack special rule if it used Reaction Fire.</descri
                     <cost name="pts" typeId="points" value="10.0"/>
                   </costs>
                 </selectionEntry>
+                <selectionEntry id="028a-9081-62be-f340" name="Daemon" hidden="true" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4652-e768-5037-5cc4" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c121-4a43-16b1-c38d" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="72fb-80d1-3e5a-750c" name="Daemon" hidden="false" targetId="3eda-669d-bd54-e3c0" type="rule"/>
+                    <infoLink id="3916-4c85-52ce-e23b" name="Fear" hidden="false" targetId="52ff-4074-570b-4ea1" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="15.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="0d05-c7d9-07eb-d99f" name="Preferred Enemy (Loyalist)" hidden="true" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4652-e768-5037-5cc4" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1f2e-9372-8c72-f42b" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="6bff-bba1-96a9-9eb0" name="Preferred Enemy" hidden="false" targetId="4dd2-fcb0-de6a-5b70" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="db34-7cf6-84ee-64a4" name="Outflank" hidden="true" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="631d-c6b6-1f7d-a4b7" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="set" field="0556-bc92-10f4-fac4" value="1.0">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="631d-c6b6-1f7d-a4b7" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8a65-72af-ef56-2041" type="max"/>
+                    <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0556-bc92-10f4-fac4" type="min"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="3d59-0181-b429-12e4" name="Outflank" hidden="false" targetId="de18-25a0-504b-74be" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="f640-0fcd-e546-fe0c" name="Lone Killer" hidden="true" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="631d-c6b6-1f7d-a4b7" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="set" field="78e8-9686-107a-8bbd" value="1.0">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="631d-c6b6-1f7d-a4b7" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="78e8-9686-107a-8bbd" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b7d5-642f-0c7e-333c" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="eca7-12ee-0934-980b" name="Lone Killer" hidden="false" targetId="118591f0-3c6e-53f1-4761-0af2a3a938a1" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="67a3-e392-a991-207c" name="Sabotage" hidden="true" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="631d-c6b6-1f7d-a4b7" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="72cc-60d6-0801-ef5d" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="df6c-9dcb-893d-a9e3" name="Sabotage" hidden="false" targetId="da05f14c-ee48-7a8d-f8d2-aed12bf2d26f" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="79ba-8772-1e33-2817" name="Prototype Weapons" hidden="true" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0d32-4399-cd60-62be" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0f92-411d-7904-d6bd" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="ead8-b6b7-7b0a-3d9a" name="Prototype Weapons" hidden="false" targetId="2c7d-d443-dde2-cb32" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="ad36-5b18-1af9-86ac" name="Coordinating Fire" hidden="true" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d5cb-9f8a-d0fe-9a56" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="293d-a904-6b3e-2ff9" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="6e3b-386f-3199-6915" name="Coordinating Fire" hidden="false" targetId="10fe-d4b7-a5d9-d92c" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </selectionEntry>
               </selectionEntries>
               <selectionEntryGroups>
                 <selectionEntryGroup id="ed55-b08c-3024-f8bd" name="Blackshields" hidden="true" collective="false" import="true">
@@ -11167,7 +11327,7 @@ A Unit may not use Counter Attack special rule if it used Reaction Fire.</descri
                     <cost name="pts" typeId="points" value="10.0"/>
                   </costs>
                 </entryLink>
-                <entryLink id="a094-8058-146e-8b4b" name="Veteran Tactic: Warrior’s Mettle" hidden="false" collective="false" import="true" targetId="95f4-6fa5-0631-ded8" type="selectionEntry">
+                <entryLink id="a094-8058-146e-8b4b" name="Veteran Tactic: Warrior’s Mettle" hidden="true" collective="false" import="true" targetId="95f4-6fa5-0631-ded8" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="hidden" value="false">
                       <conditions>
@@ -11205,6 +11365,27 @@ A Unit may not use Counter Attack special rule if it used Reaction Fire.</descri
                     <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8060-b524-5bfe-9f03" type="min"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fad1-76e2-72b4-0721" type="max"/>
                   </constraints>
+                </entryLink>
+                <entryLink id="6157-5752-43ad-0eec" name="Dark Channelling" hidden="true" collective="false" import="true" targetId="8e9aa9ef-7863-9522-7741-f7a3ebec8585" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="21fa-d7ce-2254-0b42" value="1.0">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4652-e768-5037-5cc4" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4652-e768-5037-5cc4" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="21fa-d7ce-2254-0b42" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f30f-3ec1-a478-389a" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
@@ -11336,6 +11517,8 @@ A Unit may not use Counter Attack special rule if it used Reaction Fire.</descri
                         <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="84ea-ada4-abe0-f064" type="equalTo"/>
                         <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3afd-ac93-1a99-4de9" type="equalTo"/>
                         <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a6cc-561c-56f9-a051" type="equalTo"/>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0d32-4399-cd60-62be" type="equalTo"/>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d5cb-9f8a-d0fe-9a56" type="equalTo"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
@@ -11354,6 +11537,8 @@ A Unit may not use Counter Attack special rule if it used Reaction Fire.</descri
                           <conditions>
                             <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="84ea-ada4-abe0-f064" type="equalTo"/>
                             <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a6cc-561c-56f9-a051" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0d32-4399-cd60-62be" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d5cb-9f8a-d0fe-9a56" type="equalTo"/>
                           </conditions>
                         </conditionGroup>
                       </conditionGroups>
@@ -11427,29 +11612,6 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                     <infoLink id="e5e5-da96-459d-dc2c" name="Lightning Claw" hidden="false" targetId="3cec-4483-3f2e-fbc2" type="profile"/>
                     <infoLink id="8abc-4b1e-3aeb-bb8a" name="Shred" hidden="false" targetId="89da-0cb5-bee4-8ec2" type="rule"/>
                     <infoLink id="a827-7cba-8641-b326" name="Specialist Weapon" hidden="false" targetId="7ee3-d437-bc44-3630" type="rule"/>
-                  </infoLinks>
-                  <costs>
-                    <cost name="pts" typeId="points" value="5.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="5baa-7812-3569-ed65" name="Master-crafted Heavy Bolter" hidden="false" collective="false" import="true" type="upgrade">
-                  <modifiers>
-                    <modifier type="set" field="hidden" value="true">
-                      <conditions>
-                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0d32-4399-cd60-62be" type="equalTo"/>
-                      </conditions>
-                    </modifier>
-                  </modifiers>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="faca-74b6-2c28-8163" type="max"/>
-                  </constraints>
-                  <infoLinks>
-                    <infoLink id="a6a6-ea52-babd-2001" name="Heavy Bolter" hidden="false" targetId="271e-6286-86cc-06dd" type="profile">
-                      <modifiers>
-                        <modifier type="append" field="5479706523232344415441232323" value="Master-crafted"/>
-                      </modifiers>
-                    </infoLink>
-                    <infoLink id="8e65-6864-803a-16ed" name="Master-crafted" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule"/>
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="5.0"/>
@@ -12814,7 +12976,7 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                           <conditionGroups>
                             <conditionGroup type="or">
                               <conditions>
-                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5baa-7812-3569-ed65" type="equalTo"/>
+                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c1cd-7182-1f30-4e29" type="equalTo"/>
                                 <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a161-76b3-9ef1-da7b" type="equalTo"/>
                               </conditions>
                             </conditionGroup>
@@ -13501,22 +13663,17 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                     <cost name="pts" typeId="points" value="20.0"/>
                   </costs>
                 </selectionEntry>
-                <selectionEntry id="4c2d-4442-b4e9-2069" name="Master-crafted (Delegatus)" hidden="false" collective="false" import="true" type="upgrade">
+                <selectionEntry id="4c2d-4442-b4e9-2069" name="Master-crafted (Delegatus)" hidden="true" collective="false" import="true" type="upgrade">
                   <modifiers>
-                    <modifier type="set" field="c01c-ce24-9ab3-5e43" value="1.0">
+                    <modifier type="set" field="hidden" value="false">
                       <conditions>
                         <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d2a8-fe6d-b793-225b" type="equalTo"/>
-                      </conditions>
-                    </modifier>
-                    <modifier type="set" field="hidden" value="true">
-                      <conditions>
-                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d2a8-fe6d-b793-225b" type="equalTo"/>
                       </conditions>
                     </modifier>
                   </modifiers>
                   <constraints>
                     <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0f82-7b43-9a68-3c40" type="min"/>
-                    <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c01c-ce24-9ab3-5e43" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c01c-ce24-9ab3-5e43" type="max"/>
                   </constraints>
                   <infoLinks>
                     <infoLink id="12e4-b229-d480-9787" name="Master-crafted" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule"/>
@@ -13525,16 +13682,16 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                     <cost name="pts" typeId="points" value="10.0"/>
                   </costs>
                 </selectionEntry>
-                <selectionEntry id="990c-75b4-5347-1b17" name="Master-crafted one weapon (Champion)" hidden="false" collective="false" import="true" type="upgrade">
+                <selectionEntry id="990c-75b4-5347-1b17" name="Master-crafted One Weapon (Champion)" hidden="true" collective="false" import="true" type="upgrade">
                   <modifiers>
                     <modifier type="set" field="a3dd-7521-5b14-e375" value="1.0">
                       <conditions>
                         <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7336-2cf5-3705-2ee2" type="equalTo"/>
                       </conditions>
                     </modifier>
-                    <modifier type="set" field="hidden" value="true">
+                    <modifier type="set" field="hidden" value="false">
                       <conditions>
-                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7336-2cf5-3705-2ee2" type="equalTo"/>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7336-2cf5-3705-2ee2" type="equalTo"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -13552,9 +13709,14 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                 <selectionEntry id="5d52-4258-1b84-6ccb" name="Suspensor Web" hidden="true" collective="false" import="true" type="upgrade">
                   <modifiers>
                     <modifier type="set" field="hidden" value="false">
-                      <conditions>
-                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a2d0-d202-f0ce-d081" type="equalTo"/>
-                      </conditions>
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a2d0-d202-f0ce-d081" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d5cb-9f8a-d0fe-9a56" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
                     </modifier>
                   </modifiers>
                   <constraints>
@@ -13586,11 +13748,11 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                     <cost name="pts" typeId="points" value="10.0"/>
                   </costs>
                 </selectionEntry>
-                <selectionEntry id="9003-41e0-26df-7757" name="Master-crafted one weapon (Iron Father)" hidden="false" collective="false" import="true" type="upgrade">
+                <selectionEntry id="9003-41e0-26df-7757" name="Master-crafted One Weapon (Iron Father)" hidden="true" collective="false" import="true" type="upgrade">
                   <modifiers>
-                    <modifier type="set" field="hidden" value="true">
+                    <modifier type="set" field="hidden" value="false">
                       <conditions>
-                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fcb3-10fd-341f-986e" type="equalTo"/>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fcb3-10fd-341f-986e" type="equalTo"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -13602,6 +13764,104 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="72c0-6528-3386-1e2d" name="Cameleoline" page="0" hidden="false" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditionGroups>
+                            <conditionGroup type="or">
+                              <conditions>
+                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b26e-ba33-ff55-3fd6" type="equalTo"/>
+                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ba6-dda6-d587-3da7" type="equalTo"/>
+                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="28d4-97c4-3355-1b98" type="equalTo"/>
+                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a6cc-561c-56f9-a051" type="equalTo"/>
+                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3afd-ac93-1a99-4de9" type="equalTo"/>
+                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="84ea-ada4-abe0-f064" type="equalTo"/>
+                              </conditions>
+                            </conditionGroup>
+                            <conditionGroup type="and">
+                              <conditions>
+                                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="09b8-26b3-b27d-621a" type="equalTo"/>
+                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="631d-c6b6-1f7d-a4b7" type="equalTo"/>
+                              </conditions>
+                            </conditionGroup>
+                          </conditionGroups>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="739d-1b0c-9367-6bf4" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="8721-f8b8-4d94-3451" name="Cameleoline" hidden="false" targetId="7be155f9-ef45-9937-8e60-2c588cb88201" type="profile"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="eade-abca-8b41-1c8f" name="Master-crafted Weapon (Gunnery Centurion)" hidden="true" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d5cb-9f8a-d0fe-9a56" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="47e0-56b8-4a01-5ea3" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="e57d-85f4-379e-dcc0" name="Master-crafted" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="73cc-30c4-14ca-f749" name="Healing Balms" hidden="true" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="91b7-35be-30cc-4c3f" value="1.0">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0f8d-5060-0530-d1f9" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0f8d-5060-0530-d1f9" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="91b7-35be-30cc-4c3f" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c0af-da79-b55a-323f" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="7717-736e-7a2e-3f78" name="Healing Balms" hidden="false" targetId="19fd-5e19-5228-0cc9" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="25.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="36e9-335b-8f71-f7da" name="Garm-blood vial" hidden="true" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0f8d-5060-0530-d1f9" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3f29-0629-fe98-b1c4" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="f7bb-289f-18cf-885c" name="Rending" hidden="false" targetId="8269-2cd6-9236-16e7" type="rule"/>
+                    <infoLink id="95da-5067-bd24-1dbb" name="Garm-blood vial" hidden="false" targetId="c648-3c59-a719-8297" type="profile"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -13721,6 +13981,7 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                           <conditions>
                             <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2832-4cb2-3a2c-5683" type="equalTo"/>
                             <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="34fa-286c-521b-2899" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d5cb-9f8a-d0fe-9a56" type="equalTo"/>
                           </conditions>
                         </conditionGroup>
                       </conditionGroups>
@@ -13743,27 +14004,6 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                     <cost name="pts" typeId="points" value="5.0"/>
                   </costs>
                 </entryLink>
-                <entryLink id="d9c1-27b0-cc73-b6d6" name="Cameleoline" hidden="false" collective="false" import="true" targetId="0d86175b-00bf-8a27-6964-d6eec7f81169" type="selectionEntry">
-                  <modifiers>
-                    <modifier type="set" field="hidden" value="true">
-                      <conditionGroups>
-                        <conditionGroup type="or">
-                          <conditions>
-                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b26e-ba33-ff55-3fd6" type="equalTo"/>
-                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ba6-dda6-d587-3da7" type="equalTo"/>
-                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="28d4-97c4-3355-1b98" type="equalTo"/>
-                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a6cc-561c-56f9-a051" type="equalTo"/>
-                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3afd-ac93-1a99-4de9" type="equalTo"/>
-                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="84ea-ada4-abe0-f064" type="equalTo"/>
-                          </conditions>
-                        </conditionGroup>
-                      </conditionGroups>
-                    </modifier>
-                  </modifiers>
-                  <costs>
-                    <cost name="pts" typeId="points" value="5.0"/>
-                  </costs>
-                </entryLink>
                 <entryLink id="5c39-2fc8-1c2b-17dc" name="Infravisor" hidden="false" collective="false" import="true" targetId="4d465f07-675f-0f55-c8cb-ca43c5e2adba" type="selectionEntry">
                   <costs>
                     <cost name="pts" typeId="points" value="5.0"/>
@@ -13781,7 +14021,7 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                     <cost name="pts" typeId="points" value="10.0"/>
                   </costs>
                 </entryLink>
-                <entryLink id="fbbf-0b34-64cc-874d" name="Servo-arm" hidden="false" collective="false" import="true" targetId="4c4b-b3ad-f37b-0dcf" type="selectionEntry">
+                <entryLink id="fbbf-0b34-64cc-874d" name="Servo-arm" hidden="true" collective="false" import="true" targetId="4c4b-b3ad-f37b-0dcf" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="hidden" value="false">
                       <conditionGroups>
@@ -13796,6 +14036,194 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                   </modifiers>
                   <costs>
                     <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="306a-8210-d765-fde3" name="Augury Scanner" hidden="true" collective="false" import="true" targetId="7e20-c85a-2e04-dd0b" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d5cb-9f8a-d0fe-9a56" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0d32-4399-cd60-62be" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="aded-1955-fced-f1b8" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                    <modifier type="set" field="points" value="5.0">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="aded-1955-fced-f1b8" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0d32-4399-cd60-62be" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="b400-9e6c-6ffb-d8e4" name="Armistos / Gunnery Centurion Weapons (Select 1)" hidden="true" collective="false" import="true">
+              <modifiers>
+                <modifier type="set" field="d267-f0c9-8837-8448" value="1.0">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d5cb-9f8a-d0fe-9a56" type="equalTo"/>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0d32-4399-cd60-62be" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+                <modifier type="set" field="hidden" value="false">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d5cb-9f8a-d0fe-9a56" type="equalTo"/>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0d32-4399-cd60-62be" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d267-f0c9-8837-8448" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b128-097a-707b-2ea0" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="c1cd-7182-1f30-4e29" name="Master-crafted Heavy Bolter" hidden="true" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0d32-4399-cd60-62be" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="104d-68fe-cd6e-ea27" type="max"/>
+                  </constraints>
+                  <profiles>
+                    <profile id="7b93-2ae7-be09-a5fe" name="Master-crafted Heavy Bolter" publicationId="ca571888--pubN106502" page="177" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+                      <characteristics>
+                        <characteristic name="Range" typeId="52616e676523232344415441232323">36&quot;</characteristic>
+                        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">5</characteristic>
+                        <characteristic name="AP" typeId="415023232344415441232323">4</characteristic>
+                        <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 3, Master-crafted</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <infoLinks>
+                    <infoLink id="1a3b-8b08-75f9-da5e" name="Master-crafted" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="3a37-6377-c0d2-39ea" name="Master-crafted Vulkite Culverin" hidden="true" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0d32-4399-cd60-62be" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f30c-3af5-c157-d68b" type="max"/>
+                  </constraints>
+                  <profiles>
+                    <profile id="bd2e-a4bf-d40f-8774" name="Master-crafted Volkite Culverin" publicationId="ca571888--pubN106502" page="178" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+                      <characteristics>
+                        <characteristic name="Range" typeId="52616e676523232344415441232323">45&quot;</characteristic>
+                        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">6</characteristic>
+                        <characteristic name="AP" typeId="415023232344415441232323">5</characteristic>
+                        <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 4, Deflagrate</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <infoLinks>
+                    <infoLink id="8deb-0b91-fe4f-9574" name="Master-crafted" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <entryLinks>
+                <entryLink id="bbf3-f82c-e857-45ba" name="Autocannon" hidden="true" collective="false" import="true" targetId="0137-bfce-22c9-8f03" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d5cb-9f8a-d0fe-9a56" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="505c-654e-c080-ac12" name="Missile Launcher" hidden="true" collective="false" import="true" targetId="e5d2-e10d-1552-c5c6" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d5cb-9f8a-d0fe-9a56" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="3562-0460-fce7-bbfc" name="Multi-melta" hidden="true" collective="false" import="true" targetId="d1c0-746f-2b39-5f17" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d5cb-9f8a-d0fe-9a56" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <costs>
+                    <cost name="pts" typeId="points" value="15.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="590d-cd53-267a-66ec" name="Volkite Culverin" hidden="true" collective="false" import="true" targetId="8700-d2ba-d829-3f5f" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d5cb-9f8a-d0fe-9a56" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <costs>
+                    <cost name="pts" typeId="points" value="15.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="cf7a-492c-c553-9977" name="Plasma Cannon" hidden="true" collective="false" import="true" targetId="9f1b-7c69-13d6-56b5" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d5cb-9f8a-d0fe-9a56" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <costs>
+                    <cost name="pts" typeId="points" value="20.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="1b4f-9192-0a5b-a121" name="Lascannon" hidden="true" collective="false" import="true" targetId="8036-b730-d533-e31f" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d5cb-9f8a-d0fe-9a56" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <costs>
+                    <cost name="pts" typeId="points" value="25.0"/>
                   </costs>
                 </entryLink>
               </entryLinks>
@@ -13845,6 +14273,7 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                       <conditions>
                         <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f3ce-93fe-445b-b5aa" type="equalTo"/>
                         <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e77c-43f9-71c0-a632" type="equalTo"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="83c2-692c-6560-3d68" type="equalTo"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
@@ -13879,6 +14308,7 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                         <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f3ce-93fe-445b-b5aa" type="equalTo"/>
                         <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e77c-43f9-71c0-a632" type="equalTo"/>
                         <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8fc1-75d3-7414-71ff" type="equalTo"/>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="72c0-6528-3386-1e2d" type="equalTo"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
@@ -13907,6 +14337,7 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                         <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f3ce-93fe-445b-b5aa" type="equalTo"/>
                         <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e77c-43f9-71c0-a632" type="equalTo"/>
                         <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8fc1-75d3-7414-71ff" type="equalTo"/>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="72c0-6528-3386-1e2d" type="equalTo"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
@@ -13934,6 +14365,7 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                       <conditions>
                         <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f3ce-93fe-445b-b5aa" type="equalTo"/>
                         <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e77c-43f9-71c0-a632" type="equalTo"/>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="72c0-6528-3386-1e2d" type="equalTo"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
@@ -14951,7 +15383,7 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                                 <conditionGroup type="and">
                                   <conditions>
                                     <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8ec6-01a2-a384-fc01" type="equalTo"/>
-                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8eed-07ab-2697-6716" type="atLeast"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8eed-07ab-2697-6716" type="equalTo"/>
                                   </conditions>
                                 </conditionGroup>
                                 <conditionGroup type="and">
@@ -15016,7 +15448,7 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                                 <conditionGroup type="and">
                                   <conditions>
                                     <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9f7e-e17f-0160-2e3b" type="equalTo"/>
-                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a28b-4fd2-7335-f4e3" type="atLeast"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a28b-4fd2-7335-f4e3" type="equalTo"/>
                                   </conditions>
                                 </conditionGroup>
                                 <conditionGroup type="and">
@@ -15045,7 +15477,7 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                                 <conditionGroup type="and">
                                   <conditions>
                                     <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="197c-a30c-b107-d542" type="equalTo"/>
-                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9003-41e0-26df-7757" type="atLeast"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9003-41e0-26df-7757" type="equalTo"/>
                                   </conditions>
                                 </conditionGroup>
                                 <conditionGroup type="and">
@@ -15071,6 +15503,235 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                             <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b93-5209-638f-f215" type="equalTo"/>
                             <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="00cf-de58-1648-1321" type="equalTo"/>
                           </conditions>
+                        </conditionGroup>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4652-e768-5037-5cc4" type="equalTo"/>
+                          </conditions>
+                          <conditionGroups>
+                            <conditionGroup type="or">
+                              <conditionGroups>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0d05-c7d9-07eb-d99f" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="028a-9081-62be-f340" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d062-ccde-3885-8157" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="028a-9081-62be-f340" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5476-e8db-b6b0-4a1e" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0d05-c7d9-07eb-d99f" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21a0-14df-d719-e116" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="028a-9081-62be-f340" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5476-e8db-b6b0-4a1e" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="028a-9081-62be-f340" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0d05-c7d9-07eb-d99f" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d062-ccde-3885-8157" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0d05-c7d9-07eb-d99f" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21a0-14df-d719-e116" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                              </conditionGroups>
+                            </conditionGroup>
+                          </conditionGroups>
+                        </conditionGroup>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="631d-c6b6-1f7d-a4b7" type="equalTo"/>
+                          </conditions>
+                          <conditionGroups>
+                            <conditionGroup type="or">
+                              <conditionGroups>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5476-e8db-b6b0-4a1e" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="64f3-dde0-ce54-8812" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5476-e8db-b6b0-4a1e" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="72c0-6528-3386-1e2d" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="67a3-e392-a991-207c" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="72c0-6528-3386-1e2d" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="67a3-e392-a991-207c" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="64f3-dde0-ce54-8812" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="72c0-6528-3386-1e2d" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="64f3-dde0-ce54-8812" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="67a3-e392-a991-207c" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5476-e8db-b6b0-4a1e" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                              </conditionGroups>
+                            </conditionGroup>
+                          </conditionGroups>
+                        </conditionGroup>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0d32-4399-cd60-62be" type="equalTo"/>
+                          </conditions>
+                          <conditionGroups>
+                            <conditionGroup type="or">
+                              <conditionGroups>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7e20-c85a-2e04-dd0b" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="226b-daab-2b5a-fc19" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="79ba-8772-1e33-2817" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7e20-c85a-2e04-dd0b" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="226b-daab-2b5a-fc19" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="79ba-8772-1e33-2817" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                              </conditionGroups>
+                            </conditionGroup>
+                          </conditionGroups>
+                        </conditionGroup>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d5cb-9f8a-d0fe-9a56" type="equalTo"/>
+                          </conditions>
+                          <conditionGroups>
+                            <conditionGroup type="or">
+                              <conditionGroups>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ad36-5b18-1af9-86ac" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="226b-daab-2b5a-fc19" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7e20-c85a-2e04-dd0b" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b4ea-a586-86a9-02eb" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7e20-c85a-2e04-dd0b" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="eade-abca-8b41-1c8f" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5d52-4258-1b84-6ccb" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7e20-c85a-2e04-dd0b" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7e20-c85a-2e04-dd0b" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="eade-abca-8b41-1c8f" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="eade-abca-8b41-1c8f" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ad36-5b18-1af9-86ac" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ad36-5b18-1af9-86ac" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7e20-c85a-2e04-dd0b" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="eade-abca-8b41-1c8f" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="226b-daab-2b5a-fc19" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b4ea-a586-86a9-02eb" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5d52-4258-1b84-6ccb" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7e20-c85a-2e04-dd0b" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ad36-5b18-1af9-86ac" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                              </conditionGroups>
+                            </conditionGroup>
+                          </conditionGroups>
+                        </conditionGroup>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0f8d-5060-0530-d1f9" type="equalTo"/>
+                          </conditions>
+                          <conditionGroups>
+                            <conditionGroup type="or">
+                              <conditionGroups>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cbea-12f3-6fd6-399f" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="36e9-335b-8f71-f7da" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1cd9-4374-7652-9168" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cbea-12f3-6fd6-399f" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1cd9-4374-7652-9168" type="equalTo"/>
+                                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="36e9-335b-8f71-f7da" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                              </conditionGroups>
+                            </conditionGroup>
+                          </conditionGroups>
                         </conditionGroup>
                       </conditionGroups>
                     </conditionGroup>
@@ -15220,12 +15881,16 @@ Sniper Rifle + Expert Marksman (Location: Basic, Cost 5pts, Not Mandatory)</desc
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="867e-b770-ac62-2ed2" type="max"/>
                   </constraints>
                   <rules>
-                    <rule id="d76d-6c58-fbfe-87ab" name="Custom " hidden="false">
-                      <description>Custom 
- (Location: Specialisation &amp; Legion Special Rules, Cost pts, Mandatory)
- (Location: Wargear, Cost pts, Not Mandatory)
- (Location: Melee, Cost pts each, Not Mandatory)
- (Location: Basic, Cost pts each, Not Mandatory)</description>
+                    <rule id="d76d-6c58-fbfe-87ab" name="Custom Saboteur" hidden="false">
+                      <description>Custom Saboteur
+Must start in Reserves
+Lone Killer (Location: Specialisation &amp; Legion Special Rules, Cost 0pts, Mandatory)
+Outflank (Location: Specialisation &amp; Legion Special Rules, Cost 5pts, Mandatory)
+Cameleoline (Location: Wargear, Cost 5pts, Not Mandatory)
+Sabotage (Location: Specialisation &amp; Legion Special Rules, Cost 10pts, Not Mandatory)
+Grenade: Psyk-out Grenades (Location: Grenades, Cost 5pts, Not Mandatory)
+Transvectic Generators^ (Location: Psyarkana, Cost 25pts, Not Mandatory)
+</description>
                     </rule>
                   </rules>
                   <categoryLinks>
@@ -15252,8 +15917,8 @@ Sniper Rifle + Expert Marksman (Location: Basic, Cost 5pts, Not Mandatory)</desc
 Unlocks Pale Hunters Rite of War
 Terminator Armour is Tartaros only
 Infiltrate (model + attached unit)  (Location: Specialisation &amp; Legion Special Rules, Cost 10pts, Mandatory)
-Shrouded (Location: Specialisation &amp; Legion Special Rules, Cost 10pts, Non-Mandatory)
-Blood Scent (Marked for Death) (Location: Specialisation &amp; Legion Special Rules, Cost 10pts, Non-Mandatory)</description>
+Shrouded (Location: Specialisation &amp; Legion Special Rules, Cost 10pts, Not Mandatory)
+Blood Scent (Marked for Death) (Location: Specialisation &amp; Legion Special Rules, Cost 10pts, Not Mandatory)</description>
                     </rule>
                   </rules>
                   <categoryLinks>
@@ -15281,8 +15946,8 @@ Blood Scent (Marked for Death) (Location: Specialisation &amp; Legion Special Ru
 Unlocks Bloodied Claws Rite of War
 Must have +1 Grey Slayer squad  (Location: Specialisation &amp; Legion Special Rules, Cost 0pts, Mandatory)
 Veteran Tactic: Warrior’s Mettle  (Location: Specialisation &amp; Legion Special Rules, Cost 5pts, Mandatory)
-Warrior’s Mettle  (Location: Specialisation &amp; Legion Special Rules, Cost 15pts, Non-Mandatory)
-Howl of the Death Wolf  (Location: Specialisation &amp; Legion Special Rules, Cost 30pts, Non-Mandatory)
+Warrior’s Mettle  (Location: Specialisation &amp; Legion Special Rules, Cost 15pts, Not Mandatory)
+Howl of the Death Wolf  (Location: Specialisation &amp; Legion Special Rules, Cost 30pts, Not Mandatory)
 
  (Location: Wargear, Cost pts, Not Mandatory)
  (Location: Melee, Cost pts each, Not Mandatory)
@@ -15362,12 +16027,14 @@ Battlesmith (Location: Specialisation &amp; Legion Special Rules, Cost 10pts, No
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aa17-492f-5c39-793b" type="max"/>
                   </constraints>
                   <rules>
-                    <rule id="0159-b8c4-1eee-6683" name="Custom " hidden="false">
-                      <description>Custom 
- (Location: Specialisation &amp; Legion Special Rules, Cost pts, Mandatory)
- (Location: Wargear, Cost pts, Not Mandatory)
- (Location: Melee, Cost pts each, Not Mandatory)
- (Location: Basic, Cost pts each, Not Mandatory)</description>
+                    <rule id="0159-b8c4-1eee-6683" name="Custom Gunnery Centurion" hidden="false">
+                      <description>Custom Gunnery Centurion
+Must select 1 of the following weapons Autocannon / Missile Launcher / Multi-melta / Volkite Culverin / Plasma Cannon / Lascannon (Location: Armistos / Gunnery Centurion Weapons, Cost 10 / 10 / 15 / 15 / 20 / 25pts, Mandatory) 
+Master-crafted Weapon (Gunnery Centurion) (Location: Wargear, Cost 5pts, Not Mandatory)
+Coordinating Fire (Location: Specialisation &amp; Legion Special Rules, Cost 10pts, Not Mandatory)
+Augury Scanner (Location: Wargear, Cost 10pts, Not Mandatory)
+Nuncio Vox (Location: Wargear, Cost 10pts, Not Mandatory)
+Suspensor Web (Location: Wargear, Cost 5pts, Not Mandatory)</description>
                     </rule>
                   </rules>
                   <categoryLinks>
@@ -15535,12 +16202,13 @@ Battlesmith (Location: Specialisation &amp; Legion Special Rules, Cost 10pts, No
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9f55-8009-4dd1-8c4f" type="max"/>
                   </constraints>
                   <rules>
-                    <rule id="ea92-488a-c43f-0302" name="Custom " hidden="false">
-                      <description>Custom 
- (Location: Specialisation &amp; Legion Special Rules, Cost pts, Mandatory)
- (Location: Wargear, Cost pts, Not Mandatory)
- (Location: Melee, Cost pts each, Not Mandatory)
- (Location: Basic, Cost pts each, Not Mandatory)</description>
+                    <rule id="ea92-488a-c43f-0302" name="Custom Speaker of the Dead" hidden="false">
+                      <description>Custom Speaker of the Dead
+Healing Balms (Location: Wargear, Cost 25pts, Mandatory)
+Garm Blood Vial (Location: Wargear, Cost 5pts, Not Mandatory)
+Preferred Enemy (Infantry) (Location: Specialisation &amp; Legion Special Rules, Cost 10pts, Not Mandatory)
+Fearless  (Location: Specialisation &amp; Legion Special Rules, Cost 15pts, Not Mandatory)
+</description>
                     </rule>
                   </rules>
                   <costs>
@@ -15607,12 +16275,12 @@ Battlesmith (Location: Specialisation &amp; Legion Special Rules, Cost 10pts, No
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="be69-1b34-b1be-2170" type="max"/>
                   </constraints>
                   <rules>
-                    <rule id="8ed4-085e-05b9-ef7a" name="Custom " hidden="false">
-                      <description>Custom 
- (Location: Specialisation &amp; Legion Special Rules, Cost pts, Mandatory)
- (Location: Wargear, Cost pts, Not Mandatory)
- (Location: Melee, Cost pts each, Not Mandatory)
- (Location: Basic, Cost pts each, Not Mandatory)</description>
+                    <rule id="8ed4-085e-05b9-ef7a" name="Custom Armistos" hidden="false">
+                      <description>Custom Armistos
+Master-crafted Heavy Bolter OR Volkite Culverin (Location: Armistos / Gunnery Centurion Weapons, Cost 5/10pts each, Mandatory)
+Prototype Weapons (Location: Specialisation &amp; Legion Special Rules, Cost 5pts, Not Mandatory)
+Augury Scanner (Location: Wargear, Cost 5pts, Not Mandatory)
+Stubborn (Location: Specialisation &amp; Legion Special Rules, Cost 5pts, Not Mandatory)</description>
                     </rule>
                   </rules>
                   <costs>
@@ -15651,17 +16319,23 @@ Iron Halo (Location: Shields and Fields, Cost 25/10pts depending on if in Termy 
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9b32-7897-04f8-4766" type="max"/>
                   </constraints>
                   <rules>
-                    <rule id="e1b5-bf6f-8322-3015" name="Custom " hidden="false">
-                      <description>Custom 
- (Location: Specialisation &amp; Legion Special Rules, Cost pts, Mandatory)
- (Location: Wargear, Cost pts, Not Mandatory)
- (Location: Melee, Cost pts each, Not Mandatory)
- (Location: Basic, Cost pts each, Not Mandatory)</description>
+                    <rule id="e1b5-bf6f-8322-3015" name="Custom Diabolist" hidden="false">
+                      <description>Custom Diabolist
+Unlocks Dark Brethren Rite of War
+Dark Channeling (Location: Specialisation &amp; Legion Special Rules, Cost 10pts, Mandatory)
+Daemon (5++, Fear) (Location: Specialisation &amp; Legion Special Rules, Cost 15pts, Not Mandatory)
+Preferred Enemy (Loyalist) (Location: Specialisation &amp; Legion Special Rules, Cost 10pts, Not Mandatory)
+Transvectic Generators#^ (Location: Psyarkana, Cost 25pts, Not Mandatory)
+Sacrificial Enervation^ (Location: Specialisation &amp; Legion Special Rules, Cost 20pts, Not Mandatory)
+Digittalis Arcanis^ (Location: Psyarkana, Cost 30pts, Not Mandatory)</description>
                     </rule>
                   </rules>
                   <categoryLinks>
                     <categoryLink id="1326-d2f5-882b-9435" name="Compulsory HQ" hidden="false" targetId="becd-7a6d-e80f-878e" primary="false"/>
                   </categoryLinks>
+                  <entryLinks>
+                    <entryLink id="3207-f9e0-ce1b-ae59" name="Diabolist" hidden="false" collective="false" import="true" targetId="04c7-e335-05c0-43bb" type="selectionEntry"/>
+                  </entryLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="0.0"/>
                   </costs>
@@ -15783,9 +16457,14 @@ Master of Cybernetica (Location: Specialisation &amp; Legion Special Rules, Cost
         <selectionEntryGroup id="cb47-a51a-9399-b049" name="Mobility / Unit Type (0-1)" hidden="false" collective="false" import="true">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3aaa-366b-7265-5402" type="equalTo"/>
-              </conditions>
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0d32-4399-cd60-62be" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3aaa-366b-7265-5402" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
             </modifier>
           </modifiers>
           <constraints>
@@ -15812,6 +16491,7 @@ Master of Cybernetica (Location: Specialisation &amp; Legion Special Rules, Cost
                         <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe8b-2145-2541-9062" type="equalTo"/>
                         <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="af34-c67e-eef6-024d" type="equalTo"/>
                         <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4c4b-b3ad-f37b-0dcf" type="equalTo"/>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="72c0-6528-3386-1e2d" type="equalTo"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
@@ -15845,6 +16525,7 @@ Master of Cybernetica (Location: Specialisation &amp; Legion Special Rules, Cost
                         <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe8b-2145-2541-9062" type="equalTo"/>
                         <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4652-e768-5037-5cc4" type="equalTo"/>
                         <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="af34-c67e-eef6-024d" type="equalTo"/>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="72c0-6528-3386-1e2d" type="equalTo"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
@@ -15907,6 +16588,7 @@ Master of Cybernetica (Location: Specialisation &amp; Legion Special Rules, Cost
                         <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe8b-2145-2541-9062" type="equalTo"/>
                         <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="af34-c67e-eef6-024d" type="equalTo"/>
                         <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4652-e768-5037-5cc4" type="equalTo"/>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="72c0-6528-3386-1e2d" type="equalTo"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
@@ -16143,11 +16825,19 @@ Master of Cybernetica (Location: Specialisation &amp; Legion Special Rules, Cost
             <entryLink id="0a95-0e58-99ce-d282" name="Psyk-out Grenades" hidden="true" collective="false" import="true" targetId="64f3-dde0-ce54-8812" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="hidden" value="false">
-                  <conditions>
-                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a2d0-d202-f0ce-d081" type="equalTo"/>
-                  </conditions>
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="631d-c6b6-1f7d-a4b7" type="equalTo"/>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a2d0-d202-f0ce-d081" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
                 </modifier>
               </modifiers>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
@@ -16257,6 +16947,50 @@ Master of Cybernetica (Location: Specialisation &amp; Legion Special Rules, Cost
               </modifiers>
               <costs>
                 <cost name="pts" typeId="points" value="60.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="b7c9-efd1-fd9e-0366" name="Tansvectic Generators" hidden="true" collective="false" import="true" targetId="5476-e8db-b6b0-4a1e" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="631d-c6b6-1f7d-a4b7" type="equalTo"/>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4652-e768-5037-5cc4" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <categoryLinks>
+                <categoryLink id="f1dc-6bbb-4a61-b7e4" name="# Restiction" hidden="false" targetId="c821-d9f2-5684-64fa" primary="false"/>
+              </categoryLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="25.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="50cc-f09b-f1e5-5aeb" name="The Digittalis Arcanis" hidden="true" collective="false" import="true" targetId="21a0-14df-d719-e116" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <conditions>
+                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4652-e768-5037-5cc4" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <costs>
+                <cost name="pts" typeId="points" value="30.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="6c10-a57c-8cd3-8854" name="Sacrificial Innervation" hidden="true" collective="false" import="true" targetId="d062-ccde-3885-8157" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <conditions>
+                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4652-e768-5037-5cc4" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <costs>
+                <cost name="pts" typeId="points" value="20.0"/>
               </costs>
             </entryLink>
           </entryLinks>

--- a/(HH) Solar Auxilia - Crusade Army List.cat
+++ b/(HH) Solar Auxilia - Crusade Army List.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="7f243fc5-c5fd-8b2c-7b07-907bf684bb72" name="Solar Auxilia" revision="70" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="124" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="7f243fc5-c5fd-8b2c-7b07-907bf684bb72" name="Solar Auxilia" revision="71" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="124" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="7f243fc5--pubN65537" name="Crusade Imperialis"/>
     <publication id="7f243fc5--pubN65563" name="AoDRB"/>
@@ -5073,7 +5073,7 @@ Precision Shots</description>
               <infoLinks>
                 <infoLink id="bb60-0b64-32da-a9c0" hidden="false" targetId="d1d6a67c-d459-abd8-5e7d-41900b3a84f4" type="profile"/>
                 <infoLink id="e204-3e7c-ecf3-b9b1" hidden="false" targetId="4006-78dc-d90d-7c8c" type="profile"/>
-                <infoLink id="3ee2-72b9-a8ce-0f74" hidden="false" targetId="d9f7-775b-1047-f335" type="profile"/>
+                <infoLink id="3ee2-72b9-a8ce-0f74" name="Krak Grenade (Shooting)" hidden="false" targetId="d9f7-775b-1047-f335" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
@@ -6137,6 +6137,7 @@ Precision Shots</description>
         <infoLink id="90d0-e280-c88b-494d" name="Frag Grenades" hidden="false" targetId="d890-1b84-bbd9-12d3" type="profile"/>
         <infoLink id="3514-ac76-f1bd-85b0" name="Krak Grenade (Shooting)" hidden="false" targetId="d9f7-775b-1047-f335" type="profile"/>
         <infoLink id="71fe-c3d9-597e-3d16" name="Adamantium Will" hidden="false" targetId="df87-e991-2d30-dc38" type="rule"/>
+        <infoLink id="2a71-fb91-e80f-5c5f" name="Krak Grenade (Assault)" hidden="false" targetId="ba14-6731-7c9d-ef15" type="profile"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="5dc2-461c-3d6e-80d4-485123232344415441232323" hidden="false" targetId="485123232344415441232323" primary="true"/>
@@ -6869,7 +6870,8 @@ Precision Shots</description>
         <infoLink id="f720-d3b5-78ee-fd3f" hidden="false" targetId="470a38b3-ad69-52de-2996-36fa27f50e04" type="rule"/>
         <infoLink id="c126-b0f8-030d-269a" hidden="false" targetId="dff0089a-4273-26a0-d96f-b5a36d57a18f" type="profile"/>
         <infoLink id="c6bd-c7c4-a471-2817" name="New InfoLink" hidden="false" targetId="d890-1b84-bbd9-12d3" type="profile"/>
-        <infoLink id="dfab-076d-c93b-f0f5" name="K" hidden="false" targetId="d9f7-775b-1047-f335" type="profile"/>
+        <infoLink id="dfab-076d-c93b-f0f5" name="Krak Grenade (Shooting)" hidden="false" targetId="d9f7-775b-1047-f335" type="profile"/>
+        <infoLink id="53e7-7633-1f8b-167b" name="Krak Grenade (Assault)" hidden="false" targetId="ba14-6731-7c9d-ef15" type="profile"/>
       </infoLinks>
       <selectionEntries>
         <selectionEntry id="b49e-9074-891c-d6bd" name="Sergeant" hidden="false" collective="false" import="true" type="upgrade">
@@ -7226,9 +7228,10 @@ Precision Shots</description>
         <infoLink id="5c35-dbd3-0d0f-dd6b" hidden="false" targetId="aa451588-557c-7f81-2b3f-d17583985f38" type="rule"/>
         <infoLink id="72ff-ba57-25eb-9e56" hidden="false" targetId="470a38b3-ad69-52de-2996-36fa27f50e04" type="rule"/>
         <infoLink id="cadc-9598-a19e-13e6" hidden="false" targetId="0f466e26-4de9-d53c-5270-4c95dcf6867e" type="rule"/>
-        <infoLink id="90aa-c16a-c5ff-b725" hidden="false" targetId="86f51528-f2ce-a3eb-15d1-9396cf0548c7" type="profile"/>
+        <infoLink id="90aa-c16a-c5ff-b725" name="Void Armour" hidden="false" targetId="86f51528-f2ce-a3eb-15d1-9396cf0548c7" type="profile"/>
         <infoLink id="7a74-5453-4fc8-58d5" name="New InfoLink" hidden="false" targetId="d890-1b84-bbd9-12d3" type="profile"/>
-        <infoLink id="f9e4-da05-424e-ee29" name="K" hidden="false" targetId="d9f7-775b-1047-f335" type="profile"/>
+        <infoLink id="f9e4-da05-424e-ee29" name="Krak Grenade (Shooting)" hidden="false" targetId="d9f7-775b-1047-f335" type="profile"/>
+        <infoLink id="d863-3305-9148-7413" name="Krak Grenade (Assault)" hidden="false" targetId="ba14-6731-7c9d-ef15" type="profile"/>
       </infoLinks>
       <selectionEntries>
         <selectionEntry id="4c5d-f901-b563-d4df" name="Sergeant" hidden="false" collective="false" import="true" type="upgrade">
@@ -7707,7 +7710,7 @@ Precision Shots</description>
         <infoLink id="2a9a-b1b3-d900-d6f9" hidden="false" targetId="0f466e26-4de9-d53c-5270-4c95dcf6867e" type="rule"/>
         <infoLink id="b897-a2dd-f2d5-cb21" hidden="false" targetId="dff0089a-4273-26a0-d96f-b5a36d57a18f" type="profile"/>
         <infoLink id="3a6b-cc58-686f-3037" name="New InfoLink" hidden="false" targetId="6d06-5ea0-9a17-ca97" type="rule"/>
-        <infoLink id="6deb-ee93-bb59-8f92" name="K" hidden="false" targetId="d9f7-775b-1047-f335" type="profile"/>
+        <infoLink id="6deb-ee93-bb59-8f92" name="Krak Grenade (Shooting)" hidden="false" targetId="d9f7-775b-1047-f335" type="profile"/>
         <infoLink id="22e6-5021-8a4b-5b72" name="Frag Grenades" hidden="false" targetId="d890-1b84-bbd9-12d3" type="profile"/>
         <infoLink id="6b27-2e11-2663-cc9d" name="Krak Grenade (Assault)" hidden="false" targetId="ba14-6731-7c9d-ef15" type="profile"/>
       </infoLinks>
@@ -8162,7 +8165,7 @@ Precision Shots</description>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="4523-bc78-92a6-74d7" name="Veletarii may exchange their Volkite Chargers for:" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="4523-bc78-92a6-74d7" name="Veletarii may exchange their Volkite Chargers for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="d68a-6dac-41ca-7d1d">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1f14-3c57-3806-37cb" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d259-696e-8f7d-2b72" type="max"/>
@@ -8426,7 +8429,7 @@ Precision Shots</description>
       <infoLinks>
         <infoLink id="b6dc-dc83-a4d3-7a5c" name="Kinetic Grenade" hidden="false" targetId="d1d6a67c-d459-abd8-5e7d-41900b3a84f4" type="profile"/>
         <infoLink id="65d5-a87b-2b9a-787e" hidden="false" targetId="4006-78dc-d90d-7c8c" type="profile"/>
-        <infoLink id="d720-ba97-200b-a67a" name="Krak Grenade" hidden="false" targetId="d9f7-775b-1047-f335" type="profile"/>
+        <infoLink id="d720-ba97-200b-a67a" name="Krak Grenade (Shooting)" hidden="false" targetId="d9f7-775b-1047-f335" type="profile"/>
       </infoLinks>
       <costs>
         <cost name="pts" typeId="points" value="5.0"/>


### PR DESCRIPTION
**Solar Aux**

Krak Grenade: Assault profile added.

Void Armour: Really odd one. Basically the rules are circular. Void Armour counts as Hardened armour, which gets the same rule as Reinforced Void Armour, which gains all the benefits of Void Armour... The reroll is worded slightly differently on each, but is identical in effect as its just vs templates and blasts. I think the old Hardened armour was just reroll 1s.

Veletaris: default weapon sorted

**Militia**

Muster of Worlds. Warrior Elite, Genecrafted, Survivors of Dark Age, Feral Warriors, Blade and Fury & Abhuman Helots
Frenzon added Rage rule.
Gorgon: Fixed transport part.
Malcador: Fixed lack of Fast Rule

**Legions**

Ebon Keshig: Added Compulsory Elites Category to other elites. Compulsory Elites category added for Garrison Raiders and ZM Attacker forces. Only 1 Elite that I know of always counts as Support Squad (Ebon Keshig) So all the rest have it added to them. Tried to tie the adding of that category to those 2 force org charts, but it wouldn't allow (or i couldn't work out why it wouldn't).

Nostraman Chainglaive: Corrected Strength (again)
Destroyer Sergeant: Fixed issue that they weren't being flagged as a character. This was preventing some weapon selections.

Outriders: Fixed issue for Power Weapons.

