### PR TITLE
Lots of ZM restrictions, few rules.

### DIFF
--- a/(HH) Daemons of the Ruinstorm Army List.cat
+++ b/(HH) Daemons of the Ruinstorm Army List.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="8700-b3bb-a471-a0ad" name="Daemons of the Ruinstorm" revision="18" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="130" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="8700-b3bb-a471-a0ad" name="Daemons of the Ruinstorm" revision="19" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="132" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="8700-b3bb-pubN65537" name="HH8: Malevolence"/>
     <publication id="8700-b3bb-pubN75780" name="BRB"/>
@@ -25,6 +25,76 @@
           <description>One box on a Force Organisation chart allows you to make one selection from that part of your army list. Dark boxes indicate compulsory selections, which must be included as part of the army, while the lighter boxes indicate optional choices, which are only included as part of the army if the player in question chooses to do so. If constructing an army using the Crusade Force Organisation chart, this would mean that an army would be required to take at least one HQ choice and two Troops choices. These compulsory choices are intended to ensure that the core of each army is illustrative of the force represented by the Army List in use, and that all armies are capable of properly participating in the varied missions available to players in the Age of Darkness.</description>
         </rule>
       </rules>
+    </categoryEntry>
+    <categoryEntry id="c9f6-0db2-037e-468d" name="Beasts" publicationId="ca571888--pubN106502" page="" hidden="false">
+      <infoLinks>
+        <infoLink id="024f-14e4-30c5-3a5a" name="Fleet" hidden="false" targetId="69e5-fc02-1f9d-63c2" type="rule"/>
+        <infoLink id="5210-0f89-a6a6-9fd0" name="Beasts" hidden="false" targetId="b53a-eba8-e3f8-4ae8" type="rule"/>
+      </infoLinks>
+    </categoryEntry>
+    <categoryEntry id="cbd7-da20-4ef1-fbda" name="Cavalry" publicationId="ca571888--pubN106502" page="" hidden="false">
+      <infoLinks>
+        <infoLink id="0671-4aa9-3f1e-2e5c" name="Fleet" hidden="false" targetId="69e5-fc02-1f9d-63c2" type="rule"/>
+        <infoLink id="ba01-afb0-5f62-665d" name="Hammer of Wrath" hidden="false" targetId="6f66-b417-6004-0916" type="rule"/>
+        <infoLink id="7749-34cc-757f-e03d" name="Cavalry" hidden="false" targetId="d956-6030-d01f-5f3a" type="rule"/>
+      </infoLinks>
+    </categoryEntry>
+    <categoryEntry id="12ca-5271-bc77-cd4f" name="Flying Monstrous Creature" publicationId="ca571888--pubN106502" hidden="false">
+      <infoLinks>
+        <infoLink id="03a7-38c5-cc0a-0269" name="Fear" hidden="false" targetId="52ff-4074-570b-4ea1" type="rule"/>
+        <infoLink id="b008-ad13-e989-0bf6" name="Fearless" hidden="false" targetId="dc70-e199-5525-e78c" type="rule"/>
+        <infoLink id="f172-ab41-151c-1868" name="Hammer of Wrath" hidden="false" targetId="6f66-b417-6004-0916" type="rule"/>
+        <infoLink id="ce27-c76f-dbda-99e0" name="Move Through Cover" hidden="false" targetId="6d06-5ea0-9a17-ca97" type="rule"/>
+        <infoLink id="60ee-d9ba-a2ff-216f" name="Relentless" hidden="false" targetId="3c7d-a1fa-c68b-caad" type="rule"/>
+        <infoLink id="8f4b-f55b-eab5-3dfa" name="Smash" hidden="false" targetId="4284-18a1-9844-a0bd" type="rule"/>
+        <infoLink id="7b2e-a074-31ad-7d1c" name="Strikedown" hidden="false" targetId="dd83-7fb9-6f58-0c96" type="rule"/>
+        <infoLink id="12c7-360c-75f3-bf44" name="Vector Strike" hidden="false" targetId="5341-7110-d8d4-171a" type="rule"/>
+        <infoLink id="a37d-0c25-7aec-1b80" name="Feel No Pain" hidden="false" targetId="9bdd-5ec7-8dd6-63c0" type="rule"/>
+      </infoLinks>
+    </categoryEntry>
+    <categoryEntry id="3fd6-be25-ed1a-1799" name="Gargantuan Creature" publicationId="ca571888--pubN106502" page="" hidden="false">
+      <infoLinks>
+        <infoLink id="ea21-96be-b399-862a" name="Fear" hidden="false" targetId="52ff-4074-570b-4ea1" type="rule"/>
+        <infoLink id="5296-e5be-927e-bab5" name="Fearless" hidden="false" targetId="dc70-e199-5525-e78c" type="rule"/>
+        <infoLink id="066d-5cc2-194b-43ac" name="Hammer of Wrath" hidden="false" targetId="6f66-b417-6004-0916" type="rule"/>
+        <infoLink id="d942-c314-7374-0ff6" name="Move Through Cover" hidden="false" targetId="6d06-5ea0-9a17-ca97" type="rule"/>
+        <infoLink id="3acb-3be7-5eef-e925" name="Relentless" hidden="false" targetId="3c7d-a1fa-c68b-caad" type="rule"/>
+        <infoLink id="e2c9-6cbf-73b3-d987" name="Smash" hidden="false" targetId="4284-18a1-9844-a0bd" type="rule"/>
+        <infoLink id="8c60-6204-4040-4da0" name="Strikedown" hidden="false" targetId="dd83-7fb9-6f58-0c96" type="rule"/>
+        <infoLink id="5b36-988d-1779-27dc" name="Feel No Pain" hidden="false" targetId="9bdd-5ec7-8dd6-63c0" type="rule"/>
+      </infoLinks>
+    </categoryEntry>
+    <categoryEntry id="677c-f197-e522-3b68" name="Monstrous Creature" publicationId="ca571888--pubN106502" hidden="false">
+      <constraints>
+        <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f58a-0e6c-ed1d-a4c7" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="20fb-0751-0748-ab8c" name="Fear" hidden="false" targetId="52ff-4074-570b-4ea1" type="rule"/>
+        <infoLink id="8df7-30f3-1414-7580" name="Hammer of Wrath" hidden="false" targetId="6f66-b417-6004-0916" type="rule"/>
+        <infoLink id="c444-9a87-fdbf-103f" name="Move Through Cover" hidden="false" targetId="6d06-5ea0-9a17-ca97" type="rule"/>
+        <infoLink id="a2a4-af89-648e-af60" name="Relentless" hidden="false" targetId="3c7d-a1fa-c68b-caad" type="rule"/>
+        <infoLink id="448f-6868-eb2d-72ce" name="Smash" hidden="false" targetId="4284-18a1-9844-a0bd" type="rule"/>
+      </infoLinks>
+    </categoryEntry>
+    <categoryEntry id="abaf-c4f2-142d-0deb" name="Flying Gargantuan Creature" publicationId="ca571888--pubN106502" page="" hidden="false">
+      <infoLinks>
+        <infoLink id="d6a1-9bfd-8276-d60a" name="Fear" hidden="false" targetId="52ff-4074-570b-4ea1" type="rule"/>
+        <infoLink id="fb0e-ccea-8cd4-e34b" name="Fearless" hidden="false" targetId="dc70-e199-5525-e78c" type="rule"/>
+        <infoLink id="1c68-a338-eea3-bd01" name="Hammer of Wrath" hidden="false" targetId="6f66-b417-6004-0916" type="rule"/>
+        <infoLink id="7672-c698-8cbf-4f5c" name="Move Through Cover" hidden="false" targetId="6d06-5ea0-9a17-ca97" type="rule"/>
+        <infoLink id="a8ee-4432-4467-695e" name="Relentless" hidden="false" targetId="3c7d-a1fa-c68b-caad" type="rule"/>
+        <infoLink id="4068-37b8-8536-f24d" name="Smash" hidden="false" targetId="4284-18a1-9844-a0bd" type="rule"/>
+        <infoLink id="aa61-178f-88cc-0647" name="Strikedown" hidden="false" targetId="dd83-7fb9-6f58-0c96" type="rule"/>
+        <infoLink id="032a-7426-7c85-0902" name="Feel No Pain" hidden="false" targetId="9bdd-5ec7-8dd6-63c0" type="rule"/>
+        <infoLink id="c091-8b61-b393-dd6a" name="Vector Strike" hidden="false" targetId="5341-7110-d8d4-171a" type="rule"/>
+      </infoLinks>
+    </categoryEntry>
+    <categoryEntry id="613e-f21f-788e-ce0a" name="Jump Units" hidden="false">
+      <infoLinks>
+        <infoLink id="0228-524d-d77d-bca8" name="Bulky" hidden="false" targetId="38d5-b6eb-bda8-2497" type="rule"/>
+        <infoLink id="c121-c5c1-c5d5-5a4d" name="Deep Strike" hidden="false" targetId="d219-2314-4834-c054" type="rule"/>
+        <infoLink id="94b4-4201-8a69-34bb" name="Jump Unit" hidden="false" targetId="8cb0-ff25-22a2-d480" type="rule"/>
+      </infoLinks>
     </categoryEntry>
   </categoryEntries>
   <forceEntries>
@@ -142,6 +212,176 @@
         <categoryLink id="6906-8d5c-0003-dead" name="Compulsory Troops" hidden="false" targetId="0547-e031-0d25-4c6c" primary="false">
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6655-db71-2cde-3974" type="min"/>
+          </constraints>
+        </categoryLink>
+      </categoryLinks>
+    </forceEntry>
+    <forceEntry id="f398-6ade-f25f-e336" name=" Zone Mortalis - Attacker" hidden="false">
+      <infoLinks>
+        <infoLink id="62bd-394e-d27f-9198" name="ZM (Unusable)" hidden="false" targetId="b1da-bb0d-6990-b5c7" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="dfc4-a2a4-d7c4-77de" name="Elites" hidden="false" targetId="456c6974657323232344415441232323" primary="false">
+          <constraints>
+            <constraint field="selections" scope="force" value="3.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="c29c-c350-1407-bf64" type="max"/>
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="2f56-3aac-8309-ecfe" type="min"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="7965-a291-bed6-c43f" name="HQ" hidden="false" targetId="485123232344415441232323" primary="false">
+          <constraints>
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="4374-294f-832f-76db" type="min"/>
+            <constraint field="selections" scope="force" value="2.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="5c79-7514-227c-179d" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="2d3e-9513-9f77-d0c2" name="Fast Attack" hidden="false" targetId="466173742041747461636b23232344415441232323" primary="false">
+          <constraints>
+            <constraint field="selections" scope="force" value="2.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="1d52-f13e-f80b-82c0" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="48ea-fa47-de6a-904d" name="Troops" hidden="false" targetId="54726f6f707323232344415441232323" primary="false">
+          <constraints>
+            <constraint field="selections" scope="force" value="3.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="7413-e67d-c282-8a6b" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="f083-8d63-1ecb-e807" name="Heavy Support" hidden="false" targetId="486561767920537570706f727423232344415441232323" primary="false">
+          <constraints>
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="bcc7-20c2-7757-adfb" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="df93-c044-652c-8f80" name="Use Playtest Rules" hidden="false" targetId="fdf4-0683-3e84-5a4b" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="9c98-d63e-0368-02e0" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="e60c-69d9-d799-370f" name="Mournival Rules" hidden="false" targetId="dbe0-716f-797c-66f7" primary="false"/>
+        <categoryLink id="6e81-4044-874b-3b4c" name="ZM (Unusable)" hidden="false" targetId="9335-93c1-6af7-feb0" primary="false">
+          <constraints>
+            <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2964-6331-c4cd-387b" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="5c67-5031-2844-5f44" name="Flying Monstrous Creature" hidden="false" targetId="12ca-5271-bc77-cd4f" primary="false">
+          <constraints>
+            <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7797-5859-4cee-3251" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="a419-a168-2a18-6fbb" name="Flying Gargantuan Creature" hidden="false" targetId="abaf-c4f2-142d-0deb" primary="false">
+          <constraints>
+            <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="36f4-8de7-1259-005f" type="max"/>
+          </constraints>
+        </categoryLink>
+      </categoryLinks>
+    </forceEntry>
+    <forceEntry id="a0b6-1a2f-3d64-b9d4" name=" Zone Mortalis - Combatant" hidden="false">
+      <infoLinks>
+        <infoLink id="e8cc-6700-113d-159b" name="ZM (Unusable)" hidden="false" targetId="b1da-bb0d-6990-b5c7" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="362f-1bd2-7eeb-3d4d" name="Elites" hidden="false" targetId="456c6974657323232344415441232323" primary="false">
+          <constraints>
+            <constraint field="selections" scope="force" value="2.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="a2e4-f3b4-345e-e55b" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="4a16-5374-4f67-bad4" name="HQ" hidden="false" targetId="485123232344415441232323" primary="false">
+          <constraints>
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="cc71-ad4c-e9a2-0f0c" type="min"/>
+            <constraint field="selections" scope="force" value="2.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="0d49-755e-7d1b-d041" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="5d85-263f-cb32-cf04" name="Fast Attack" hidden="false" targetId="466173742041747461636b23232344415441232323" primary="false">
+          <constraints>
+            <constraint field="selections" scope="force" value="2.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="011d-d009-9b9c-af97" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="66c1-bc9d-a755-f553" name="Troops" hidden="false" targetId="54726f6f707323232344415441232323" primary="false">
+          <constraints>
+            <constraint field="selections" scope="force" value="3.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="0314-e0f9-0417-5931" type="max"/>
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="b2b5-0052-00d4-a742" type="min"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="2089-6afa-52e2-dd99" name="Heavy Support" hidden="false" targetId="486561767920537570706f727423232344415441232323" primary="false">
+          <constraints>
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="dc07-36ac-f843-e7ab" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="785d-b8ce-1553-ddb4" name="Use Playtest Rules" hidden="false" targetId="fdf4-0683-3e84-5a4b" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="a641-3b5f-3d8a-b329" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="ffab-8fb7-bd15-7965" name="Mournival Rules" hidden="false" targetId="dbe0-716f-797c-66f7" primary="false"/>
+        <categoryLink id="e2b2-655f-fe7a-98e1" name="ZM (Unusable)" hidden="false" targetId="9335-93c1-6af7-feb0" primary="false">
+          <constraints>
+            <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e543-b87c-6260-1d96" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="0f1d-9bf2-e239-62bf" name="Flying Monstrous Creature" hidden="false" targetId="12ca-5271-bc77-cd4f" primary="false">
+          <constraints>
+            <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ddd2-7d01-ac01-0a3d" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="3e32-be03-ab34-3339" name="Flying Monstrous Creature" hidden="false" targetId="12ca-5271-bc77-cd4f" primary="false">
+          <constraints>
+            <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="431c-ae7a-9ed5-3e11" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="89f9-de2b-f74c-8996" name="Flying Monstrous Creature" hidden="false" targetId="12ca-5271-bc77-cd4f" primary="false">
+          <constraints>
+            <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3cd1-198e-9df7-ab73" type="max"/>
+          </constraints>
+        </categoryLink>
+      </categoryLinks>
+    </forceEntry>
+    <forceEntry id="41d1-3cca-834f-f8e0" name=" Zone Mortalis - Defender" hidden="false">
+      <infoLinks>
+        <infoLink id="a5b8-bbba-feb4-c74b" name="ZM (Unusable)" hidden="false" targetId="b1da-bb0d-6990-b5c7" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="7025-eb83-1ed5-a55e" name="Elites" hidden="false" targetId="456c6974657323232344415441232323" primary="false">
+          <constraints>
+            <constraint field="selections" scope="force" value="2.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="3be4-794d-53e9-d0f2" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="920a-3949-0919-91fe" name="HQ" hidden="false" targetId="485123232344415441232323" primary="false">
+          <constraints>
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="2322-b77f-bcd7-7c0f" type="min"/>
+            <constraint field="selections" scope="force" value="2.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="0dc3-9798-8926-519d" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="8f1a-0c20-c42c-7ba3" name="Fast Attack" hidden="false" targetId="466173742041747461636b23232344415441232323" primary="false">
+          <constraints>
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="d17e-41e0-6cd4-73df" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="27f8-2082-5563-6cd1" name="Troops" hidden="false" targetId="54726f6f707323232344415441232323" primary="false">
+          <constraints>
+            <constraint field="selections" scope="force" value="4.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="272d-58e2-83c9-7cd5" type="max"/>
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="ebc0-698f-365f-a92d" type="min"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="e6d3-351c-e131-374a" name="Heavy Support" hidden="false" targetId="486561767920537570706f727423232344415441232323" primary="false">
+          <constraints>
+            <constraint field="selections" scope="force" value="2.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="9ab0-8aa9-5caa-7e0e" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="5e53-c92d-485c-2a62" name="Use Playtest Rules" hidden="false" targetId="fdf4-0683-3e84-5a4b" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="0e86-a83d-4c38-2aa4" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="4147-6754-b5cd-9f8c" name="Mournival Rules" hidden="false" targetId="dbe0-716f-797c-66f7" primary="false"/>
+        <categoryLink id="4ba6-cd5c-cec7-aee5" name="ZM (Unusable)" hidden="false" targetId="9335-93c1-6af7-feb0" primary="false">
+          <constraints>
+            <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="167a-bf63-eb63-91e9" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="3284-edd9-5c39-e5b0" name="Flying Monstrous Creature" hidden="false" targetId="12ca-5271-bc77-cd4f" primary="false">
+          <constraints>
+            <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e3ea-74d0-43a2-14a7" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="76b4-fca6-7d7a-9ca8" name="Flying Gargantuan Creature" hidden="false" targetId="abaf-c4f2-142d-0deb" primary="false">
+          <constraints>
+            <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4d91-3ec5-d55a-39f2" type="max"/>
           </constraints>
         </categoryLink>
       </categoryLinks>
@@ -279,6 +519,17 @@
             </conditionGroup>
           </conditionGroups>
         </modifier>
+        <modifier type="add" field="category" value="9335-93c1-6af7-feb0">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="f398-6ade-f25f-e336" type="instanceOf"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="a0b6-1a2f-3d64-b9d4" type="instanceOf"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="41d1-3cca-834f-f8e0" type="instanceOf"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
       </modifiers>
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4571-257a-8d04-03c5" type="max"/>
@@ -297,6 +548,11 @@
             <modifier type="set" field="b6e4-f425-e952-d617" value="0.0">
               <conditions>
                 <condition field="selections" scope="92c6-2146-8ca7-bd35" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4a3e-a87e-7efc-0a7a" type="atLeast"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="613e-f21f-788e-ce0a">
+              <conditions>
+                <condition field="selections" scope="12ad-550e-4bd4-a82b" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7d02-f800-e124-ea50" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -349,6 +605,23 @@
           </costs>
         </selectionEntry>
         <selectionEntry id="1aa6-e8a8-4288-3545" name="Ruinstorm Daemon Lord" hidden="false" collective="false" import="true" type="model">
+          <modifiers>
+            <modifier type="add" field="category" value="677c-f197-e522-3b68">
+              <conditions>
+                <condition field="selections" scope="92c6-2146-8ca7-bd35" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4a3e-a87e-7efc-0a7a" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="12ca-5271-bc77-cd4f">
+              <conditions>
+                <condition field="selections" scope="92c6-2146-8ca7-bd35" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4a3e-a87e-7efc-0a7a" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="613e-f21f-788e-ce0a">
+              <conditions>
+                <condition field="selections" scope="92c6-2146-8ca7-bd35" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7d02-f800-e124-ea50" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="77dd-9d50-20dc-2179" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b10f-ec48-11ab-db5e" type="min"/>
@@ -532,6 +805,13 @@ D6	Warlord Trait
       </costs>
     </selectionEntry>
     <selectionEntry id="5eaf-49f3-f745-fd30" name="Ruinstorm Daemon Brutes" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="add" field="category" value="613e-f21f-788e-ce0a">
+          <conditions>
+            <condition field="selections" scope="5eaf-49f3-f745-fd30" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7d02-f800-e124-ea50" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="5a79-01c8-c1c7-ef77" name="Elites" hidden="false" targetId="456c6974657323232344415441232323" primary="true"/>
       </categoryLinks>
@@ -598,11 +878,31 @@ D6	Warlord Trait
       </costs>
     </selectionEntry>
     <selectionEntry id="b13b-5247-2078-4daf" name="Ruinstorm Greater Daemon" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="add" field="category" value="9335-93c1-6af7-feb0">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="f398-6ade-f25f-e336" type="instanceOf"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="a0b6-1a2f-3d64-b9d4" type="instanceOf"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="41d1-3cca-834f-f8e0" type="instanceOf"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="de3d-2656-aeae-8bf0" name="HQ" hidden="false" targetId="485123232344415441232323" primary="true"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="53c0-0b7b-42e5-0eda" name="Ruinstorm Greater Daemon" hidden="false" collective="false" import="true" type="model">
+          <modifiers>
+            <modifier type="add" field="category" value="613e-f21f-788e-ce0a">
+              <conditions>
+                <condition field="selections" scope="b13b-5247-2078-4daf" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7d02-f800-e124-ea50" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fccf-db2f-d1a3-333f" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2342-0d11-6faa-3e91" type="min"/>
@@ -613,6 +913,9 @@ D6	Warlord Trait
             <infoLink id="457d-b0e6-5b62-7959" name="Parting the Veil" hidden="false" targetId="c828-3e09-a384-735b" type="rule"/>
             <infoLink id="182e-0e1b-2138-80a2" name="Tides of Madness" hidden="false" targetId="a2dc-7a16-0067-a4db" type="rule"/>
           </infoLinks>
+          <categoryLinks>
+            <categoryLink id="e072-d1ce-761b-dbf5" name="Monstrous Creature" hidden="false" targetId="677c-f197-e522-3b68" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="pts" typeId="points" value="160.0"/>
           </costs>
@@ -630,6 +933,13 @@ D6	Warlord Trait
       </costs>
     </selectionEntry>
     <selectionEntry id="721a-409b-1ce8-0c50" name="Ruinstorm Daemon Chosen" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="add" field="category" value="613e-f21f-788e-ce0a">
+          <conditions>
+            <condition field="selections" scope="721a-409b-1ce8-0c50" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7d02-f800-e124-ea50" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="b09a-30f0-39d0-6fb3" name="HQ" hidden="false" targetId="485123232344415441232323" primary="true"/>
       </categoryLinks>
@@ -663,8 +973,22 @@ D6	Warlord Trait
       </costs>
     </selectionEntry>
     <selectionEntry id="1137-8ddd-d812-1e70" name="Ruinstorm Daemon Cavalry" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="add" field="category" value="9335-93c1-6af7-feb0">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="f398-6ade-f25f-e336" type="instanceOf"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="a0b6-1a2f-3d64-b9d4" type="instanceOf"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="41d1-3cca-834f-f8e0" type="instanceOf"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="5571-9b8f-6e12-06ee" name="Fast Attack" hidden="false" targetId="466173742041747461636b23232344415441232323" primary="true"/>
+        <categoryLink id="0a17-c42d-084c-8ba8" name="Cavalry" hidden="false" targetId="cbd7-da20-4ef1-fbda" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="85a4-e359-e057-894b" name="Ruinstorm Daemon Cavalry" hidden="false" collective="false" import="true" type="model">
@@ -725,6 +1049,9 @@ D6	Warlord Trait
             <infoLink id="05e0-619e-d483-f6d8" name="Parting the Veil" hidden="false" targetId="c828-3e09-a384-735b" type="rule"/>
             <infoLink id="5b68-2d93-1e75-1bbd" name="Tide of Madness" hidden="false" targetId="a2dc-7a16-0067-a4db" type="rule"/>
           </infoLinks>
+          <categoryLinks>
+            <categoryLink id="45b9-cf8c-0843-4137" name="Beasts" hidden="false" targetId="c9f6-0db2-037e-468d" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="pts" typeId="points" value="25.0"/>
           </costs>
@@ -761,6 +1088,13 @@ D6	Warlord Trait
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="f757-a9dc-829d-0f07" name="Ruinstorm Daemon Swarms" hidden="false" collective="false" import="true" type="model">
+          <modifiers>
+            <modifier type="add" field="category" value="613e-f21f-788e-ce0a">
+              <conditions>
+                <condition field="selections" scope="ae3c-2429-b663-dcbc" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7d02-f800-e124-ea50" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="86a6-8205-e620-15e3" type="max"/>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bc7f-6c95-1d6f-e290" type="min"/>
@@ -819,6 +1153,9 @@ D6	Warlord Trait
             <infoLink id="00dc-b3fb-0251-fc7d" name="Parting the Veil" hidden="false" targetId="c828-3e09-a384-735b" type="rule"/>
             <infoLink id="6e5c-f987-dd80-741d" name="Tides of Madness" hidden="false" targetId="a2dc-7a16-0067-a4db" type="rule"/>
           </infoLinks>
+          <categoryLinks>
+            <categoryLink id="a782-81b0-128d-fab4" name="Flying Monstrous Creature" hidden="false" targetId="12ca-5271-bc77-cd4f" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="pts" typeId="points" value="160.0"/>
           </costs>
@@ -836,6 +1173,19 @@ D6	Warlord Trait
       </costs>
     </selectionEntry>
     <selectionEntry id="bf7e-0c26-b8b8-758a" name="Ruinstorm Daemon Behemoth" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="add" field="category" value="9335-93c1-6af7-feb0">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="f398-6ade-f25f-e336" type="instanceOf"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="a0b6-1a2f-3d64-b9d4" type="instanceOf"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="41d1-3cca-834f-f8e0" type="instanceOf"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="bba1-7f66-485f-9ec7" name="Heavy Support" hidden="false" targetId="486561767920537570706f727423232344415441232323" primary="true"/>
       </categoryLinks>
@@ -852,6 +1202,9 @@ D6	Warlord Trait
             <infoLink id="4831-8f48-8753-0e79" name="Unstoppable" hidden="false" targetId="7e4c-02df-f834-6a66" type="rule"/>
             <infoLink id="07b7-23ac-cc68-ba70" name="Ruinstorm Daemon Behemoth" hidden="false" targetId="74df-5659-4f1c-ed58" type="profile"/>
           </infoLinks>
+          <categoryLinks>
+            <categoryLink id="5a78-b102-d858-b800" name="Monstrous Creature" hidden="false" targetId="677c-f197-e522-3b68" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="pts" typeId="points" value="0.0"/>
           </costs>
@@ -869,6 +1222,19 @@ D6	Warlord Trait
       </costs>
     </selectionEntry>
     <selectionEntry id="b7a8-a1e3-5f05-fc69" name="Ruinstorm Greater Daemon Beasts" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="add" field="category" value="9335-93c1-6af7-feb0">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="f398-6ade-f25f-e336" type="instanceOf"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="a0b6-1a2f-3d64-b9d4" type="instanceOf"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="41d1-3cca-834f-f8e0" type="instanceOf"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="3e95-5559-6cef-3f4c" name="Heavy Support" hidden="false" targetId="486561767920537570706f727423232344415441232323" primary="true"/>
       </categoryLinks>
@@ -886,6 +1252,7 @@ D6	Warlord Trait
           </infoLinks>
           <categoryLinks>
             <categoryLink id="0d64-7058-4063-127e" name="Heavy Support" hidden="false" targetId="486561767920537570706f727423232344415441232323" primary="true"/>
+            <categoryLink id="8c28-1660-4792-07f0" name="Monstrous Creature" hidden="false" targetId="677c-f197-e522-3b68" primary="false"/>
           </categoryLinks>
           <costs>
             <cost name="pts" typeId="points" value="100.0"/>
@@ -1072,6 +1439,19 @@ D6	Warlord Trait
       </costs>
     </selectionEntry>
     <selectionEntry id="ea70-5e79-b1a0-3256" name="Ruinstorm Arch-Daemon" hidden="false" collective="false" import="true" type="model">
+      <modifiers>
+        <modifier type="add" field="category" value="9335-93c1-6af7-feb0">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="f398-6ade-f25f-e336" type="instanceOf"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="a0b6-1a2f-3d64-b9d4" type="instanceOf"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="41d1-3cca-834f-f8e0" type="instanceOf"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <infoLinks>
         <infoLink id="17ab-6c0d-90e1-5146" name="Parting the Veil" hidden="false" targetId="c828-3e09-a384-735b" type="rule"/>
         <infoLink id="107e-5fd7-28c1-d676" name="Tide of Madness" hidden="false" targetId="a2dc-7a16-0067-a4db" type="rule"/>
@@ -1106,6 +1486,18 @@ D6	Warlord Trait
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="1aff-adeb-3152-60b5" name="Arch-Daemon Emanations" publicationId="8700-b3bb-pubN65537" page="252" hidden="false" collective="false" import="true">
+          <modifiers>
+            <modifier type="add" field="category" value="3fd6-be25-ed1a-1799">
+              <conditions>
+                <condition field="selections" scope="ea70-5e79-b1a0-3256" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8432-da5e-4922-f15d" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="abaf-c4f2-142d-0deb">
+              <conditions>
+                <condition field="selections" scope="ea70-5e79-b1a0-3256" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8432-da5e-4922-f15d" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ae1-eac8-937c-b423" type="max"/>
           </constraints>
@@ -1637,11 +2029,17 @@ D6	Warlord Trait
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="57a3-4b72-0f26-bbbd" type="max"/>
               </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="1035-4ff3-e9eb-8247" name="CF Ambiguity (Optional if 2+)" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="687c-0bf6-6966-f567" type="max"/>
               </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
@@ -1690,11 +2088,17 @@ D6	Warlord Trait
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="faf8-01d1-2861-744e" type="max"/>
               </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="951e-1e11-a700-1d09" name="LO Ambiguity (Optional if 2+)" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a21-7ff1-5a1d-feaf" type="max"/>
               </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
@@ -1753,11 +2157,17 @@ D6	Warlord Trait
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="678f-6ecb-deb3-c0ba" type="max"/>
               </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="4ea2-35d3-a04d-1bb0" name="CS Ambiguity (Optional if 2+)" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="657a-fcb7-9f19-0a9a" type="max"/>
               </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
@@ -1828,6 +2238,9 @@ End of Days: Each enemy unit destroyed, removed from play or forced to flee from
               <infoLinks>
                 <infoLink id="edfd-3415-6225-0454" name="Creeping Scourge Warlord Traits" hidden="false" targetId="9e12-7d53-9c60-6694" type="rule"/>
               </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="9e9c-85ab-4132-2f4e" name="Lurid Onslaught Warlord Traits" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
@@ -1836,6 +2249,9 @@ End of Days: Each enemy unit destroyed, removed from play or forced to flee from
               <infoLinks>
                 <infoLink id="e864-b432-12a5-e68c" name="Lurid Onslaught Warlord Traits" hidden="false" targetId="2a17-7af2-a4f5-ee71" type="rule"/>
               </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="dbac-f6d9-bd19-d058" name="Maddening Swarms Warlord Traits" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
@@ -1844,6 +2260,9 @@ End of Days: Each enemy unit destroyed, removed from play or forced to flee from
               <infoLinks>
                 <infoLink id="e12b-78e6-ecfd-70d7" name="Maddening Swarms Warlord Traits" hidden="false" targetId="0fce-bbc4-7258-a2f6" type="rule"/>
               </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="8191-bb7d-e276-4c64" name="Mirror of Hatred Warlord Traits" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
@@ -1852,6 +2271,9 @@ End of Days: Each enemy unit destroyed, removed from play or forced to flee from
               <infoLinks>
                 <infoLink id="19e0-c49f-35d4-43ac" name="Mirror of Hatred Warlord Traits" hidden="false" targetId="9736-92fb-77f2-ec69" type="rule"/>
               </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="c1c3-43d2-696b-d10a" name="Crimson Fury Warlord Traits" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
@@ -1860,6 +2282,9 @@ End of Days: Each enemy unit destroyed, removed from play or forced to flee from
               <infoLinks>
                 <infoLink id="28d4-4f29-cc0b-3533" name="Crimson Fury Warlord Traits" hidden="false" targetId="8f2e-6b7a-7bed-a789" type="rule"/>
               </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
@@ -1927,6 +2352,9 @@ Eternal Rivalry: If Sanguinius is removed as a casualty while it is fighting in 
         <infoLink id="de3b-fd31-de3e-0d42" name="Hatred" hidden="false" targetId="7c6c-4e25-e4d4-9728" type="rule"/>
         <infoLink id="ab16-e2ca-d661-eb58" name="Preferred Enemy" hidden="false" targetId="4dd2-fcb0-de6a-5b70" type="rule"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="121b-d348-1f2e-d6bc" name="Flying Monstrous Creature" hidden="false" targetId="12ca-5271-bc77-cd4f" primary="false"/>
+      </categoryLinks>
       <entryLinks>
         <entryLink id="5394-5b8e-7434-eba2" name="Molten Blood" hidden="false" collective="false" import="true" targetId="e001-8e2e-f957-4bb7" type="selectionEntry">
           <constraints>
@@ -2475,6 +2903,9 @@ Eternal Rivalry: If Sanguinius is removed as a casualty while it is fighting in 
         <infoLink id="353e-1277-1a14-9c97" name="Parting the Veil" hidden="false" targetId="c828-3e09-a384-735b" type="rule"/>
         <infoLink id="d71a-00d1-7f68-2ff6" name="Eternal Warrior" hidden="false" targetId="3e0b-be9f-b7eb-8c5e" type="rule"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="49a9-b11a-1c52-6934" name="Monstrous Creature" hidden="false" targetId="677c-f197-e522-3b68" primary="false"/>
+      </categoryLinks>
       <entryLinks>
         <entryLink id="4602-1266-d39b-cf44" name="Shroud of Darkness" hidden="false" collective="false" import="true" targetId="8600-a910-cd18-0f0a" type="selectionEntry">
           <constraints>
@@ -2504,6 +2935,17 @@ Eternal Rivalry: If Sanguinius is removed as a casualty while it is fighting in 
               <conditions>
                 <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dc24-bd44-bce4-a7f1" type="equalTo"/>
                 <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="92c6-2146-8ca7-bd35" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="add" field="category" value="9335-93c1-6af7-feb0">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="f398-6ade-f25f-e336" type="instanceOf"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="a0b6-1a2f-3d64-b9d4" type="instanceOf"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="41d1-3cca-834f-f8e0" type="instanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -2560,6 +3002,9 @@ Models in combat with Sam us Unbound, as well as those taking Fear tests in orde
         <infoLink id="efd0-5ac6-109b-98ef" name="Armourbane" hidden="false" targetId="e182-50cd-0867-9a8d" type="rule"/>
         <infoLink id="7501-1e5f-b12f-8bff" name="Murderous Strike" hidden="false" targetId="b0c5-b980-95e5-b181" type="rule"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="2fc4-635d-d6ca-2525" name="Monstrous Creature" hidden="false" targetId="677c-f197-e522-3b68" primary="false"/>
+      </categoryLinks>
       <entryLinks>
         <entryLink id="52be-9af4-6d05-1496" name="Brass Collars" hidden="false" collective="false" import="true" targetId="da14-1454-058f-f0cd" type="selectionEntry">
           <constraints>

--- a/(HH) Daemons of the Ruinstorm Army List.cat
+++ b/(HH) Daemons of the Ruinstorm Army List.cat
@@ -728,6 +728,19 @@ D6	Warlord Trait
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="23df-3d35-fc4d-f51a" name="Ruinstorm Lesser Daemons" hidden="false" collective="false" import="true" type="model">
+          <modifiers>
+            <modifier type="set" field="2129-273d-758e-06fd" value="15.0">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="f398-6ade-f25f-e336" type="instanceOf"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="a0b6-1a2f-3d64-b9d4" type="instanceOf"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="41d1-3cca-834f-f8e0" type="instanceOf"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="20.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2129-273d-758e-06fd" type="max"/>
             <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6400-e7ee-9f4c-0e6e" type="min"/>
@@ -2386,6 +2399,19 @@ Eternal Rivalry: If Sanguinius is removed as a casualty while it is fighting in 
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="c4a1-6f68-d186-1fb8" name="Possessed Legionaries" publicationId="8700-b3bb-pubN65537" hidden="false" collective="false" import="true" type="model">
+          <modifiers>
+            <modifier type="set" field="7dcb-21fd-89eb-c921" value="15.0">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="f398-6ade-f25f-e336" type="instanceOf"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="a0b6-1a2f-3d64-b9d4" type="instanceOf"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="41d1-3cca-834f-f8e0" type="instanceOf"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7f5e-0c92-2620-c236" type="min"/>
             <constraint field="selections" scope="parent" value="20.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7dcb-21fd-89eb-c921" type="max"/>
@@ -2774,6 +2800,19 @@ Eternal Rivalry: If Sanguinius is removed as a casualty while it is fighting in 
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="6778-7a1d-24a3-3ac4" name="Possessed Auxiliaries" hidden="false" collective="false" import="true" type="model">
+          <modifiers>
+            <modifier type="set" field="4cae-1769-89ba-b5e5" value="15.0">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="f398-6ade-f25f-e336" type="instanceOf"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="a0b6-1a2f-3d64-b9d4" type="instanceOf"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="41d1-3cca-834f-f8e0" type="instanceOf"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="20.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4cae-1769-89ba-b5e5" type="max"/>
             <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="21b1-5cce-b10b-c03d" type="min"/>

--- a/(HH) Daemons of the Ruinstorm Army List.cat
+++ b/(HH) Daemons of the Ruinstorm Army List.cat
@@ -14,7 +14,8 @@
     <categoryEntry id="486561767920537570706f727423232344415441232323" name="Heavy Support" hidden="false"/>
     <categoryEntry id="2271-1b9a-5c30-9676" name="Aetheric Dominion" hidden="false">
       <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c9fb-b8e5-20db-b9b9" type="max"/>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c9fb-b8e5-20db-b9b9" type="min"/>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="86b2-5e9b-c913-73e4" type="max"/>
       </constraints>
     </categoryEntry>
     <categoryEntry id="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" name="Lords of War" hidden="false"/>
@@ -137,7 +138,8 @@
         </categoryLink>
         <categoryLink id="7a11-130d-e08e-65be" name="Aetheric Dominion" hidden="false" targetId="2271-1b9a-5c30-9676" primary="false">
           <constraints>
-            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7bd9-4ea2-c150-12a5" type="max"/>
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7bd9-4ea2-c150-12a5" type="max"/>
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="33f3-f482-c2f8-353c" type="min"/>
           </constraints>
         </categoryLink>
         <categoryLink id="63e0-0102-d8af-800e" name="Compulsory Troops" hidden="false" targetId="0547-e031-0d25-4c6c" primary="false">
@@ -163,7 +165,8 @@
       <categoryLinks>
         <categoryLink id="5936-60c0-10a5-dbd8" name="Aetheric Dominion" hidden="false" targetId="2271-1b9a-5c30-9676" primary="false">
           <constraints>
-            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2ce0-a2b7-e89c-8cd4" type="max"/>
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2ce0-a2b7-e89c-8cd4" type="min"/>
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="cd89-542d-b9f3-400c" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="5c6b-3027-0572-11c5" name="HQ" hidden="false" targetId="485123232344415441232323" primary="false">
@@ -269,6 +272,18 @@
             <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="36f4-8de7-1259-005f" type="max"/>
           </constraints>
         </categoryLink>
+        <categoryLink id="cf6e-c774-167c-49b8" name="Aliens and Daemons" hidden="false" targetId="cd09-c1c6-237a-798e" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="951e-7bf1-6634-a45d" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="feac-bec5-fe39-97ef" type="min"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="8fe7-91f0-98b0-8b29" name="Aetheric Dominion" hidden="false" targetId="2271-1b9a-5c30-9676" primary="false">
+          <constraints>
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ae84-9d85-c1a7-66a1" type="max"/>
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fff3-944a-a5a5-697b" type="min"/>
+          </constraints>
+        </categoryLink>
       </categoryLinks>
     </forceEntry>
     <forceEntry id="a0b6-1a2f-3d64-b9d4" name=" Zone Mortalis - Combatant" hidden="false">
@@ -329,6 +344,18 @@
             <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3cd1-198e-9df7-ab73" type="max"/>
           </constraints>
         </categoryLink>
+        <categoryLink id="353d-52f3-65a9-2e14" name="Aliens and Daemons" hidden="false" targetId="cd09-c1c6-237a-798e" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e5a4-d7e0-0fbe-1bb4" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ba9b-9c7b-509a-be03" type="min"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="a6cd-e310-59b5-2f63" name="Aetheric Dominion" hidden="false" targetId="2271-1b9a-5c30-9676" primary="false">
+          <constraints>
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b40f-70e6-69a2-c978" type="max"/>
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fad2-7581-5daa-d42e" type="min"/>
+          </constraints>
+        </categoryLink>
       </categoryLinks>
     </forceEntry>
     <forceEntry id="41d1-3cca-834f-f8e0" name=" Zone Mortalis - Defender" hidden="false">
@@ -382,6 +409,18 @@
         <categoryLink id="76b4-fca6-7d7a-9ca8" name="Flying Gargantuan Creature" hidden="false" targetId="abaf-c4f2-142d-0deb" primary="false">
           <constraints>
             <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4d91-3ec5-d55a-39f2" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="a6cf-39df-1f80-7cc7" name="Aliens and Daemons" hidden="false" targetId="cd09-c1c6-237a-798e" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4a6d-6bc0-2dc9-4c58" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e283-f40f-6ef2-7e37" type="min"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="2eca-39b9-2df0-04ea" name="Aetheric Dominion" hidden="false" targetId="2271-1b9a-5c30-9676" primary="false">
+          <constraints>
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bb1c-fe7a-cc70-c1cc" type="max"/>
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ee6f-f78a-f1b5-651e" type="min"/>
           </constraints>
         </categoryLink>
       </categoryLinks>

--- a/(HH) Imperialis Militia and Cults Army List.cat
+++ b/(HH) Imperialis Militia and Cults Army List.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="90aa-c2c8-ffb0-496e" name="Imperialis Militia and Cults Army List" revision="112" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="130" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="90aa-c2c8-ffb0-496e" name="Imperialis Militia and Cults Army List" revision="113" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="132" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="90aa-c2c8-pubN65537" name="Crusade Imperialis"/>
     <publication id="90aa-c2c8-pubN65563" name="AoDRB"/>
@@ -401,6 +401,9 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
       </categoryLinks>
     </forceEntry>
     <forceEntry id="089f-7e79-bde1-90dd" name=" Zone Mortalis - Attacker" hidden="false">
+      <infoLinks>
+        <infoLink id="5be6-4d9d-995a-e0c1" name="ZM (Unusable)" hidden="false" targetId="b1da-bb0d-6990-b5c7" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="089f-7e79-bde1-90dd-456c6974657323232344415441232323" name="Elites" hidden="false" targetId="456c6974657323232344415441232323" primary="false">
           <constraints>
@@ -436,9 +439,32 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
           </constraints>
         </categoryLink>
         <categoryLink id="6e3c-278f-1fe5-df94" name="Mournival Rules" hidden="false" targetId="dbe0-716f-797c-66f7" primary="false"/>
+        <categoryLink id="d607-45c9-adc1-9380" name="ZM (Unusable)" hidden="false" targetId="9335-93c1-6af7-feb0" primary="false">
+          <constraints>
+            <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e2ec-7ca7-b263-2f78" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="7101-3b48-28cf-ee92" name="Flyer" hidden="false" targetId="df44-81ea-e2ee-9849" primary="false">
+          <constraints>
+            <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2b53-c306-fd55-582d" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="7ae8-44c3-b003-51f0" name="Flying Monstrous Creature" hidden="false" targetId="25d0-388c-dd16-af9a" primary="false">
+          <constraints>
+            <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f29e-23fd-e152-a81d" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="0a57-e799-baaa-5a31" name="Dedicated Transport" hidden="false" targetId="c407-80ff-568e-3394" primary="false">
+          <constraints>
+            <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="13d6-ecde-96f0-0e28" type="max"/>
+          </constraints>
+        </categoryLink>
       </categoryLinks>
     </forceEntry>
     <forceEntry id="7b39-af6b-52e1-b4d7" name=" Zone Mortalis - Defender" hidden="false">
+      <infoLinks>
+        <infoLink id="b95b-bb78-5baf-9849" name="ZM (Unusable)" hidden="false" targetId="b1da-bb0d-6990-b5c7" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="7b39-af6b-52e1-b4d7-456c6974657323232344415441232323" name="Elites" hidden="false" targetId="456c6974657323232344415441232323" primary="false">
           <constraints>
@@ -470,9 +496,32 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
           </constraints>
         </categoryLink>
         <categoryLink id="64a7-0135-65c0-7fa2" name="Mournival Rules" hidden="false" targetId="dbe0-716f-797c-66f7" primary="false"/>
+        <categoryLink id="3892-e9f1-8392-34c6" name="ZM (Unusable)" hidden="false" targetId="9335-93c1-6af7-feb0" primary="false">
+          <constraints>
+            <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bbfa-184e-c2d8-f4c5" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="21c7-e98f-5814-47db" name="Dedicated Transport" hidden="false" targetId="c407-80ff-568e-3394" primary="false">
+          <constraints>
+            <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7164-5e05-e331-f01a" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="cca7-ad76-4989-27e5" name="Flyer" hidden="false" targetId="df44-81ea-e2ee-9849" primary="false">
+          <constraints>
+            <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="403e-e6d3-3369-274f" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="3722-d058-11ff-0148" name="Flying Monstrous Creature" hidden="false" targetId="25d0-388c-dd16-af9a" primary="false">
+          <constraints>
+            <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5bf4-09a2-4b9b-2b22" type="max"/>
+          </constraints>
+        </categoryLink>
       </categoryLinks>
     </forceEntry>
     <forceEntry id="7e48-c376-8ffe-8ae7" name=" Zone Mortalis - Combatant" hidden="false">
+      <infoLinks>
+        <infoLink id="abb0-f423-c4f9-2167" name="ZM (Unusable)" hidden="false" targetId="b1da-bb0d-6990-b5c7" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="7e48-c376-8ffe-8ae7-456c6974657323232344415441232323" name="Elites" hidden="false" targetId="456c6974657323232344415441232323" primary="false">
           <constraints>
@@ -508,6 +557,26 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
           </constraints>
         </categoryLink>
         <categoryLink id="9cdd-504a-8562-88b3" name="Mournival Rules" hidden="false" targetId="dbe0-716f-797c-66f7" primary="false"/>
+        <categoryLink id="5d4b-4983-146a-982b" name="ZM (Unusable)" hidden="false" targetId="9335-93c1-6af7-feb0" primary="false">
+          <constraints>
+            <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0c20-9490-9f25-ea76" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="2e2d-b2fc-a927-7e5d" name="Dedicated Transport" hidden="false" targetId="c407-80ff-568e-3394" primary="false">
+          <constraints>
+            <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="93bb-36f9-3b1a-84a5" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="50fe-1ec9-e88d-445d" name="Flyer" hidden="false" targetId="df44-81ea-e2ee-9849" primary="false">
+          <constraints>
+            <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8697-a08a-6a95-9bce" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="c6d7-28a6-568d-c0ae" name="Flying Monstrous Creature" hidden="false" targetId="25d0-388c-dd16-af9a" primary="false">
+          <constraints>
+            <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="963e-c37f-d5d5-9021" type="max"/>
+          </constraints>
+        </categoryLink>
       </categoryLinks>
     </forceEntry>
     <forceEntry id="d1ef-61e1-3d67-5a19" name="Optional - Onslaught" hidden="false">
@@ -860,7 +929,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <categoryLink id="528e-9c01-4106-31c8" name="New CategoryLink" hidden="false" targetId="8a8c-ed20-7427-ddff" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="d11b-5df0-04e8-0742" name="Auxilia Thunderbolt Heavy Fighter" hidden="false" collective="false" import="true" targetId="ba9a-493a-cf26-21c9" type="selectionEntry">
+    <entryLink id="d11b-5df0-04e8-0742" name="Thunderbolt Heavy Fighter, Auxilia" hidden="false" collective="false" import="true" targetId="ba9a-493a-cf26-21c9" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="d11b-5df0-04e8-0742-466173742041747461636b23232344415441232323" hidden="false" targetId="466173742041747461636b23232344415441232323" primary="true"/>
         <categoryLink id="f01c-95a4-ee59-e1d8" name="New CategoryLink" hidden="false" targetId="8a8c-ed20-7427-ddff" primary="false"/>
@@ -1677,6 +1746,19 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
       </costs>
     </selectionEntry>
     <selectionEntry id="46fa-9f49-315a-2044" name="Gorgon Heavy Transporter, Auxilia" hidden="false" collective="false" import="true" type="upgrade">
+      <modifiers>
+        <modifier type="add" field="category" value="9335-93c1-6af7-feb0">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7e48-c376-8ffe-8ae7" type="instanceOf"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7b39-af6b-52e1-b4d7" type="instanceOf"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="089f-7e79-bde1-90dd" type="instanceOf"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
       </constraints>
@@ -2026,6 +2108,19 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
       </costs>
     </selectionEntry>
     <selectionEntry id="3738-7adf-ea3d-8a7e" name="Land Raider Proteus" publicationId="90aa-c2c8-pubN76431" page="0" hidden="false" collective="false" import="true" type="upgrade">
+      <modifiers>
+        <modifier type="add" field="category" value="9335-93c1-6af7-feb0">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7e48-c376-8ffe-8ae7" type="instanceOf"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7b39-af6b-52e1-b4d7" type="instanceOf"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="089f-7e79-bde1-90dd" type="instanceOf"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
       </constraints>
@@ -4286,6 +4381,7 @@ D3     Mutation
       </infoLinks>
       <categoryLinks>
         <categoryLink id="dede-7586-dc68-e605" name="New CategoryLink" hidden="false" targetId="8a8c-ed20-7427-ddff" primary="false"/>
+        <categoryLink id="5712-07a5-eb5c-3aa5" name="Flyer" hidden="false" targetId="df44-81ea-e2ee-9849" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="c5d7-549b-f41b-e340" name="Twin-Linked Autocannons" hidden="false" collective="false" import="true" type="upgrade">
@@ -7176,6 +7272,62 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="1dbf-2c4c-f4dd-54ca" name="Grenadiers" hidden="false" collective="false" import="true" type="model">
+          <modifiers>
+            <modifier type="set" field="7354-b9f7-6a2a-7765" value="14.0">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="f299-898a-b637-0aa2" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="aac8-334f-0aa5-7916" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7e48-c376-8ffe-8ae7" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7b39-af6b-52e1-b4d7" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="089f-7e79-bde1-90dd" type="instanceOf"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="set" field="7354-b9f7-6a2a-7765" value="13.0">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="f299-898a-b637-0aa2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="aac8-334f-0aa5-7916" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7e48-c376-8ffe-8ae7" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7b39-af6b-52e1-b4d7" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="089f-7e79-bde1-90dd" type="instanceOf"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="set" field="7354-b9f7-6a2a-7765" value="12.0">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="f299-898a-b637-0aa2" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="aac8-334f-0aa5-7916" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7e48-c376-8ffe-8ae7" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7b39-af6b-52e1-b4d7" type="instanceOf"/>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="089f-7e79-bde1-90dd" type="instanceOf"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="27c6-b3e3-22d9-3911" type="min"/>
             <constraint field="selections" scope="parent" value="17.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7354-b9f7-6a2a-7765" type="max"/>
@@ -8461,6 +8613,26 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
       </costs>
     </selectionEntry>
     <selectionEntry id="c542-ddd4-6b6b-f761" name="Infantry Squad, Imperialis Militia" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="add" field="category" value="9335-93c1-6af7-feb0">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="c542-ddd4-6b6b-f761" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c177-6310-e521-ecd9" type="equalTo"/>
+              </conditions>
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7e48-c376-8ffe-8ae7" type="instanceOf"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7b39-af6b-52e1-b4d7" type="instanceOf"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="089f-7e79-bde1-90dd" type="instanceOf"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="28c8-6342-6ce7-b142" name="New CategoryLink" hidden="false" targetId="8a8c-ed20-7427-ddff" primary="false"/>
       </categoryLinks>
@@ -8704,6 +8876,18 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
           </costs>
         </selectionEntry>
         <selectionEntry id="1884-69d1-90e1-0688" name="Militia Auxiliaries" hidden="false" collective="false" import="true" type="model">
+          <modifiers>
+            <modifier type="set" field="d408-f627-3be9-2e88" value="14.0">
+              <conditions>
+                <condition field="selections" scope="c542-ddd4-6b6b-f761" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d703-37c0-d6a2-4ee6" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="5f78-f6c8-9768-b123" value="14.0">
+              <conditions>
+                <condition field="selections" scope="c542-ddd4-6b6b-f761" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d703-37c0-d6a2-4ee6" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d408-f627-3be9-2e88" type="min"/>
             <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5f78-f6c8-9768-b123" type="max"/>
@@ -8960,6 +9144,54 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
+        <selectionEntryGroup id="c177-6310-e521-ecd9" name="Infantry Squad, Imperialis Militia in ZM" hidden="true" collective="false" import="true">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7e48-c376-8ffe-8ae7" type="instanceOf"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7b39-af6b-52e1-b4d7" type="instanceOf"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="089f-7e79-bde1-90dd" type="instanceOf"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="set" field="0191-a3e8-27d4-9ce1" value="1.0">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7e48-c376-8ffe-8ae7" type="instanceOf"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7b39-af6b-52e1-b4d7" type="instanceOf"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="089f-7e79-bde1-90dd" type="instanceOf"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9d10-f392-5fa1-df7a" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0191-a3e8-27d4-9ce1" type="min"/>
+          </constraints>
+          <rules>
+            <rule id="3a59-2da5-fbd9-2635" name="Infantry Squad, Imperialis Militia in ZM" hidden="false">
+              <description>Due to the new 2019 ZM rules. This unit is not able to be used in ZM as it is over 15 models, and unlike Solar Aux, does not have a rule allowing squads to be split.
+As such if you wish to use them in ZM there are a couple of &quot;House Rules&quot; commonly adopted. These are to split the unit into 2 equal size units, as per Solar Aux, Reduce the number of models to 15, though continue to pay the full cost for the unit.</description>
+            </rule>
+          </rules>
+          <selectionEntries>
+            <selectionEntry id="29ba-324a-8676-abf0" name="Split" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="21e5-c4c4-841d-f4ef" type="max"/>
+              </constraints>
+            </selectionEntry>
+            <selectionEntry id="d703-37c0-d6a2-4ee6" name="Reduce models to 15 at same cost" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dde2-1eea-97a6-505f" type="max"/>
+              </constraints>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
         <entryLink id="ca26-178e-70e8-164f" name="Provenance" hidden="false" collective="false" import="true" targetId="9d50-7127-dc55-d542" type="selectionEntryGroup"/>
@@ -8969,6 +9201,26 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
       </costs>
     </selectionEntry>
     <selectionEntry id="7689-6fdc-260e-d041" name="Inducted Levy Squad" publicationId="90aa-c2c8-pubN73486" page="194" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="add" field="category" value="9335-93c1-6af7-feb0">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="7689-6fdc-260e-d041" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a79a-479c-272f-8a18" type="equalTo"/>
+              </conditions>
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7e48-c376-8ffe-8ae7" type="instanceOf"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7b39-af6b-52e1-b4d7" type="instanceOf"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="089f-7e79-bde1-90dd" type="instanceOf"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <rules>
         <rule id="c40e-20eb-49fc-e6fa" name="Disposable" publicationId="90aa-c2c8-pubN73486" page="194" hidden="false">
           <description>The opposing player never gains victory points for</description>
@@ -8995,6 +9247,18 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="5116-a266-b4b0-fdca" name="Levy Auxiliaries" hidden="false" collective="false" import="true" type="model">
+          <modifiers>
+            <modifier type="set" field="5549-d4ee-fb23-8986" value="14.0">
+              <conditions>
+                <condition field="selections" scope="7689-6fdc-260e-d041" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7d0e-ca92-be0e-51d3" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="6056-ad13-2433-db9d" value="14.0">
+              <conditions>
+                <condition field="selections" scope="7689-6fdc-260e-d041" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7d0e-ca92-be0e-51d3" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5549-d4ee-fb23-8986" type="min"/>
             <constraint field="selections" scope="parent" value="49.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6056-ad13-2433-db9d" type="max"/>
@@ -9310,7 +9574,7 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="0d70-d476-a38f-ab09" name="May replace Auxilia Rifles with:" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="0d70-d476-a38f-ab09" name="May replace Auxilia Rifles with:" hidden="false" collective="false" import="true" defaultSelectionEntryId="9f18-b737-0321-afa7">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e777-657f-6f5c-af73" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8e79-4aaf-01c9-36d6" type="min"/>
@@ -9369,6 +9633,57 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="a79a-479c-272f-8a18" name="Inducted Levy Squad in ZM" hidden="true" collective="false" import="true">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7e48-c376-8ffe-8ae7" type="instanceOf"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7b39-af6b-52e1-b4d7" type="instanceOf"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="089f-7e79-bde1-90dd" type="instanceOf"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="set" field="8a89-9412-cf67-8de5" value="1.0">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7e48-c376-8ffe-8ae7" type="instanceOf"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7b39-af6b-52e1-b4d7" type="instanceOf"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="089f-7e79-bde1-90dd" type="instanceOf"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2739-e412-4b0f-610d" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8a89-9412-cf67-8de5" type="min"/>
+          </constraints>
+          <rules>
+            <rule id="1c0f-bf60-5c17-b6d5" name="Inducted Levy Squad in ZM" hidden="false">
+              <description>Due to the new 2019 ZM rules. This unit is not able to be used in ZM as it is over 15 models, and unlike Solar Aux, does not have a rule allowing squads to be split.
+As such if you wish to use them in ZM there are a couple of &quot;House Rules&quot; commonly adopted. These are to split the unit into 2 equal size units, as per Solar Aux, Reduce the number of models to 15, though continue to pay the full cost for the unit.</description>
+            </rule>
+          </rules>
+          <selectionEntries>
+            <selectionEntry id="02a7-112e-fedb-360c" name="Split" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b1fc-90be-6c04-14b8" type="max"/>
+              </constraints>
+            </selectionEntry>
+            <selectionEntry id="7d0e-ca92-be0e-51d3" name="Reduce models to 15 at same cost" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c160-f426-70c8-fd83" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -9599,6 +9914,19 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
       </costs>
     </selectionEntry>
     <selectionEntry id="5163-ab15-9959-6efd" name="Aurox Armoured Transport" hidden="false" collective="false" import="true" type="model">
+      <modifiers>
+        <modifier type="add" field="category" value="9335-93c1-6af7-feb0">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7e48-c376-8ffe-8ae7" type="instanceOf"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7b39-af6b-52e1-b4d7" type="instanceOf"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="089f-7e79-bde1-90dd" type="instanceOf"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ac5a-7586-55ab-0dc3" type="max"/>
       </constraints>

--- a/(HH) Mechanicum - Taghmata Army List.cat
+++ b/(HH) Mechanicum - Taghmata Army List.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="cf03-f607-41dc-7545" name="Mechanicum: Taghmata Army List" revision="107" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="130" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="cf03-f607-41dc-7545" name="Mechanicum: Taghmata Army List" revision="108" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="132" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="cf03-f607-pubN65537" name="Horus Heresy: Taghmata Army List"/>
     <publication id="cf03-f607-pubN65563" name="AoDRB"/>
@@ -145,7 +145,20 @@ A wound cannot be re-allocated onto a gun model from a successful Look Out, Sir 
         <infoLink id="c85f-7d12-3ba1-3f16" name="Trust Move" hidden="false" targetId="97c4-1c1c-3727-757f" type="rule"/>
       </infoLinks>
     </categoryEntry>
-    <categoryEntry id="25d0-388c-dd16-af9a" name="Flying Monstrous Creature" hidden="false"/>
+    <categoryEntry id="25d0-388c-dd16-af9a" name="Flying Monstrous Creature" hidden="false">
+      <infoLinks>
+        <infoLink id="f690-4338-67d6-1546" name="Fear" hidden="false" targetId="52ff-4074-570b-4ea1" type="rule"/>
+        <infoLink id="cda4-b713-7790-3e29" name="Fearless" hidden="false" targetId="dc70-e199-5525-e78c" type="rule"/>
+        <infoLink id="8df1-1326-9d28-aaec" name="Feel No Pain" hidden="false" targetId="9bdd-5ec7-8dd6-63c0" type="rule"/>
+        <infoLink id="e118-0e47-9184-d155" name="Hammer of Wrath" hidden="false" targetId="6f66-b417-6004-0916" type="rule"/>
+        <infoLink id="cbb9-3d52-7d1d-822f" name="Jink" hidden="false" targetId="d3e5-b43d-a89c-3bd8" type="rule"/>
+        <infoLink id="5d43-b84b-5e65-934b" name="Move Through Cover" hidden="false" targetId="6d06-5ea0-9a17-ca97" type="rule"/>
+        <infoLink id="6daf-a351-22f2-bf30" name="Relentless" hidden="false" targetId="3c7d-a1fa-c68b-caad" type="rule"/>
+        <infoLink id="f174-7dcd-d9fb-da78" name="Smash" hidden="false" targetId="4284-18a1-9844-a0bd" type="rule"/>
+        <infoLink id="5799-4d21-f00f-5dea" name="Strikedown" hidden="false" targetId="dd83-7fb9-6f58-0c96" type="rule"/>
+        <infoLink id="c3f8-9224-a6a2-1cc9" name="Vector Strike" hidden="false" targetId="5341-7110-d8d4-171a" type="rule"/>
+      </infoLinks>
+    </categoryEntry>
     <categoryEntry id="7fdd-2a97-d0e9-6524" name="Cybernetica Cortex" hidden="false">
       <constraints>
         <constraint field="selections" scope="parent" value="-1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5bde-e31b-6025-43ba" type="max"/>
@@ -578,6 +591,9 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
       </categoryLinks>
     </forceEntry>
     <forceEntry id="089f-7e79-bde1-90dd" name=" Zone Mortalis - Attacker" hidden="false">
+      <infoLinks>
+        <infoLink id="5276-05ea-96b5-79d8" name="ZM (Unusable)" hidden="false" targetId="b1da-bb0d-6990-b5c7" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="089f-7e79-bde1-90dd-456c6974657323232344415441232323" name="Elites" hidden="false" targetId="456c6974657323232344415441232323" primary="false">
           <constraints>
@@ -613,9 +629,27 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
           </constraints>
         </categoryLink>
         <categoryLink id="6279-d5af-6cde-41e9" name="Mournival Rules" hidden="false" targetId="dbe0-716f-797c-66f7" primary="false"/>
+        <categoryLink id="c27f-1272-d0cb-350d" name="Flying Monstrous Creature" hidden="false" targetId="25d0-388c-dd16-af9a" primary="false">
+          <constraints>
+            <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="af73-b299-9617-aaa0" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="2add-d5d6-949c-f516" name="Dedicated Transport" hidden="false" targetId="c407-80ff-568e-3394" primary="false">
+          <constraints>
+            <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="29e5-77c6-2bbf-06c1" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="a38a-c045-a79a-27c2" name="ZM (Unusable)" hidden="false" targetId="9335-93c1-6af7-feb0" primary="false">
+          <constraints>
+            <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="220d-b992-09e4-8204" type="max"/>
+          </constraints>
+        </categoryLink>
       </categoryLinks>
     </forceEntry>
     <forceEntry id="7b39-af6b-52e1-b4d7" name=" Zone Mortalis - Defender" hidden="false">
+      <infoLinks>
+        <infoLink id="2408-3def-5445-35f4" name="ZM (Unusable)" hidden="false" targetId="b1da-bb0d-6990-b5c7" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="7b39-af6b-52e1-b4d7-456c6974657323232344415441232323" name="Elites" hidden="false" targetId="456c6974657323232344415441232323" primary="false">
           <constraints>
@@ -647,9 +681,27 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
           </constraints>
         </categoryLink>
         <categoryLink id="5f45-c44a-9087-4af2" name="Mournival Rules" hidden="false" targetId="dbe0-716f-797c-66f7" primary="false"/>
+        <categoryLink id="52bc-0420-8b3d-ee40" name="Dedicated Transport" hidden="false" targetId="c407-80ff-568e-3394" primary="false">
+          <constraints>
+            <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="771d-da3f-c56c-e6e6" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="8911-2625-68c3-3482" name="Flying Monstrous Creature" hidden="false" targetId="25d0-388c-dd16-af9a" primary="false">
+          <constraints>
+            <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ecd0-2089-c55f-dc91" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="d17f-6957-135c-3279" name="ZM (Unusable)" hidden="false" targetId="9335-93c1-6af7-feb0" primary="false">
+          <constraints>
+            <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="464c-0b30-d5a5-8a54" type="max"/>
+          </constraints>
+        </categoryLink>
       </categoryLinks>
     </forceEntry>
     <forceEntry id="7e48-c376-8ffe-8ae7" name=" Zone Mortalis - Combatant" hidden="false">
+      <infoLinks>
+        <infoLink id="a61c-0a22-4adf-7316" name="ZM (Unusable)" hidden="false" targetId="b1da-bb0d-6990-b5c7" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="7e48-c376-8ffe-8ae7-456c6974657323232344415441232323" name="Elites" hidden="false" targetId="456c6974657323232344415441232323" primary="false">
           <constraints>
@@ -685,6 +737,21 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
           </constraints>
         </categoryLink>
         <categoryLink id="4eee-7c91-c9b8-c7e7" name="Mournival Rules" hidden="false" targetId="dbe0-716f-797c-66f7" primary="false"/>
+        <categoryLink id="3e75-4d5c-0389-df7a" name="Dedicated Transport" hidden="false" targetId="c407-80ff-568e-3394" primary="false">
+          <constraints>
+            <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d4ba-88a1-e335-e4e6" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="7852-2eec-e298-8dd8" name="Flying Monstrous Creature" hidden="false" targetId="25d0-388c-dd16-af9a" primary="false">
+          <constraints>
+            <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d6e0-55e7-c8c6-9937" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="5d88-a5ce-b0aa-d122" name="ZM (Unusable)" hidden="false" targetId="9335-93c1-6af7-feb0" primary="false">
+          <constraints>
+            <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a3d8-e5cc-f45c-93f5" type="max"/>
+          </constraints>
+        </categoryLink>
       </categoryLinks>
     </forceEntry>
     <forceEntry id="d1ef-61e1-3d67-5a19" name="Optional - Onslaught" hidden="false">
@@ -1775,6 +1842,19 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
       </costs>
     </selectionEntry>
     <selectionEntry id="d7c6-3866-37eb-af76" name="Thanatar Class Siege-automata Maniple" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="add" field="category" value="9335-93c1-6af7-feb0">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7e48-c376-8ffe-8ae7" type="instanceOf"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7b39-af6b-52e1-b4d7" type="instanceOf"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="089f-7e79-bde1-90dd" type="instanceOf"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <infoLinks>
         <infoLink id="67d4-e1ef-588a-47e9" name="Cybernetica Cortex" hidden="false" targetId="f6c9-cdb7-c695-5b6b" type="rule"/>
         <infoLink id="cba2-88ce-8788-ec9b" hidden="false" targetId="d5cf-bd98-2854-13cf" type="rule"/>
@@ -1818,6 +1898,9 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
               </characteristics>
             </profile>
           </profiles>
+          <categoryLinks>
+            <categoryLink id="d141-6521-34a1-7f4c" name="Monstrous Creature" hidden="false" targetId="8ec4-17b5-7fea-c682" primary="false"/>
+          </categoryLinks>
           <selectionEntries>
             <selectionEntry id="98c4-5b80-0e20-b196" name="Automantic Shielding" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
@@ -2599,6 +2682,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <categoryLink id="6e40-5da5-bb74-c2b3" name="New CategoryLink" hidden="false" targetId="8ec4-17b5-7fea-c682" primary="false"/>
         <categoryLink id="d115-15ed-f2d3-34bc" name="New CategoryLink" hidden="false" targetId="78ea-eea8-0ac5-b7de" primary="false"/>
         <categoryLink id="e1b4-f1a3-f823-70e0" name="Cybernetica Cortex" hidden="false" targetId="7fdd-2a97-d0e9-6524" primary="false"/>
+        <categoryLink id="1908-5ab0-4a08-c29a" name="Jump Infantry" hidden="false" targetId="47cf-71bb-d59d-f9de" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="c4ff-8b86-a4c4-ad96" name="Automantic Shielding" hidden="false" collective="false" import="true" type="upgrade">
@@ -3256,6 +3340,19 @@ Reduces transport capacity to 8.</description>
       </infoLinks>
       <selectionEntries>
         <selectionEntry id="92f0-d2fd-187f-9640" name="Scyllax Guardian-Automata" hidden="false" collective="false" import="true" type="model">
+          <modifiers>
+            <modifier type="set" field="maxSelections" value="15.0">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7e48-c376-8ffe-8ae7" type="instanceOf"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7b39-af6b-52e1-b4d7" type="instanceOf"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="089f-7e79-bde1-90dd" type="instanceOf"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
             <constraint field="selections" scope="parent" value="16.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
@@ -3972,6 +4069,9 @@ Reduces transport capacity to 8.</description>
         <infoLink id="5bb9-0cc1-443d-66d1" name="New InfoLink" hidden="false" targetId="6e59-4afd-8668-f066" type="rule"/>
         <infoLink id="a1e7-c5e5-c102-f1d7" name="New InfoLink" hidden="false" targetId="c584-ada8-935d-9ed7" type="profile"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="b244-d815-1350-5e74" name="Dedicated Transport" hidden="false" targetId="c407-80ff-568e-3394" primary="false"/>
+      </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="6aa5-2f0e-f94f-d297" name="Psyarkana" hidden="false" collective="false" import="true">
           <constraints>
@@ -4071,6 +4171,19 @@ Reduces transport capacity to 8.</description>
       </costs>
     </selectionEntry>
     <selectionEntry id="c472-6345-24b3-f952" name="Secutarii" hidden="false" collective="false" import="true" type="model">
+      <modifiers>
+        <modifier type="set" field="159d-4f16-5905-7fb4" value="14.0">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7e48-c376-8ffe-8ae7" type="instanceOf"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7b39-af6b-52e1-b4d7" type="instanceOf"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="089f-7e79-bde1-90dd" type="instanceOf"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <constraints>
         <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c608-7245-f009-8fef" type="min"/>
         <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="159d-4f16-5905-7fb4" type="max"/>
@@ -4264,7 +4377,7 @@ Reduces transport capacity to 8.</description>
         </entryLink>
         <entryLink id="9933-fe28-89b7-4b5b" hidden="false" collective="false" import="true" targetId="ae94-81c7-edf1-b10d" type="selectionEntry"/>
         <entryLink id="d5c3-1c21-5714-e009" hidden="false" collective="false" import="true" targetId="7b6e-1246-67b8-f13b" type="selectionEntry"/>
-        <entryLink id="0c3c-5921-cc0e-1ab3" hidden="false" collective="false" import="true" targetId="04fc-9823-28ea-591d" type="selectionEntryGroup"/>
+        <entryLink id="0c3c-5921-cc0e-1ab3" name="Dedicated Transport" hidden="false" collective="false" import="true" targetId="04fc-9823-28ea-591d" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
@@ -4546,7 +4659,7 @@ Reduces transport capacity to 8.</description>
             <cost name="pts" typeId="points" value="12.0"/>
           </costs>
         </entryLink>
-        <entryLink id="bc60-ee64-0ab8-641b" hidden="false" collective="false" import="true" targetId="04fc-9823-28ea-591d" type="selectionEntryGroup"/>
+        <entryLink id="bc60-ee64-0ab8-641b" name="Dedicated Transport" hidden="false" collective="false" import="true" targetId="04fc-9823-28ea-591d" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
@@ -4873,6 +4986,9 @@ Buildings and Fortifications D</description>
             <infoLink id="108c-2c8f-0691-20c0" name="Reactor Blast" hidden="false" targetId="d5cf-bd98-2854-13cf" type="rule"/>
             <infoLink id="4f87-aafa-7784-8aef" name="Atomantic Shielding" hidden="false" targetId="13e0-4939-5232-8d85" type="profile"/>
           </infoLinks>
+          <categoryLinks>
+            <categoryLink id="4fed-4a02-b031-79a9" name="Flying Monstrous Creature" hidden="false" targetId="25d0-388c-dd16-af9a" primary="false"/>
+          </categoryLinks>
           <selectionEntries>
             <selectionEntry id="6afd-13e0-1ef7-991d" name="Vultarax arc blaster " hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
@@ -5067,6 +5183,9 @@ Buildings and Fortifications D</description>
         <infoLink id="11e3-434a-8e7d-29cb" name="New InfoLink" hidden="false" targetId="4771-b711-0e74-3aee" type="rule"/>
         <infoLink id="ef03-4124-3221-1bb3" name="Binaric Stratagems" hidden="false" targetId="6595-834d-8a6d-5fc6" type="rule"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="bee3-9da6-5d0a-1a1b" name="Infantry" hidden="false" targetId="f74d-4679-75a6-1252" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="6461-6b48-a0ef-5384" name="May be equipped with any of the following" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
@@ -5817,6 +5936,9 @@ Buildings and Fortifications D</description>
             <infoLink id="8eb3-009d-01f0-0de0" name="Stubborn" hidden="false" targetId="7be5-30af-1a02-0a89" type="rule"/>
             <infoLink id="6f9c-a5e6-0654-d020" name="Bulky" hidden="false" targetId="38d5-b6eb-bda8-2497" type="rule"/>
           </infoLinks>
+          <categoryLinks>
+            <categoryLink id="eda5-fe64-2a52-4157" name="Jetpack Infantry" hidden="false" targetId="afa3-c43a-c8c1-d8b6" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="pts" typeId="points" value="40.0"/>
           </costs>
@@ -6013,6 +6135,19 @@ Buildings and Fortifications D</description>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="9e7e-232f-e016-6ce8" name="Tech-thrall" hidden="false" collective="false" import="true" type="model">
+          <modifiers>
+            <modifier type="set" field="0cc6-3756-885d-1bc4" value="15.0">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7e48-c376-8ffe-8ae7" type="instanceOf"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7b39-af6b-52e1-b4d7" type="instanceOf"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="089f-7e79-bde1-90dd" type="instanceOf"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3f6c-82d1-e38d-14ba" type="min"/>
             <constraint field="selections" scope="parent" value="20.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0cc6-3756-885d-1bc4" type="max"/>
@@ -6625,6 +6760,9 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2bfd-a995-d2e5-382c" type="min"/>
             <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f4c4-9c60-8443-d81b" type="max"/>
           </constraints>
+          <categoryLinks>
+            <categoryLink id="9223-db9f-5f97-f41f" name="Jump Infantry" hidden="false" targetId="47cf-71bb-d59d-f9de" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="pts" typeId="points" value="50.0"/>
           </costs>
@@ -8301,6 +8439,19 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
       </costs>
     </selectionEntry>
     <selectionEntry id="93b9-6dc9-3d02-db32" name="Thanatar-Calix Class Siege-Automata" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="add" field="category" value="9335-93c1-6af7-feb0">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7e48-c376-8ffe-8ae7" type="instanceOf"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7b39-af6b-52e1-b4d7" type="instanceOf"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="089f-7e79-bde1-90dd" type="instanceOf"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile id="ca31-e06c-7410-8919" name="Thanatar-Calix Class Siege-Automata" publicationId="cf03-f607-pubN76270" page="52" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
           <modifiers>
@@ -8336,6 +8487,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
       </infoLinks>
       <categoryLinks>
         <categoryLink id="57e5-70a0-f35a-349f" name="New CategoryLink" hidden="false" targetId="7fdd-2a97-d0e9-6524" primary="false"/>
+        <categoryLink id="9085-3583-d3bf-6181" name="Monstrous Creature" hidden="false" targetId="8ec4-17b5-7fea-c682" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="42b7-fe6e-988c-3f8a" name="Automantic Shielding" hidden="false" collective="false" import="true" type="upgrade">
@@ -8472,6 +8624,19 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
       </costs>
     </selectionEntry>
     <selectionEntry id="c888-532b-f933-ce1d" name="Thanatar-Cynis Class Siege-Automata Maniple" publicationId="cf03-f607-pubN76780" page="54" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="add" field="category" value="9335-93c1-6af7-feb0">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7e48-c376-8ffe-8ae7" type="instanceOf"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7b39-af6b-52e1-b4d7" type="instanceOf"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="089f-7e79-bde1-90dd" type="instanceOf"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <infoLinks>
         <infoLink id="d194-e400-90d7-2889" hidden="false" targetId="f6c9-cdb7-c695-5b6b" type="rule"/>
         <infoLink id="46a9-6200-ac2b-d99c" hidden="false" targetId="797e55b1-251e-6606-9cb3-64661b0b18a3" type="rule"/>
@@ -8514,6 +8679,9 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
               </characteristics>
             </profile>
           </profiles>
+          <categoryLinks>
+            <categoryLink id="2832-0399-099d-d731" name="Monstrous Creature" hidden="false" targetId="8ec4-17b5-7fea-c682" primary="false"/>
+          </categoryLinks>
           <selectionEntries>
             <selectionEntry id="6a4b-45b6-033c-0dd7" name="Automantic Shielding" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
@@ -8688,6 +8856,8 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
       <categoryLinks>
         <categoryLink id="02c8-6cbe-00e5-fce6" hidden="false" targetId="466173742041747461636b23232344415441232323" primary="true"/>
         <categoryLink id="1449-68ac-de22-3305" name="New CategoryLink" hidden="false" targetId="7fdd-2a97-d0e9-6524" primary="false"/>
+        <categoryLink id="45ce-d684-2b54-5f39" name="Monstrous Creature" hidden="false" targetId="8ec4-17b5-7fea-c682" primary="false"/>
+        <categoryLink id="25d5-1c35-5a76-d5a2" name="Jump Infantry" hidden="false" targetId="47cf-71bb-d59d-f9de" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="59eb-2bde-5f62-2350" name="Automantic Shielding" hidden="false" collective="false" import="true" type="upgrade">
@@ -11951,6 +12121,9 @@ In addition to its weapon attacks, units assaulting a model or unit with a gravi
             <infoLink id="9c8f-3606-07d8-f1b7" name="Stubborn" hidden="false" targetId="7be5-30af-1a02-0a89" type="rule"/>
             <infoLink id="659b-8da3-6778-1292" name="Bulky" hidden="false" targetId="38d5-b6eb-bda8-2497" type="rule"/>
           </infoLinks>
+          <categoryLinks>
+            <categoryLink id="ab35-99cc-77cd-3aab" name="Jetpack Infantry" hidden="false" targetId="afa3-c43a-c8c1-d8b6" primary="false"/>
+          </categoryLinks>
           <costs>
             <cost name="pts" typeId="points" value="40.0"/>
           </costs>
@@ -12143,6 +12316,19 @@ In addition to its weapon attacks, units assaulting a model or unit with a gravi
       </costs>
     </selectionEntry>
     <selectionEntry id="6ad8-fbf2-07a8-237c" name="Mechanicum Knight Moirax Talon" publicationId="ece2-a265-6237-7efa" page="" hidden="false" collective="false" import="true" type="model">
+      <modifiers>
+        <modifier type="add" field="category" value="9335-93c1-6af7-feb0">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7e48-c376-8ffe-8ae7" type="instanceOf"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7b39-af6b-52e1-b4d7" type="instanceOf"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="089f-7e79-bde1-90dd" type="instanceOf"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <constraints>
         <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="deb7-d6bb-7e7d-6076" type="max"/>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c2ff-3d6f-b15f-722a" type="min"/>
@@ -12327,6 +12513,19 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
       </costs>
     </selectionEntry>
     <selectionEntry id="678d-0533-f5f7-2e43" name="Questoris Knight Armiger Talon" hidden="false" collective="false" import="true" type="upgrade">
+      <modifiers>
+        <modifier type="add" field="category" value="9335-93c1-6af7-feb0">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7e48-c376-8ffe-8ae7" type="instanceOf"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7b39-af6b-52e1-b4d7" type="instanceOf"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="089f-7e79-bde1-90dd" type="instanceOf"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <constraints>
         <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f378-f460-6e34-0907" type="max"/>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b0a6-77ed-aa3a-1717" type="min"/>
@@ -17894,7 +18093,7 @@ A Unit may not use Counter Attack special rule if it used Reaction Fire.</descri
     </selectionEntryGroup>
     <selectionEntryGroup id="04fc-9823-28ea-591d" name="Dedicated Transport" hidden="false" collective="false" import="true">
       <entryLinks>
-        <entryLink id="5463-6ffb-af3e-757a" name="" hidden="false" collective="false" import="true" targetId="bb6538b0-0f23-8a43-9752-dd356ba76e46" type="selectionEntry"/>
+        <entryLink id="5463-6ffb-af3e-757a" name="Triaros Armoured Conveyor" hidden="false" collective="false" import="true" targetId="bb6538b0-0f23-8a43-9752-dd356ba76e46" type="selectionEntry"/>
       </entryLinks>
     </selectionEntryGroup>
     <selectionEntryGroup id="4e41-e567-a14d-8e3a" name="Triaros/Karacnos optionals:" hidden="false" collective="false" import="true">

--- a/(HH) Solar Auxilia - Crusade Army List.cat
+++ b/(HH) Solar Auxilia - Crusade Army List.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="7f243fc5-c5fd-8b2c-7b07-907bf684bb72" name="Solar Auxilia" revision="77" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="130" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="7f243fc5-c5fd-8b2c-7b07-907bf684bb72" name="Solar Auxilia" revision="78" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="132" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="7f243fc5--pubN65537" name="Crusade Imperialis"/>
     <publication id="7f243fc5--pubN65563" name="AoDRB"/>
@@ -502,6 +502,9 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
       </categoryLinks>
     </forceEntry>
     <forceEntry id="089f-7e79-bde1-90dd" name=" Zone Mortalis - Attacker" hidden="false">
+      <infoLinks>
+        <infoLink id="9667-f7ef-18c6-37d4" name="ZM (Unusable)" hidden="false" targetId="b1da-bb0d-6990-b5c7" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="089f-7e79-bde1-90dd-456c6974657323232344415441232323" name="Elites" hidden="false" targetId="456c6974657323232344415441232323" primary="false">
           <constraints>
@@ -537,9 +540,32 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
           </constraints>
         </categoryLink>
         <categoryLink id="7c39-1e5e-4eb3-4baa" name="Mournival Rules" hidden="false" targetId="dbe0-716f-797c-66f7" primary="false"/>
+        <categoryLink id="dfa7-34f2-287a-6dd3" name="Dedicated Transport" hidden="false" targetId="c407-80ff-568e-3394" primary="false">
+          <constraints>
+            <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2738-264a-7dad-c1df" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="d87c-1389-a1aa-aa3e" name="Flyer" hidden="false" targetId="df44-81ea-e2ee-9849" primary="false">
+          <constraints>
+            <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="eccd-425c-8166-5595" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="bf56-db96-a2ef-c2f9" name="Flying Monstrous Creature" hidden="false" targetId="25d0-388c-dd16-af9a" primary="false">
+          <constraints>
+            <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fce7-36b3-2f6b-7272" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="3dd2-86a7-e8d2-6ed3" name="ZM (Unusable)" hidden="false" targetId="9335-93c1-6af7-feb0" primary="false">
+          <constraints>
+            <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ad2d-40df-6798-2806" type="max"/>
+          </constraints>
+        </categoryLink>
       </categoryLinks>
     </forceEntry>
     <forceEntry id="7b39-af6b-52e1-b4d7" name=" Zone Mortalis - Defender" hidden="false">
+      <infoLinks>
+        <infoLink id="5726-083b-ffbd-2643" name="ZM (Unusable)" hidden="false" targetId="b1da-bb0d-6990-b5c7" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="7b39-af6b-52e1-b4d7-456c6974657323232344415441232323" name="Elites" hidden="false" targetId="456c6974657323232344415441232323" primary="false">
           <constraints>
@@ -571,9 +597,32 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
           </constraints>
         </categoryLink>
         <categoryLink id="d3d6-2093-a20a-04bb" name="Mournival Rules" hidden="false" targetId="dbe0-716f-797c-66f7" primary="false"/>
+        <categoryLink id="a05c-635d-6088-18b2" name="Dedicated Transport" hidden="false" targetId="c407-80ff-568e-3394" primary="false">
+          <constraints>
+            <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5947-60f1-a42d-3ca7" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="eb79-a596-4aad-8049" name="Flyer" hidden="false" targetId="df44-81ea-e2ee-9849" primary="false">
+          <constraints>
+            <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9eb9-e0e6-63b4-8c05" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="4350-c7de-940a-b631" name="Flying Monstrous Creature" hidden="false" targetId="25d0-388c-dd16-af9a" primary="false">
+          <constraints>
+            <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="cc61-dfdc-8122-4e3c" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="6bfc-4b87-8afe-b237" name="ZM (Unusable)" hidden="false" targetId="9335-93c1-6af7-feb0" primary="false">
+          <constraints>
+            <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0440-b633-e6b8-4eb2" type="max"/>
+          </constraints>
+        </categoryLink>
       </categoryLinks>
     </forceEntry>
     <forceEntry id="7e48-c376-8ffe-8ae7" name=" Zone Mortalis - Combatant" hidden="false">
+      <infoLinks>
+        <infoLink id="2b92-0983-75f9-cdd2" name="ZM (Unusable)" hidden="false" targetId="b1da-bb0d-6990-b5c7" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="7e48-c376-8ffe-8ae7-456c6974657323232344415441232323" name="Elites" hidden="false" targetId="456c6974657323232344415441232323" primary="false">
           <constraints>
@@ -609,6 +658,26 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
           </constraints>
         </categoryLink>
         <categoryLink id="893e-0817-adf1-189f" name="Mournival Rules" hidden="false" targetId="dbe0-716f-797c-66f7" primary="false"/>
+        <categoryLink id="f822-601e-87fe-28cb" name="Dedicated Transport" hidden="false" targetId="c407-80ff-568e-3394" primary="false">
+          <constraints>
+            <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fa5f-d3b6-ddd7-f973" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="d65d-deff-f811-d91b" name="Flyer" hidden="false" targetId="df44-81ea-e2ee-9849" primary="false">
+          <constraints>
+            <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="074e-667c-bdd8-a71d" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="73bb-7be6-2e46-89fd" name="Flying Monstrous Creature" hidden="false" targetId="25d0-388c-dd16-af9a" primary="false">
+          <constraints>
+            <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="930b-0df4-1bdf-8366" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="f222-c4ea-4613-2016" name="ZM (Unusable)" hidden="false" targetId="9335-93c1-6af7-feb0" primary="false">
+          <constraints>
+            <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2699-311c-2cd7-274d" type="max"/>
+          </constraints>
+        </categoryLink>
       </categoryLinks>
     </forceEntry>
     <forceEntry id="d1ef-61e1-3d67-5a19" name="Optional - Onslaught" hidden="false">
@@ -1677,6 +1746,9 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
       <rules>
         <rule id="f398bd6b-2e18-1ec7-4551-214479f13698" name="Deep Strike" hidden="false"/>
       </rules>
+      <categoryLinks>
+        <categoryLink id="a2e0-176c-0fc8-7ef0" name="Flyer" hidden="false" targetId="df44-81ea-e2ee-9849" primary="false"/>
+      </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="5e63e341-fb9f-a6e9-49d5-ad07cab4e38d" name="May take one of the following:" hidden="false" collective="false" import="true">
           <constraints>
@@ -2549,10 +2621,13 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0e0e-34b0-7f23-c3c5" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="2572-9259-0efd-b251" hidden="false" collective="false" import="true" targetId="1c41cdb2-f7c8-ea03-d50d-4f68772731f2" type="selectionEntry">
+            <entryLink id="2572-9259-0efd-b251" name="Dracosan Armoured Transport" hidden="false" collective="false" import="true" targetId="1c41cdb2-f7c8-ea03-d50d-4f68772731f2" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="maxSelections" value="3.0"/>
               </modifiers>
+              <categoryLinks>
+                <categoryLink id="6104-9c30-f608-58e6" name="Dedicated Transport" hidden="false" targetId="c407-80ff-568e-3394" primary="false"/>
+              </categoryLinks>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
@@ -3591,6 +3666,9 @@ EDITORS NOTE... I think this rule is now redundant, as I think the rules for how
         <infoLink id="b427-c3af-ced4-1310" name="New InfoLink" hidden="false" targetId="2e96-21ae-353e-8742" type="rule"/>
         <infoLink id="55b9-04a4-c212-bb3b" name="Agile (Flyers Only)" hidden="false" targetId="24a2-9868-b6e4-4789" type="rule"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="0556-8ab4-e9f4-ae62" name="Flyer" hidden="false" targetId="df44-81ea-e2ee-9849" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="d1e6-1c61-fb76-f094" name="Twin-Linked Lascannon" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
@@ -3601,6 +3679,9 @@ EDITORS NOTE... I think this rule is now redundant, as I think the rules for how
             <infoLink id="6dca-02d1-52c2-c3c5" name="Twin-Linked Lascannon" hidden="false" targetId="2cd1-0fb3-7484-e486" type="profile"/>
             <infoLink id="d1a3-3c95-1264-c953" name="Twin-linked" hidden="false" targetId="10a8-8d89-0bec-3e21" type="rule"/>
           </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -4536,9 +4617,21 @@ EDITORS NOTE... I think this rule is now redundant, as I think the rules for how
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6dc5-b403-0c76-52cc" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="8e7f-b7e3-b631-2e11" name="Dracosan Armoured Transport" hidden="false" collective="false" import="true" targetId="1c41cdb2-f7c8-ea03-d50d-4f68772731f2" type="selectionEntry"/>
-            <entryLink id="15cc-e7a9-f2d2-1775" name="Auxilia Arvus Lighter Orbital Shuttle" hidden="false" collective="false" import="true" targetId="98e057b6-29c7-b240-8a57-a936b45c1299" type="selectionEntry"/>
-            <entryLink id="5c96-4202-04b9-66e1" name="Aurox Armoured Transport" hidden="false" collective="false" import="true" targetId="5163-ab15-9959-6efd" type="selectionEntry"/>
+            <entryLink id="8e7f-b7e3-b631-2e11" name="Dracosan Armoured Transport" hidden="false" collective="false" import="true" targetId="1c41cdb2-f7c8-ea03-d50d-4f68772731f2" type="selectionEntry">
+              <categoryLinks>
+                <categoryLink id="b62e-cb28-9d5a-ebcb" name="Dedicated Transport" hidden="false" targetId="c407-80ff-568e-3394" primary="false"/>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="15cc-e7a9-f2d2-1775" name="Auxilia Arvus Lighter Orbital Shuttle" hidden="false" collective="false" import="true" targetId="98e057b6-29c7-b240-8a57-a936b45c1299" type="selectionEntry">
+              <categoryLinks>
+                <categoryLink id="f113-3362-e3e8-f79d" name="Dedicated Transport" hidden="false" targetId="c407-80ff-568e-3394" primary="false"/>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="5c96-4202-04b9-66e1" name="Saturnyne Pattern Aurox Armoured Transport" hidden="false" collective="false" import="true" targetId="5163-ab15-9959-6efd" type="selectionEntry">
+              <categoryLinks>
+                <categoryLink id="bfb3-244a-f7f7-327a" name="Dedicated Transport" hidden="false" targetId="c407-80ff-568e-3394" primary="false"/>
+              </categoryLinks>
+            </entryLink>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
@@ -4627,6 +4720,9 @@ Precision Shots</description>
           </modifiers>
         </infoLink>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="48c1-b4ae-6856-9baf" name="Flyer" hidden="false" targetId="df44-81ea-e2ee-9849" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="cba2-c90f-a958-898e" name="Twin-Linked Autocannons" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
@@ -5206,44 +5302,13 @@ Precision Shots</description>
       <constraints>
         <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0300-050b-636f-262b" type="max"/>
       </constraints>
-      <profiles>
-        <profile id="eea9-3e7c-ede9-b465" name="Veletarii" publicationId="7f243fc5--pubN74753" page="266" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
-          <characteristics>
-            <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry</characteristic>
-            <characteristic name="WS" typeId="575323232344415441232323">4</characteristic>
-            <characteristic name="BS" typeId="425323232344415441232323">4</characteristic>
-            <characteristic name="S" typeId="5323232344415441232323">3</characteristic>
-            <characteristic name="T" typeId="5423232344415441232323">3</characteristic>
-            <characteristic name="W" typeId="5723232344415441232323">1</characteristic>
-            <characteristic name="I" typeId="4923232344415441232323">3</characteristic>
-            <characteristic name="A" typeId="4123232344415441232323">1</characteristic>
-            <characteristic name="LD" typeId="4c4423232344415441232323">8</characteristic>
-            <characteristic name="Save" typeId="5361766523232344415441232323">4+</characteristic>
-          </characteristics>
-        </profile>
-        <profile id="3315-3f0e-7d2d-851e" name="Prime" publicationId="7f243fc5--pubN74753" page="266" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
-          <characteristics>
-            <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry (Character)</characteristic>
-            <characteristic name="WS" typeId="575323232344415441232323">4</characteristic>
-            <characteristic name="BS" typeId="425323232344415441232323">4</characteristic>
-            <characteristic name="S" typeId="5323232344415441232323">3</characteristic>
-            <characteristic name="T" typeId="5423232344415441232323">3</characteristic>
-            <characteristic name="W" typeId="5723232344415441232323">1</characteristic>
-            <characteristic name="I" typeId="4923232344415441232323">3</characteristic>
-            <characteristic name="A" typeId="4123232344415441232323">2</characteristic>
-            <characteristic name="LD" typeId="4c4423232344415441232323">9</characteristic>
-            <characteristic name="Save" typeId="5361766523232344415441232323">4+</characteristic>
-          </characteristics>
-        </profile>
-      </profiles>
       <rules>
         <rule id="4e40-a4c5-4933-e0d9" name="Preferred Enemy (Infantry)" hidden="false"/>
       </rules>
       <infoLinks>
         <infoLink id="bd5d-4e2d-568b-d3db" hidden="false" targetId="470a38b3-ad69-52de-2996-36fa27f50e04" type="rule"/>
-        <infoLink id="2d7f-d76c-9d23-2345" hidden="false" targetId="aa451588-557c-7f81-2b3f-d17583985f38" type="rule"/>
+        <infoLink id="2d7f-d76c-9d23-2345" name="Close Formation Fighting" hidden="false" targetId="aa451588-557c-7f81-2b3f-d17583985f38" type="rule"/>
         <infoLink id="1f5c-02e3-491d-d60b" name="" hidden="false" targetId="dff0089a-4273-26a0-d96f-b5a36d57a18f" type="profile"/>
-        <infoLink id="cefc-537b-d247-f6c9" name="Volkite Charger" hidden="false" targetId="44d2260d-9431-a6d0-6ba3-de04b559ba5b" type="profile"/>
         <infoLink id="53d8-6694-98c1-ac55" name="Deflagrate" hidden="false" targetId="b46a-a3ec-91a5-5001" type="rule"/>
         <infoLink id="79b8-d67d-5a1c-a4dd" name="New InfoLink" hidden="false" targetId="6d06-5ea0-9a17-ca97" type="rule"/>
         <infoLink id="7e48-716a-8c7e-10b5" name="Frag Grenades" hidden="false" targetId="d890-1b84-bbd9-12d3" type="profile"/>
@@ -5259,6 +5324,22 @@ Precision Shots</description>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="bafe-0473-0172-870d" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6090-14d7-2304-50a8" type="max"/>
           </constraints>
+          <profiles>
+            <profile id="dc0c-3d13-16ec-4e63" name="Household Retinue Prime" publicationId="7f243fc5--pubN74753" page="266" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+              <characteristics>
+                <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry (Character)</characteristic>
+                <characteristic name="WS" typeId="575323232344415441232323">4</characteristic>
+                <characteristic name="BS" typeId="425323232344415441232323">4</characteristic>
+                <characteristic name="S" typeId="5323232344415441232323">3</characteristic>
+                <characteristic name="T" typeId="5423232344415441232323">3</characteristic>
+                <characteristic name="W" typeId="5723232344415441232323">1</characteristic>
+                <characteristic name="I" typeId="4923232344415441232323">3</characteristic>
+                <characteristic name="A" typeId="4123232344415441232323">2</characteristic>
+                <characteristic name="LD" typeId="4c4423232344415441232323">9</characteristic>
+                <characteristic name="Save" typeId="5361766523232344415441232323">4+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
           <selectionEntryGroups>
             <selectionEntryGroup id="8499-673c-8a97-fd93" name="May take:" hidden="false" collective="false" import="true">
               <entryLinks>
@@ -5562,6 +5643,28 @@ Precision Shots</description>
             <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
+        <selectionEntry id="3b70-146d-6bd6-d8a6" name="Veletarii" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f9a6-02e3-b914-7be9" type="min"/>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="024a-241b-9244-b5cf" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="2289-bbed-6ec6-8b73" name="Household Retinue Veletarii" publicationId="7f243fc5--pubN74753" page="266" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
+              <characteristics>
+                <characteristic name="Unit Type" typeId="556e6974205479706523232344415441232323">Infantry</characteristic>
+                <characteristic name="WS" typeId="575323232344415441232323">4</characteristic>
+                <characteristic name="BS" typeId="425323232344415441232323">4</characteristic>
+                <characteristic name="S" typeId="5323232344415441232323">3</characteristic>
+                <characteristic name="T" typeId="5423232344415441232323">3</characteristic>
+                <characteristic name="W" typeId="5723232344415441232323">1</characteristic>
+                <characteristic name="I" typeId="4923232344415441232323">3</characteristic>
+                <characteristic name="A" typeId="4123232344415441232323">1</characteristic>
+                <characteristic name="LD" typeId="4c4423232344415441232323">8</characteristic>
+                <characteristic name="Save" typeId="5361766523232344415441232323">4+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+        </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="6c8e-03dd-0065-4992" name="Veletarii may exchange their Volkite Chargers for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="9ffb-6178-aa7a-108f">
@@ -5642,12 +5745,23 @@ Precision Shots</description>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f3ab-8029-40f8-fcf5" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="12a3-b7b8-3193-9e26" hidden="false" collective="false" import="true" targetId="1c41cdb2-f7c8-ea03-d50d-4f68772731f2" type="selectionEntry"/>
-            <entryLink id="bfb1-1015-8611-60bd" hidden="false" collective="false" import="true" targetId="98e057b6-29c7-b240-8a57-a936b45c1299" type="selectionEntry"/>
+            <entryLink id="12a3-b7b8-3193-9e26" name="Dracosan Armoured Transport" hidden="false" collective="false" import="true" targetId="1c41cdb2-f7c8-ea03-d50d-4f68772731f2" type="selectionEntry">
+              <categoryLinks>
+                <categoryLink id="ff49-d4b4-4019-8ec0" name="Dedicated Transport" hidden="false" targetId="c407-80ff-568e-3394" primary="false"/>
+              </categoryLinks>
+            </entryLink>
+            <entryLink id="bfb1-1015-8611-60bd" name="Auxilia Arvus Lighter Orbital Shuttle" hidden="false" collective="false" import="true" targetId="98e057b6-29c7-b240-8a57-a936b45c1299" type="selectionEntry">
+              <categoryLinks>
+                <categoryLink id="b008-2942-2024-eb17" name="Dedicated Transport" hidden="false" targetId="c407-80ff-568e-3394" primary="false"/>
+              </categoryLinks>
+            </entryLink>
             <entryLink id="1134-bd8b-bf24-07d5" name="Terrax Pattern Termite Assault Drill" hidden="false" collective="false" import="true" targetId="3879-9d90-7c4a-5905" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8e4e-889e-ab86-8244" type="max"/>
               </constraints>
+              <categoryLinks>
+                <categoryLink id="7a01-061c-5ab4-b42a" name="Dedicated Transport" hidden="false" targetId="c407-80ff-568e-3394" primary="false"/>
+              </categoryLinks>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
@@ -7350,7 +7464,7 @@ Precision Shots</description>
         <infoLink id="72ff-ba57-25eb-9e56" hidden="false" targetId="470a38b3-ad69-52de-2996-36fa27f50e04" type="rule"/>
         <infoLink id="cadc-9598-a19e-13e6" hidden="false" targetId="0f466e26-4de9-d53c-5270-4c95dcf6867e" type="rule"/>
         <infoLink id="90aa-c16a-c5ff-b725" name="Void Armour" hidden="false" targetId="86f51528-f2ce-a3eb-15d1-9396cf0548c7" type="profile"/>
-        <infoLink id="7a74-5453-4fc8-58d5" name="New InfoLink" hidden="false" targetId="d890-1b84-bbd9-12d3" type="profile"/>
+        <infoLink id="7a74-5453-4fc8-58d5" name="Frag Grenades" hidden="false" targetId="d890-1b84-bbd9-12d3" type="profile"/>
         <infoLink id="f9e4-da05-424e-ee29" name="Krak Grenade (Shooting)" hidden="false" targetId="d9f7-775b-1047-f335" type="profile"/>
         <infoLink id="d863-3305-9148-7413" name="Krak Grenade (Assault)" hidden="false" targetId="ba14-6731-7c9d-ef15" type="profile"/>
       </infoLinks>
@@ -8329,8 +8443,15 @@ Precision Shots</description>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5915-223c-3206-33fa" type="max"/>
               </constraints>
+              <categoryLinks>
+                <categoryLink id="096b-5448-7048-aa79" name="Dedicated Transport" hidden="false" targetId="c407-80ff-568e-3394" primary="false"/>
+              </categoryLinks>
             </entryLink>
-            <entryLink id="a597-4df8-f2b0-cffa" name="Aurox Armoured Transport" hidden="false" collective="false" import="true" targetId="5163-ab15-9959-6efd" type="selectionEntry"/>
+            <entryLink id="a597-4df8-f2b0-cffa" name="Saturnyne Pattern Aurox Armoured Transport" hidden="false" collective="false" import="true" targetId="5163-ab15-9959-6efd" type="selectionEntry">
+              <categoryLinks>
+                <categoryLink id="0ea9-06a9-2566-a08b" name="Dedicated Transport" hidden="false" targetId="c407-80ff-568e-3394" primary="false"/>
+              </categoryLinks>
+            </entryLink>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>

--- a/(HH) Talons of the Emperor Army List.cat
+++ b/(HH) Talons of the Emperor Army List.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="a30a-7522-3343-553a" name="Talons of the Emperor" revision="103" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="130" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="a30a-7522-3343-553a" name="Talons of the Emperor" revision="104" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="132" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="a30a-7522-pubN65537" name="HH7 / HH8"/>
     <publication id="a30a-7522-pubN69988" name="Forgeworld.co.uk"/>
@@ -24,6 +24,8 @@
     <categoryEntry id="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" name="Lords of War" hidden="false"/>
     <categoryEntry id="466f7274696669636174696f6e23232344415441232323" name="Fortification" hidden="false"/>
     <categoryEntry id="d7ea-8c56-c01f-53b4" name="Compulsory HQ" hidden="false"/>
+    <categoryEntry id="3193-9c47-85a9-d0f9" name="Dedicated Transport" hidden="false"/>
+    <categoryEntry id="1638-5261-fd55-f53b" name="Flyer" hidden="false"/>
   </categoryEntries>
   <forceEntries>
     <forceEntry id="98db-b4ba-fbcd-3239" name=" Crusade" hidden="false">
@@ -147,6 +149,9 @@
       </categoryLinks>
     </forceEntry>
     <forceEntry id="089f-7e79-bde1-90dd" name=" Zone Mortalis - Attacker" hidden="false">
+      <infoLinks>
+        <infoLink id="2296-256f-2b5c-1dc1" name="ZM (Unusable)" hidden="false" targetId="b1da-bb0d-6990-b5c7" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="089f-7e79-bde1-90dd-456c6974657323232344415441232323" name="Elites" hidden="false" targetId="456c6974657323232344415441232323" primary="false">
           <constraints>
@@ -187,9 +192,27 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2f94-f82c-5b66-a2e2" type="min"/>
           </constraints>
         </categoryLink>
+        <categoryLink id="f258-0417-dd4b-ad00" name="ZM (Unusable)" hidden="false" targetId="9335-93c1-6af7-feb0" primary="false">
+          <constraints>
+            <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="cacd-bfef-bbf7-a307" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="fd99-2a41-e69a-d033" name="Dedicated Transport" hidden="false" targetId="3193-9c47-85a9-d0f9" primary="false">
+          <constraints>
+            <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d1e0-cda1-6924-6c32" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="ba80-443e-96d1-4589" name="Flyer" hidden="false" targetId="1638-5261-fd55-f53b" primary="false">
+          <constraints>
+            <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d9e1-07f9-cb24-f4e0" type="max"/>
+          </constraints>
+        </categoryLink>
       </categoryLinks>
     </forceEntry>
     <forceEntry id="7b39-af6b-52e1-b4d7" name=" Zone Mortalis - Defender" hidden="false">
+      <infoLinks>
+        <infoLink id="3151-ba35-d847-ba20" name="ZM (Unusable)" hidden="false" targetId="b1da-bb0d-6990-b5c7" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="7b39-af6b-52e1-b4d7-456c6974657323232344415441232323" name="Elites" hidden="false" targetId="456c6974657323232344415441232323" primary="false">
           <constraints>
@@ -226,9 +249,27 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="df3c-a9c7-b7bb-d415" type="min"/>
           </constraints>
         </categoryLink>
+        <categoryLink id="b57f-d8fb-fef1-19f7" name="ZM (Unusable)" hidden="false" targetId="9335-93c1-6af7-feb0" primary="false">
+          <constraints>
+            <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b9ee-2d09-d007-b268" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="5e97-3375-3fe6-f9c4" name="Dedicated Transport" hidden="false" targetId="3193-9c47-85a9-d0f9" primary="false">
+          <constraints>
+            <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7ae1-5a81-5f0e-053f" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="62ae-0dd2-7763-bf8c" name="Flyer" hidden="false" targetId="1638-5261-fd55-f53b" primary="false">
+          <constraints>
+            <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="293a-5dea-d555-6232" type="max"/>
+          </constraints>
+        </categoryLink>
       </categoryLinks>
     </forceEntry>
     <forceEntry id="7e48-c376-8ffe-8ae7" name=" Zone Mortalis - Combatant" hidden="false">
+      <infoLinks>
+        <infoLink id="754d-05d8-29fc-9d13" name="ZM (Unusable)" hidden="false" targetId="b1da-bb0d-6990-b5c7" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="7e48-c376-8ffe-8ae7-456c6974657323232344415441232323" name="Elites" hidden="false" targetId="456c6974657323232344415441232323" primary="false">
           <constraints>
@@ -267,6 +308,21 @@
         <categoryLink id="b8b8-6554-d311-aaf6" name="Compulsory HQ" hidden="false" targetId="d7ea-8c56-c01f-53b4" primary="false">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4b2d-4504-00d3-3ef3" type="min"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="1f9c-90d6-d56a-d037" name="ZM (Unusable)" hidden="false" targetId="9335-93c1-6af7-feb0" primary="false">
+          <constraints>
+            <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3fae-80aa-08f4-0cd4" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="0f23-273b-c522-d73a" name="Dedicated Transport" hidden="false" targetId="3193-9c47-85a9-d0f9" primary="false">
+          <constraints>
+            <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="23ae-3be2-e14c-f4f6" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="5662-4ddb-1b07-c0b4" name="Flyer" hidden="false" targetId="1638-5261-fd55-f53b" primary="false">
+          <constraints>
+            <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a9ff-a7a1-7d54-4a08" type="max"/>
           </constraints>
         </categoryLink>
       </categoryLinks>
@@ -1215,7 +1271,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="22c1-269e-5afb-b58d" type="min"/>
           </constraints>
         </entryLink>
-        <entryLink id="b1da-cf75-29de-2197" name="New EntryLink" hidden="false" collective="false" import="true" targetId="c43b-5c09-9eae-27ba" type="selectionEntryGroup">
+        <entryLink id="b1da-cf75-29de-2197" name="Legio Custodes Dedicated Transport" hidden="false" collective="false" import="true" targetId="c43b-5c09-9eae-27ba" type="selectionEntryGroup">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
@@ -2748,6 +2804,9 @@
         <infoLink id="f4b0-9572-f331-95b0" name="Coronus Grav-Carrier" hidden="false" targetId="fb44-2178-c180-a450" type="profile"/>
         <infoLink id="34b2-68c4-f7c7-f6af" name="Coronus Grav-Carrier" hidden="false" targetId="e63f-762a-dde4-4c66" type="profile"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="8d80-29e7-d8bd-e4ed" name="Dedicated Transport" hidden="false" targetId="3193-9c47-85a9-d0f9" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="5be0-5093-ebf4-d943" name="Twin-Linked Lastrum Bolt Cannon" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
@@ -2850,6 +2909,9 @@
         <infoLink id="815f-e4ad-3b77-caa9" name="New InfoLink" hidden="false" targetId="0d66-14c9-d2f4-708b" type="rule"/>
         <infoLink id="4944-b4c3-6e1a-9a69" name="New InfoLink" hidden="false" targetId="18d0-fdf0-c554-cb34" type="rule"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="fef1-fd8d-e78d-b7f4" name="Dedicated Transport" hidden="false" targetId="3193-9c47-85a9-d0f9" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="d103-ec57-4509-2617" name="Two Twin-Linked Missile Launchers" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
@@ -4605,6 +4667,19 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="5804-0f3c-116f-46e2" name="Legio Custodes Telemon Heavy Dreadnought" hidden="false" collective="false" import="true" type="upgrade">
+      <modifiers>
+        <modifier type="add" field="category" value="9335-93c1-6af7-feb0">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7e48-c376-8ffe-8ae7" type="instanceOf"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7b39-af6b-52e1-b4d7" type="instanceOf"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="089f-7e79-bde1-90dd" type="instanceOf"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile id="0dd1-7b8c-1e91-3fc7" name="Multi-Layer Refractor Field" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
           <characteristics>
@@ -4717,6 +4792,9 @@ decided.</description>
         <infoLink id="b532-2bdc-a230-1aaa" name="Deep Strike" hidden="false" targetId="d219-2314-4834-c054" type="rule"/>
         <infoLink id="d5e4-db8d-4ea2-f1cc" name="Armoured Ceramite" hidden="false" targetId="3138-683d-a9a0-570d" type="rule"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink id="abc7-60ba-9e6d-0cfd" name="Flyer" hidden="false" targetId="1638-5261-fd55-f53b" primary="false"/>
+      </categoryLinks>
       <selectionEntries>
         <selectionEntry id="4247-e61e-0be7-5d54" name="Macro Arae-shrike" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>

--- a/The Horus Heresy.gst
+++ b/The Horus Heresy.gst
@@ -12719,6 +12719,22 @@ King Slayer (3 Victory points): If the opposing army includes a Primarch, this m
 • No model mounted on a base larger than 60mm may be chosen.*
 *Note: The terrain may still confine you, so caveat emptor!</description>
     </rule>
+    <rule id="b53a-eba8-e3f8-4ae8" name="Beasts" hidden="false">
+      <description>MOVEMENT
+Beasts can move up to 12&quot; in the Movement phase. Beasts are not slowed by difficult terrain (even when charging) and automatically pass Dangerous Terrain tests.
+FALL BACK MOVES
+Beasts make Fall Back moves just like Infantry, except that they move 3D6&quot;.
+SPECIAL RULES
+Beasts have the Fleet special rule.</description>
+    </rule>
+    <rule id="d956-6030-d01f-5f3a" name="Cavalry" hidden="false">
+      <description>MOVEMENT
+Cavalry can move up to 12&quot; in the Movement phase. Cavalry are not slowed down by difficult terrain (even when charging). However, Cavalry models treat all difficult terrain as dangerous terrain instead.
+FALL BACK MOVES
+Cavalry make Fall Back moves just like Infantry, except that they move 3D6&quot;.
+SPECIAL RULES
+Cavalry have the Fleet and Hammer of Wrath special rules.</description>
+    </rule>
   </sharedRules>
   <sharedProfiles>
     <profile id="74effb54-87f7-8481-9e5f-86d9e3ed37c2" name="Battle Servitor Control" publicationId="ca571888--pubN67227" page="43" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">

--- a/The Horus Heresy.gst
+++ b/The Horus Heresy.gst
@@ -202,6 +202,7 @@
     <categoryEntry id="a660-a665-c4aa-5e82" name="Superheavy Options" hidden="false"/>
     <categoryEntry id="a7c6-e380-f10f-9798" name="Mechanicum" hidden="false"/>
     <categoryEntry id="6077-281f-c55d-9bf0" name="Allied Detachment" hidden="false"/>
+    <categoryEntry id="9335-93c1-6af7-feb0" name="ZM (Unusable)" hidden="false"/>
   </categoryEntries>
   <forceEntries>
     <forceEntry id="61f7-09c7-326c-8c49" name="New ForceEntry" hidden="true">
@@ -12708,6 +12709,15 @@ King Slayer (3 Victory points): If the opposing army includes a Primarch, this m
     </rule>
     <rule id="575f-1255-f276-df91" name="By Falsehood Cloaked" publicationId="ca571888--pubN89821" page="209" hidden="false">
       <description>Knights-Errant may deploy via Deep Strike, and when doing so does not roll to scatter. On the controlling player’s turn that he deploys, and throughout the opposing player’s following player turn, any shots made against a Knight-Errant having deployed in this manner are made as Snap Shots. In addition, any charges made against Garro during this time count as Disordered.</description>
+    </rule>
+    <rule id="b1da-bb0d-6990-b5c7" name="ZM (Unusable)" publicationId="ca571888--pubN106705" page="https://www.warhammer-community.com/wp-content/uploads/2019/11/HHZone_Mortalis_Rules.pdf" hidden="false">
+      <description>Forces selected for fighting in a Zone Mortalis action should be chosen from their army list as normal with the following exceptions:
+• No units may select a Dedicated Transport option.
+• No unit with a starting size greater than 15 models, before being joined by Independent Characters, may be chosen.
+• No vehicles other than Walkers may be chosen, unless their models are no more than 4&quot; wide.*
+• No Flyers or Flying Monstrous Creatures of any kind or size may be chosen.
+• No model mounted on a base larger than 60mm may be chosen.*
+*Note: The terrain may still confine you, so caveat emptor!</description>
     </rule>
   </sharedRules>
   <sharedProfiles>


### PR DESCRIPTION
#1655 mainly

Added some more improvements for Salamander players, including relinking hand flamers, flamers and combi-flamers to the LA one which has the bonus Strength included. Also corrected a couple of spelling issue in one of their ROW (copy paste errors by the look of it).
Implemented stage one of the ZM updates by implementing a new category "ZM (Unusable)" to the GST which was added to each of the ZM Force Org charts and then adding the category to:
Arquitor, Deredeo, Land Raiders, Leviathan, Spartan. I also added it to Rhino (as it is only available as a dedicated transport, though like the Whildwind Scorp or Predators is actually less than 4" wide), All Flyers

Also added restriction to max 15 models for: Assault squads, Blackshield Marauders, Breachers squads, Grey Slayers, Medusan Immortals, Phalanx Warders, Tactical squads.

Militia ZM restrictions put in the same as LA ones and adding a few more rules for unit types in categories.

Also added restriction to max 15 models for Grenadiers (including taking any special weapon guys).
Also with Levy and Militia Infantry Squads, 2 optional rules have been added. The first is to be able to split the squads like Solar are allowed to, or to reduce the unit down to 15models at the same cost.

Just finished Solar Aux. Not much to do on there.

Mech was just restricting thralls, scyllax, secutarii to 15s. Also preventing Armigers, Flyers, Moirax, Thanatars and Vultarax from being selected. Also did a bit of tidy up with additional rules info for monsters and stuff.

Daemons also done as well. Also did a bit of tidy up with additional rules info for monsters and stuff.

@capitaladot shouldn't require a test as I've had a play around with it. However if you want to do a quick one, or if you find any other missing units that should be restricted then let me know. If not then I'll push tomorrow or maybe day after.