### PR TITLE
1748, 1750, 1752 and some other fixes

### DIFF
--- a/(HH) Solar Auxilia - Crusade Army List.cat
+++ b/(HH) Solar Auxilia - Crusade Army List.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="7f243fc5-c5fd-8b2c-7b07-907bf684bb72" name="Solar Auxilia" revision="71" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="124" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="7f243fc5-c5fd-8b2c-7b07-907bf684bb72" name="Solar Auxilia" revision="72" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="124" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="7f243fc5--pubN65537" name="Crusade Imperialis"/>
     <publication id="7f243fc5--pubN65563" name="AoDRB"/>
@@ -863,7 +863,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
     </selectionEntry>
   </selectionEntries>
   <entryLinks>
-    <entryLink id="6b03-f826-dd80-1ce8" name="New EntryLink" hidden="false" collective="false" import="true" targetId="48db-84ca-2bad-520f" type="selectionEntry">
+    <entryLink id="6b03-f826-dd80-1ce8" name="Castellax Class Battle-Automata Maniple" hidden="false" collective="false" import="true" targetId="48db-84ca-2bad-520f" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="6b03-f826-dd80-1ce8-486561767920537570706f727423232344415441232323" hidden="false" targetId="486561767920537570706f727423232344415441232323" primary="true"/>
       </categoryLinks>
@@ -876,19 +876,25 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
     <entryLink id="1af8-06c0-2f57-8603" name="Baneblade" hidden="false" collective="false" import="true" targetId="093f-6472-95d0-553f" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="1af8-06c0-2f57-8603-1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
+        <categoryLink id="00f7-e8e8-70bf-1796" name="Tank" hidden="false" targetId="e59c-462e-9d9c-66dd" primary="false"/>
+        <categoryLink id="77a7-9aa0-1b73-884a" name="Vehicle" hidden="false" targetId="53bd-99e7-aba0-e79f" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="7b0f-dc90-b9a9-ccb1" name="Auxilia Malcador Heavy Tank" hidden="false" collective="false" import="true" targetId="bbd0-e64e-b0a8-fa02" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="7b0f-dc90-b9a9-ccb1-486561767920537570706f727423232344415441232323" hidden="false" targetId="486561767920537570706f727423232344415441232323" primary="true"/>
+        <categoryLink id="96de-0d9f-a1c7-a562" name="Tank" hidden="false" targetId="e59c-462e-9d9c-66dd" primary="false"/>
+        <categoryLink id="c3be-6dc2-71ee-11d8" name="Vehicle" hidden="false" targetId="53bd-99e7-aba0-e79f" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="5df9-a74f-6efd-2178" name="New EntryLink" hidden="false" collective="false" import="true" targetId="c2ec-a4e1-69b4-ff6f" type="selectionEntry">
+    <entryLink id="5df9-a74f-6efd-2178" name="Auxilia Malcador Infernus Special Weapons Tank" hidden="false" collective="false" import="true" targetId="c2ec-a4e1-69b4-ff6f" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="5df9-a74f-6efd-2178-486561767920537570706f727423232344415441232323" hidden="false" targetId="486561767920537570706f727423232344415441232323" primary="true"/>
+        <categoryLink id="5adc-f99c-0754-e0ed" name="Tank" hidden="false" targetId="e59c-462e-9d9c-66dd" primary="false"/>
+        <categoryLink id="f36a-7f77-ef94-369c" name="Vehicle" hidden="false" targetId="53bd-99e7-aba0-e79f" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="fda8-80a5-9849-61c5" name="New EntryLink" hidden="false" collective="false" import="true" targetId="0fb7-454b-56be-de75" type="selectionEntry">
+    <entryLink id="fda8-80a5-9849-61c5" name="Auxilia Ogryn Charonite Squad" hidden="false" collective="false" import="true" targetId="0fb7-454b-56be-de75" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="fda8-80a5-9849-61c5-456c6974657323232344415441232323" hidden="false" targetId="456c6974657323232344415441232323" primary="true"/>
       </categoryLinks>
@@ -909,6 +915,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
       <categoryLinks>
         <categoryLink id="f027-594d-3cfd-cd2e-1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
         <categoryLink id="ba13-ff31-ec9a-3578" name="New CategoryLink" hidden="false" targetId="e59c-462e-9d9c-66dd" primary="false"/>
+        <categoryLink id="256d-06db-b06f-5fa3" name="Vehicle" hidden="false" targetId="53bd-99e7-aba0-e79f" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="0211-db93-3cb5-85d8" name="Shadowsword" hidden="false" collective="false" import="true" targetId="ed2c-8dcf-d0d2-720e" type="selectionEntry">
@@ -918,7 +925,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <categoryLink id="c9ce-e72d-318c-37d3" name="New CategoryLink" hidden="false" targetId="53bd-99e7-aba0-e79f" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="1869-3d95-4fb1-a015" name="New EntryLink" hidden="false" collective="false" import="true" targetId="c0f1-168d-ee43-1300" type="selectionEntry">
+    <entryLink id="1869-3d95-4fb1-a015" name="Auxilia Primaris-Lightning Strike Fighter" hidden="false" collective="false" import="true" targetId="c0f1-168d-ee43-1300" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="1869-3d95-4fb1-a015-466173742041747461636b23232344415441232323" hidden="false" targetId="466173742041747461636b23232344415441232323" primary="true"/>
       </categoryLinks>
@@ -928,7 +935,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <categoryLink id="acb2-c9d3-955a-d67c-466173742041747461636b23232344415441232323" hidden="false" targetId="466173742041747461636b23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="ef71-f326-0a36-7ef6" name="New EntryLink" hidden="false" collective="false" import="true" targetId="2124-49d9-00fa-c94b" type="selectionEntry">
+    <entryLink id="ef71-f326-0a36-7ef6" name="Auxilia Medicae Detachment" hidden="false" collective="false" import="true" targetId="2124-49d9-00fa-c94b" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="ef71-f326-0a36-7ef6-456c6974657323232344415441232323" hidden="false" targetId="456c6974657323232344415441232323" primary="true"/>
       </categoryLinks>
@@ -943,7 +950,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <categoryLink id="cae6-1e2b-1637-69d4-54726f6f707323232344415441232323" hidden="false" targetId="54726f6f707323232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="7139-ddbc-00d9-fc95" name="New EntryLink" hidden="false" collective="false" import="true" targetId="37e7-47a2-33b3-c00a" type="selectionEntry">
+    <entryLink id="7139-ddbc-00d9-fc95" name="Auxilia Thunderbolt Heavy Fighter" hidden="false" collective="false" import="true" targetId="37e7-47a2-33b3-c00a" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="7139-ddbc-00d9-fc95-466173742041747461636b23232344415441232323" hidden="false" targetId="466173742041747461636b23232344415441232323" primary="true"/>
       </categoryLinks>
@@ -959,19 +966,20 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
       <categoryLinks>
         <categoryLink id="2f4d-d355-342c-867c-1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
         <categoryLink id="3ba3-8ad7-d5ab-21a4" name="New CategoryLink" hidden="false" targetId="e59c-462e-9d9c-66dd" primary="false"/>
+        <categoryLink id="1c6e-0237-eaa0-7933" name="Vehicle" hidden="false" targetId="53bd-99e7-aba0-e79f" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="3b5f-5e48-487e-2c15" name="New EntryLink" hidden="false" collective="false" import="true" targetId="15d3-828f-6f4e-7afe" type="selectionEntry">
+    <entryLink id="3b5f-5e48-487e-2c15" name="Enginseer Auxillia" hidden="false" collective="false" import="true" targetId="15d3-828f-6f4e-7afe" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="3b5f-5e48-487e-2c15-456c6974657323232344415441232323" hidden="false" targetId="456c6974657323232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="3a6b-d72e-edbf-b176" name="New EntryLink" hidden="false" collective="false" import="true" targetId="4c22-81fd-dbe1-6c2c" type="selectionEntry">
+    <entryLink id="3a6b-d72e-edbf-b176" name="Surgeon-Primus Aevos Jovan" hidden="false" collective="false" import="true" targetId="4c22-81fd-dbe1-6c2c" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="3a6b-d72e-edbf-b176-456c6974657323232344415441232323" hidden="false" targetId="456c6974657323232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="b707-0417-df50-af71" name="New EntryLink" hidden="false" collective="false" import="true" targetId="7ca8-8b43-5619-a278" type="selectionEntry">
+    <entryLink id="b707-0417-df50-af71" name="Tarantula Sentry Gun Battery" hidden="false" collective="false" import="true" targetId="7ca8-8b43-5619-a278" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="b707-0417-df50-af71-466173742041747461636b23232344415441232323" hidden="false" targetId="466173742041747461636b23232344415441232323" primary="true"/>
       </categoryLinks>
@@ -981,7 +989,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <categoryLink id="f1cb-6941-2b56-b808" name="HQ" hidden="false" targetId="485123232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="a18e-befe-2f05-5ba4" name="New EntryLink" hidden="false" collective="false" import="true" targetId="b00d-ff04-d487-5d69" type="selectionEntry">
+    <entryLink id="a18e-befe-2f05-5ba4" name="Cyclops Remote Demolitions Unit" hidden="false" collective="false" import="true" targetId="b00d-ff04-d487-5d69" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="a18e-befe-2f05-5ba4-486561767920537570706f727423232344415441232323" hidden="false" targetId="486561767920537570706f727423232344415441232323" primary="true"/>
       </categoryLinks>
@@ -996,7 +1004,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <categoryLink id="de56-2141-e0ec-9e91-485123232344415441232323" hidden="false" targetId="485123232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="e9d4-32e6-14fd-7c2a" name="New EntryLink" hidden="false" collective="false" import="true" targetId="326e-b466-256d-58e5" type="selectionEntry">
+    <entryLink id="e9d4-32e6-14fd-7c2a" name="Household Retinue Squad" hidden="false" collective="false" import="true" targetId="326e-b466-256d-58e5" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="e9d4-32e6-14fd-7c2a-456c6974657323232344415441232323" hidden="false" targetId="456c6974657323232344415441232323" primary="true"/>
       </categoryLinks>
@@ -1016,6 +1024,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
       <categoryLinks>
         <categoryLink id="d2ae-bbb7-2f71-981e-1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
         <categoryLink id="1370-010d-7c12-7f0e" name="New CategoryLink" hidden="false" targetId="e59c-462e-9d9c-66dd" primary="false"/>
+        <categoryLink id="f4b0-5285-ce3d-112b" name="Vehicle" hidden="false" targetId="53bd-99e7-aba0-e79f" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="0928-af97-fee1-bcd3" name="Thallax Cohort" hidden="false" collective="false" import="true" targetId="1781-17c5-6a04-eeff" type="selectionEntry">
@@ -1023,12 +1032,12 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <categoryLink id="0928-af97-fee1-bcd3-486561767920537570706f727423232344415441232323" hidden="false" targetId="486561767920537570706f727423232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="1c86-d154-d063-e62e" name="New EntryLink" hidden="false" collective="false" import="true" targetId="16d6-25c4-af92-4329" type="selectionEntry">
+    <entryLink id="1c86-d154-d063-e62e" name="Aquila Strongpoint" hidden="false" collective="false" import="true" targetId="16d6-25c4-af92-4329" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="1c86-d154-d063-e62e-1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="5a5c-01af-11c5-5803" name="New EntryLink" hidden="false" collective="false" import="true" targetId="fb92-d215-2011-f911" type="selectionEntry">
+    <entryLink id="5a5c-01af-11c5-5803" name="Warlord-Sinister Pattern Battle Psi-Titan" hidden="false" collective="false" import="true" targetId="fb92-d215-2011-f911" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -1040,22 +1049,22 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <categoryLink id="5a5c-01af-11c5-5803-1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="9f23-23d5-fed5-1474" name="New EntryLink" hidden="false" collective="false" import="true" targetId="221e-c435-df50-4f56" type="selectionEntry">
+    <entryLink id="9f23-23d5-fed5-1474" name="Allegiance" hidden="false" collective="false" import="true" targetId="221e-c435-df50-4f56" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="9f23-23d5-fed5-1474-5297-7e0f-fa0b-3537" hidden="false" targetId="5297-7e0f-fa0b-3537" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="ae0d-2b21-a9ba-adce" name="New EntryLink" hidden="false" collective="false" import="true" targetId="04bf-6c22-19fb-4e46" type="selectionEntry">
+    <entryLink id="ae0d-2b21-a9ba-adce" name="Vengeance Weapon Battery" hidden="false" collective="false" import="true" targetId="04bf-6c22-19fb-4e46" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="ae0d-2b21-a9ba-adce-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="d19b-f10a-be09-ee22" name="New EntryLink" hidden="false" collective="false" import="true" targetId="0f73-97f2-b832-f6d0" type="selectionEntry">
+    <entryLink id="d19b-f10a-be09-ee22" name="Defence Line" hidden="false" collective="false" import="true" targetId="0f73-97f2-b832-f6d0" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="d19b-f10a-be09-ee22-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="157f-bd76-fb21-b9e9" name="New EntryLink" hidden="false" collective="false" import="true" targetId="df05-8179-624e-f8b2" type="selectionEntry">
+    <entryLink id="157f-bd76-fb21-b9e9" name="Defence Emplacement" hidden="false" collective="false" import="true" targetId="df05-8179-624e-f8b2" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="157f-bd76-fb21-b9e9-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
@@ -1065,32 +1074,32 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <categoryLink id="d4c0-2f64-4c98-bc85-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="9b91-280c-c805-fa2d" name="New EntryLink" hidden="false" collective="false" import="true" targetId="a172-78de-aaa6-2201" type="selectionEntry">
+    <entryLink id="9b91-280c-c805-fa2d" name="Firestorm Redoubt" hidden="false" collective="false" import="true" targetId="a172-78de-aaa6-2201" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="9b91-280c-c805-fa2d-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="ed33-8c4d-db63-a65c" name="imp" hidden="false" collective="false" import="true" targetId="6140-dc64-5896-957f" type="selectionEntry">
+    <entryLink id="ed33-8c4d-db63-a65c" name="Manufactorum" hidden="false" collective="false" import="true" targetId="6140-dc64-5896-957f" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="ed33-8c4d-db63-a65c-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="f97f-4b09-a18c-a11a" name="New EntryLink" hidden="false" collective="false" import="true" targetId="595a-908e-96a1-f121" type="selectionEntry">
+    <entryLink id="f97f-4b09-a18c-a11a" name="Shrine of the Aquila" hidden="false" collective="false" import="true" targetId="595a-908e-96a1-f121" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="f97f-4b09-a18c-a11a-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="075d-aaf8-c6cd-c6e9" name="New EntryLink" hidden="false" collective="false" import="true" targetId="c05d-2231-2481-4037" type="selectionEntry">
+    <entryLink id="075d-aaf8-c6cd-c6e9" name="Imperial Primus Redoubt" hidden="false" collective="false" import="true" targetId="c05d-2231-2481-4037" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="075d-aaf8-c6cd-c6e9-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="9ebc-b85f-06a3-8a9e" name="New EntryLink" hidden="false" collective="false" import="true" targetId="e10f-7b90-ecd3-80a5" type="selectionEntry">
+    <entryLink id="9ebc-b85f-06a3-8a9e" name="Basilica Administratum" hidden="false" collective="false" import="true" targetId="e10f-7b90-ecd3-80a5" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="9ebc-b85f-06a3-8a9e-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="1509-dfb5-9260-5d22" name="New EntryLink" hidden="false" collective="false" import="true" targetId="55c6-268b-357f-d070" type="selectionEntry">
+    <entryLink id="1509-dfb5-9260-5d22" name="Bastion" hidden="false" collective="false" import="true" targetId="55c6-268b-357f-d070" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="1509-dfb5-9260-5d22-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
@@ -1100,27 +1109,27 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <categoryLink id="f297-91c5-8c5b-2b5d-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="898a-9ac6-9c01-e938" name="New EntryLink" hidden="false" collective="false" import="true" targetId="0116-c81b-1c0f-251c" type="selectionEntry">
+    <entryLink id="898a-9ac6-9c01-e938" name="Bunker" hidden="false" collective="false" import="true" targetId="0116-c81b-1c0f-251c" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="898a-9ac6-9c01-e938-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="ec84-c89c-307c-0bdf" name="New EntryLink" hidden="false" collective="false" import="true" targetId="e0b3-77ca-af76-bd8b" type="selectionEntry">
+    <entryLink id="ec84-c89c-307c-0bdf" name="Sanctum Imperialis" hidden="false" collective="false" import="true" targetId="e0b3-77ca-af76-bd8b" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="ec84-c89c-307c-0bdf-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="b9f4-f8bc-b427-bdab" name="New EntryLink" hidden="false" collective="false" import="true" targetId="ab80-0fef-3e93-8e64" type="selectionEntry">
+    <entryLink id="b9f4-f8bc-b427-bdab" name="Legio Titanicus Warlord Battle Titan" hidden="false" collective="false" import="true" targetId="ab80-0fef-3e93-8e64" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="b9f4-f8bc-b427-bdab-1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="d868-02cd-b8ac-0205" name="New EntryLink" hidden="false" collective="false" import="true" targetId="b894-adfc-6d3d-fde4" type="selectionEntry">
+    <entryLink id="d868-02cd-b8ac-0205" name="Legio Titanicus Warhound Scout Titan" hidden="false" collective="false" import="true" targetId="b894-adfc-6d3d-fde4" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="d868-02cd-b8ac-0205-1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="f100-1e23-6a64-d011" name="New EntryLink" hidden="false" collective="false" import="true" targetId="1fa3-1f86-94a6-bf48" type="selectionEntry">
+    <entryLink id="f100-1e23-6a64-d011" name="Legio Titanicus Reaver Battle Titan" hidden="false" collective="false" import="true" targetId="1fa3-1f86-94a6-bf48" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="f100-1e23-6a64-d011-1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
       </categoryLinks>
@@ -1197,6 +1206,8 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
     <entryLink id="8825-dc6b-737e-8a18" name="Banehammer" hidden="false" collective="false" import="true" targetId="27c7-0760-039c-2cd7" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="571e-0087-314f-2ce8" name="New CategoryLink" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
+        <categoryLink id="26e0-955f-531a-bdd3" name="Vehicle" hidden="false" targetId="53bd-99e7-aba0-e79f" primary="false"/>
+        <categoryLink id="d7fd-6643-ae86-e9f0" name="Tank" hidden="false" targetId="e59c-462e-9d9c-66dd" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="7530-b0f8-f1bb-c85b" name="Solar Aux Superheavy" hidden="false" collective="false" import="true" targetId="58c0-ce76-35a9-5c2e" type="selectionEntry">
@@ -3025,7 +3036,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink id="84d3-6e53-7d8f-cd37" hidden="false" targetId="11bec7a8-6060-53c9-572c-0df68bf9fa78" type="rule"/>
+        <infoLink id="84d3-6e53-7d8f-cd37" name="Explorer Adaptation" hidden="false" targetId="11bec7a8-6060-53c9-572c-0df68bf9fa78" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="9df9-f881-2c7a-e3cd" name="New CategoryLink" hidden="false" targetId="53bd-99e7-aba0-e79f" primary="false"/>


### PR DESCRIPTION
#1748 Solar Aux tank commander fix.
 
#1750 Farith Redloss and Holguin added for Dark Angels from warhammer community article https://www.warhammer-community.com/wp-content/uploads/2020/08/1l6eGjsX4M1sCXdB.pdf

#1752 fix for reavers involving hardened armour.

Also a bunch of clearing up of publications stuff. Still needs a ton of work though.