### PR TITLE
Various Fixes to first push of Book 9

### DIFF
--- a/(HH) Imperialis Militia and Cults Army List.cat
+++ b/(HH) Imperialis Militia and Cults Army List.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="90aa-c2c8-ffb0-496e" name="Imperialis Militia and Cults Army List" revision="106" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="124" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="90aa-c2c8-ffb0-496e" name="Imperialis Militia and Cults Army List" revision="107" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="127" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="90aa-c2c8-pubN65537" name="Crusade Imperialis"/>
     <publication id="90aa-c2c8-pubN65563" name="AoDRB"/>
@@ -6600,8 +6600,8 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
                             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="12b7-d76d-e3db-ce7b" type="min"/>
                           </constraints>
                           <infoLinks>
-                            <infoLink id="2465-fdd3-2c12-c661" name="New InfoLink" hidden="false" targetId="40ea-f002-47cb-4e4e" type="rule"/>
-                            <infoLink id="709e-08e6-d867-04bf" name="New InfoLink" hidden="false" targetId="1b7d-61e2-261f-f902" type="profile"/>
+                            <infoLink id="2465-fdd3-2c12-c661" name="Shell Shock" hidden="false" targetId="40ea-f002-47cb-4e4e" type="rule"/>
+                            <infoLink id="709e-08e6-d867-04bf" name="Quad Mortar (Frag)" hidden="false" targetId="1b7d-61e2-261f-f902" type="profile"/>
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="0.0"/>
@@ -6609,7 +6609,7 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
                         </selectionEntry>
                       </selectionEntries>
                       <costs>
-                        <cost name="pts" typeId="points" value="35.0"/>
+                        <cost name="pts" typeId="points" value="25.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="bc80-7f4e-77b3-562d" name="Quad Multi-laser" hidden="false" collective="false" import="true" type="upgrade">
@@ -7632,7 +7632,7 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
                 </modifier>
               </modifiers>
             </entryLink>
-            <entryLink id="a77f-881e-9fc6-7653" hidden="false" collective="false" import="true" targetId="11ce-7e74-239c-fee7" type="selectionEntry">
+            <entryLink id="a77f-881e-9fc6-7653" name="Rhino Armoured Carrier" hidden="false" collective="false" import="true" targetId="11ce-7e74-239c-fee7" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
@@ -7667,11 +7667,6 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
             </entryLink>
             <entryLink id="e924-f45e-dedd-b358" name="Terrax Pattern Termite Assault Drill" hidden="false" collective="false" import="true" targetId="1b44-8c50-86ae-9a67" type="selectionEntry">
               <modifiers>
-                <modifier type="set" field="hidden" value="true">
-                  <conditions>
-                    <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d18f-6d15-942c-0ac5" type="equalTo"/>
-                  </conditions>
-                </modifier>
                 <modifier type="set" field="hidden" value="true">
                   <conditionGroups>
                     <conditionGroup type="or">
@@ -9409,57 +9404,15 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
       </costs>
     </selectionEntry>
     <selectionEntry id="1b44-8c50-86ae-9a67" name="Terrax Pattern Termite Assault Drill" hidden="false" collective="false" import="true" type="unit">
-      <profiles>
-        <profile id="177e-631e-36f5-d4dd" name="Terrax Pattern Termite Assault Drill" publicationId="90aa-c2c8-pubN110519" hidden="false" typeId="56656869636c6523232344415441232323" typeName="Vehicle">
-          <characteristics>
-            <characteristic name="BS" typeId="425323232344415441232323">4</characteristic>
-            <characteristic name="Front" typeId="46726f6e7423232344415441232323">12</characteristic>
-            <characteristic name="Side" typeId="5369646523232344415441232323">12</characteristic>
-            <characteristic name="Rear" typeId="5265617223232344415441232323">10</characteristic>
-            <characteristic name="HP" typeId="485023232344415441232323">3</characteristic>
-            <characteristic name="Type" typeId="5479706523232344415441232323">Tank, Transport</characteristic>
-          </characteristics>
-        </profile>
-        <profile id="ec21-e085-c763-e48a" name="Terrax Pattern Termite Assault Drill (Transport)" hidden="false" typeId="307d-047f-ca13-706b" typeName="Transport">
-          <characteristics>
-            <characteristic name="Capacity" typeId="8285-4205-b6cd-8473">12*</characteristic>
-            <characteristic name="Fire Points" typeId="b270-a7f9-22b2-3702">None</characteristic>
-            <characteristic name="Access Points" typeId="d17b-0342-b1dc-b8e7">Two access hatches**</characteristic>
-          </characteristics>
-        </profile>
-      </profiles>
-      <rules>
-        <rule id="713e-a9b4-a3ce-d1a6" name="Crawling Advance" hidden="false">
-          <description>A Termite Assault Drill may never move faster than Combat Speed or move Flat Out.</description>
-        </rule>
-        <rule id="c9de-425e-bace-6cb3" name="Death From Below" hidden="false">
-          <description>Instead of the usual rules for Deep Striking, when a Subterranean Assault vehicle enters play via Deep Strike, place a Large Blast (5&quot;) marker on the table and scatter this to determine the final position of its arrival as per the Deep Strike special rule.
-
-Should this marker scatter on top of impassable terrain, a building, ruin, fortification, vehicle or any unit engaged in combat, reduce the scatter distance by the minimum required to avoid the obstacle. If the marker representing the arrival of the Termite was displaced in this way by a vehicle or fortification, the closest vehicle or fortification to the marker immediately suffers a Str 10 AP- hit
-– vehicles are hit on their Side armour. If the arrival of the Termite was instead displaced by any units engaged in close combat, all units in that combat suffer D6 Str 6 AP 4 hits. After the final position of the marker is determined, if the marker covers or touches any enemy or friendly unit, then that unit also suffers D6 Str 6 AP 4 hits.
-
-After all damage is resolved, the Subterranean Assault vehicle may be placed in any orientation so long as the centre of the Large Blast (5&quot;) marker is underneath part of the vehicle’s hull and it remains 1&quot; away from any fortification, vehicle or unit engaged in combat. The area under the Large Blast (5&quot;) marker is now difficult terrain for the rest of the game. Players may, should they wish to, instead
-represent this area with a piece of crater terrain. 
-Should a Subterranean Assault vehicle be placed on top of any unit which does not pose an obstacle to its arrival as described above, the Death from Below special rule allows it to be placed as though the unit was not there. If some models in the unit would end up underneath the Subterranean Assault vehicle when it reaches its final position (it makes no difference whether the unit is Falling
-Back or not), these models must be moved by the controlling player out of the way by the shortest distance, leaving at least 1&quot; between them and the Subterranean Assault vehicle (and indeed any other unit) whilst maintaining unit coherency and staying on the tabletop. Any models that cannot manage this are crushed and removed from play as casualties with no saves allowed.</description>
-        </rule>
-        <rule id="255d-2ce6-727e-364b" name="Melta Cutters" hidden="false">
-          <description>A Termite Assault Drill ignores difficult terrain and dangerous terrain. In addition, it adds +2 to its Strength when making ramming attacks against fortifications.</description>
-        </rule>
-        <rule id="6b3b-8961-6c32-a5d4" name="Subterranean Assault" hidden="false">
-          <description>Should the Termite Assault Drill, and any unit it transports, enter play using the Deep Strike special rule, they count as being a Subterranean Assault vehicle for the wider use of the Subterranean Assault rule for your army. At the beginning of the controlling player’s first turn, they must choose half of their Subterranean Assault vehicles held in reserve for the purpose of Deep Striking (rounding up) to make a Subterranean Assault. These units arrive on the controlling player’s first player turn. The arrival of any
-remaining Subterranean Assault vehicles in the player’s force is rolled for as usual for the mission.
-
-This rule, while similar in function to the Drop Pod Assault special rule, does not interact with it for the purposes of calculating how many units may arrive on the table by Deep Strike. Armies may consist of units with both the Drop Pod Assault and Subterranean Assault rules unless otherwise noted.</description>
-        </rule>
-        <rule id="2138-c152-f007-3485" name="Terrax Pattern Termite Assault Drill" hidden="false">
-          <description>* May not carry models with the Bulky, Very Bulky or Extremely Bulky special rules
-
-** In practice you may choose to open and embark/disembark from a single hatch on either side of the hull.</description>
-        </rule>
-      </rules>
       <infoLinks>
         <infoLink id="68e5-9288-bd4a-9530" name="Deep Strike" hidden="false" targetId="d219-2314-4834-c054" type="rule"/>
+        <infoLink id="4a77-3484-4213-7de5" name="Terrax Pattern Termite Assault Drill (Transport)" hidden="false" targetId="9902-1e3c-b99c-f7cf" type="profile"/>
+        <infoLink id="c5d3-df1e-b78c-2130" name="Crawling Advance" hidden="false" targetId="d130-69b4-bcb9-7454" type="rule"/>
+        <infoLink id="3d7a-f7d7-3456-1973" name="Death From Below" hidden="false" targetId="3cd1-bdfb-4585-182c" type="rule"/>
+        <infoLink id="de33-4f9e-da41-d34c" name="Melta Cutters" hidden="false" targetId="1ace-c133-de63-e4f0" type="rule"/>
+        <infoLink id="952f-ff08-a3fa-8685" name="Subterranean Assault" hidden="false" targetId="1679-b036-dc3a-c6a6" type="rule"/>
+        <infoLink id="47af-0b22-f10d-aa43" name="Terrax Pattern Termite Assault Drill" hidden="false" targetId="cb11-e201-f31b-d74e" type="rule"/>
+        <infoLink id="d46d-e5ba-7670-35c6" name="Terrax Pattern Termite Assault Drill" hidden="false" targetId="70c1-f71a-6ceb-0cab" type="profile"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="a041-1473-958f-103f" name="New CategoryLink" hidden="false" targetId="e4e0-c5d1-3430-f101" primary="false"/>
@@ -9482,15 +9435,10 @@ This rule, while similar in function to the Drop Pod Assault special rule, does 
         </selectionEntryGroup>
         <selectionEntryGroup id="2277-a1e7-86d5-5d77" name="May take any of the following" hidden="false" collective="false" import="true">
           <entryLinks>
-            <entryLink id="9c7a-f245-d753-60e9" name="Armoured Ceramite" hidden="false" collective="false" import="true" targetId="eef6-a613-e479-7274" type="selectionEntry">
-              <modifiers>
-                <modifier type="set" field="points" value="20"/>
-              </modifiers>
-            </entryLink>
             <entryLink id="f245-43b3-795f-64f0" name="Extra Armour" hidden="false" collective="false" import="true" targetId="ad5d-6b1a-2708-3616" type="selectionEntry">
-              <modifiers>
-                <modifier type="set" field="points" value="5"/>
-              </modifiers>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
@@ -9573,13 +9521,13 @@ This rule, while similar in function to the Drop Pod Assault special rule, does 
           </selectionEntries>
           <entryLinks>
             <entryLink id="0f2c-8214-fdcc-a97f" name="Heavy Flamer" hidden="false" collective="false" import="true" targetId="ead9-305c-a7e7-323e" type="selectionEntry">
-              <modifiers>
-                <modifier type="set" field="points" value="10"/>
-              </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9952-606c-7c67-f5bc" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5bed-223b-6122-2f22" type="max"/>
               </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
@@ -9601,24 +9549,24 @@ This rule, while similar in function to the Drop Pod Assault special rule, does 
       </costs>
     </selectionEntry>
     <selectionEntry id="8bbc-b165-3c51-623d" name="Carnodon Strike Squadron" hidden="false" collective="false" import="true" type="upgrade">
-      <profiles>
-        <profile id="dd1b-a652-3da1-5f78" name="Carnodon Strike Squadron" hidden="false" typeId="56656869636c6523232344415441232323" typeName="Vehicle">
-          <characteristics>
-            <characteristic name="BS" typeId="425323232344415441232323">3</characteristic>
-            <characteristic name="Front" typeId="46726f6e7423232344415441232323">12</characteristic>
-            <characteristic name="Side" typeId="5369646523232344415441232323">11</characteristic>
-            <characteristic name="Rear" typeId="5265617223232344415441232323">10</characteristic>
-            <characteristic name="HP" typeId="485023232344415441232323">3</characteristic>
-            <characteristic name="Type" typeId="5479706523232344415441232323">Vehicle (Tank)</characteristic>
-          </characteristics>
-        </profile>
-      </profiles>
       <selectionEntries>
         <selectionEntry id="680b-ee72-feeb-5acd" name="Carnodon Tank" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a625-3b6e-4476-b60d" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="97d9-de32-fa28-f3d7" type="min"/>
           </constraints>
+          <profiles>
+            <profile id="f2f3-6e3f-2702-935f" name="Carnodon Strike Squadron" hidden="false" typeId="56656869636c6523232344415441232323" typeName="Vehicle">
+              <characteristics>
+                <characteristic name="BS" typeId="425323232344415441232323">3</characteristic>
+                <characteristic name="Front" typeId="46726f6e7423232344415441232323">12</characteristic>
+                <characteristic name="Side" typeId="5369646523232344415441232323">11</characteristic>
+                <characteristic name="Rear" typeId="5265617223232344415441232323">10</characteristic>
+                <characteristic name="HP" typeId="485023232344415441232323">3</characteristic>
+                <characteristic name="Type" typeId="5479706523232344415441232323">Vehicle (Tank)</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
           <selectionEntries>
             <selectionEntry id="b892-5200-7994-59c8" name="Heavy Stubber" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
@@ -9684,7 +9632,7 @@ This rule, while similar in function to the Drop Pod Assault special rule, does 
                     <infoLink id="8307-7532-c7a2-7e06" name="Autocannon" hidden="false" targetId="d55f-eed0-800f-5789" type="profile"/>
                   </infoLinks>
                   <costs>
-                    <cost name="pts" typeId="points" value="10.0"/>
+                    <cost name="pts" typeId="points" value="5.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="c3e8-a070-abb4-30d1" name="Two Heavy Bolters" hidden="false" collective="false" import="true" type="upgrade">

--- a/(HH) Mechanicum - Taghmata Army List.cat
+++ b/(HH) Mechanicum - Taghmata Army List.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="cf03-f607-41dc-7545" name="Mechanicum: Taghmata Army List" revision="103" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="127" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="cf03-f607-41dc-7545" name="Mechanicum: Taghmata Army List" revision="104" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="127" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="cf03-f607-pubN65537" name="Horus Heresy: Taghmata Army List"/>
     <publication id="cf03-f607-pubN65563" name="AoDRB"/>
@@ -2250,6 +2250,9 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
               </characteristics>
             </profile>
           </profiles>
+          <categoryLinks>
+            <categoryLink id="89d9-f05e-802f-f3bd" name="Monstrous Creature" hidden="false" targetId="8ec4-17b5-7fea-c682" primary="false"/>
+          </categoryLinks>
           <selectionEntries>
             <selectionEntry id="1b52-8c7c-83a4-64a9" name="Two Rotor Cannons" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
@@ -3098,6 +3101,8 @@ Reduces transport capacity to 8.</description>
       </constraints>
       <infoLinks>
         <infoLink id="1820e89c-0c65-f0ec-48cf-443c8f480688" name="Paragon of Metal" hidden="false" targetId="cb2c-171e-df0f-2bec" type="rule"/>
+        <infoLink id="322e-5140-fa8f-7cb4" name="It Will Not Die" hidden="false" targetId="72d9-7041-9d30-d150" type="rule"/>
+        <infoLink id="70cc-7cb1-baf7-b996" name="Rampage" hidden="false" targetId="0ba8-83bc-74c1-43c2" type="rule"/>
       </infoLinks>
       <costs>
         <cost name="pts" typeId="points" value="35.0"/>
@@ -3967,15 +3972,8 @@ Reduces transport capacity to 8.</description>
         <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="159d-4f16-5905-7fb4" type="max"/>
       </constraints>
       <infoLinks>
-        <infoLink id="3621-5c61-4157-e478" hidden="false" targetId="c1bc-dda3-fb87-e016" type="profile">
-          <modifiers>
-            <modifier type="append" field="name" value="Peltast"/>
-          </modifiers>
-        </infoLink>
+        <infoLink id="3621-5c61-4157-e478" name="Secutarii" hidden="false" targetId="c1bc-dda3-fb87-e016" type="profile"/>
       </infoLinks>
-      <costs>
-        <cost name="pts" typeId="points" value="11.0"/>
-      </costs>
     </selectionEntry>
     <selectionEntry id="c968-115e-0e8b-7836" name="Arc Lance" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -4148,8 +4146,15 @@ Reduces transport capacity to 8.</description>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="9cb4-df13-2a96-b366" name="" hidden="false" collective="false" import="true" targetId="5cd6-814b-5784-13f5" type="selectionEntry"/>
-        <entryLink id="3b53-d120-06ae-a40c" hidden="false" collective="false" import="true" targetId="c472-6345-24b3-f952" type="selectionEntry"/>
+        <entryLink id="9cb4-df13-2a96-b366" name="Kyropatris field generator" hidden="false" collective="false" import="true" targetId="5cd6-814b-5784-13f5" type="selectionEntry"/>
+        <entryLink id="3b53-d120-06ae-a40c" name="Secutarii" hidden="false" collective="false" import="true" targetId="c472-6345-24b3-f952" type="selectionEntry">
+          <modifiers>
+            <modifier type="append" field="name" value="Peltast"/>
+          </modifiers>
+          <costs>
+            <cost name="pts" typeId="points" value="11.0"/>
+          </costs>
+        </entryLink>
         <entryLink id="9933-fe28-89b7-4b5b" hidden="false" collective="false" import="true" targetId="ae94-81c7-edf1-b10d" type="selectionEntry"/>
         <entryLink id="d5c3-1c21-5714-e009" hidden="false" collective="false" import="true" targetId="7b6e-1246-67b8-f13b" type="selectionEntry"/>
         <entryLink id="0c3c-5921-cc0e-1ab3" hidden="false" collective="false" import="true" targetId="04fc-9823-28ea-591d" type="selectionEntryGroup"/>
@@ -4426,11 +4431,13 @@ Reduces transport capacity to 8.</description>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="a3b5-07e3-8e3f-416b" name="" hidden="false" collective="false" import="true" targetId="c472-6345-24b3-f952" type="selectionEntry">
+        <entryLink id="a3b5-07e3-8e3f-416b" name="Secutarii" hidden="false" collective="false" import="true" targetId="c472-6345-24b3-f952" type="selectionEntry">
           <modifiers>
             <modifier type="append" field="name" value="Hoplite"/>
-            <modifier type="set" field="points" value="12"/>
           </modifiers>
+          <costs>
+            <cost name="pts" typeId="points" value="12.0"/>
+          </costs>
         </entryLink>
         <entryLink id="bc60-ee64-0ab8-641b" hidden="false" collective="false" import="true" targetId="04fc-9823-28ea-591d" type="selectionEntryGroup"/>
       </entryLinks>
@@ -4748,6 +4755,7 @@ Buildings and Fortifications D</description>
           <infoLinks>
             <infoLink id="b3c4-af74-c849-5319" name="Night Vision" hidden="false" targetId="a225-e39b-3699-c8f8" type="rule"/>
             <infoLink id="108c-2c8f-0691-20c0" name="Reactor Blast" hidden="false" targetId="d5cf-bd98-2854-13cf" type="rule"/>
+            <infoLink id="4f87-aafa-7784-8aef" name="Atomantic Shielding" hidden="false" targetId="13e0-4939-5232-8d85" type="profile"/>
           </infoLinks>
           <selectionEntries>
             <selectionEntry id="6afd-13e0-1ef7-991d" name="Vultarax arc blaster " hidden="false" collective="false" import="true" type="upgrade">
@@ -5854,11 +5862,7 @@ Buildings and Fortifications D</description>
       </selectionEntryGroups>
       <entryLinks>
         <entryLink id="4934-4c1a-b0c8-c4b0" name="Triaros Armoured Conveyor" hidden="false" collective="false" import="true" targetId="bb6538b0-0f23-8a43-9752-dd356ba76e46" type="selectionEntry"/>
-        <entryLink id="5c7f-660a-ddf0-5fcf" name="May be upgraded with one of the following augment upgrades:" hidden="false" collective="false" import="true" targetId="be81-6f96-f70e-ec07" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="b39b-9817-025c-62da" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ea20-0077-988a-5fee" type="min"/>
-          </constraints>
-        </entryLink>
+        <entryLink id="34f7-3e65-e199-3c74" name="May be upgraded with one of the following augment upgrades:" hidden="false" collective="false" import="true" targetId="34ef-5d4f-eacc-55f7" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="15.0"/>
@@ -9279,7 +9283,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6022-4d73-3523-ad79" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="0c77-9ab0-e472-5840" hidden="false" collective="false" import="true" targetId="e1ca-c072-fd46-7a57" type="selectionEntryGroup"/>
+            <entryLink id="0c77-9ab0-e472-5840" name="Relics of the Dark Age of Technology" hidden="false" collective="false" import="true" targetId="e1ca-c072-fd46-7a57" type="selectionEntryGroup"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0.0"/>
@@ -17592,11 +17596,12 @@ A Unit may not use Counter Attack special rule if it used Reaction Fire.</descri
           </profiles>
           <rules>
             <rule id="ec82-1bf7-4662-0944" name="Uncontrolled Replication" publicationId="cf03-f607-pubN99227" page="223" hidden="false">
-              <description>Should a model be slain by the Nanyte Blaster, roll a D6. On a 4+ center a
-                                Large Blast marker on the model&apos;s position and resolve a blast attack at Str 5 AP 2.
-                                Further casualties may themselves trigger futher Uncontrolled Replications.</description>
+              <description>Should a model be slain by the Nanyte Blaster, roll a D6. On a 4+ center a Large Blast marker on the model&apos;s position and resolve a blast attack at Str 5 AP 2. Further casualties may themselves trigger futher Uncontrolled Replications.</description>
             </rule>
           </rules>
+          <infoLinks>
+            <infoLink id="95c6-de49-5ae7-1a08" name="Fleshbane" hidden="false" targetId="4575-0a0a-caaf-e4bf" type="rule"/>
+          </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="40.0"/>
           </costs>
@@ -17607,6 +17612,13 @@ A Unit may not use Counter Attack special rule if it used Reaction Fire.</descri
             <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
             <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
           </constraints>
+          <profiles>
+            <profile id="b62b-c095-fea4-786c" name="Warp Shunt Field" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
+              <characteristics>
+                <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">The warp shunt field provides the bearer with a 3+ Invulnerable save against Shooting attacks only. In addition, for every 6 rolled when saving against an enemy attack that draws a direct line of sight between shooter and target, the enemy unit that fired the shot takes D6 Str 5 AP- hits. </characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
           <costs>
             <cost name="pts" typeId="points" value="35.0"/>
           </costs>
@@ -17617,6 +17629,13 @@ A Unit may not use Counter Attack special rule if it used Reaction Fire.</descri
             <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
             <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
           </constraints>
+          <profiles>
+            <profile id="9ba8-3404-fc44-7a22" name="Phase-Walker" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
+              <characteristics>
+                <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Instead of moving normally in the Movement phase, the bearer may be removed and replaced anywhere else on the table, so long as they are not engaged in an assault or inside a transport vehicle or budding.  If the model is to be repositioned in a location that is within their line of sight, they are simply positioned where the player desires. If the target location is outside of the character&apos;s line of sight, make a Dangerous Terrain test for every solid object along the path including all models, vehicles, terrain pieces, buildings, etc) and so long as the character survives, place them in the desired position. Having been moved, the character counts as having deployed via Deep Strike, and so counts as having moved, but may shoot, run, etc, as normal.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
           <costs>
             <cost name="pts" typeId="points" value="45.0"/>
           </costs>
@@ -17627,6 +17646,13 @@ A Unit may not use Counter Attack special rule if it used Reaction Fire.</descri
             <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
             <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
           </constraints>
+          <profiles>
+            <profile id="88fc-f415-cc79-c185" name="Combat Augment Array" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
+              <characteristics>
+                <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Once per game, declared at the beginning of the controlling plaver&apos;s player turn, the character may count any dice roil as automatically rolling a 6. At the end of that player turn, the model should make a Toughness test for every wound they have remaining. Each failed test results in the character sustaining a wound, with no saves of any kind of Feel No Pain rolls possible.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
           <costs>
             <cost name="pts" typeId="points" value="35.0"/>
           </costs>
@@ -17637,6 +17663,13 @@ A Unit may not use Counter Attack special rule if it used Reaction Fire.</descri
             <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
             <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
           </constraints>
+          <profiles>
+            <profile id="0ce9-2a28-173a-d017" name="Cloaking Array" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
+              <characteristics>
+                <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Once per game, at the beginning of any game rum. the cloaking array may be activated. For that entire game turn, the bearer may not be targeted by shooring or declared as the subject ot a charge. Enemy models with the Psyker or Daemon rule are not atiected by the cloaking arrav, as thev have other means ot perceiving their foe. Should such a model shoot or assault the bearer, the cloaking array ceases to function immediately. The bearer may not use the array if joined to another unit, or engaged in an assault, and may not move, shoot, charge or declare any other actions while it is in efiect.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
           <costs>
             <cost name="pts" typeId="points" value="40.0"/>
           </costs>
@@ -17647,6 +17680,13 @@ A Unit may not use Counter Attack special rule if it used Reaction Fire.</descri
             <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
             <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
           </constraints>
+          <profiles>
+            <profile id="4838-4bae-d932-9bb5" name="Void Shield Harness" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
+              <characteristics>
+                <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">The void shield harness has an area of effect equal to a Large Blast (3&quot;) marker,centred on the hearer. Any shooting attack that originates from outside of the protected area and hits a target inside it instead hits the void shield - which has an Armour value of 12. A glancing or penetrating hit (or any hit from a Destroyer weapon) causes it to collapse. Once the shield is collapsed, further hits strike the original target instead. If the shield is collapsed, at the end to each to the controlling player&apos;s player turns roll a Db. On a roll of the shield is instantly restored.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
           <costs>
             <cost name="pts" typeId="points" value="40.0"/>
           </costs>
@@ -17667,19 +17707,26 @@ A Unit may not use Counter Attack special rule if it used Reaction Fire.</descri
               </characteristics>
             </profile>
           </profiles>
-          <rules>
-            <rule id="172b-b755-72a7-c782" name="Contagium Mechanica" publicationId="cf03-f607-pubN99227" page="224" hidden="false"/>
-          </rules>
+          <infoLinks>
+            <infoLink id="02ef-ad1b-af0d-2fb1" name="Haywire" hidden="false" targetId="6970-1bf3-b33e-5dce" type="rule"/>
+          </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="30.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="2c7a-d4dd-d5fe-59a6" name="Cortica Primus" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="2c7a-d4dd-d5fe-59a6" name="Cortica Primus" publicationId="cf03-f607-pubN99227" page="224" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
             <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
             <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
           </constraints>
+          <profiles>
+            <profile id="07e8-974a-096e-a920" name="Cortica Primus" publicationId="cf03-f607-pubN99227" page="224" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
+              <characteristics>
+                <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">The cortica Primus counts as a Cortex Controller. In addition, if the bearer uses a Cybertheurgy power to target a friendly unit, the effect of the power used applies not to one model in that unit, but to all eligible models in that unit. If the power is failed however, the subsequent roll on the Cybertheurgy Mishap table is modified by the number of models over the first it was attempted on. For example, if target unit consisted of three Battle-Automata, the roll on the Mishap table would be modified by a +2.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
           <costs>
             <cost name="pts" typeId="points" value="30.0"/>
           </costs>

--- a/(HH) Solar Auxilia - Crusade Army List.cat
+++ b/(HH) Solar Auxilia - Crusade Army List.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="7f243fc5-c5fd-8b2c-7b07-907bf684bb72" name="Solar Auxilia" revision="72" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="124" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="7f243fc5-c5fd-8b2c-7b07-907bf684bb72" name="Solar Auxilia" revision="73" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="127" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="7f243fc5--pubN65537" name="Crusade Imperialis"/>
     <publication id="7f243fc5--pubN65563" name="AoDRB"/>
@@ -5551,6 +5551,11 @@ Precision Shots</description>
           <entryLinks>
             <entryLink id="12a3-b7b8-3193-9e26" hidden="false" collective="false" import="true" targetId="1c41cdb2-f7c8-ea03-d50d-4f68772731f2" type="selectionEntry"/>
             <entryLink id="bfb1-1015-8611-60bd" hidden="false" collective="false" import="true" targetId="98e057b6-29c7-b240-8a57-a936b45c1299" type="selectionEntry"/>
+            <entryLink id="1134-bd8b-bf24-07d5" name="Terrax Pattern Termite Assault Drill" hidden="false" collective="false" import="true" targetId="3879-9d90-7c4a-5905" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8e4e-889e-ab86-8244" type="max"/>
+              </constraints>
+            </entryLink>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
@@ -7219,9 +7224,21 @@ Precision Shots</description>
           </costs>
         </selectionEntry>
       </selectionEntries>
-      <entryLinks>
-        <entryLink id="43a7-6efa-89c9-4afa" name="Aurox Armoured Transport" hidden="false" collective="false" import="true" targetId="5163-ab15-9959-6efd" type="selectionEntry"/>
-      </entryLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="7737-eb6c-4f1c-341c" name="Dedicated Transport" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="293d-161c-9b6d-92f9" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="ebe9-899f-e2ba-bdef" name="Saturnyne Pattern Aurox Armoured Transport" hidden="false" collective="false" import="true" targetId="5163-ab15-9959-6efd" type="selectionEntry"/>
+            <entryLink id="e6d9-e16d-bc29-eba1" name="Terrax Pattern Termite Assault Drill" hidden="false" collective="false" import="true" targetId="3879-9d90-7c4a-5905" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="395f-fcff-e945-5222" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="125.0"/>
       </costs>
@@ -7719,7 +7736,7 @@ Precision Shots</description>
         <infoLink id="5278-6635-dc60-2502" name="Disciplined Fire" hidden="false" targetId="470a38b3-ad69-52de-2996-36fa27f50e04" type="rule"/>
         <infoLink id="18d2-7dc9-8e72-6d3d" hidden="false" targetId="aa451588-557c-7f81-2b3f-d17583985f38" type="rule"/>
         <infoLink id="2a9a-b1b3-d900-d6f9" hidden="false" targetId="0f466e26-4de9-d53c-5270-4c95dcf6867e" type="rule"/>
-        <infoLink id="b897-a2dd-f2d5-cb21" hidden="false" targetId="dff0089a-4273-26a0-d96f-b5a36d57a18f" type="profile"/>
+        <infoLink id="b897-a2dd-f2d5-cb21" name="Reinforced Void Armour" hidden="false" targetId="dff0089a-4273-26a0-d96f-b5a36d57a18f" type="profile"/>
         <infoLink id="3a6b-cc58-686f-3037" name="New InfoLink" hidden="false" targetId="6d06-5ea0-9a17-ca97" type="rule"/>
         <infoLink id="6deb-ee93-bb59-8f92" name="Krak Grenade (Shooting)" hidden="false" targetId="d9f7-775b-1047-f335" type="profile"/>
         <infoLink id="22e6-5021-8a4b-5b72" name="Frag Grenades" hidden="false" targetId="d890-1b84-bbd9-12d3" type="profile"/>
@@ -8210,10 +8227,20 @@ Precision Shots</description>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
+        <selectionEntryGroup id="bd7c-bae0-39a4-5309" name="Dedicated Transport" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8e18-03a1-8b26-12ad" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="5434-fa92-dd78-0bb1" name="Terrax Pattern Termite Assault Drill" hidden="false" collective="false" import="true" targetId="3879-9d90-7c4a-5905" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5915-223c-3206-33fa" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="a597-4df8-f2b0-cffa" name="Aurox Armoured Transport" hidden="false" collective="false" import="true" targetId="5163-ab15-9959-6efd" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
       </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="04fd-d9b3-808a-05a2" name="Aurox Armoured Transport" hidden="false" collective="false" import="true" targetId="5163-ab15-9959-6efd" type="selectionEntry"/>
-      </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="115.0"/>
       </costs>
@@ -8446,64 +8473,22 @@ Precision Shots</description>
         <cost name="pts" typeId="points" value="5.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="3879-9d90-7c4a-5905" name="Terrax Pattern Termite Assault Drill" publicationId="7f243fc5--pubN110665" page="https://www.forgeworld.co.uk/resources/PDF/Downloads//Terrax_Termite%20_Solar_Auxilia.pdf" hidden="false" collective="false" import="true" type="unit">
-      <profiles>
-        <profile id="2865-d3c2-de9d-4306" name="Terrax Pattern Termite Assault Drill" hidden="false" typeId="56656869636c6523232344415441232323" typeName="Vehicle">
-          <characteristics>
-            <characteristic name="BS" typeId="425323232344415441232323">4</characteristic>
-            <characteristic name="Front" typeId="46726f6e7423232344415441232323">12</characteristic>
-            <characteristic name="Side" typeId="5369646523232344415441232323">12</characteristic>
-            <characteristic name="Rear" typeId="5265617223232344415441232323">10</characteristic>
-            <characteristic name="HP" typeId="485023232344415441232323">3</characteristic>
-            <characteristic name="Type" typeId="5479706523232344415441232323">Tank, Transport</characteristic>
-          </characteristics>
-        </profile>
-        <profile id="6529-5f6a-5498-f563" name="Terrax Pattern Termite Assault Drill (Transport)" hidden="false" typeId="307d-047f-ca13-706b" typeName="Transport">
-          <characteristics>
-            <characteristic name="Capacity" typeId="8285-4205-b6cd-8473">12*</characteristic>
-            <characteristic name="Fire Points" typeId="b270-a7f9-22b2-3702">None</characteristic>
-            <characteristic name="Access Points" typeId="d17b-0342-b1dc-b8e7">Two access hatches**</characteristic>
-          </characteristics>
-        </profile>
-      </profiles>
-      <rules>
-        <rule id="6622-cf2d-530a-dc3f" name="Crawling Advance" hidden="false">
-          <description>A Termite Assault Drill may never move faster than Combat Speed or move Flat Out.</description>
-        </rule>
-        <rule id="54ea-56d1-2076-d8f4" name="Death From Below" hidden="false">
-          <description>Instead of the usual rules for Deep Striking, when a Subterranean Assault vehicle enters play via Deep Strike, place a Large Blast (5&quot;) marker on the table and scatter this to determine the final position of its arrival as per the Deep Strike special rule.
-
-Should this marker scatter on top of impassable terrain, a building, ruin, fortification, vehicle or any unit engaged in combat, reduce the scatter distance by the minimum required to avoid the obstacle. If the marker representing the arrival of the Termite was displaced in this way by a vehicle or fortification, the closest vehicle or fortification to the marker immediately suffers a Str 10 AP- hit
-– vehicles are hit on their Side armour. If the arrival of the Termite was instead displaced by any units engaged in close combat, all units in that combat suffer D6 Str 6 AP 4 hits. After the final position of the marker is determined, if the marker covers or touches any enemy or friendly unit, then that unit also suffers D6 Str 6 AP 4 hits.
-
-After all damage is resolved, the Subterranean Assault vehicle may be placed in any orientation so long as the centre of the Large Blast (5&quot;) marker is underneath part of the vehicle’s hull and it remains 1&quot; away from any fortification, vehicle or unit engaged in combat. The area under the Large Blast (5&quot;) marker is now difficult terrain for the rest of the game. Players may, should they wish to, instead represent this area with a piece of crater terrain.
-
-Should a Subterranean Assault vehicle be placed on top of any unit which does not pose an obstacle to its arrival as described above, the Death from Below special rule allows it to be placed as though the unit was not there. If some models in the unit would end up underneath the Subterranean Assault vehicle when it reaches its final position (it makes no difference whether the unit is Falling Back or not), these models must be moved by the controlling player out of the way by the shortest distance, leaving at least 1&quot; between them and the Subterranean Assault vehicle (and indeed any other unit) whilst maintaining unit coherency and staying on the tabletop. Any models that cannot manage this are crushed and removed from play as casualties with no saves allowed.</description>
-        </rule>
-        <rule id="21c3-a032-c598-2f23" name="Melta Cutters" hidden="false">
-          <description>A Termite Assault Drill ignores difficult terrain and dangerous terrain.
-In addition, it adds +2 to its Strength when making ramming attacks against fortifications.</description>
-        </rule>
-        <rule id="d90a-b3b6-9e5d-3d5f" name="Subterranean Assault" hidden="false">
-          <description>Should the Termite Assault Drill, and any unit it transports, enter play using the Deep Strike special rule, they count as being a
-Subterranean Assault vehicle for the wider use of the Subterranean Assault rule for your army. At the beginning of the controlling
-player’s first turn, they must choose half of their Subterranean Assault vehicles held in reserve for the purpose of Deep Striking
-(rounding up) to make a Subterranean Assault. These units arrive on the controlling player’s first player turn. The arrival of any
-remaining Subterranean Assault vehicles in the player’s force is rolled for as usual for the mission.
-
-This rule, while similar in function to the Drop Pod Assault special rule, does not interact with it for the purposes of calculating how
-many units may arrive on the table by Deep Strike. Armies may consist of units with both the Drop Pod Assault and Subterranean
-Assault rules unless otherwise noted.</description>
-        </rule>
-        <rule id="4bb0-8de3-842a-74d3" name="Terrax Pattern Termite Assault Drill" hidden="false">
-          <description>* May not carry models with the Bulky, Very Bulky or Extremely Bulky special rules
-
-** In practice you may choose to open and embar/disembark from a single hatch on either side of the hull.</description>
-        </rule>
-      </rules>
+    <selectionEntry id="3879-9d90-7c4a-5905" name="Terrax Pattern Termite Assault Drill" publicationId="690c-3e82-3080-6bc0" page="198" hidden="false" collective="false" import="true" type="unit">
       <infoLinks>
         <infoLink id="fe34-e7a2-598e-13ec" name="Deep Strike" hidden="false" targetId="d219-2314-4834-c054" type="rule"/>
+        <infoLink id="dbd1-0897-0bde-ce3a" name="Terrax Pattern Termite Assault Drill" hidden="false" targetId="70c1-f71a-6ceb-0cab" type="profile"/>
+        <infoLink id="e0b6-a5ab-311a-4457" name="Terrax Pattern Termite Assault Drill (Transport)" hidden="false" targetId="9902-1e3c-b99c-f7cf" type="profile"/>
+        <infoLink id="a9e7-e97b-0a2f-8853" name="Crawling Advance" hidden="false" targetId="d130-69b4-bcb9-7454" type="rule"/>
+        <infoLink id="ab6b-42dc-7345-65f1" name="Death From Below" hidden="false" targetId="3cd1-bdfb-4585-182c" type="rule"/>
+        <infoLink id="d974-318b-5c06-82cc" name="Melta Cutters" hidden="false" targetId="1ace-c133-de63-e4f0" type="rule"/>
+        <infoLink id="76d7-6aa1-5dd5-fe20" name="Subterranean Assault" hidden="false" targetId="1679-b036-dc3a-c6a6" type="rule"/>
+        <infoLink id="51e7-8f47-eb68-d880" name="Terrax Pattern Termite Assault Drill" hidden="false" targetId="cb11-e201-f31b-d74e" type="rule"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="8f8e-fc67-710e-2c2c" name="Tank" hidden="false" targetId="e59c-462e-9d9c-66dd" primary="false"/>
+        <categoryLink id="0012-b1a5-f7c1-9a8e" name="Vehicle" hidden="false" targetId="53bd-99e7-aba0-e79f" primary="false"/>
+        <categoryLink id="e93b-1791-ff26-df88" name="Transport" hidden="false" targetId="e4e0-c5d1-3430-f101" primary="false"/>
+      </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="4a45-5d22-1578-96f5" name="May take any of the following" hidden="false" collective="false" import="true">
           <entryLinks>
@@ -8513,31 +8498,33 @@ Assault rules unless otherwise noted.</description>
               </modifiers>
             </entryLink>
             <entryLink id="490f-1a02-5547-507a" name="Extra Armour" hidden="false" collective="false" import="true" targetId="37f8-a81d-7f21-ca31" type="selectionEntry">
-              <modifiers>
-                <modifier type="set" field="points" value="25"/>
-              </modifiers>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="8d6d-b360-4f50-213b" name="Select 2" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="8d6d-b360-4f50-213b" name="Select 2" hidden="false" collective="false" import="true" defaultSelectionEntryId="e310-8ca8-22a9-93c9">
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e06d-ffd8-39fb-4a37" type="min"/>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e38c-1706-c86e-7a1c" type="max"/>
           </constraints>
+          <selectionEntries>
+            <selectionEntry id="2ca7-9d23-8b47-28e5" name="Twin-Linked Volkite Charger" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0a05-b117-19af-7388" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="9207-20e6-76d1-48ec" name="Deflagrate" hidden="false" targetId="b46a-a3ec-91a5-5001" type="rule"/>
+                <infoLink id="9361-bf51-2fb5-e990" name="Volkite Charger" hidden="false" targetId="c440-1f53-4d20-5cab" type="profile"/>
+              </infoLinks>
+            </selectionEntry>
+          </selectionEntries>
           <entryLinks>
             <entryLink id="e310-8ca8-22a9-93c9" name="Heavy Flamer" hidden="false" collective="false" import="true" targetId="ead9-305c-a7e7-323e" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="81ed-2fd9-a92a-d52a" type="max"/>
                 <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="00fa-b39c-93a8-8bb1" type="min"/>
-              </constraints>
-            </entryLink>
-            <entryLink id="3a67-1b99-5081-0e17" name="Volkite Charger" hidden="false" collective="false" import="true" targetId="ac42-b184-e3fe-a554" type="selectionEntry">
-              <modifiers>
-                <modifier type="set" field="name" value="Twin-linked Volkite Charger"/>
-                <modifier type="set" field="points" value="0.0"/>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7ad2-a9c9-1fc3-5bab" type="max"/>
               </constraints>
             </entryLink>
           </entryLinks>
@@ -8570,12 +8557,12 @@ Assault rules unless otherwise noted.</description>
         <cost name="pts" typeId="points" value="5.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="5163-ab15-9959-6efd" name="Aurox Armoured Transport" hidden="false" collective="false" import="true" type="model">
+    <selectionEntry id="5163-ab15-9959-6efd" name="Saturnyne Pattern Aurox Armoured Transport" publicationId="690c-3e82-3080-6bc0" page="204" hidden="false" collective="false" import="true" type="model">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ac5a-7586-55ab-0dc3" type="max"/>
       </constraints>
       <profiles>
-        <profile id="96d8-cf90-33d8-2542" name="Aurox Armoured Transport" hidden="false" typeId="56656869636c6523232344415441232323" typeName="Vehicle">
+        <profile id="96d8-cf90-33d8-2542" name="Saturnyne Pattern Aurox Armoured Transport" hidden="false" typeId="56656869636c6523232344415441232323" typeName="Vehicle">
           <characteristics>
             <characteristic name="BS" typeId="425323232344415441232323">3</characteristic>
             <characteristic name="Front" typeId="46726f6e7423232344415441232323">11</characteristic>
@@ -8585,7 +8572,7 @@ Assault rules unless otherwise noted.</description>
             <characteristic name="Type" typeId="5479706523232344415441232323">Vehicle, Tank, Transport</characteristic>
           </characteristics>
         </profile>
-        <profile id="782c-b980-4385-5f84" name="Aurox Armoured Transport (Transport)" hidden="false" typeId="307d-047f-ca13-706b" typeName="Transport">
+        <profile id="782c-b980-4385-5f84" name="Saturnyne Pattern Aurox Armoured Transport (Transport)" publicationId="690c-3e82-3080-6bc0" page="204" hidden="false" typeId="307d-047f-ca13-706b" typeName="Transport">
           <characteristics>
             <characteristic name="Capacity" typeId="8285-4205-b6cd-8473">10; may not carry models with the Bulky, Very Bulky, or Extremely Bulky special rules.</characteristic>
             <characteristic name="Fire Points" typeId="b270-a7f9-22b2-3702">2</characteristic>
@@ -8593,6 +8580,9 @@ Assault rules unless otherwise noted.</description>
           </characteristics>
         </profile>
       </profiles>
+      <infoLinks>
+        <infoLink id="d938-0c51-0e61-202d" name="Explorer Adaptation" hidden="false" targetId="11bec7a8-6060-53c9-572c-0df68bf9fa78" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="9822-d135-2890-9dc6" name="New CategoryLink" hidden="false" targetId="c407-80ff-568e-3394" primary="false"/>
         <categoryLink id="cfca-c84d-deca-35d9" name="New CategoryLink" hidden="false" targetId="e59c-462e-9d9c-66dd" primary="false"/>
@@ -8621,13 +8611,13 @@ Assault rules unless otherwise noted.</description>
           </selectionEntries>
           <entryLinks>
             <entryLink id="0f2c-8214-fdcc-a97f" name="Heavy Flamer" hidden="false" collective="false" import="true" targetId="ead9-305c-a7e7-323e" type="selectionEntry">
-              <modifiers>
-                <modifier type="set" field="points" value="5"/>
-              </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9952-606c-7c67-f5bc" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5bed-223b-6122-2f22" type="max"/>
               </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
             </entryLink>
             <entryLink id="0852-8fd7-7a81-63d4" name="Multi-laser" hidden="false" collective="false" import="true" targetId="d3b4-93b8-3ccd-745e" type="selectionEntry">
               <constraints>
@@ -8651,9 +8641,9 @@ Assault rules unless otherwise noted.</description>
       </selectionEntryGroups>
       <entryLinks>
         <entryLink id="6cce-2691-fb97-d344" name="Extra Armour" hidden="false" collective="false" import="true" targetId="37f8-a81d-7f21-ca31" type="selectionEntry">
-          <modifiers>
-            <modifier type="set" field="points" value="5"/>
-          </modifiers>
+          <costs>
+            <cost name="pts" typeId="points" value="5.0"/>
+          </costs>
         </entryLink>
       </entryLinks>
       <costs>
@@ -8661,25 +8651,23 @@ Assault rules unless otherwise noted.</description>
       </costs>
     </selectionEntry>
     <selectionEntry id="64a9-ab91-8d63-467a" name="Saturnyne Pattern Carnodon Strike Squadron" hidden="false" collective="false" import="true" type="upgrade">
-      <profiles>
-        <profile id="17c8-5a67-3589-294d" name="Carnodon Strike Squadron" hidden="false" typeId="56656869636c6523232344415441232323" typeName="Vehicle">
-          <characteristics>
-            <characteristic name="BS" typeId="425323232344415441232323">3</characteristic>
-            <characteristic name="Front" typeId="46726f6e7423232344415441232323">12</characteristic>
-            <characteristic name="Side" typeId="5369646523232344415441232323">11</characteristic>
-            <characteristic name="Rear" typeId="5265617223232344415441232323">10</characteristic>
-            <characteristic name="HP" typeId="485023232344415441232323">3</characteristic>
-            <characteristic name="Type" typeId="5479706523232344415441232323">Vehicle (Tank)</characteristic>
-          </characteristics>
-        </profile>
-      </profiles>
       <selectionEntries>
-        <selectionEntry id="4a49-f521-54f8-9e75" name="Carnodon Tank" hidden="false" collective="false" import="true" type="model">
-          <rules>
-            <rule id="2321-f605-f4b1-6fc9" name="Explorator Adaption" hidden="false">
-              <description>Vehicles with this special rule have an invulnerable save of 6+ against any attack with the Blast or Template special rule, and count as Void Hardened in games where this might have an effect. Failed Dangerous Terrain tests by vehicles with this special rule must be re-rolled.</description>
-            </rule>
-          </rules>
+        <selectionEntry id="4a49-f521-54f8-9e75" name="Saturnyne Pattern Carnodon Strike Tank" publicationId="690c-3e82-3080-6bc0" page="205" hidden="false" collective="false" import="true" type="model">
+          <profiles>
+            <profile id="fc34-47c0-333e-080f" name="Saturnyne Pattern Carnodon Strike Squadron" publicationId="690c-3e82-3080-6bc0" page="205" hidden="false" typeId="56656869636c6523232344415441232323" typeName="Vehicle">
+              <characteristics>
+                <characteristic name="BS" typeId="425323232344415441232323">3</characteristic>
+                <characteristic name="Front" typeId="46726f6e7423232344415441232323">12</characteristic>
+                <characteristic name="Side" typeId="5369646523232344415441232323">11</characteristic>
+                <characteristic name="Rear" typeId="5265617223232344415441232323">10</characteristic>
+                <characteristic name="HP" typeId="485023232344415441232323">3</characteristic>
+                <characteristic name="Type" typeId="5479706523232344415441232323">Vehicle (Tank)</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="01ca-0ce7-9fc0-2333" name="Explorer Adaptation" hidden="false" targetId="11bec7a8-6060-53c9-572c-0df68bf9fa78" type="rule"/>
+          </infoLinks>
           <selectionEntries>
             <selectionEntry id="83b9-8b9a-794c-db1d" name="Smoke Launchers" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
@@ -8718,7 +8706,7 @@ Assault rules unless otherwise noted.</description>
             </selectionEntry>
           </selectionEntries>
           <selectionEntryGroups>
-            <selectionEntryGroup id="e108-04cb-7048-40d9" name="May exchange both of its sponson-mounted multi-lasers for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="49ce-5152-e9fa-3fd1">
+            <selectionEntryGroup id="e108-04cb-7048-40d9" name="May exchange both of its sponson-mounted multi-lasers for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="5eb5-ebaa-482b-5502">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="abe6-4b49-7cbe-ad06" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e80-8724-50cc-9181" type="max"/>
@@ -8765,7 +8753,7 @@ Assault rules unless otherwise noted.</description>
                     <infoLink id="b239-2408-b1db-193e" name="Multi-laser" hidden="false" targetId="9e5daeb2-93d7-cac7-9d23-c85b81e46ea2" type="profile"/>
                   </infoLinks>
                   <costs>
-                    <cost name="pts" typeId="points" value="0.0"/>
+                    <cost name="pts" typeId="points" value="5.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="5eb5-ebaa-482b-5502" name="Two Volkite Calivers" hidden="false" collective="false" import="true" type="upgrade">
@@ -8774,6 +8762,7 @@ Assault rules unless otherwise noted.</description>
                   </constraints>
                   <infoLinks>
                     <infoLink id="3de5-7535-0af9-5f51" name="Volkite Caliver" hidden="false" targetId="626c-d79c-9bb7-3407" type="profile"/>
+                    <infoLink id="95b4-c21c-eafe-132d" name="Deflagrate" hidden="false" targetId="b46a-a3ec-91a5-5001" type="rule"/>
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="5.0"/>
@@ -8792,7 +8781,7 @@ Assault rules unless otherwise noted.</description>
                 </selectionEntry>
               </selectionEntries>
             </selectionEntryGroup>
-            <selectionEntryGroup id="b505-b743-faa1-f870" name="May exchange its twin-linked multi-laser for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="5234-93df-ed9d-1163">
+            <selectionEntryGroup id="b505-b743-faa1-f870" name="May exchange its Volkite Culverin for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="2535-5f0b-af69-8b38">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c258-00bf-7709-3b14" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="30b2-4dcd-a16d-3639" type="min"/>
@@ -8819,7 +8808,7 @@ Assault rules unless otherwise noted.</description>
                     <infoLink id="32a4-685e-5295-29f9" name="Lascannon" hidden="false" targetId="1cce-972c-022a-2590" type="profile"/>
                   </infoLinks>
                   <costs>
-                    <cost name="pts" typeId="points" value="25.0"/>
+                    <cost name="pts" typeId="points" value="20.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="5234-93df-ed9d-1163" name="Twin-Linked Multi-Laser" hidden="false" collective="false" import="true" type="upgrade">
@@ -8831,7 +8820,7 @@ Assault rules unless otherwise noted.</description>
                     <infoLink id="32a9-4424-0878-4d91" name="Multi-laser" hidden="false" targetId="9e5daeb2-93d7-cac7-9d23-c85b81e46ea2" type="profile"/>
                   </infoLinks>
                   <costs>
-                    <cost name="pts" typeId="points" value="0.0"/>
+                    <cost name="pts" typeId="points" value="5.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="2535-5f0b-af69-8b38" name="Volkite Culverin" hidden="false" collective="false" import="true" type="upgrade">
@@ -8840,6 +8829,7 @@ Assault rules unless otherwise noted.</description>
                   </constraints>
                   <infoLinks>
                     <infoLink id="d4d4-a64c-cb50-9c36" name="Volkite Culverin" hidden="false" targetId="13bbdf99-5b72-187e-9a9b-203ff8ab08ae" type="profile"/>
+                    <infoLink id="82be-dd4f-9113-e366" name="Deflagrate" hidden="false" targetId="b46a-a3ec-91a5-5001" type="rule"/>
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="0.0"/>
@@ -8848,6 +8838,9 @@ Assault rules unless otherwise noted.</description>
               </selectionEntries>
             </selectionEntryGroup>
             <selectionEntryGroup id="a82c-1eef-aacd-c0f9" name="May Take:" hidden="false" collective="false" import="true">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9ba1-b819-c437-d99f" type="max"/>
+              </constraints>
               <selectionEntries>
                 <selectionEntry id="359a-396e-ab04-39a3" name="Multi-Laser" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
@@ -8873,26 +8866,24 @@ Assault rules unless otherwise noted.</description>
                 </selectionEntry>
               </selectionEntries>
             </selectionEntryGroup>
+            <selectionEntryGroup id="2692-2a28-c7aa-4b47" name="Psyarkana" hidden="false" collective="false" import="true">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="938a-1f17-0187-ead5" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="0777-23b7-2c9b-bd38" name="Armatus Necrotechnica" hidden="false" collective="false" import="true" targetId="e78c-d1a1-c20f-dae8" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false"/>
+                  </modifiers>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
           </selectionEntryGroups>
           <costs>
             <cost name="pts" typeId="points" value="65.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="d056-3536-054c-e390" name="Psyarkana" hidden="false" collective="false" import="true">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="10a0-60de-1a1d-0806" type="max"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="e9e7-e5c8-0421-adcc" name="Armatus Necrotechnica" hidden="false" collective="false" import="true" targetId="e78c-d1a1-c20f-dae8" type="selectionEntry">
-              <modifiers>
-                <modifier type="set" field="hidden" value="false"/>
-              </modifiers>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>


### PR DESCRIPTION
#1783
Combi-Grenade Launcher: changed Stasis Shells from free and must to take to 5 points and optional (even if every DA player will buy them anyways)
Combi-Grenade Launcher is in the selection named as "Grenade Launcher"
Jetbike Sky Seeker: Changed Stasis Shell points from 5 per quad to 5 per model
Destroyer Grenade Launcher: added Stasis Shells
Headsman's axe was flagged is hidden for headsman in Raptors
Saber Tank Volkite Saker got changed in Book 9 to 0pts, 
Sabre Strike Tank lost the Missle Lock rule, which was added to the Sabre Missiles directly
"The Unbroken Vow" RoW wasn't hidden from other legions
Tact squads not being compulsory when they should be in many RoW that they should be.
Breacher Squads and a few others can take Rad Grenades in the Eskarton Imperative without Dreadwing Rule

Plasma Burners and other Plasma stuff

Various units Dedicated Transport options corrected. This was mainly to do with Steel Fist and Ironwing interactions. Previously it was just coded to show if Steel Wing was selected, without requiring the component of the Scion of Ironwing being present. This was corrected.
Contekar fixes so the claw now costs 15pts. Also available as a Reward of Treason.
Deathwing Companion Melta Bomb cost fix.

Solar, Militia and Mech updates for book 9 (some were reverted, and now ok to put back in