### PR TITLE
Update (HH) Imperialis Militia and Cults Army List.cat

### DIFF
--- a/(HH) Imperialis Militia and Cults Army List.cat
+++ b/(HH) Imperialis Militia and Cults Army List.cat
@@ -1477,7 +1477,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
       </constraints>
       <rules>
         <rule id="9066-81bf-e6dd-0afc" name="Advanced Weapons" publicationId="90aa-c2c8-pubN73486" page="188" hidden="false">
-          <description>Strength of weapons increased by +1.  Must be taken by all eligible squads.</description>
+          <description>Strength of las-weapons and rotor cannons increased by +1.  Must be taken by all eligible squads.</description>
         </rule>
       </rules>
       <costs>


### PR DESCRIPTION
## Description
Hi there, so first time making a PR for this project (and probably my last time but), it's been an issue that's kinda been bugging me: in the Imperialis Militia and Cults rules, the Advanced Weapons upgraded afforded by Survivors of the Dark Age only affects las weapons and rotor cannons, but the wording of it here implied it affected Bolters too. (If there's an FAQ anywhere that changes that I'm really sorry). It's nothing major so I didn't think I needed to fill out the rest of this but... Tada?
