### PR TITLE
Lots of Stuff

### DIFF
--- a/(HH) Imperialis Militia and Cults Army List.cat
+++ b/(HH) Imperialis Militia and Cults Army List.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="90aa-c2c8-ffb0-496e" name="Imperialis Militia and Cults Army List" revision="108" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="128" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="90aa-c2c8-ffb0-496e" name="Imperialis Militia and Cults Army List" revision="109" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="130" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="90aa-c2c8-pubN65537" name="Crusade Imperialis"/>
     <publication id="90aa-c2c8-pubN65563" name="AoDRB"/>
@@ -848,7 +848,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <categoryLink id="ffce-c460-f223-44f3" name="New CategoryLink" hidden="false" targetId="8a8c-ed20-7427-ddff" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="6ba7-d9d9-6fc1-b9cc" name="Auxilia Ogryn Brute Squad" hidden="false" collective="false" import="true" targetId="0390-b19f-2fd3-a817" type="selectionEntry">
+    <entryLink id="6ba7-d9d9-6fc1-b9cc" name="Ogryn Brute Squad, Auxilia" hidden="false" collective="false" import="true" targetId="0390-b19f-2fd3-a817" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="6ba7-d9d9-6fc1-b9cc-456c6974657323232344415441232323" hidden="false" targetId="456c6974657323232344415441232323" primary="true"/>
         <categoryLink id="3e66-4160-5624-7fef" name="New CategoryLink" hidden="false" targetId="8a8c-ed20-7427-ddff" primary="false"/>
@@ -1322,6 +1322,45 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eefe-6292-095f-911f" type="min"/>
       </constraints>
+    </entryLink>
+    <entryLink id="7ca5-b5b0-120c-a53a" name="Nathaniel Garro" hidden="false" collective="false" import="true" targetId="f86d-ae13-1d89-f1a1" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8422-428c-7e5d-3fed" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="b8bf-e6e1-d54a-bcb3" name="New CategoryLink" hidden="false" targetId="485123232344415441232323" primary="true"/>
+        <categoryLink id="fadd-6025-77a9-dcd2" name="Infantry" hidden="false" targetId="f74d-4679-75a6-1252" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="7ccd-f4bf-3af8-500f" name="Tylos Rubio" hidden="false" collective="false" import="true" targetId="7baf-1c2e-6b5d-b865" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8422-428c-7e5d-3fed" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="6879-83fe-4728-5bce" name="New CategoryLink" hidden="false" targetId="485123232344415441232323" primary="true"/>
+        <categoryLink id="7a3e-e196-a976-d408" name="Infantry" hidden="false" targetId="f74d-4679-75a6-1252" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="0a76-3fab-9c5c-d1e0" name="Knight-Errant" hidden="false" collective="false" import="true" targetId="0b3e-7f6d-3556-5446" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8422-428c-7e5d-3fed" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="fb7e-571c-82e1-b79d" name="New CategoryLink" hidden="false" targetId="485123232344415441232323" primary="true"/>
+        <categoryLink id="73e4-69a8-937f-5bd4" name="Infantry" hidden="false" targetId="f74d-4679-75a6-1252" primary="false"/>
+      </categoryLinks>
     </entryLink>
   </entryLinks>
   <sharedSelectionEntries>
@@ -5208,7 +5247,7 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0f36-0140-1e63-3e26" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="48fb-7ace-f6eb-b96b" hidden="false" targetId="6950-0e85-bb60-2beb" type="profile"/>
+                <infoLink id="48fb-7ace-f6eb-b96b" name="Iron Halo" hidden="false" targetId="10b59cf4-3c97-e3e0-2185-853bcde6d112" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
@@ -10955,11 +10994,6 @@ A model may only use this weapon if it has successfully charged that player turn
     <profile id="3751-727c-d4e3-9cef" name="Illum Flares" publicationId="90aa-c2c8-pubN76431" page="90" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
       <characteristics>
         <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">May drop a single flare per turn.  Fired just as bombs - flare is placed after scattering.  Leave in place until the end of the turn.  Any unit targeting an enemy within 12&quot; of the flare gains Night Vision for the shooting phase.  Split fire does not apply.  </characteristic>
-      </characteristics>
-    </profile>
-    <profile id="6950-0e85-bb60-2beb" name="Iron Halo" publicationId="90aa-c2c8-pubN73486" page="183" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
-      <characteristics>
-        <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Provides a 4++ Invulnerable save. </characteristic>
       </characteristics>
     </profile>
     <profile id="bb95-3b87-dcfb-3473" name="Laslock" publicationId="90aa-c2c8-pubN73486" page="179" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">

--- a/(HH) Mechanicum - Questoris Knight.cat
+++ b/(HH) Mechanicum - Questoris Knight.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="32d1ddc6-3187-cf6f-3bf8-9891e527a002" name="Questoris Knight Crusade Army" revision="53" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="128" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="32d1ddc6-3187-cf6f-3bf8-9891e527a002" name="Questoris Knight Crusade Army" revision="54" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="130" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="32d1ddc6--pubN65537" name="Age of Darkness Crusade Army List"/>
     <publication id="32d1ddc6--pubN66650" name="HH4: Conquest"/>
@@ -93,6 +93,11 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="b9ef-f553-91bf-05d6" type="max"/>
           </constraints>
         </categoryLink>
+        <categoryLink id="3b74-a066-7876-2842" name="Compulsory HQ" hidden="false" targetId="becd-7a6d-e80f-878e" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6b8c-2e1c-f0d3-dba1" type="min"/>
+          </constraints>
+        </categoryLink>
       </categoryLinks>
     </forceEntry>
     <forceEntry id="e16c-65fe-d3da-fb93" name="Allied Detachment" hidden="false">
@@ -178,6 +183,7 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
       </rules>
       <categoryLinks>
         <categoryLink id="c9c2bc37-7048-4ed5-80c0-fb13d224f96a-485123232344415441232323" hidden="false" targetId="485123232344415441232323" primary="true"/>
+        <categoryLink id="55c4-b31c-c68f-9cd9" name="Compulsory HQ" hidden="false" targetId="becd-7a6d-e80f-878e" primary="false"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="0d826049-6db2-6635-065c-6b6c34faf886" name="Knight Armour" hidden="false" collective="false" import="true" targetId="3fc4-9d7f-969b-35bb" type="selectionEntryGroup"/>
@@ -384,6 +390,7 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
       </rules>
       <categoryLinks>
         <categoryLink id="33d55e37-58db-535e-ffb4-0c9136c15e25-485123232344415441232323" hidden="false" targetId="485123232344415441232323" primary="true"/>
+        <categoryLink id="72e0-76e7-3456-b46b" name="Compulsory HQ" hidden="false" targetId="becd-7a6d-e80f-878e" primary="false"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="d68922c4-1f12-ba8f-c17f-65225738046d" hidden="false" collective="false" import="true" targetId="3fc4-9d7f-969b-35bb" type="selectionEntryGroup"/>
@@ -429,6 +436,7 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
       </modifiers>
       <categoryLinks>
         <categoryLink id="849c-0f60-509d-16d1-485123232344415441232323" hidden="false" targetId="485123232344415441232323" primary="true"/>
+        <categoryLink id="a25f-09bc-594c-e815" name="Compulsory HQ" hidden="false" targetId="becd-7a6d-e80f-878e" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="3135-573f-145d-9803" name="Castellax Class Battle-Automata Maniple" hidden="false" collective="false" import="true" targetId="48db-84ca-2bad-520f" type="selectionEntry">
@@ -460,12 +468,12 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
         <categoryLink id="02c6-f507-ac2e-504c-5297-7e0f-fa0b-3537" hidden="false" targetId="5297-7e0f-fa0b-3537" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="9112-60df-c178-6f7b" name="New EntryLink" hidden="false" collective="false" import="true" targetId="1fa3-1f86-94a6-bf48" type="selectionEntry">
+    <entryLink id="9112-60df-c178-6f7b" name="Legio Titanicus Reaver Battle Titan" hidden="false" collective="false" import="true" targetId="1fa3-1f86-94a6-bf48" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="9112-60df-c178-6f7b-1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="4e49-8766-3548-9870" name="New EntryLink" hidden="false" collective="false" import="true" targetId="fb92-d215-2011-f911" type="selectionEntry">
+    <entryLink id="4e49-8766-3548-9870" name="Warlord-Sinister Pattern Battle Psi-Titan" hidden="false" collective="false" import="true" targetId="fb92-d215-2011-f911" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -477,12 +485,12 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
         <categoryLink id="4e49-8766-3548-9870-1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="4179-a726-fc3c-addf" name="New EntryLink" hidden="false" collective="false" import="true" targetId="b894-adfc-6d3d-fde4" type="selectionEntry">
+    <entryLink id="4179-a726-fc3c-addf" name="Legio Titanicus Warhound Scout Titan" hidden="false" collective="false" import="true" targetId="b894-adfc-6d3d-fde4" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="4179-a726-fc3c-addf-1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="53b7-53cc-3df0-a8a1" name="New EntryLink" hidden="false" collective="false" import="true" targetId="ab80-0fef-3e93-8e64" type="selectionEntry">
+    <entryLink id="53b7-53cc-3df0-a8a1" name="Legio Titanicus Warlord Battle Titan" hidden="false" collective="false" import="true" targetId="ab80-0fef-3e93-8e64" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="53b7-53cc-3df0-a8a1-1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
       </categoryLinks>
@@ -492,7 +500,7 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
         <categoryLink id="3f06-44f6-7e22-ed9a-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="fa5a-7dbb-c0ea-2f53" name="New EntryLink" hidden="false" collective="false" import="true" targetId="e10f-7b90-ecd3-80a5" type="selectionEntry">
+    <entryLink id="fa5a-7dbb-c0ea-2f53" name="Basilica Administratum" hidden="false" collective="false" import="true" targetId="e10f-7b90-ecd3-80a5" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="fa5a-7dbb-c0ea-2f53-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
@@ -508,6 +516,48 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="55b1-94e9-819f-fc99" type="min"/>
       </constraints>
+    </entryLink>
+    <entryLink id="8e7c-1851-8041-e857" name="Tylos Rubio" hidden="false" collective="false" import="true" targetId="7baf-1c2e-6b5d-b865" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="513f-ab95-ad10-b2ec" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="01ac-fa30-3771-cd61" name="HQ" hidden="false" targetId="485123232344415441232323" primary="true"/>
+        <categoryLink id="eba6-99d6-42ac-a505" name="Infantry" hidden="false" targetId="f74d-4679-75a6-1252" primary="false"/>
+        <categoryLink id="b2ce-8c33-ecc5-f88d" name="Legiones Astartes" hidden="false" targetId="0c56-27b8-a737-c9fd" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="1547-5656-afe7-b3a2" name="Knight-Errant" hidden="false" collective="false" import="true" targetId="0b3e-7f6d-3556-5446" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="513f-ab95-ad10-b2ec" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="c9ba-a0ac-4a8e-1b37" name="HQ" hidden="false" targetId="485123232344415441232323" primary="true"/>
+        <categoryLink id="b2c0-d007-21b6-4379" name="Infantry" hidden="false" targetId="f74d-4679-75a6-1252" primary="false"/>
+        <categoryLink id="7231-77a8-4f25-6f9c" name="Legiones Astartes" hidden="false" targetId="0c56-27b8-a737-c9fd" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="e0c9-f09a-f40f-93ea" name="Nathaniel Garro" hidden="false" collective="false" import="true" targetId="f86d-ae13-1d89-f1a1" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="513f-ab95-ad10-b2ec" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="dbf7-3a65-97e9-8c62" name="HQ" hidden="false" targetId="485123232344415441232323" primary="true"/>
+        <categoryLink id="cc22-0396-3020-9e3f" name="Infantry" hidden="false" targetId="f74d-4679-75a6-1252" primary="false"/>
+        <categoryLink id="9b08-3e1a-4b4b-4bbb" name="Legiones Astartes" hidden="false" targetId="0c56-27b8-a737-c9fd" primary="false"/>
+      </categoryLinks>
     </entryLink>
   </entryLinks>
   <sharedSelectionEntries>

--- a/(HH) Mechanicum - Taghmata Army List.cat
+++ b/(HH) Mechanicum - Taghmata Army List.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="cf03-f607-41dc-7545" name="Mechanicum: Taghmata Army List" revision="107" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="129" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="cf03-f607-41dc-7545" name="Mechanicum: Taghmata Army List" revision="107" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="130" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="cf03-f607-pubN65537" name="Horus Heresy: Taghmata Army List"/>
     <publication id="cf03-f607-pubN65563" name="AoDRB"/>
@@ -1687,6 +1687,48 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4d7b-4958-83cf-382b" type="min"/>
       </constraints>
     </entryLink>
+    <entryLink id="9efa-e3a0-7078-866c" name="Nathaniel Garro" hidden="false" collective="false" import="true" targetId="f86d-ae13-1d89-f1a1" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a735-9091-b1d2-02d8" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="34eb-582c-1079-9d2c" name="New CategoryLink" hidden="false" targetId="485123232344415441232323" primary="true"/>
+        <categoryLink id="63ac-f223-fdf2-a17c" name="Infantry" hidden="false" targetId="f74d-4679-75a6-1252" primary="false"/>
+        <categoryLink id="ed33-96d4-a684-e04f" name="Legiones Astartes" hidden="false" targetId="0c56-27b8-a737-c9fd" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="3ee1-4302-5a48-c41b" name="Tylos Rubio" hidden="false" collective="false" import="true" targetId="7baf-1c2e-6b5d-b865" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a735-9091-b1d2-02d8" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="d18c-977e-d04c-ac2f" name="New CategoryLink" hidden="false" targetId="485123232344415441232323" primary="true"/>
+        <categoryLink id="6054-8b48-5d04-b3d0" name="Infantry" hidden="false" targetId="f74d-4679-75a6-1252" primary="false"/>
+        <categoryLink id="fda0-8b6c-763b-6fcd" name="Legiones Astartes" hidden="false" targetId="0c56-27b8-a737-c9fd" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="7bac-2b8b-f84f-f144" name="Knight-Errant" hidden="false" collective="false" import="true" targetId="0b3e-7f6d-3556-5446" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a735-9091-b1d2-02d8" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="b33b-6833-c797-e37c" name="New CategoryLink" hidden="false" targetId="485123232344415441232323" primary="true"/>
+        <categoryLink id="8392-b02f-c751-91e6" name="Infantry" hidden="false" targetId="f74d-4679-75a6-1252" primary="false"/>
+        <categoryLink id="985c-5091-fd1f-e026" name="Legiones Astartes" hidden="false" targetId="0c56-27b8-a737-c9fd" primary="false"/>
+      </categoryLinks>
+    </entryLink>
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="04c4-8239-657a-ced2" name="Support Squad" hidden="false" collective="false" import="true" type="upgrade">
@@ -2853,7 +2895,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
       </constraints>
       <infoLinks>
-        <infoLink id="2a1320e1-ea30-d401-4f75-92c91f2fadf9" hidden="false" targetId="10b59cf4-3c97-e3e0-2185-853bcde6d112" type="profile"/>
+        <infoLink id="642e-3d4f-0dc1-f799" name="Iron Halo" hidden="false" targetId="10b59cf4-3c97-e3e0-2185-853bcde6d112" type="profile"/>
       </infoLinks>
       <costs>
         <cost name="pts" typeId="points" value="25.0"/>
@@ -3008,7 +3050,7 @@ Reduces transport capacity to 8.</description>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="161e-2f1f-42ac-1b77" name="Flare Shield" hidden="false" targetId="a7069849-cdd7-ffb1-8088-8300704afcae" type="profile"/>
+                <infoLink id="161e-2f1f-42ac-1b77" name="Flare Shield" hidden="false" targetId="cb4a-644f-bd8d-7d97" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
@@ -3952,7 +3994,7 @@ Reduces transport capacity to 8.</description>
           </modifiers>
         </entryLink>
         <entryLink id="a381-97d9-7a14-e63b" name="New EntryLink" hidden="false" collective="false" import="true" targetId="0a18-686c-1dfb-4b71" type="selectionEntry"/>
-        <entryLink id="8b10-c322-064d-314d" name="New EntryLink" hidden="false" collective="false" import="true" targetId="48e5-e3dc-433e-d5a6" type="selectionEntry"/>
+        <entryLink id="8b10-c322-064d-314d" name="Twin-Linked Mauler Bolt Cannon" hidden="false" collective="false" import="true" targetId="48e5-e3dc-433e-d5a6" type="selectionEntry"/>
         <entryLink id="ea9b-623f-5a9a-c1cb" name="New EntryLink" hidden="false" collective="false" import="true" targetId="f2a5-f499-58e1-21e8" type="selectionEntry"/>
       </entryLinks>
       <costs>
@@ -4516,7 +4558,7 @@ Reduces transport capacity to 8.</description>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3333-7c65-5394-7d26" type="max"/>
       </constraints>
       <infoLinks>
-        <infoLink id="6ea9-d8b5-696c-9158" name="Flare Shield" hidden="false" targetId="a7069849-cdd7-ffb1-8088-8300704afcae" type="profile"/>
+        <infoLink id="6ea9-d8b5-696c-9158" name="Flare Shield" hidden="false" targetId="cb4a-644f-bd8d-7d97" type="profile"/>
       </infoLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
@@ -4539,9 +4581,18 @@ Reduces transport capacity to 8.</description>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="480b-8bad-7d34-baa3" type="min"/>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b431-1501-6b7e-9b71" type="max"/>
       </constraints>
+      <profiles>
+        <profile id="28cd-1498-53ab-b337" name="Twin-linked Mauler Bolt Cannon" publicationId="ca571888--pubN106502" page="177" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="52616e676523232344415441232323">24&quot;</characteristic>
+            <characteristic name="Strength" typeId="537472656e67746823232344415441232323">6</characteristic>
+            <characteristic name="AP" typeId="415023232344415441232323">3</characteristic>
+            <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 3, Pinning, Twin-linked</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
       <infoLinks>
-        <infoLink id="643e-1f16-94e6-6c70" hidden="false" targetId="0225-fc80-29f1-09db" type="profile"/>
-        <infoLink id="85fd-6270-ca0b-77d1" name="New InfoLink" hidden="false" targetId="10a8-8d89-0bec-3e21" type="rule"/>
+        <infoLink id="85fd-6270-ca0b-77d1" name="Twin-linked" hidden="false" targetId="10a8-8d89-0bec-3e21" type="rule"/>
       </infoLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
@@ -4595,30 +4646,30 @@ Reduces transport capacity to 8.</description>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="5e35-a71f-5e13-e6dc" name="New EntryLink" hidden="false" collective="false" import="true" targetId="776e-2ea5-2be8-fee3" type="selectionEntry"/>
+        <entryLink id="5e35-a71f-5e13-e6dc" name="Flare Shield" hidden="false" collective="false" import="true" targetId="776e-2ea5-2be8-fee3" type="selectionEntry"/>
         <entryLink id="56d4-93c4-a502-cdd0" name="Triaros/Karacnos optionals:" hidden="false" collective="false" import="true" targetId="4e41-e567-a14d-8e3a" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="name" value="May take any of the following:"/>
           </modifiers>
         </entryLink>
         <entryLink id="8f96-0dba-f6cb-ec83" name="New EntryLink" hidden="false" collective="false" import="true" targetId="0a18-686c-1dfb-4b71" type="selectionEntry"/>
-        <entryLink id="f45c-8e8d-bfe0-0dd7" name="New EntryLink" hidden="false" collective="false" import="true" targetId="c36a-4017-0eb5-c8d2" type="selectionEntry"/>
-        <entryLink id="9cd0-475b-7369-3013" name="Karacnos mortar battery" hidden="false" collective="false" import="true" targetId="81f0-cd7e-d2fe-e7a0" type="selectionEntry"/>
+        <entryLink id="f45c-8e8d-bfe0-0dd7" name="Lightning Blaster Sentinel" hidden="false" collective="false" import="true" targetId="c36a-4017-0eb5-c8d2" type="selectionEntry"/>
+        <entryLink id="9cd0-475b-7369-3013" name="Karacnos Mortar Battery" hidden="false" collective="false" import="true" targetId="81f0-cd7e-d2fe-e7a0" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="225.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="c36a-4017-0eb5-c8d2" name="Lightning Blaster Sentinel" publicationId="cf03-f607-pubN92488" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="c36a-4017-0eb5-c8d2" name="Lightning-Blaster Sentinel" publicationId="cf03-f607-pubN92488" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ff7b-0ca7-4a3f-2653" type="max"/>
         <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="673e-3c4d-f573-c25b" type="min"/>
       </constraints>
       <infoLinks>
-        <infoLink id="03e2-99c3-7a3a-07e3" name="New InfoLink" hidden="false" targetId="e709-46b3-c321-9484" type="profile"/>
+        <infoLink id="03e2-99c3-7a3a-07e3" name="Lightning-Blaster Sentinel" hidden="false" targetId="e709-46b3-c321-9484" type="profile"/>
         <infoLink id="eece-b51d-21eb-7fb3" name="New InfoLink" hidden="false" targetId="8269-2cd6-9236-16e7" type="rule"/>
         <infoLink id="187b-9c0d-a255-47a5" name="New InfoLink" hidden="false" targetId="89da-0cb5-bee4-8ec2" type="rule"/>
-        <infoLink id="34f2-d4c2-6479-ae57" name="New InfoLink" hidden="false" targetId="e571-5701-104d-9e3d" type="profile"/>
+        <infoLink id="34f2-d4c2-6479-ae57" name="Lightning-Blaster Sentinels" hidden="false" targetId="e571-5701-104d-9e3d" type="profile"/>
       </infoLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
@@ -5324,7 +5375,7 @@ Buildings and Fortifications D</description>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c881-5b1e-a213-889b" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="bdd7-9edb-3ba8-3c08" hidden="false" targetId="a7069849-cdd7-ffb1-8088-8300704afcae" type="profile"/>
+                <infoLink id="bdd7-9edb-3ba8-3c08" name="Flare Shield" hidden="false" targetId="cb4a-644f-bd8d-7d97" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
@@ -18281,11 +18332,6 @@ A Unit may not use Counter Attack special rule if it used Reaction Fire.</descri
         <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">A model with this upgrade increases its BS by +1 and reduces enemy cover saves by -1. </characteristic>
       </characteristics>
     </profile>
-    <profile id="a7069849-cdd7-ffb1-8088-8300704afcae" name="Flare Shield" publicationId="cf03-f607-pubN80892" page="89" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
-      <characteristics>
-        <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">A flare shield operates against shooting attacks that strike the vehicle&apos;s front arc.  It reduces the strength of attacks by weapons with the Templae or Blast type by -2, and other shooting attacks by -1.  A flare shield has no effect on attacks from close combat or with the Destroyer rule.   Note that for Vultarax (and other monstrous creatures) the flare shield applies to all ranged attacks against the automata as it has no &apos;Front Arc&apos;.</characteristic>
-      </characteristics>
-    </profile>
     <profile id="a820a8ed-f726-09ac-2a57-9caf6cdb42de" name="Galvanic Traction Drive" publicationId="cf03-f607-pubN76979" page="228" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
       <characteristics>
         <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">This unit must re-roll failed Dangerous Terrain tests.  </characteristic>
@@ -18421,11 +18467,6 @@ A Unit may not use Counter Attack special rule if it used Reaction Fire.</descri
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">2</characteristic>
         <characteristic name="AP" typeId="415023232344415441232323">5</characteristic>
         <characteristic name="Type" typeId="5479706523232344415441232323">Assault 1, Fleshbane, Rad-Phage</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="10b59cf4-3c97-e3e0-2185-853bcde6d112" name="Iron Halo" page="0" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
-      <characteristics>
-        <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Confers 4++ Invulnerable Save</characteristic>
       </characteristics>
     </profile>
     <profile id="926a370f-f4c1-b644-34f2-c348a5ce36c0" name="Irradiation Engine" publicationId="cf03-f607-pubN123006" page="240" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
@@ -18915,7 +18956,7 @@ A Unit may not use Counter Attack special rule if it used Reaction Fire.</descri
         <characteristic name="Access Points" typeId="d17b-0342-b1dc-b8e7">Two, one of each side of the hull</characteristic>
       </characteristics>
     </profile>
-    <profile id="e709-46b3-c321-9484" name="Lightning Blaster Sentinal" publicationId="cf03-f607-pubN92488" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+    <profile id="e709-46b3-c321-9484" name="Lightning-Blaster Sentinel" publicationId="cf03-f607-pubN92488" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">18&quot;</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">7</characteristic>
@@ -18923,9 +18964,10 @@ A Unit may not use Counter Attack special rule if it used Reaction Fire.</descri
         <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 3, Shred, Rending</characteristic>
       </characteristics>
     </profile>
-    <profile id="e571-5701-104d-9e3d" name="Lightning Blaster Sentinels" publicationId="cf03-f607-pubN76979" page="224" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
+    <profile id="e571-5701-104d-9e3d" name="Lightning-Blaster Sentinels" publicationId="cf03-f607-pubN76979" page="224" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
       <characteristics>
-        <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Each is a pintle-mounted Sentinel which can be fired in addition to any other weapons the vehicle is carrying without penalty and may target units separately from the vehicles main armament. If reduced to firing snap shots, it may do so at BS 2.</characteristic>
+        <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Slaved weapons operated and targeted by their own servitor-brains, the lightning-blasters which are sponson-mounted on the Karacnos are able to respond automatically to any threat while the vehicle&apos;s crew manage the operation of their temperamental and powerful primary weapons system.
+Each lightning-blaster sentinel may target units separately from the Karacnos&apos; main weapon and has the following profile. If reduced to firing Snap Shots, it may do so at BS 2.</characteristic>
       </characteristics>
     </profile>
     <profile id="0345-be6c-3862-1bf7" name="Karacnos motar battery" publicationId="cf03-f607-pubN92488" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">

--- a/(HH) Mechanicum - Taghmata Army List.cat
+++ b/(HH) Mechanicum - Taghmata Army List.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="cf03-f607-41dc-7545" name="Mechanicum: Taghmata Army List" revision="106" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="129" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="cf03-f607-41dc-7545" name="Mechanicum: Taghmata Army List" revision="107" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="129" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="cf03-f607-pubN65537" name="Horus Heresy: Taghmata Army List"/>
     <publication id="cf03-f607-pubN65563" name="AoDRB"/>
@@ -2908,9 +2908,6 @@ A model equipped with a machinator array may make two additional attacks per tur
       </costs>
     </selectionEntry>
     <selectionEntry id="0de5-5b51-907d-e5e2" name="Macrocarid Explorator" hidden="false" collective="false" import="true" type="model">
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
       <profiles>
         <profile id="1208-f8bb-cf2b-5f30" name="Macrocarid Explorator" publicationId="cf03-f607-pubN76270" page="55" hidden="false" typeId="56656869636c6523232344415441232323" typeName="Vehicle">
           <characteristics>
@@ -10492,7 +10489,11 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
       </selectionEntryGroups>
       <entryLinks>
         <entryLink id="fc9b-b619-b8cd-bf76" name="Cyber-familiar" hidden="false" collective="false" import="true" targetId="dd09a633-0c59-7ea7-d62e-e978aefb3cff" type="selectionEntry"/>
-        <entryLink id="c692-95ee-a268-68e5" hidden="false" collective="false" import="true" targetId="0de5-5b51-907d-e5e2" type="selectionEntry"/>
+        <entryLink id="c692-95ee-a268-68e5" name="Macrocarid Explorator" hidden="false" collective="false" import="true" targetId="0de5-5b51-907d-e5e2" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b7f8-541d-3dc4-4f14" type="max"/>
+          </constraints>
+        </entryLink>
         <entryLink id="e253-f716-a506-e14e" name="Machinator Array" hidden="false" collective="false" import="true" targetId="9d9f-63d3-f635-7fd5" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="points" value="0.0"/>

--- a/(HH) Solar Auxilia - Crusade Army List.cat
+++ b/(HH) Solar Auxilia - Crusade Army List.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="7f243fc5-c5fd-8b2c-7b07-907bf684bb72" name="Solar Auxilia" revision="74" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="128" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="7f243fc5-c5fd-8b2c-7b07-907bf684bb72" name="Solar Auxilia" revision="75" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="130" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="7f243fc5--pubN65537" name="Crusade Imperialis"/>
     <publication id="7f243fc5--pubN65563" name="AoDRB"/>
@@ -1265,6 +1265,48 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9088-dd81-ce0c-df55" type="min"/>
       </constraints>
+    </entryLink>
+    <entryLink id="47fb-5d12-db42-3098" name="Nathaniel Garro" hidden="false" collective="false" import="true" targetId="f86d-ae13-1d89-f1a1" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ca2a-4940-90bf-1a80" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="dfe3-b6fc-3769-7f73" name="New CategoryLink" hidden="false" targetId="485123232344415441232323" primary="true"/>
+        <categoryLink id="5699-89ac-ebad-6fb5" name="Infantry" hidden="false" targetId="f74d-4679-75a6-1252" primary="false"/>
+        <categoryLink id="1aa0-8475-0d2f-695c" name="Legiones Astartes" hidden="false" targetId="0c56-27b8-a737-c9fd" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="2f75-e7f8-b9a2-6e50" name="Knight-Errant" hidden="false" collective="false" import="true" targetId="0b3e-7f6d-3556-5446" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ca2a-4940-90bf-1a80" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="7779-2926-7159-20e2" name="New CategoryLink" hidden="false" targetId="485123232344415441232323" primary="true"/>
+        <categoryLink id="d574-165c-2e06-bde8" name="Infantry" hidden="false" targetId="f74d-4679-75a6-1252" primary="false"/>
+        <categoryLink id="3dec-934a-3ef8-bd36" name="Legiones Astartes" hidden="false" targetId="0c56-27b8-a737-c9fd" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="30ea-d07e-bee1-8e55" name="Tylos Rubio" hidden="false" collective="false" import="true" targetId="7baf-1c2e-6b5d-b865" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ca2a-4940-90bf-1a80" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="f095-1354-8571-ffc5" name="New CategoryLink" hidden="false" targetId="485123232344415441232323" primary="true"/>
+        <categoryLink id="3cac-a655-47f5-fad1" name="Infantry" hidden="false" targetId="f74d-4679-75a6-1252" primary="false"/>
+        <categoryLink id="18c8-59e5-62a0-af4c" name="Legiones Astartes" hidden="false" targetId="0c56-27b8-a737-c9fd" primary="false"/>
+      </categoryLinks>
     </entryLink>
   </entryLinks>
   <sharedSelectionEntries>
@@ -6159,7 +6201,7 @@ Precision Shots</description>
         <infoLink id="6d63-e21a-67f8-50db" hidden="false" targetId="aa451588-557c-7f81-2b3f-d17583985f38" type="rule"/>
         <infoLink id="185d-7e03-a69b-abb6" hidden="false" targetId="f7437df9-95af-6a73-4ee8-3bdb569d0d01" type="rule"/>
         <infoLink id="4491-17e1-e4a5-9153" name="Psi-jammer" hidden="false" targetId="1c03eb3f-dd49-171f-e5eb-b22d40798be7" type="profile"/>
-        <infoLink id="08d0-fb6d-bfd3-b4b9" name="Iron Halo" hidden="false" targetId="8dc7-dfa6-7907-496b" type="profile"/>
+        <infoLink id="08d0-fb6d-bfd3-b4b9" name="Iron Halo" hidden="false" targetId="10b59cf4-3c97-e3e0-2185-853bcde6d112" type="profile"/>
         <infoLink id="60ee-87b7-52d5-dc7d" name="It Will Not Die" hidden="false" targetId="72d9-7041-9d30-d150" type="rule"/>
         <infoLink id="90d0-e280-c88b-494d" name="Frag Grenades" hidden="false" targetId="d890-1b84-bbd9-12d3" type="profile"/>
         <infoLink id="3514-ac76-f1bd-85b0" name="Krak Grenade (Shooting)" hidden="false" targetId="d9f7-775b-1047-f335" type="profile"/>
@@ -8318,7 +8360,7 @@ Precision Shots</description>
     </selectionEntry>
     <selectionEntry id="6bdd-a78c-4106-b30c" name="Iron Halo" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
-        <infoLink id="518c-346b-28de-8d65" name="Iron Halo" hidden="false" targetId="8dc7-dfa6-7907-496b" type="profile"/>
+        <infoLink id="518c-346b-28de-8d65" name="Iron Halo" hidden="false" targetId="10b59cf4-3c97-e3e0-2185-853bcde6d112" type="profile"/>
       </infoLinks>
       <costs>
         <cost name="pts" typeId="points" value="10.0"/>
@@ -9468,11 +9510,6 @@ If your army contains none of the above, but does contain one or more Auxilia Ta
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">2</characteristic>
         <characteristic name="AP" typeId="415023232344415441232323">5</characteristic>
         <characteristic name="Type" typeId="5479706523232344415441232323">Assault 1, Fleshbane, Rad-Phage</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="8dc7-dfa6-7907-496b" name="Iron Halo" page="0" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
-      <characteristics>
-        <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Confers 4++ Invulnerable Save</characteristic>
       </characteristics>
     </profile>
     <profile id="f30af14f-b0dc-3aec-51a6-3e12555e4a4a" name="Irradiation Engine" publicationId="7f243fc5--pubN116331" page="240" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">

--- a/(HH) Talons of the Emperor Army List.cat
+++ b/(HH) Talons of the Emperor Army List.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="a30a-7522-3343-553a" name="Talons of the Emperor" revision="102" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="128" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="a30a-7522-3343-553a" name="Talons of the Emperor" revision="103" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="130" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="a30a-7522-pubN65537" name="HH7 / HH8"/>
     <publication id="a30a-7522-pubN69988" name="Forgeworld.co.uk"/>
@@ -23,6 +23,7 @@
     <categoryEntry id="5297-7e0f-fa0b-3537" name="Allegiance" hidden="false"/>
     <categoryEntry id="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" name="Lords of War" hidden="false"/>
     <categoryEntry id="466f7274696669636174696f6e23232344415441232323" name="Fortification" hidden="false"/>
+    <categoryEntry id="d7ea-8c56-c01f-53b4" name="Compulsory HQ" hidden="false"/>
   </categoryEntries>
   <forceEntries>
     <forceEntry id="98db-b4ba-fbcd-3239" name=" Crusade" hidden="false">
@@ -72,6 +73,11 @@
           </constraints>
         </categoryLink>
         <categoryLink id="1551-86a0-a987-6cf3" name="Mournival Rules" hidden="false" targetId="dbe0-716f-797c-66f7" primary="false"/>
+        <categoryLink id="2cb9-13e4-9dc0-085a" name="Compulsory HQ" hidden="false" targetId="d7ea-8c56-c01f-53b4" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="867c-5aa5-a006-9849" type="min"/>
+          </constraints>
+        </categoryLink>
       </categoryLinks>
     </forceEntry>
     <forceEntry id="657a-bc81-4ae3-8a5b" name="Allied Detachment" hidden="false">
@@ -133,6 +139,11 @@
             <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bb88-e34a-6159-8441" type="max"/>
           </constraints>
         </categoryLink>
+        <categoryLink id="6f7f-0fd3-3f66-8699" name="Compulsory HQ" hidden="false" targetId="d7ea-8c56-c01f-53b4" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fc85-1fb5-0d72-b2d2" type="min"/>
+          </constraints>
+        </categoryLink>
       </categoryLinks>
     </forceEntry>
     <forceEntry id="089f-7e79-bde1-90dd" name=" Zone Mortalis - Attacker" hidden="false">
@@ -171,6 +182,11 @@
           </constraints>
         </categoryLink>
         <categoryLink id="9acb-dbaf-382f-42cd" name="Mournival Rules" hidden="false" targetId="dbe0-716f-797c-66f7" primary="false"/>
+        <categoryLink id="6bb1-1fa6-012f-3176" name="Compulsory HQ" hidden="false" targetId="d7ea-8c56-c01f-53b4" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2f94-f82c-5b66-a2e2" type="min"/>
+          </constraints>
+        </categoryLink>
       </categoryLinks>
     </forceEntry>
     <forceEntry id="7b39-af6b-52e1-b4d7" name=" Zone Mortalis - Defender" hidden="false">
@@ -205,6 +221,11 @@
           </constraints>
         </categoryLink>
         <categoryLink id="e71d-d101-c736-075c" name="Mournival Rules" hidden="false" targetId="dbe0-716f-797c-66f7" primary="false"/>
+        <categoryLink id="0893-2a74-6b21-d9cb" name="Compulsory HQ" hidden="false" targetId="d7ea-8c56-c01f-53b4" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="df3c-a9c7-b7bb-d415" type="min"/>
+          </constraints>
+        </categoryLink>
       </categoryLinks>
     </forceEntry>
     <forceEntry id="7e48-c376-8ffe-8ae7" name=" Zone Mortalis - Combatant" hidden="false">
@@ -243,6 +264,11 @@
           </constraints>
         </categoryLink>
         <categoryLink id="7da7-5612-3d00-7202" name="Mournival Rules" hidden="false" targetId="dbe0-716f-797c-66f7" primary="false"/>
+        <categoryLink id="b8b8-6554-d311-aaf6" name="Compulsory HQ" hidden="false" targetId="d7ea-8c56-c01f-53b4" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4b2d-4504-00d3-3ef3" type="min"/>
+          </constraints>
+        </categoryLink>
       </categoryLinks>
     </forceEntry>
     <forceEntry id="d1ef-61e1-3d67-5a19" name="Optional - Onslaught" hidden="false">
@@ -288,6 +314,11 @@
           </constraints>
         </categoryLink>
         <categoryLink id="642d-98e0-7a4d-29ba" name="Mournival Rules" hidden="false" targetId="dbe0-716f-797c-66f7" primary="false"/>
+        <categoryLink id="739d-3ece-81bc-ee2d" name="Compulsory HQ" hidden="false" targetId="d7ea-8c56-c01f-53b4" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e020-e636-43c2-21e4" type="min"/>
+          </constraints>
+        </categoryLink>
       </categoryLinks>
     </forceEntry>
     <forceEntry id="3a6f-6d67-a8b2-e911" name="Optional - Castellan" hidden="false">
@@ -338,6 +369,11 @@
           </constraints>
         </categoryLink>
         <categoryLink id="3c2a-3fcb-1c75-8340" name="Mournival Rules" hidden="false" targetId="dbe0-716f-797c-66f7" primary="false"/>
+        <categoryLink id="fe63-df8a-ab8f-f8c8" name="Compulsory HQ" hidden="false" targetId="d7ea-8c56-c01f-53b4" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="856d-dd37-1fe0-c772" type="min"/>
+          </constraints>
+        </categoryLink>
       </categoryLinks>
     </forceEntry>
     <forceEntry id="f715-cdf4-0c5e-213a" name="Optional - Leviathan" hidden="false">
@@ -396,6 +432,11 @@
           </constraints>
         </categoryLink>
         <categoryLink id="4d97-7651-ecd8-68ca" name="Mournival Rules" hidden="false" targetId="dbe0-716f-797c-66f7" primary="false"/>
+        <categoryLink id="041f-c854-dbc0-1138" name="Compulsory HQ" hidden="false" targetId="d7ea-8c56-c01f-53b4" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2077-9471-5126-e83a" type="min"/>
+          </constraints>
+        </categoryLink>
       </categoryLinks>
     </forceEntry>
     <forceEntry id="8666-c0df-4dfa-08f1" name=" Strategic Raid - Garrison" hidden="false">
@@ -444,6 +485,11 @@
           </constraints>
         </categoryLink>
         <categoryLink id="defb-6067-82a7-eb34" name="Mournival Rules" hidden="false" targetId="dbe0-716f-797c-66f7" primary="false"/>
+        <categoryLink id="977e-e521-3071-d1b3" name="Compulsory HQ" hidden="false" targetId="d7ea-8c56-c01f-53b4" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5797-2d83-8c01-0aae" type="min"/>
+          </constraints>
+        </categoryLink>
       </categoryLinks>
     </forceEntry>
   </forceEntries>
@@ -471,7 +517,7 @@
     </selectionEntry>
   </selectionEntries>
   <entryLinks>
-    <entryLink id="55a4-3c7c-28ec-878f" name="New EntryLink" hidden="false" collective="false" import="true" targetId="dab7-cef6-7603-3be2" type="selectionEntry">
+    <entryLink id="55a4-3c7c-28ec-878f" name="Legio Custodes Sentinel Guard Squad" hidden="false" collective="false" import="true" targetId="dab7-cef6-7603-3be2" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="55a4-3c7c-28ec-878f-54726f6f707323232344415441232323" hidden="false" targetId="54726f6f707323232344415441232323" primary="true"/>
       </categoryLinks>
@@ -486,27 +532,29 @@
         <categoryLink id="527b-773b-9fc2-3664-486561767920537570706f727423232344415441232323" hidden="false" targetId="486561767920537570706f727423232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="597e-fb29-b8f0-bca5" name="New EntryLink" hidden="false" collective="false" import="true" targetId="38a5-b278-eb49-3779" type="selectionEntry">
+    <entryLink id="597e-fb29-b8f0-bca5" name="Constantin Valdor" hidden="false" collective="false" import="true" targetId="38a5-b278-eb49-3779" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="597e-fb29-b8f0-bca5-485123232344415441232323" hidden="false" targetId="485123232344415441232323" primary="true"/>
+        <categoryLink id="9a1b-a509-668e-9276" name="Compulsory HQ" hidden="false" targetId="d7ea-8c56-c01f-53b4" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="de59-9a90-c4b5-5469" name="New EntryLink" hidden="false" collective="false" import="true" targetId="cc00-5542-b66c-07ee" type="selectionEntry">
+    <entryLink id="de59-9a90-c4b5-5469" name="Jenetia Krole" hidden="false" collective="false" import="true" targetId="cc00-5542-b66c-07ee" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="de59-9a90-c4b5-5469-485123232344415441232323" hidden="false" targetId="485123232344415441232323" primary="true"/>
+        <categoryLink id="dc2f-9f49-3dfe-270d" name="Compulsory HQ" hidden="false" targetId="d7ea-8c56-c01f-53b4" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="b1fb-32c1-f910-6651" name="New EntryLink" hidden="false" collective="false" import="true" targetId="e5cb-9892-6a0d-9c40" type="selectionEntry">
+    <entryLink id="b1fb-32c1-f910-6651" name="Legio Custodes Agamatus Jetbike Squadron" hidden="false" collective="false" import="true" targetId="e5cb-9892-6a0d-9c40" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="b1fb-32c1-f910-6651-466173742041747461636b23232344415441232323" hidden="false" targetId="466173742041747461636b23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="00ee-96bc-de42-dc49" name="New EntryLink" hidden="false" collective="false" import="true" targetId="6ced-0f69-b659-41da" type="selectionEntry">
+    <entryLink id="00ee-96bc-de42-dc49" name="Legio Custodes Aquilon Terminator Squad" hidden="false" collective="false" import="true" targetId="6ced-0f69-b659-41da" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="00ee-96bc-de42-dc49-456c6974657323232344415441232323" hidden="false" targetId="456c6974657323232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="433c-9641-fae4-c698" name="New EntryLink" hidden="false" collective="false" import="true" targetId="95b0-bc7c-b477-069b" type="selectionEntry">
+    <entryLink id="433c-9641-fae4-c698" name="Legio Custodes Contemptor-Achillus Dreadnought" hidden="false" collective="false" import="true" targetId="95b0-bc7c-b477-069b" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="433c-9641-fae4-c698-456c6974657323232344415441232323" hidden="false" targetId="456c6974657323232344415441232323" primary="true"/>
       </categoryLinks>
@@ -516,7 +564,7 @@
         <categoryLink id="fe13-642f-90dd-c376-486561767920537570706f727423232344415441232323" hidden="false" targetId="486561767920537570706f727423232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="ce30-2f93-dba9-98c0" name="New EntryLink" hidden="false" collective="false" import="true" targetId="d290-734d-18b9-e387" type="selectionEntry">
+    <entryLink id="ce30-2f93-dba9-98c0" name="Legio Custodes Hetaeron Guard Squad" hidden="false" collective="false" import="true" targetId="d290-734d-18b9-e387" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="ce30-2f93-dba9-98c0-456c6974657323232344415441232323" hidden="false" targetId="456c6974657323232344415441232323" primary="true"/>
       </categoryLinks>
@@ -526,7 +574,7 @@
         <categoryLink id="2e56-bd49-d9f3-9cb5-466173742041747461636b23232344415441232323" hidden="false" targetId="466173742041747461636b23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="69f7-13e8-abc8-7e8f" name="New EntryLink" hidden="false" collective="false" import="true" targetId="5f2c-6d5f-60a2-c648" type="selectionEntry">
+    <entryLink id="69f7-13e8-abc8-7e8f" name="Legio Custodes Sagittarum Guard Squad" hidden="false" collective="false" import="true" targetId="5f2c-6d5f-60a2-c648" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="69f7-13e8-abc8-7e8f-486561767920537570706f727423232344415441232323" hidden="false" targetId="486561767920537570706f727423232344415441232323" primary="true"/>
       </categoryLinks>
@@ -534,14 +582,16 @@
     <entryLink id="7066-ede9-5077-68d6" name="Legio Custodes Shield Captain" hidden="false" collective="false" import="true" targetId="5e4a-d122-6e76-2634" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="7066-ede9-5077-68d6-485123232344415441232323" hidden="false" targetId="485123232344415441232323" primary="true"/>
+        <categoryLink id="b9b8-ab09-7476-bbc7" name="Compulsory HQ" hidden="false" targetId="d7ea-8c56-c01f-53b4" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="64f9-bed3-1fd6-3379" name="New EntryLink" hidden="false" collective="false" import="true" targetId="1ebb-ff7d-d5f8-ee60" type="selectionEntry">
+    <entryLink id="64f9-bed3-1fd6-3379" name="Sisters of Silence Excruciatus Cadre" hidden="false" collective="false" import="true" targetId="1ebb-ff7d-d5f8-ee60" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="64f9-bed3-1fd6-3379-485123232344415441232323" hidden="false" targetId="485123232344415441232323" primary="true"/>
+        <categoryLink id="ba74-f364-80de-638a" name="Compulsory HQ" hidden="false" targetId="d7ea-8c56-c01f-53b4" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="52cd-55ec-998f-deb6" name="New EntryLink" hidden="false" collective="false" import="true" targetId="80ba-e9bc-4e45-0c8f" type="selectionEntry">
+    <entryLink id="52cd-55ec-998f-deb6" name="Sisters of Silence Oblivion Knight Cadre" hidden="false" collective="false" import="true" targetId="80ba-e9bc-4e45-0c8f" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="52cd-55ec-998f-deb6-456c6974657323232344415441232323" hidden="false" targetId="456c6974657323232344415441232323" primary="true"/>
       </categoryLinks>
@@ -549,59 +599,60 @@
     <entryLink id="b954-9079-02fb-cbf5" name="Sisters of Silence Oblivion Knight-Centura" hidden="false" collective="false" import="true" targetId="26dd-4eb2-fe70-ea73" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="b954-9079-02fb-cbf5-485123232344415441232323" hidden="false" targetId="485123232344415441232323" primary="true"/>
+        <categoryLink id="52f5-4d00-c6e5-94d4" name="Compulsory HQ" hidden="false" targetId="d7ea-8c56-c01f-53b4" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="7d31-27e1-340d-9f3f" name="New EntryLink" hidden="false" collective="false" import="true" targetId="17c2-d576-4704-9d48" type="selectionEntry">
+    <entryLink id="7d31-27e1-340d-9f3f" name="Sisters of Silence Persuer Cadre" hidden="false" collective="false" import="true" targetId="17c2-d576-4704-9d48" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="7d31-27e1-340d-9f3f-466173742041747461636b23232344415441232323" hidden="false" targetId="466173742041747461636b23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="4cf4-c467-a64c-ed40" name="New EntryLink" hidden="false" collective="false" import="true" targetId="2547-40ab-cb22-90a2" type="selectionEntry">
+    <entryLink id="4cf4-c467-a64c-ed40" name="Sisters of Silence Prosecutor Cadre" hidden="false" collective="false" import="true" targetId="2547-40ab-cb22-90a2" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="4cf4-c467-a64c-ed40-54726f6f707323232344415441232323" hidden="false" targetId="54726f6f707323232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="e31e-ad7b-b162-dcf5" name="New EntryLink" hidden="false" collective="false" import="true" targetId="08a1-0907-5ed0-2a6c" type="selectionEntry">
+    <entryLink id="e31e-ad7b-b162-dcf5" name="Sisters of Silence Seeker Cadre" hidden="false" collective="false" import="true" targetId="08a1-0907-5ed0-2a6c" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="e31e-ad7b-b162-dcf5-486561767920537570706f727423232344415441232323" hidden="false" targetId="486561767920537570706f727423232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="990c-a548-b447-1e9a" name="New EntryLink" hidden="false" collective="false" import="true" targetId="7017-b303-200f-730b" type="selectionEntry">
+    <entryLink id="990c-a548-b447-1e9a" name="Sisters of Silence Vigilator Cadre" hidden="false" collective="false" import="true" targetId="7017-b303-200f-730b" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="990c-a548-b447-1e9a-54726f6f707323232344415441232323" hidden="false" targetId="54726f6f707323232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="df91-2dd1-d3bf-007a" name="New EntryLink" hidden="false" collective="false" import="true" targetId="16d6-25c4-af92-4329" type="selectionEntry">
+    <entryLink id="df91-2dd1-d3bf-007a" name="Aquila Strongpoint" hidden="false" collective="false" import="true" targetId="16d6-25c4-af92-4329" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="df91-2dd1-d3bf-007a-1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="ec5b-a27a-4574-fcbb" name="New EntryLink" hidden="false" collective="false" import="true" targetId="fb92-d215-2011-f911" type="selectionEntry">
+    <entryLink id="ec5b-a27a-4574-fcbb" name="Warlord-Sinister Pattern Battle Psi-Titan" hidden="false" collective="false" import="true" targetId="fb92-d215-2011-f911" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="ec5b-a27a-4574-fcbb-1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="a6e2-0bf3-51ac-d3e9" name="New EntryLink" hidden="false" collective="false" import="true" targetId="a172-78de-aaa6-2201" type="selectionEntry">
+    <entryLink id="a6e2-0bf3-51ac-d3e9" name="Firestorm Redoubt" hidden="false" collective="false" import="true" targetId="a172-78de-aaa6-2201" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="a6e2-0bf3-51ac-d3e9-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="3e1c-c1d7-5869-99af" name="New EntryLink" hidden="false" collective="false" import="true" targetId="df05-8179-624e-f8b2" type="selectionEntry">
+    <entryLink id="3e1c-c1d7-5869-99af" name="Defence Emplacement" hidden="false" collective="false" import="true" targetId="df05-8179-624e-f8b2" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="3e1c-c1d7-5869-99af-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="6350-dbfb-92aa-1a71" name="New EntryLink" hidden="false" collective="false" import="true" targetId="04bf-6c22-19fb-4e46" type="selectionEntry">
+    <entryLink id="6350-dbfb-92aa-1a71" name="Vengeance Weapon Battery" hidden="false" collective="false" import="true" targetId="04bf-6c22-19fb-4e46" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="6350-dbfb-92aa-1a71-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="8bb3-5432-57ce-d3c6" name="New EntryLink" hidden="false" collective="false" import="true" targetId="0f73-97f2-b832-f6d0" type="selectionEntry">
+    <entryLink id="8bb3-5432-57ce-d3c6" name="Defence Line" hidden="false" collective="false" import="true" targetId="0f73-97f2-b832-f6d0" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="8bb3-5432-57ce-d3c6-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="5e81-c325-81e7-585b" name="New EntryLink" hidden="false" collective="false" import="true" targetId="595a-908e-96a1-f121" type="selectionEntry">
+    <entryLink id="5e81-c325-81e7-585b" name="Shrine of the Aquila" hidden="false" collective="false" import="true" targetId="595a-908e-96a1-f121" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="5e81-c325-81e7-585b-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
@@ -611,37 +662,37 @@
         <categoryLink id="1b5c-a6b3-188c-511b-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="bd48-8789-0713-9aba" name="New EntryLink" hidden="false" collective="false" import="true" targetId="e0b3-77ca-af76-bd8b" type="selectionEntry">
+    <entryLink id="bd48-8789-0713-9aba" name="Sanctum Imperialis" hidden="false" collective="false" import="true" targetId="e0b3-77ca-af76-bd8b" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="bd48-8789-0713-9aba-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="84a7-8b67-aa9e-b91b" name="New EntryLink" hidden="false" collective="false" import="true" targetId="0116-c81b-1c0f-251c" type="selectionEntry">
+    <entryLink id="84a7-8b67-aa9e-b91b" name="Bunker" hidden="false" collective="false" import="true" targetId="0116-c81b-1c0f-251c" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="84a7-8b67-aa9e-b91b-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="123f-629b-f3e4-b9e0" name="New EntryLink" hidden="false" collective="false" import="true" targetId="3015-0b77-e848-c0f5" type="selectionEntry">
+    <entryLink id="123f-629b-f3e4-b9e0" name="Plasma Obliterator" hidden="false" collective="false" import="true" targetId="3015-0b77-e848-c0f5" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="123f-629b-f3e4-b9e0-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="d6ad-e26f-6719-568c" name="New EntryLink" hidden="false" collective="false" import="true" targetId="c05d-2231-2481-4037" type="selectionEntry">
+    <entryLink id="d6ad-e26f-6719-568c" name="Imperial Primus Redoubt" hidden="false" collective="false" import="true" targetId="c05d-2231-2481-4037" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="d6ad-e26f-6719-568c-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="7f84-41bd-8d98-965d" name="New EntryLink" hidden="false" collective="false" import="true" targetId="e40b-468f-f1d7-d05d" type="selectionEntry">
+    <entryLink id="7f84-41bd-8d98-965d" name="Imperial Castelum Stronghold" hidden="false" collective="false" import="true" targetId="e40b-468f-f1d7-d05d" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="7f84-41bd-8d98-965d-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="664b-7f0c-e827-a28b" name="New EntryLink" hidden="false" collective="false" import="true" targetId="55c6-268b-357f-d070" type="selectionEntry">
+    <entryLink id="664b-7f0c-e827-a28b" name="Bastion" hidden="false" collective="false" import="true" targetId="55c6-268b-357f-d070" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="664b-7f0c-e827-a28b-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="07bd-ce47-7d2a-3145" name="New EntryLink" hidden="false" collective="false" import="true" targetId="e10f-7b90-ecd3-80a5" type="selectionEntry">
+    <entryLink id="07bd-ce47-7d2a-3145" name="Basilica Administratum" hidden="false" collective="false" import="true" targetId="e10f-7b90-ecd3-80a5" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="07bd-ce47-7d2a-3145-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
@@ -651,12 +702,12 @@
         <categoryLink id="c837-6391-c00e-39f3-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="b692-9da3-7f7c-e767" name="New EntryLink" hidden="false" collective="false" import="true" targetId="ab80-0fef-3e93-8e64" type="selectionEntry">
+    <entryLink id="b692-9da3-7f7c-e767" name="Legio Titanicus Warlord Battle Titan" hidden="false" collective="false" import="true" targetId="ab80-0fef-3e93-8e64" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="b692-9da3-7f7c-e767-1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="0826-246b-1403-0735" name="New EntryLink" hidden="false" collective="false" import="true" targetId="b894-adfc-6d3d-fde4" type="selectionEntry">
+    <entryLink id="0826-246b-1403-0735" name="Legio Titanicus Warhound Scout Titan" hidden="false" collective="false" import="true" targetId="b894-adfc-6d3d-fde4" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="0826-246b-1403-0735-1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
       </categoryLinks>
@@ -747,12 +798,28 @@
       </modifiers>
       <categoryLinks>
         <categoryLink id="f535-e7b9-097b-5969" name="New CategoryLink" hidden="false" targetId="485123232344415441232323" primary="true"/>
+        <categoryLink id="a6a9-ca33-c44a-c690" name="Compulsory HQ" hidden="false" targetId="d7ea-8c56-c01f-53b4" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="934e-e981-da9e-cdf2" name="Allied Detachment" hidden="false" collective="false" import="true" targetId="c91a-6e83-93ce-54ac" type="selectionEntry">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c242-7ae8-d4a7-ba4e" type="min"/>
       </constraints>
+    </entryLink>
+    <entryLink id="0e9c-e470-b412-174a" name="Nathaniel Garro" hidden="false" collective="false" import="true" targetId="f86d-ae13-1d89-f1a1" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="dbbd-5c5d-4d70-d345" name="New CategoryLink" hidden="false" targetId="485123232344415441232323" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="d683-f201-b77f-c9af" name="Tylos Rubio" hidden="false" collective="false" import="true" targetId="7baf-1c2e-6b5d-b865" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="8ae1-af94-c2ee-1bb2" name="New CategoryLink" hidden="false" targetId="485123232344415441232323" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="b22a-c4d7-d40e-19f4" name="Knight-Errant" hidden="false" collective="false" import="true" targetId="0b3e-7f6d-3556-5446" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="ee88-dc38-fe06-b31b" name="New CategoryLink" hidden="false" targetId="485123232344415441232323" primary="true"/>
+      </categoryLinks>
     </entryLink>
   </entryLinks>
   <sharedSelectionEntries>
@@ -5411,7 +5478,7 @@ decided.</description>
         </selectionEntry>
         <selectionEntry id="c60c-dfd9-c5b8-50d1" name="Iron Halo" hidden="false" collective="false" import="true" type="upgrade">
           <infoLinks>
-            <infoLink id="49b1-6f24-3e38-5397" name="New InfoLink" hidden="false" targetId="e8d9-eb1e-3e42-09b1" type="profile"/>
+            <infoLink id="49b1-6f24-3e38-5397" name="Iron Halo" hidden="false" targetId="10b59cf4-3c97-e3e0-2185-853bcde6d112" type="profile"/>
           </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="0.0"/>
@@ -6537,11 +6604,6 @@ Overawe(+1 to the total score to determine the result of an assault)</descriptio
     <profile id="ccdd-40a2-abb2-09a3" name="Teleportation Transponder" publicationId="a30a-7522-pubN95872" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
       <characteristics>
         <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">A unit comprising models that are all equipped with teleportation transponders gains the Deep Strike rule.</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="e8d9-eb1e-3e42-09b1" name="Iron Halo" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
-      <characteristics>
-        <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">4++</characteristic>
       </characteristics>
     </profile>
     <profile id="a660-c6dd-f169-e9f3" name="Refractor Feild" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">

--- a/The Horus Heresy.gst
+++ b/The Horus Heresy.gst
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<gameSystem id="ca571888-56a9-c58e-ddaf-54f4713538bc" name="Warhammer 30,000 - The Horus Heresy" revision="129" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
+<gameSystem id="ca571888-56a9-c58e-ddaf-54f4713538bc" name="Warhammer 30,000 - The Horus Heresy" revision="130" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
   <publications>
     <publication id="ca571888--pubN65537" name="Forgeworld Horus Heresy Series"/>
     <publication id="ca571888--pubN66489" name="HH:MT"/>
@@ -9218,6 +9218,680 @@ Any abilities that allow the vehicle to fire multiple shots will use the same sh
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
+    <selectionEntry id="f86d-ae13-1d89-f1a1" name="Nathaniel Garro" hidden="false" collective="false" import="true" type="model">
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="0502-289b-0165-c2ae" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="33f8-4b9e-37b0-3cf4" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="2353-9b70-a546-3383" name="Nathaniel Garro" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+          <characteristics>
+            <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry (Character)</characteristic>
+            <characteristic name="WS" typeId="575323232344415441232323">5</characteristic>
+            <characteristic name="BS" typeId="425323232344415441232323">5</characteristic>
+            <characteristic name="S" typeId="5323232344415441232323">4</characteristic>
+            <characteristic name="T" typeId="5423232344415441232323">4</characteristic>
+            <characteristic name="W" typeId="5723232344415441232323">3</characteristic>
+            <characteristic name="I" typeId="4923232344415441232323">5</characteristic>
+            <characteristic name="A" typeId="4123232344415441232323">4</characteristic>
+            <characteristic name="LD" typeId="4c4423232344415441232323">10</characteristic>
+            <characteristic name="Save" typeId="5361766523232344415441232323">2+</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="4576-19c0-a8b4-3e00" name="The Aquila Imperator" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
+          <characteristics>
+            <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Grants a 4+ Invulnerable save, increasing to a 3 when fighting in a challenge.  </characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="cb46-9ba0-5909-e284" name="Preferred Enemy (Traitor Space Marines)" hidden="false">
+          <description>A unit that contains at least one model with this special rule re-rolls failed To Hit and To Wound rolls of 1 if attacking its Preferred Enemy. This applies both to shooting and close combat attacks.</description>
+        </rule>
+        <rule id="4b80-59db-9369-a6ca" name="The Emperor Protects" hidden="false">
+          <description>The first time Garro loses his last wound, make a Leadership test. If the test is passed, he remains in play with a single wound remaining.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="6703-e75f-0d9d-f7f7" name="Independent Character" hidden="false" targetId="3ad4-1c37-d60b-1a4e" type="rule"/>
+        <infoLink id="b0ca-f20d-74ad-1a3b" name="By Falsehood Cloaked" hidden="false" targetId="575f-1255-f276-df91" type="rule"/>
+        <infoLink id="2eb0-5cda-9545-e977" name="Oath of Moment" hidden="false" targetId="0d00-d0cd-12d1-d3b0" type="rule"/>
+        <infoLink id="09ba-ff98-b5f6-6fdb" name="Eternal Warrior" hidden="false" targetId="3e0b-be9f-b7eb-8c5e" type="rule"/>
+        <infoLink id="ae7b-be26-72e9-522d" name="Precision Strikes" hidden="false" targetId="a080-af1b-fb2e-4860" type="rule"/>
+        <infoLink id="85b7-0f77-7325-abf8" name="Precision Shots" hidden="false" targetId="4771-b711-0e74-3aee" type="rule"/>
+        <infoLink id="769c-c9d2-d4e9-1a93" name="Implacable Advance" hidden="false" targetId="5ecb-551d-0f68-3a79" type="rule"/>
+      </infoLinks>
+      <selectionEntries>
+        <selectionEntry id="8a3c-0035-71b3-1f0d" name="Libertas" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="16dd-671c-7a2e-3a4d" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="94bc-0f2f-7691-874a" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="7c0b-3913-64f5-86b6" name="Libertas" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
+                <characteristic name="Strength" typeId="537472656e67746823232344415441232323">1</characteristic>
+                <characteristic name="AP" typeId="415023232344415441232323">3</characteristic>
+                <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Two-handed, Edge of Truth</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="a0bd-fc76-b3f6-fe1b" name="Edge of Truth" hidden="false">
+              <description>When fighting in a Challenge, every wound that Garro causes on his foe is counted as two for calculating Combat Resolution.</description>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="eb1e-6fe9-cf9b-8267" name="Rending" hidden="false" targetId="8269-2cd6-9236-16e7" type="rule"/>
+            <infoLink id="704a-35fa-0ca8-ca21" name="Two-Handed" hidden="false" targetId="b11c-0ef4-af6b-d96f" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="0db8-a258-3874-1f82" name="Paragon Bolter" hidden="false" collective="false" import="true" targetId="ccce-756b-608b-5d8b" type="selectionEntry"/>
+        <entryLink id="d9bd-d367-c3d6-b8b3" name="Legiones Astartes" hidden="false" collective="false" import="true" targetId="4014-7d86-22e9-5d96" type="selectionEntry"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="175.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ccce-756b-608b-5d8b" name="Paragon Bolter" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="03a9-ef47-7905-e1e9" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ef7d-463d-308c-1cbf" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="7ade-2472-4d9e-b984" name="Paragon Bolter" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="52616e676523232344415441232323">24&quot;</characteristic>
+            <characteristic name="Strength" typeId="537472656e67746823232344415441232323">4</characteristic>
+            <characteristic name="AP" typeId="415023232344415441232323">5</characteristic>
+            <characteristic name="Type" typeId="5479706523232344415441232323">Assault 3, Rending, Master-crafted</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="5f9c-487d-e797-f155" name="Rending" hidden="false" targetId="8269-2cd6-9236-16e7" type="rule"/>
+        <infoLink id="7ce9-b36f-1609-e68d" name="Master-crafted" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4014-7d86-22e9-5d96" name="Legiones Astartes" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1e67-5920-ee61-e529" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6540-4eb5-6087-c4fb" type="min"/>
+      </constraints>
+      <rules>
+        <rule id="31b1-4bb2-e8c5-8fe8" name="Legiones Astartes" page="" hidden="false">
+          <description>- Units with this special rules may always attempt to regroup regardless of casualties.</description>
+        </rule>
+      </rules>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0b3e-7f6d-3556-5446" name="Knight-Errant" hidden="false" collective="false" import="true" type="model">
+      <profiles>
+        <profile id="85cf-9401-70bd-63fd" name="Knight-Errant" publicationId="ca571888--pubN89821" page="212" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+          <characteristics>
+            <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry (Character)</characteristic>
+            <characteristic name="WS" typeId="575323232344415441232323">5</characteristic>
+            <characteristic name="BS" typeId="425323232344415441232323">5</characteristic>
+            <characteristic name="S" typeId="5323232344415441232323">4</characteristic>
+            <characteristic name="T" typeId="5423232344415441232323">4</characteristic>
+            <characteristic name="W" typeId="5723232344415441232323">2</characteristic>
+            <characteristic name="I" typeId="4923232344415441232323">4</characteristic>
+            <characteristic name="A" typeId="4123232344415441232323">2</characteristic>
+            <characteristic name="LD" typeId="4c4423232344415441232323">10</characteristic>
+            <characteristic name="Save" typeId="5361766523232344415441232323">2+</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="90b4-3d5a-1cf7-b8ab" name="Preferred Enemy (Traitors)" hidden="false">
+          <description>A unit that contains at least one model with this special rule re-rolls failed To Hit and To Wound rolls of 1 if attacking its Preferred Enemy. This applies both to shooting and close combat attacks.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="b49f-395e-6956-ff12" name="Independent Character" hidden="false" targetId="3ad4-1c37-d60b-1a4e" type="rule"/>
+        <infoLink id="85b5-afcc-f6d6-f53d" name="Implacable Advance" hidden="false" targetId="5ecb-551d-0f68-3a79" type="rule"/>
+        <infoLink id="22cd-caa2-23c0-7866" name="By Falsehood Cloaked" hidden="false" targetId="575f-1255-f276-df91" type="rule"/>
+        <infoLink id="db32-8099-b338-d570" name="Oath of Moment" hidden="false" targetId="0d00-d0cd-12d1-d3b0" type="rule"/>
+        <infoLink id="f62f-67e8-89a6-159a" name="Precision Shots" hidden="false" targetId="4771-b711-0e74-3aee" type="rule"/>
+        <infoLink id="d5e2-62d6-e135-8741" name="Precision Strikes" hidden="false" targetId="a080-af1b-fb2e-4860" type="rule"/>
+        <infoLink id="81ff-9213-bb08-edb0" name="Iron Halo" hidden="false" targetId="10b59cf4-3c97-e3e0-2185-853bcde6d112" type="profile"/>
+      </infoLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="87c6-c96a-03f2-4f89" name="May take one of the following:" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0cb0-31db-a9da-774a" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="4414-2355-6986-ab08" name="Narthecium" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="794b-eea8-b135-b4f8" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="f431-cc89-a7a7-f745" name="Narthecium" hidden="false" targetId="7b47-c268-cdaf-fa1e" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="15.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="a227-f39d-b388-5677" name="Nuncio-vox" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="569b-acdd-bd85-17be" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="f457-a49e-b907-1a61" name="Nuncio-vox" hidden="false" targetId="2a0e-e1f0-5ea0-5799" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="3ece-2d5e-1492-8fc6" name="Servo-arm" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3286-6227-3c42-25f8" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="76a3-36fb-18d6-9cd3" name="Battlesmith" hidden="false" targetId="9edbc777-7d2b-011b-7488-335b14870be5" type="rule"/>
+                <infoLink id="8351-59af-61fc-7fab" name="Servo Arm" hidden="false" targetId="c3a5-c40c-b493-5cf6" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="20.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="497d-e2e6-b1b9-e6ac" name="May take:" hidden="false" collective="false" import="true">
+          <selectionEntries>
+            <selectionEntry id="c267-c9a1-c5e1-d78c" name="Melta Bombs" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="db55-beca-588b-48ac" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="5bac-a35f-5e8d-3918" name="Melta Bombs" hidden="false" targetId="a1d8-f9f3-865a-9faf" type="profile"/>
+                <infoLink id="db30-f700-0f69-cf15" name="Armourbane" hidden="false" targetId="e182-50cd-0867-9a8d" type="rule"/>
+                <infoLink id="dc3a-c063-e6a4-9ea9" name="Unwieldy" hidden="false" targetId="5eea-958c-d623-c3c9" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="ac8e-10b7-77fc-2e67" name="Jump Pack" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a055-9b5d-4a54-3a44" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="20.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="c5c1-d4e1-c8ce-5b85" name="Exchange Master-crafted Power Weapon for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="cefa-ede5-3ab9-37c8">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="fa24-1441-1a26-d7ec" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="94f7-9a5b-df83-f60d" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="5861-9125-656a-8566" name="Master-crafted Power Fist" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c055-501a-3f2f-a0d9" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="2706-2542-ef78-8513" name="Master-crafted Power Fist" publicationId="ca571888--pubN106502" page="181" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
+                    <characteristic name="Strength" typeId="537472656e67746823232344415441232323">x2</characteristic>
+                    <characteristic name="AP" typeId="415023232344415441232323">2</characteristic>
+                    <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Specialist Weapon, Unwieldy, Master-crafted</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink id="ab10-909d-fd5b-a7ee" name="Master-crafted" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule"/>
+                <infoLink id="f8ca-47d7-4e39-cb2b" name="Unwieldy" hidden="false" targetId="5eea-958c-d623-c3c9" type="rule"/>
+                <infoLink id="0818-4330-416f-1457" name="Specialist Weapon" hidden="false" targetId="7ee3-d437-bc44-3630" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="5282-c284-07f5-eeef" name="Master-crafted Lightning Claw" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d41d-99c2-c365-d084" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="b8a1-6fe8-92f7-3f4e" name="Master-crafted Lightning Claw" publicationId="ca571888--pubN106502" page="181" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
+                    <characteristic name="Strength" typeId="537472656e67746823232344415441232323">User</characteristic>
+                    <characteristic name="AP" typeId="415023232344415441232323">3</characteristic>
+                    <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Shred, Specialist Weapon, Master-crafted</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink id="5951-761e-e7e1-4210" name="Master-crafted" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule"/>
+                <infoLink id="7205-726a-89a9-e1bb" name="Shred" hidden="false" targetId="89da-0cb5-bee4-8ec2" type="rule"/>
+                <infoLink id="1088-bf1b-db20-5f74" name="Specialist Weapon" hidden="false" targetId="7ee3-d437-bc44-3630" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="c894-d5a7-30b3-2b1c" name="Master-crafted Power Axe" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6729-5b1a-762f-1e05" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="0856-2fb1-5136-91a2" name="Master-crafted Power Axe" publicationId="ca571888--pubN106502" page="181" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
+                    <characteristic name="Strength" typeId="537472656e67746823232344415441232323">+1</characteristic>
+                    <characteristic name="AP" typeId="415023232344415441232323">2</characteristic>
+                    <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Unwieldy, Master-crafted</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink id="be0c-7b74-9e84-0ea1" name="Master-crafted" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule"/>
+                <infoLink id="696d-ca1b-8679-b665" name="Unwieldy" hidden="false" targetId="5eea-958c-d623-c3c9" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="81a2-5c0c-499f-0715" name="Master-crafted Power Maul" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="685f-9669-6d1b-3845" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="8212-1212-90d3-e869" name="Master-crafted Power Maul" publicationId="ca571888--pubN106502" page="181" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
+                    <characteristic name="Strength" typeId="537472656e67746823232344415441232323">+2</characteristic>
+                    <characteristic name="AP" typeId="415023232344415441232323">4</characteristic>
+                    <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Master-crafted </characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink id="b206-979f-afaf-d6f8" name="Master-crafted" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="cefa-ede5-3ab9-37c8" name="Master-crafted Power Sword" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e853-3c35-6949-894d" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="fe81-3dbb-ade4-c9e4" name="Master-crafted Power Sword" publicationId="ca571888--pubN106502" page="181" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
+                    <characteristic name="Strength" typeId="537472656e67746823232344415441232323">User</characteristic>
+                    <characteristic name="AP" typeId="415023232344415441232323">3</characteristic>
+                    <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Master-crafted</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink id="2b67-fa58-7cde-1d63" name="Master-crafted" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="b495-c5de-61e3-ee68" name="Exchange Paragon Bolter for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="6bb8-3ca8-fdd5-acdf">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="e88a-96f2-1c49-6acd" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="ab3b-df3a-61f6-15ab" name="Sniper Rifle" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1d76-a928-5b30-1ab7" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="c45e-666f-e22f-50cd" name="Sniper Rifle" hidden="false" targetId="45a4-5982-7f8b-fb33" type="profile"/>
+                <infoLink id="7703-5afa-a247-3f57" name="Sniper" hidden="false" targetId="3919-29f5-0c68-3ecb" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="249a-3b45-9254-07b9" name="Combi-weapon: Flamer" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="da17-50eb-4478-365e" type="max"/>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="07f2-9647-e575-286b" type="min"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="d890-e806-4c62-9ddf" name="Boltgun" hidden="false" targetId="09fd-8af1-a6b1-51f7" type="profile"/>
+                <infoLink id="fb11-5860-cb62-6c9a" name="Combi-weapon: Flamer" hidden="false" targetId="518c-084b-7a8a-949e" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="c05f-dda1-1e04-74cd" name="Combi-Weapon: Grenade Launcher" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ac05-6faf-badc-c54a" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="478c-79ae-856b-1635" name="Boltgun" hidden="false" targetId="09fd-8af1-a6b1-51f7" type="profile"/>
+                <infoLink id="1c44-e38d-0896-7ddb" name="Combi-weapon: Grenade Launcher (Frag)" hidden="false" targetId="aaed-cf64-e81a-0c4f" type="profile"/>
+                <infoLink id="50bc-f184-27e0-fdb1" name="Combi-weapon: Grenade Launcher (Krak)" hidden="false" targetId="fe44-0451-8676-ccfb" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="6325-10d3-a545-db8c" name="Combi-weapon: Meltagun" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="967a-d380-0c1c-9b94" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="8a55-24c3-0995-cafc" name="New InfoLink" hidden="false" targetId="09fd-8af1-a6b1-51f7" type="profile"/>
+                <infoLink id="7bbe-6378-826b-773f" name="New InfoLink" hidden="false" targetId="d30d-adeb-818b-09e3" type="profile"/>
+                <infoLink id="159e-42c9-c9b7-3c2f" name="Melta" hidden="false" targetId="21c0-62ff-3ed2-17a7" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="7e1b-95ea-c8a8-b0b8" name="Combi-weapon: Plasma gun" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e96f-9e76-7cc2-a7f5" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="ab20-beaa-c99f-b893" name="New InfoLink" hidden="false" targetId="09fd-8af1-a6b1-51f7" type="profile"/>
+                <infoLink id="81c6-19d1-17d2-2195" name="New InfoLink" hidden="false" targetId="3729-f674-0501-ebeb" type="profile"/>
+                <infoLink id="d401-28e1-bd52-54da" name="Gets Hot" hidden="false" targetId="f4fd-d519-4769-5510" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="952b-e846-cc80-0107" name="Combi-weapon: Volkite Charger" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ffcc-2bef-01a8-2c7a" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="993c-10ab-fc6f-cd3c" name="New InfoLink" hidden="false" targetId="09fd-8af1-a6b1-51f7" type="profile"/>
+                <infoLink id="7f7a-fb39-66bf-b5af" name="New InfoLink" hidden="false" targetId="20ab-d2f5-47a5-dbe2" type="profile"/>
+                <infoLink id="b605-3f72-c601-ce19" name="Deflagrate" hidden="false" targetId="b46a-a3ec-91a5-5001" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <entryLinks>
+            <entryLink id="6bb8-3ca8-fdd5-acdf" name="Paragon Bolter" hidden="false" collective="false" import="true" targetId="ccce-756b-608b-5d8b" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="03a9-ef47-7905-e1e9" value="0.0"/>
+              </modifiers>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="05ea-550f-2ac1-930c" name="May be upgraded to:" hidden="false" collective="false" import="true">
+          <selectionEntries>
+            <selectionEntry id="7790-7f3d-ba19-dec4" name="Librarian" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7034-170e-9062-3384" type="max"/>
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="8eeb-de7b-7040-3ebd" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="a0b2-5487-5895-dcf1" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="20.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="3f85-6289-a170-cbcc" name="Psychic Mastery" hidden="false" collective="false" import="true">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7790-7f3d-ba19-dec4" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="3762-48bf-c5f1-a485" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="26d3-e889-9fc5-c13b" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="b6bc-b867-fd32-54d6" name="Psychic Mastery Level 1" page="0" hidden="false" collective="false" import="true" type="upgrade">
+              <costs>
+                <cost name="pts" typeId="points" value="20.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="48ed-c5a0-f24e-b5c3" name="Psychic Mastery Level 2" page="0" hidden="false" collective="false" import="true" type="upgrade">
+              <costs>
+                <cost name="pts" typeId="points" value="40.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="6b2b-621e-c1c3-5334" name="Exchange Master-crafted Bolt Pistol for:" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2846-6243-f61a-913f" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="d9dd-33a5-9eca-41b0" name="Master-crafted Plasma Pistol" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8e73-c7cc-3be7-6f66" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="c448-7153-e84b-5bc8" name="Master-crafted Plasma Pistol" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="52616e676523232344415441232323">12&quot;</characteristic>
+                    <characteristic name="Strength" typeId="537472656e67746823232344415441232323">7</characteristic>
+                    <characteristic name="AP" typeId="415023232344415441232323">2</characteristic>
+                    <characteristic name="Type" typeId="5479706523232344415441232323">Pistol, Get&apos;s Hot, Gets Hot, Master-crafted</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink id="d090-056c-5c64-3f6c" name="Gets Hot" hidden="false" targetId="f4fd-d519-4769-5510" type="rule"/>
+                <infoLink id="6c45-bf70-1643-b33d" name="Master-crafted" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="15.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="b874-9838-1ae1-5622" name="Master-crafted Volkite Serpenta" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="38cb-9fc8-a176-7b57" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="2260-dd2f-8150-f861" name="Master-crafted Volkite Serpenta" publicationId="ca571888--pubN106502" page="178" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="52616e676523232344415441232323">10&quot;</characteristic>
+                    <characteristic name="Strength" typeId="537472656e67746823232344415441232323">5</characteristic>
+                    <characteristic name="AP" typeId="415023232344415441232323">5</characteristic>
+                    <characteristic name="Type" typeId="5479706523232344415441232323">Pistol, Deflagrate, Master-crafted</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink id="a752-dd8d-eb40-5f76" name="Deflagrate" hidden="false" targetId="b46a-a3ec-91a5-5001" type="rule"/>
+                <infoLink id="2405-fdfe-0417-7069" name="Master-crafted" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="c76f-a8c5-b930-1acb" name="Psyarkana" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bce2-56fc-14a2-7a21" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="7b66-a683-d4b7-a30c" name="Aetherkine Projectors" hidden="false" collective="false" import="true" targetId="37fa-ba85-8a35-8977" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <conditions>
+                    <condition field="selections" scope="0b3e-7f6d-3556-5446" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7790-7f3d-ba19-dec4" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </entryLink>
+            <entryLink id="20d7-ff63-04ad-bdf2" name="Null-Amp Collars" hidden="false" collective="false" import="true" targetId="3d1a-59f3-ca2e-8ded" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <conditions>
+                    <condition field="selections" scope="0b3e-7f6d-3556-5446" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7790-7f3d-ba19-dec4" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </entryLink>
+            <entryLink id="490c-bc7c-7858-f7b8" name="Psi-resonant Pentacles" hidden="false" collective="false" import="true" targetId="199f-821c-598a-c660" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false"/>
+              </modifiers>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="6715-f7a6-80e5-6412" name="Tansvectic Generators" hidden="false" collective="false" import="true" targetId="5476-e8db-b6b0-4a1e" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <conditions>
+                    <condition field="selections" scope="0b3e-7f6d-3556-5446" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7790-7f3d-ba19-dec4" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </entryLink>
+            <entryLink id="6b06-6e93-f5b9-5c1f" name="The Digittalis Arcanis" hidden="false" collective="false" import="true" targetId="21a0-14df-d719-e116" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <conditions>
+                    <condition field="selections" scope="0b3e-7f6d-3556-5446" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7790-7f3d-ba19-dec4" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </entryLink>
+            <entryLink id="1abc-0a00-a615-4594" name="Terminal Lucidity Injectors" hidden="false" collective="false" import="true" targetId="66e2-6760-fb6a-edc3" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <conditions>
+                    <condition field="selections" scope="0b3e-7f6d-3556-5446" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7790-7f3d-ba19-dec4" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </entryLink>
+            <entryLink id="4ae3-9212-759f-3145" name="Icon of the Blazing Sun" hidden="false" collective="false" import="true" targetId="b2fe-de24-0c45-9b4d" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false"/>
+              </modifiers>
+            </entryLink>
+            <entryLink id="6d6e-b248-67da-c78c" name="Sacrificial Innervation" hidden="false" collective="false" import="true" targetId="d062-ccde-3885-8157" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <conditions>
+                    <condition field="selections" scope="0b3e-7f6d-3556-5446" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7790-7f3d-ba19-dec4" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </entryLink>
+            <entryLink id="3fd5-7220-5b9c-2d58" name="Empath Bonds" hidden="false" collective="false" import="true" targetId="963d-b106-c967-8ba6" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <conditions>
+                    <condition field="selections" scope="0b3e-7f6d-3556-5446" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7790-7f3d-ba19-dec4" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="force" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="9789-491f-fc56-f877" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="c33b-e5cd-c7b8-49a3" name="Legiones Astartes" hidden="false" collective="false" import="true" targetId="4014-7d86-22e9-5d96" type="selectionEntry"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="115.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7baf-1c2e-6b5d-b865" name="Tylos Rubio" hidden="false" collective="false" import="true" type="model">
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="d4ea-b36f-9ea1-c6a3" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="eb9b-0b6a-3ec6-d7ea" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="d2c0-fdad-1af0-fdd5" name="Tylos Rubio" publicationId="ca571888--pubN89821" page="210" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+          <characteristics>
+            <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry (Character)</characteristic>
+            <characteristic name="WS" typeId="575323232344415441232323">5</characteristic>
+            <characteristic name="BS" typeId="425323232344415441232323">5</characteristic>
+            <characteristic name="S" typeId="5323232344415441232323">4</characteristic>
+            <characteristic name="T" typeId="5423232344415441232323">4</characteristic>
+            <characteristic name="W" typeId="5723232344415441232323">2</characteristic>
+            <characteristic name="I" typeId="4923232344415441232323">5</characteristic>
+            <characteristic name="A" typeId="4123232344415441232323">2</characteristic>
+            <characteristic name="LD" typeId="4c4423232344415441232323">10</characteristic>
+            <characteristic name="Save" typeId="5361766523232344415441232323">2+</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="7624-baa9-8d1b-bdec" name="Force Sword" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="52616e676523232344415441232323"/>
+            <characteristic name="Strength" typeId="537472656e67746823232344415441232323"/>
+            <characteristic name="AP" typeId="415023232344415441232323"/>
+            <characteristic name="Type" typeId="5479706523232344415441232323"/>
+          </characteristics>
+        </profile>
+        <profile id="516e-b9f3-d12e-2be7" name="Psychic Hood" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
+          <characteristics>
+            <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="2908-f026-0047-3174" name="Preferred Enemy (Traitors)" hidden="false">
+          <description>A unit that contains at least one model with this special rule re-rolls failed To Hit and To Wound rolls of 1 if attacking its Preferred Enemy. This applies both to shooting and close combat attacks.</description>
+        </rule>
+        <rule id="bc59-735e-d83d-a4a8" name="Psionic Fury" publicationId="ca571888--pubN89821" page="210" hidden="false">
+          <description>Any unused Warp Charge points may be used during the Assault Phase to incrase the strength of Rubio&apos;s attacks on a one-to-one basis.  May not carry over or exceed S10.</description>
+        </rule>
+        <rule id="ad0b-2505-4b06-10da" name="Psyker (Mastery Level 2)" publicationId="ca571888--pubN89821" page="210" hidden="false">
+          <description>Generates powers from the Divination and Telekinesis disciplines</description>
+        </rule>
+        <rule id="3618-2837-2cba-0f05" name="Echoes of Fate" publicationId="ca571888--pubN89821" page="210" hidden="false">
+          <description>May re-roll failed Psychic tests when using powers from the Divination Discipline</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="7c4c-8d0a-ba8a-31ac" hidden="false" targetId="3ad4-1c37-d60b-1a4e" type="rule"/>
+        <infoLink id="7393-9fcd-98f6-a446" name="Implacable Advance" hidden="false" targetId="5ecb-551d-0f68-3a79" type="rule"/>
+        <infoLink id="bd18-4816-89b0-70ee" name="By Falsehood Cloaked" hidden="false" targetId="575f-1255-f276-df91" type="rule"/>
+        <infoLink id="f2ae-82d6-e741-a56c" hidden="false" targetId="0d00-d0cd-12d1-d3b0" type="rule"/>
+        <infoLink id="77e3-7128-f6d7-013d" name="New InfoLink" hidden="false" targetId="4771-b711-0e74-3aee" type="rule"/>
+        <infoLink id="57ea-6bd8-8dfc-5893" name="Precision Strikes" hidden="false" targetId="a080-af1b-fb2e-4860" type="rule"/>
+        <infoLink id="403a-baf3-5ef2-8ebd" name="Iron Halo" hidden="false" targetId="10b59cf4-3c97-e3e0-2185-853bcde6d112" type="profile"/>
+      </infoLinks>
+      <entryLinks>
+        <entryLink id="1533-2cea-823a-c269" name="Paragon Bolter" hidden="false" collective="false" import="true" targetId="ccce-756b-608b-5d8b" type="selectionEntry"/>
+        <entryLink id="1074-0c6c-470d-979c" name="Legiones Astartes" hidden="false" collective="false" import="true" targetId="4014-7d86-22e9-5d96" type="selectionEntry"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="140.0"/>
+      </costs>
+    </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup id="64e8-ec7c-e5d8-6767" name="Force Organization Chart" hidden="false" collective="false" import="true">
@@ -12017,6 +12691,24 @@ This rule, while similar in function to the Drop Pod Assault special rule, does 
 
 ** In practice you may choose to open and embar/disembark from a single hatch on either side of the hull.</description>
     </rule>
+    <rule id="0d00-d0cd-12d1-d3b0" name="Oath of Moment" publicationId="ca571888--pubN89821" page="209" hidden="false">
+      <description>Fielding a Knight-Errant dramatically alters the victory conditions for the side that includes the model, for the presence of such a fated individual is a sure indication that the mission is of dire import indeed. At the beginning of the game, at the same time that Warlord Traits and psychic powers are determined, an Oath of Moment must be secretly noted down for each model with this special rule. The note is revealed at the end of the game when Victory points are being tallied. Each Oath of Moment represents an objective which that Knight-Errant must achieve, chosen from the list below.
+
+Each of the secret objectives has an associated Victory points score – if the objective is achieved, the Knight Errant&apos;s side earns the indicated number of bonus Victory points in addition to any claimed as part of the mission. If the secret objective is not achieved, the Knight Errant’s side may not claim a victory in the battle, regardless of any other factors.
+
+Crusader (1 Victory point): The Knight Errant must end the game within the enemy’s deployment zone in order to earn the Oath of Moment Victory points.
+
+Protector (2 Victory points): Note the identity of another Independent Character in the army. This model must survive the game to earn the Oath of Moment Victory points.
+
+Hand of the Sigillite (2/3 Victory points): If objective markers are in play, the Knight-Errant must control one of the objective markers at the end of the game to earn the Oath of Moment Victory points. If the marker is in the enemy deployment zone, this Oath of Moment is worth 3 Victory points instead.
+
+Headsman (3 Victory points): The Knight-Errant must slay the enemy Warlord in a Challenge in order to earn the Oath of Moment Victory points.
+
+King Slayer (3 Victory points): If the opposing army includes a Primarch, this model must be slain for the Knight-Errant to earn the Oath of Moment Victory points</description>
+    </rule>
+    <rule id="575f-1255-f276-df91" name="By Falsehood Cloaked" publicationId="ca571888--pubN89821" page="209" hidden="false">
+      <description>Knights-Errant may deploy via Deep Strike, and when doing so does not roll to scatter. On the controlling player’s turn that he deploys, and throughout the opposing player’s following player turn, any shots made against a Knight-Errant having deployed in this manner are made as Snap Shots. In addition, any charges made against Garro during this time count as Disordered.</description>
+    </rule>
   </sharedRules>
   <sharedProfiles>
     <profile id="74effb54-87f7-8481-9e5f-86d9e3ed37c2" name="Battle Servitor Control" publicationId="ca571888--pubN67227" page="43" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
@@ -13802,6 +14494,11 @@ Jetbikes can move over all other models and terrain freely. However, if a moving
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">D</characteristic>
         <characteristic name="AP" typeId="415023232344415441232323">1</characteristic>
         <characteristic name="Type" typeId="5479706523232344415441232323">Primary Weapon 1, Massive Blast (7&quot;), Machine Destroyer</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="10b59cf4-3c97-e3e0-2185-853bcde6d112" name="Iron Halo" page="0" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
+      <characteristics>
+        <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Confers 4++ Invulnerable Save</characteristic>
       </characteristics>
     </profile>
   </sharedProfiles>


### PR DESCRIPTION
Ok, so little / big change here to make the Bodyguard / Command Squad / Retinue thing work...
Termy Command Squads can only be taken if the Praetor or other MOTL warlord has Termy Armour and is also the army warlord, or is a Primarch (as per FAQ). Specialist versions such as Justaerin, Firedrakes, Deathshroud and Deathwing Terminator Companions also have this rule.
Removed ability to select units from the Bodyguard section if Primarch is selected, with the exception of Command Squad and Termy Command Squad. The cost of others are currently counted as part of the cost of 25% LoW limitations. Until they also get an FAQ or reprint to say the same as Command Squads did).

"A single Legion Command Squad may be chosen as a retinue for a Legion Praetor, Primarch, or Legion special character with the Master of the Legion special rule which is also your Army’s Warlord. They may not be taken as part of an army on their own, instead sharing a Force Organisation chart choice with the Warlord they are selected for, nor do they add to the points of a Primarch when determining Lords of War and the 25% rule."

Macrocarid was limited to only 1 in the force due to error, Error now fixed #1821

arious old fixes from #863 (1 of many updates)

I Legion - Dark Angels
Ironwing Protocol
Dust of a Thousand Worlds: Added to the Tank Category and only shows if Ironwing is taken.
Goliaths of War - All Dreadnoughts have Fear and Tank hunter rules: Added a entry link to a rule for all Dreads which contains both rules. This entry is flagged as a min of 1 and is set to show if Ironwing Protocol is taken

Ravenwing
Sky Hunter and Outriders are the only Troops choices available: Hidden Recon squads, which was missing from what should have been hidden.
Only vehicles with Skimmer or Flyer type: Hidden all vehicles apart from flyers and skimmers: Tagged them the same as with Swift Blade with "Non-Flyer/Scimmer Vehicle" category as well
Independent Characters must have a Bike or Jetbike: Hidden all characters that aren't on bike or jetbike, including the Lion. Also hidden termy armour, On Foot, Jump Pack options for Centurion and Praetors.

III Legion - Emperors Children
The Maru Skara
May not take units with the Immobile, Heavy or Slow & Purposeful rules: Hidden Tarantula and Aquitor

Knights Errant are now usable in all lists, so long as they are loyal.

Karacnos Assault Tank and some other Mech Fixes