### PR TITLE
Terror and Allied Detachments

### DIFF
--- a/(HH) Craftworld Eldar - Asuryani Army List.cat
+++ b/(HH) Craftworld Eldar - Asuryani Army List.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="0798-288f-4f71-eab9" name="Asuryani Army List (Fanmade)" revision="6" battleScribeVersion="2.03" authorName="Dono Author / Maye Gelt the Battlescribbler" authorContact="Dono (for Content) / Maye Gelt (for Battlescibbling)" authorUrl="http://www.facebook.com/AUS30K" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="5" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="0798-288f-4f71-eab9" name="Asuryani Army List (Fanmade)" revision="7" battleScribeVersion="2.03" authorName="Dono Author / Maye Gelt the Battlescribbler" authorContact="Dono (for Content) / Maye Gelt (for Battlescibbling)" authorUrl="http://www.facebook.com/AUS30K" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="128" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="5c4c-bef9-9681-e0fc" name="30K Craftworld Aeldari - Asuryani Army List"/>
   </publications>
@@ -138,6 +138,12 @@
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ca3f-8481-537f-9e51" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3860-8976-dc6a-71f1" type="min"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="a49c-f581-2683-1d7d" name="Allied Detachment" hidden="false" targetId="6077-281f-c55d-9bf0" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c87c-ebde-2300-8fc5" type="min"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2949-3ef9-2e84-a594" type="max"/>
           </constraints>
         </categoryLink>
       </categoryLinks>
@@ -421,6 +427,11 @@
       <categoryLinks>
         <categoryLink id="ef1f-7bab-5216-33ce" name="New CategoryLink" hidden="false" targetId="cd09-c1c6-237a-798e" primary="true"/>
       </categoryLinks>
+    </entryLink>
+    <entryLink id="296f-22cd-f9e3-2b1d" name="Allied Detachment" hidden="false" collective="false" import="true" targetId="c91a-6e83-93ce-54ac" type="selectionEntry">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e785-78d1-6d5b-5cfe" type="min"/>
+      </constraints>
     </entryLink>
   </entryLinks>
   <sharedSelectionEntries>

--- a/(HH) Daemons of the Ruinstorm Army List.cat
+++ b/(HH) Daemons of the Ruinstorm Army List.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="8700-b3bb-a471-a0ad" name="Daemons of the Ruinstorm" revision="15" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="14" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="8700-b3bb-a471-a0ad" name="Daemons of the Ruinstorm" revision="16" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="128" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="8700-b3bb-pubN65537" name="HH8: Malevolence"/>
     <publication id="8700-b3bb-pubN75780" name="BRB"/>
@@ -79,6 +79,12 @@
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6ef4-e2d8-333f-abda" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f9e5-f5d6-b58b-311e" type="min"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="4952-05a3-05f6-17ef" name="Allied Detachment" hidden="false" targetId="6077-281f-c55d-9bf0" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5f22-b83e-5cc7-6a4f" type="min"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0ec3-d1a2-0ee1-9ea8" type="max"/>
           </constraints>
         </categoryLink>
       </categoryLinks>
@@ -244,6 +250,11 @@
       <categoryLinks>
         <categoryLink id="f556-e8fe-57c3-e682" name="New CategoryLink" hidden="false" targetId="cd09-c1c6-237a-798e" primary="true"/>
       </categoryLinks>
+    </entryLink>
+    <entryLink id="ee71-fb4f-ecd1-4c6f" name="Allied Detachment" hidden="false" collective="false" import="true" targetId="c91a-6e83-93ce-54ac" type="selectionEntry">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="417b-6e99-19c2-0425" type="min"/>
+      </constraints>
     </entryLink>
   </entryLinks>
   <sharedSelectionEntries>

--- a/(HH) Imperialis Militia and Cults Army List.cat
+++ b/(HH) Imperialis Militia and Cults Army List.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="90aa-c2c8-ffb0-496e" name="Imperialis Militia and Cults Army List" revision="107" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="127" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="90aa-c2c8-ffb0-496e" name="Imperialis Militia and Cults Army List" revision="108" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="128" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="90aa-c2c8-pubN65537" name="Crusade Imperialis"/>
     <publication id="90aa-c2c8-pubN65563" name="AoDRB"/>
@@ -392,6 +392,12 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
           </constraints>
         </categoryLink>
         <categoryLink id="ea32-ebdf-a9e0-1feb" name="Mournival Rules" hidden="false" targetId="dbe0-716f-797c-66f7" primary="false"/>
+        <categoryLink id="f55f-5601-3468-5b60" name="Allied Detachment" hidden="false" targetId="6077-281f-c55d-9bf0" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1f49-9113-3a25-6f55" type="min"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="440e-99b9-2dcd-6eea" type="max"/>
+          </constraints>
+        </categoryLink>
       </categoryLinks>
     </forceEntry>
     <forceEntry id="089f-7e79-bde1-90dd" name=" Zone Mortalis - Attacker" hidden="false">
@@ -1311,6 +1317,11 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
       <categoryLinks>
         <categoryLink id="7bf3-f1c5-f1a8-5f63" name="New CategoryLink" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
       </categoryLinks>
+    </entryLink>
+    <entryLink id="bad2-bba3-abb6-d599" name="Allied Detachment" hidden="false" collective="false" import="true" targetId="c91a-6e83-93ce-54ac" type="selectionEntry">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eefe-6292-095f-911f" type="min"/>
+      </constraints>
     </entryLink>
   </entryLinks>
   <sharedSelectionEntries>

--- a/(HH) Mechanicum - Questoris Knight.cat
+++ b/(HH) Mechanicum - Questoris Knight.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="32d1ddc6-3187-cf6f-3bf8-9891e527a002" name="Questoris Knight Crusade Army" revision="52" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="51" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="32d1ddc6-3187-cf6f-3bf8-9891e527a002" name="Questoris Knight Crusade Army" revision="53" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="128" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="32d1ddc6--pubN65537" name="Age of Darkness Crusade Army List"/>
     <publication id="32d1ddc6--pubN66650" name="HH4: Conquest"/>
@@ -133,6 +133,12 @@
           </constraints>
         </categoryLink>
         <categoryLink id="9e58-4f4e-5579-cb58" name="Allegiance" hidden="false" targetId="5297-7e0f-fa0b-3537" primary="false"/>
+        <categoryLink id="818e-b32f-e6f2-d131" name="Allied Detachment" hidden="false" targetId="6077-281f-c55d-9bf0" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9639-3fcc-00d3-2686" type="min"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fb89-6f1c-60fc-f94a" type="max"/>
+          </constraints>
+        </categoryLink>
       </categoryLinks>
     </forceEntry>
   </forceEntries>
@@ -497,6 +503,11 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
         <categoryLink id="4ad3-cc77-6e21-b20b" name="New CategoryLink" hidden="false" targetId="264d-166e-36c0-77b7" primary="false"/>
         <categoryLink id="b096-555b-931a-1164" name="New CategoryLink" hidden="false" targetId="53bd-99e7-aba0-e79f" primary="false"/>
       </categoryLinks>
+    </entryLink>
+    <entryLink id="97e7-4870-846f-91fb" name="Allied Detachment" hidden="false" collective="false" import="true" targetId="c91a-6e83-93ce-54ac" type="selectionEntry">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="55b1-94e9-819f-fc99" type="min"/>
+      </constraints>
     </entryLink>
   </entryLinks>
   <sharedSelectionEntries>

--- a/(HH) Mechanicum - Taghmata Army List.cat
+++ b/(HH) Mechanicum - Taghmata Army List.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="cf03-f607-41dc-7545" name="Mechanicum: Taghmata Army List" revision="104" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="127" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="cf03-f607-41dc-7545" name="Mechanicum: Taghmata Army List" revision="105" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="128" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="cf03-f607-pubN65537" name="Horus Heresy: Taghmata Army List"/>
     <publication id="cf03-f607-pubN65563" name="AoDRB"/>
@@ -567,6 +567,12 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <categoryLink id="80b5-9d75-e882-4e80" name="Compulsory Troops" hidden="false" targetId="219d-aefa-dfa5-44db" primary="false">
           <constraints>
             <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c495-b617-c344-baa4" type="min"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="b324-db14-bc95-b2e2" name="Allied Detachment" hidden="false" targetId="6077-281f-c55d-9bf0" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f633-31d6-5863-2858" type="min"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="60c5-587c-2acc-92fb" type="max"/>
           </constraints>
         </categoryLink>
       </categoryLinks>
@@ -1684,6 +1690,11 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
           </conditions>
         </modifier>
       </modifiers>
+    </entryLink>
+    <entryLink id="7225-f026-8c59-5ac4" name="Allied Detachment" hidden="false" collective="false" import="true" targetId="c91a-6e83-93ce-54ac" type="selectionEntry">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4d7b-4958-83cf-382b" type="min"/>
+      </constraints>
     </entryLink>
   </entryLinks>
   <sharedSelectionEntries>
@@ -3974,6 +3985,9 @@ Reduces transport capacity to 8.</description>
       <infoLinks>
         <infoLink id="3621-5c61-4157-e478" name="Secutarii" hidden="false" targetId="c1bc-dda3-fb87-e016" type="profile"/>
       </infoLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="c968-115e-0e8b-7836" name="Arc Lance" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>

--- a/(HH) Mechanicum - Taghmata Army List.cat
+++ b/(HH) Mechanicum - Taghmata Army List.cat
@@ -1060,18 +1060,6 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
       </categoryLinks>
     </entryLink>
     <entryLink id="ec8a-2676-2661-296e" name="Castellax Class Battle-Automata Maniple" hidden="false" collective="false" import="true" targetId="48db-84ca-2bad-520f" type="selectionEntry">
-      <modifiers>
-        <modifier type="add" field="category" value="219d-aefa-dfa5-44db">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d266-0416-a5a6-881e" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6549-e272-8b3c-6d6b" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="ec8a-2676-2661-296e-54726f6f707323232344415441232323" hidden="false" targetId="54726f6f707323232344415441232323" primary="true"/>
       </categoryLinks>
@@ -1699,42 +1687,6 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
     </entryLink>
   </entryLinks>
   <sharedSelectionEntries>
-    <selectionEntry id="36c5-d6db-7224-1e47" name="Support Unit" hidden="false" collective="false" import="true" type="upgrade">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="219d-aefa-dfa5-44db" type="instanceOf"/>
-          </conditions>
-        </modifier>
-        <modifier type="set" field="3272-f43a-2efd-59c9" value="0">
-          <conditions>
-            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="219d-aefa-dfa5-44db" type="instanceOf"/>
-          </conditions>
-        </modifier>
-        <modifier type="set" field="b0dc-cc60-79e4-e984" value="0">
-          <conditions>
-            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="219d-aefa-dfa5-44db" type="instanceOf"/>
-          </conditions>
-        </modifier>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="219d-aefa-dfa5-44db" type="instanceOf"/>
-          </conditions>
-        </modifier>
-      </modifiers>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3272-f43a-2efd-59c9" type="max"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b0dc-cc60-79e4-e984" type="min"/>
-      </constraints>
-      <rules>
-        <rule id="3011-cc8f-8dfc-e95c" name="Support Unit" publicationId="cf03-f607-pubN76270" page="41" hidden="false">
-          <description>This unit type may not be chosen as a compulsory Troops choice for the army.</description>
-        </rule>
-      </rules>
-      <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
     <selectionEntry id="04c4-8239-657a-ced2" name="Support Squad" hidden="false" collective="false" import="true" type="upgrade">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
@@ -1946,6 +1898,18 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
       </costs>
     </selectionEntry>
     <selectionEntry id="48db-84ca-2bad-520f" name="Castellax Class Battle-Automata Maniple" page="" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="append" field="name" value="(Compulsory)">
+          <conditions>
+            <condition field="selections" scope="48db-84ca-2bad-520f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0ee-a476-118f-2c11" type="equalTo"/>
+          </conditions>
+        </modifier>
+        <modifier type="add" field="category" value="219d-aefa-dfa5-44db">
+          <conditions>
+            <condition field="selections" scope="48db-84ca-2bad-520f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0ee-a476-118f-2c11" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <infoLinks>
         <infoLink id="7678-ae60-16f2-e948" name="" hidden="false" targetId="988c-d4d0-9418-1165" type="rule"/>
         <infoLink id="a7f0-6bc1-ed4a-34dc" name="New InfoLink" hidden="false" targetId="d5cf-bd98-2854-13cf" type="rule"/>
@@ -1957,6 +1921,13 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="09ad-ef83-4a62-46fe" name="Castellax class Battle-automata" page="" hidden="false" collective="false" import="true" type="model">
+          <modifiers>
+            <modifier type="set" field="2514-b4ae-39f4-093e" value="2.0">
+              <conditions>
+                <condition field="selections" scope="48db-84ca-2bad-520f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0ee-a476-118f-2c11" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2514-b4ae-39f4-093e" type="min"/>
             <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="38db-7bf2-0694-b3f4" type="max"/>
@@ -2201,10 +2172,68 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
+        <selectionEntryGroup id="7dda-f05f-f610-fcd6" name="Support or Compulsory Unit" hidden="false" collective="false" import="true" defaultSelectionEntryId="36c5-d6db-7224-1e47">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9fef-9755-dc26-aabf" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c6d2-3422-df1a-abff" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="d0ee-a476-118f-2c11" name="Compulsory" hidden="true" collective="false" import="true" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="21c2-25a4-2552-e014" value="1.0">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d266-0416-a5a6-881e" type="equalTo"/>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6549-e272-8b3c-6d6b" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+                <modifier type="set" field="hidden" value="false">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d266-0416-a5a6-881e" type="equalTo"/>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6549-e272-8b3c-6d6b" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1c24-fdf9-d423-8a3a" type="min"/>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="21c2-25a4-2552-e014" type="max"/>
+              </constraints>
+            </selectionEntry>
+            <selectionEntry id="36c5-d6db-7224-1e47" name="Support Unit" hidden="false" collective="false" import="true" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="e8eb-1cc7-3401-56d3" value="0.0">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d266-0416-a5a6-881e" type="equalTo"/>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6549-e272-8b3c-6d6b" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e8eb-1cc7-3401-56d3" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3280-844f-e64c-0f90" type="max"/>
+              </constraints>
+              <rules>
+                <rule id="45b4-2376-9876-1da7" name="Support Unit" publicationId="cf03-f607-pubN76270" page="41" hidden="false">
+                  <description>This unit type may not be chosen as a compulsory Troops choice for the army.</description>
+                </rule>
+              </rules>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="1351-345f-cd72-e42d" name="Support Unit" hidden="false" collective="false" import="true" targetId="36c5-d6db-7224-1e47" type="selectionEntry"/>
-        <entryLink id="9e93-5e2f-d21c-63bf" name="New EntryLink" hidden="false" collective="false" import="true" targetId="dff8-d7b6-960a-aa5b" type="selectionEntryGroup">
+        <entryLink id="9e93-5e2f-d21c-63bf" name="A single Maniple may be upgraded with:" hidden="false" collective="false" import="true" targetId="dff8-d7b6-960a-aa5b" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
@@ -2213,7 +2242,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink id="b6c3-b1be-9ce6-cb2f" name="New EntryLink" hidden="false" collective="false" import="true" targetId="0c9d-9eaa-d513-caa3" type="selectionEntry"/>
+        <entryLink id="b6c3-b1be-9ce6-cb2f" name="Cybernetica Cortex" hidden="false" collective="false" import="true" targetId="0c9d-9eaa-d513-caa3" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>

--- a/(HH) Mechanicum - Taghmata Army List.cat
+++ b/(HH) Mechanicum - Taghmata Army List.cat
@@ -799,6 +799,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="eb41-4630-eeb9-0f6a" type="max"/>
           </constraints>
         </categoryLink>
+        <categoryLink id="7f10-3293-320d-fa01" name="Mournival Rules" hidden="false" targetId="dbe0-716f-797c-66f7" primary="false"/>
       </categoryLinks>
     </forceEntry>
     <forceEntry id="1a2c-902b-cdb9-7640" name=" Strategic Raid - Raider" hidden="false">

--- a/(HH) Solar Auxilia - Crusade Army List.cat
+++ b/(HH) Solar Auxilia - Crusade Army List.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="7f243fc5-c5fd-8b2c-7b07-907bf684bb72" name="Solar Auxilia" revision="73" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="127" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="7f243fc5-c5fd-8b2c-7b07-907bf684bb72" name="Solar Auxilia" revision="74" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="128" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="7f243fc5--pubN65537" name="Crusade Imperialis"/>
     <publication id="7f243fc5--pubN65563" name="AoDRB"/>
@@ -493,6 +493,12 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
           </constraints>
         </categoryLink>
         <categoryLink id="bd3f-a651-bc5c-ad22" name="Mournival Rules" hidden="false" targetId="dbe0-716f-797c-66f7" primary="false"/>
+        <categoryLink id="8efd-0cad-67c8-b3c7" name="Allied Detachment" hidden="false" targetId="6077-281f-c55d-9bf0" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2be5-a4f4-38c0-ee92" type="min"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c2b4-b5fc-3e0c-2852" type="max"/>
+          </constraints>
+        </categoryLink>
       </categoryLinks>
     </forceEntry>
     <forceEntry id="089f-7e79-bde1-90dd" name=" Zone Mortalis - Attacker" hidden="false">
@@ -1254,6 +1260,11 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
       <categoryLinks>
         <categoryLink id="4cc1-64b5-ebb0-9b45" name="New CategoryLink" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
       </categoryLinks>
+    </entryLink>
+    <entryLink id="3327-f67c-b5b2-42ea" name="Allied Detachment" hidden="false" collective="false" import="true" targetId="c91a-6e83-93ce-54ac" type="selectionEntry">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9088-dd81-ce0c-df55" type="min"/>
+      </constraints>
     </entryLink>
   </entryLinks>
   <sharedSelectionEntries>
@@ -8518,6 +8529,9 @@ Precision Shots</description>
                 <infoLink id="9207-20e6-76d1-48ec" name="Deflagrate" hidden="false" targetId="b46a-a3ec-91a5-5001" type="rule"/>
                 <infoLink id="9361-bf51-2fb5-e990" name="Volkite Charger" hidden="false" targetId="c440-1f53-4d20-5cab" type="profile"/>
               </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
             </selectionEntry>
           </selectionEntries>
           <entryLinks>

--- a/(HH) Talons of the Emperor Army List.cat
+++ b/(HH) Talons of the Emperor Army List.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="a30a-7522-3343-553a" name="Talons of the Emperor" revision="101" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="120" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="a30a-7522-3343-553a" name="Talons of the Emperor" revision="102" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="128" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="a30a-7522-pubN65537" name="HH7 / HH8"/>
     <publication id="a30a-7522-pubN69988" name="Forgeworld.co.uk"/>
@@ -127,6 +127,12 @@
           </constraints>
         </categoryLink>
         <categoryLink id="1f93-7724-bb58-090f" name="Mournival Rules" hidden="false" targetId="dbe0-716f-797c-66f7" primary="false"/>
+        <categoryLink id="4024-208a-39c2-ce23" name="Allied Detachment" hidden="false" targetId="6077-281f-c55d-9bf0" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2bdb-73d5-1e8f-e29d" type="min"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bb88-e34a-6159-8441" type="max"/>
+          </constraints>
+        </categoryLink>
       </categoryLinks>
     </forceEntry>
     <forceEntry id="089f-7e79-bde1-90dd" name=" Zone Mortalis - Attacker" hidden="false">
@@ -459,6 +465,9 @@
           </constraints>
         </entryLink>
       </entryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
     </selectionEntry>
   </selectionEntries>
   <entryLinks>
@@ -537,7 +546,7 @@
         <categoryLink id="52cd-55ec-998f-deb6-456c6974657323232344415441232323" hidden="false" targetId="456c6974657323232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="b954-9079-02fb-cbf5" name="New EntryLink" hidden="false" collective="false" import="true" targetId="26dd-4eb2-fe70-ea73" type="selectionEntry">
+    <entryLink id="b954-9079-02fb-cbf5" name="Sisters of Silence Oblivion Knight-Centura" hidden="false" collective="false" import="true" targetId="26dd-4eb2-fe70-ea73" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="b954-9079-02fb-cbf5-485123232344415441232323" hidden="false" targetId="485123232344415441232323" primary="true"/>
       </categoryLinks>
@@ -739,6 +748,11 @@
       <categoryLinks>
         <categoryLink id="f535-e7b9-097b-5969" name="New CategoryLink" hidden="false" targetId="485123232344415441232323" primary="true"/>
       </categoryLinks>
+    </entryLink>
+    <entryLink id="934e-e981-da9e-cdf2" name="Allied Detachment" hidden="false" collective="false" import="true" targetId="c91a-6e83-93ce-54ac" type="selectionEntry">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c242-7ae8-d4a7-ba4e" type="min"/>
+      </constraints>
     </entryLink>
   </entryLinks>
   <sharedSelectionEntries>

--- a/The Horus Heresy.gst
+++ b/The Horus Heresy.gst
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<gameSystem id="ca571888-56a9-c58e-ddaf-54f4713538bc" name="Warhammer 30,000 - The Horus Heresy" revision="127" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
+<gameSystem id="ca571888-56a9-c58e-ddaf-54f4713538bc" name="Warhammer 30,000 - The Horus Heresy" revision="128" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
   <publications>
     <publication id="ca571888--pubN65537" name="Forgeworld Horus Heresy Series"/>
     <publication id="ca571888--pubN66489" name="HH:MT"/>
@@ -201,6 +201,7 @@
     <categoryEntry id="c00c-5a5c-3d86-f5a5" name="Mournival Centurion Unrestricted" hidden="false"/>
     <categoryEntry id="a660-a665-c4aa-5e82" name="Superheavy Options" hidden="false"/>
     <categoryEntry id="a7c6-e380-f10f-9798" name="Mechanicum" hidden="false"/>
+    <categoryEntry id="6077-281f-c55d-9bf0" name="Allied Detachment" hidden="false"/>
   </categoryEntries>
   <forceEntries>
     <forceEntry id="61f7-09c7-326c-8c49" name="New ForceEntry" hidden="true">
@@ -9188,6 +9189,17 @@ Any abilities that allow the vehicle to fire multiple shots will use the same sh
       </infoLinks>
       <costs>
         <cost name="pts" typeId="points" value="20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="c91a-6e83-93ce-54ac" name="Allied Detachment" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4698-c08c-57c9-e012" type="max"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="956a-277e-4c4a-f56b" name="New CategoryLink" hidden="false" targetId="6077-281f-c55d-9bf0" primary="true"/>
+      </categoryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>

--- a/The Horus Heresy.gst
+++ b/The Horus Heresy.gst
@@ -5609,7 +5609,7 @@ or Gargantuan Creatures. </description>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="9d1b-5e93-5172-5776" name="Primary Weapon Right Arm" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="9d1b-5e93-5172-5776" name="Primary Weapon Right Arm" hidden="false" collective="false" import="true" defaultSelectionEntryId="f51a-ef5d-f24c-1973">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="55a2-127b-d9d1-e650" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="cffb-0a62-f9ab-fb48" type="max"/>
@@ -5666,7 +5666,7 @@ or Gargantuan Creatures. </description>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="1f0d-dc4d-2872-7e74" name="Primary Weapon Left Arm" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="1f0d-dc4d-2872-7e74" name="Primary Weapon Left Arm" hidden="false" collective="false" import="true" defaultSelectionEntryId="40d2-31cb-3962-2a8b">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9f27-67a5-f9b6-7012" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a499-a415-eb9e-e8d2" type="max"/>
@@ -5746,13 +5746,16 @@ or Gargantuan Creatures. </description>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="62a9-3f80-fee9-bfe9" name="Carapace-mounted Nemesis Quake Cannon" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="62a9-3f80-fee9-bfe9" name="Carapace-mounted Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="3ec1-bf53-374d-1fa3">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9bb3-21e3-fb5d-7044" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="287e-49c4-b20a-f9e8" type="max"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="3ec1-bf53-374d-1fa3" name="Nemesis Quake Cannon" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b9e1-6d40-ebf1-6086" type="max"/>
+              </constraints>
               <rules>
                 <rule id="5c15-bf8d-bf0d-65f6" name="Seismic Shock" hidden="false">
                   <description>Units which suffer wounds or Hull points lost from this attack may only move at half their usual maximum movement, may not Run, charge or go Flat Out, and count as being in dangerous terrain on their next turn.</description>
@@ -5761,10 +5764,20 @@ or Gargantuan Creatures. </description>
               <infoLinks>
                 <infoLink id="f964-925b-eedd-f137" name="Concussive" hidden="false" targetId="9d85-46f7-f5e6-a5f7" type="rule"/>
                 <infoLink id="10ff-7985-4c6b-2ccd" name="Strikedown" hidden="false" targetId="dd83-7fb9-6f58-0c96" type="rule"/>
+                <infoLink id="e568-c25d-1615-b590" name="Nemesis Quake Cannon" hidden="false" targetId="4807-658a-4855-aa88" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
+            </selectionEntry>
+            <selectionEntry id="111f-e8b8-0721-10ab" name="Nemesis Volcano Cannon" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a711-b0ed-4720-f7eb" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="080e-e9dd-afb6-7430" name="Nemesis Volcano Cannon" hidden="false" targetId="ccf5-9177-d9c7-e896" type="profile"/>
+                <infoLink id="16d9-936a-5f2c-e7c3" name="Machine Destroyer" hidden="false" targetId="c673-4842-28f8-4e39" type="rule"/>
+              </infoLinks>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
@@ -13776,6 +13789,14 @@ Jetbikes can move over all other models and terrain freely. However, if a moving
         <characteristic name="Capacity" typeId="8285-4205-b6cd-8473">12*</characteristic>
         <characteristic name="Fire Points" typeId="b270-a7f9-22b2-3702">None</characteristic>
         <characteristic name="Access Points" typeId="d17b-0342-b1dc-b8e7">Two access hatches**</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="ccf5-9177-d9c7-e896" name="Nemesis Volcano Cannon" publicationId="ca571888--pubN95721" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="52616e676523232344415441232323">20-260&quot;</characteristic>
+        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">D</characteristic>
+        <characteristic name="AP" typeId="415023232344415441232323">1</characteristic>
+        <characteristic name="Type" typeId="5479706523232344415441232323">Primary Weapon 1, Massive Blast (7&quot;), Machine Destroyer</characteristic>
       </characteristics>
     </profile>
   </sharedProfiles>


### PR DESCRIPTION
Terror Assault Consol fix (no more limitation in book 9)

Allies restrictions added

No allies allowed list:
Onslaught FOC
ROWs:
Fury of the Ancients
Sky Hunter Phalanx
Drop Assault Vanguard
The Long March
Creeping Death
Last of the Serrated Sun
Horror Cult
Headhunter Leviathal
Hammerfall Strikeforce
Company of Bitter Iron
The Awakening Fire
The Guard of the Crimson King
The Eskaton Imperative
The Steel Fist
The Storm of War
The Unbroken Vow
The Seekers Arrow
The Serpents Bane
Ravenwing Protocol
Ironwing Protocol
The Swift Blade.
Chimerae

No Allowed Space Marine Allies
The Head of the Gorgon
3rd Company Elite
Decapitation Strike
The Hammer of Olympia
The Crimson Path
The Coils of the Hydra
Orphans of Betrayal
The Ironfire
Berserker Assault
The Maru Skara
The Dark Brethren
The Blooded Claws

Updated Corax

Updated Inner Circle Knights. Character only has 1 wound now, rather than the 2 that were in the download.

Plasma Incinerator fixes

Added Eskaton - Plasma Incinerator to Recon squads (cos they can get sniper rifles) 
Added a max 1 limit to Plasma Incinerator for Tact Support (forgot before).
Added Steel Fist Predators are only troops when Compulsory, So max 2 generally, Though Castellan and Onslaught is 3 max
Added Termys and Vets for Primarch's Chosen are only troops when Compulsory, So max 2 generally, Though Castellan and Onslaught is 3 max