### PR TITLE
Thousand Sons Cult restrictions added

### DIFF
--- a/(HH) Imperialis Militia and Cults Army List.cat
+++ b/(HH) Imperialis Militia and Cults Army List.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="90aa-c2c8-ffb0-496e" name="Imperialis Militia and Cults Army List" revision="113" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="132" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="90aa-c2c8-ffb0-496e" name="Imperialis Militia and Cults Army List" revision="114" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="132" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="90aa-c2c8-pubN65537" name="Crusade Imperialis"/>
     <publication id="90aa-c2c8-pubN65563" name="AoDRB"/>
@@ -1674,7 +1674,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="a0bc-b1e2-f3ce-36ee" hidden="false" targetId="3448-7621-7c68-7eb9" type="profile"/>
+                <infoLink id="a0bc-b1e2-f3ce-36ee" name="Chaff/Flare Launchers" hidden="false" targetId="c3bb10b0-0ad1-3d7e-5b6e-20b2f57fbaba" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
@@ -1685,7 +1685,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="66c1-a010-bc45-b029" hidden="false" targetId="ae6a-c619-bf7c-1caf" type="profile"/>
+                <infoLink id="66c1-a010-bc45-b029" name="Armoured Cockpit" hidden="false" targetId="06710a9d-a2a8-638f-91b0-2af2fb3e95c2" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
@@ -1878,7 +1878,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="cad6-3a34-90c1-522d" hidden="false" targetId="5585-9f3b-c886-36e2" type="profile"/>
+                <infoLink id="cad6-3a34-90c1-522d" name="Armoured Ceramite" hidden="false" targetId="2e87b8ca-7cd1-78b9-2116-246015e7935e" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
@@ -3823,7 +3823,7 @@ D3     Mutation
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="98e2-91f5-0a13-18d0" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="8b29-80a8-7dbb-dd80" hidden="false" targetId="5585-9f3b-c886-36e2" type="profile"/>
+                <infoLink id="8b29-80a8-7dbb-dd80" name="Armoured Ceramite" hidden="false" targetId="2e87b8ca-7cd1-78b9-2116-246015e7935e" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
@@ -3891,7 +3891,7 @@ D3     Mutation
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="718a-cdcd-e793-9620" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="302d-f41d-d7f1-cf4b" hidden="false" targetId="23af-6391-0bcf-9f10" type="profile"/>
+                <infoLink id="302d-f41d-d7f1-cf4b" name="Auxiliary Drive" hidden="false" targetId="c5c3-cf81-76c6-b0c0" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
@@ -4299,7 +4299,7 @@ D3     Mutation
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="087a-0f61-b14b-50c8" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="19e6-b0ff-a6ea-d4a0" hidden="false" targetId="5585-9f3b-c886-36e2" type="profile"/>
+                <infoLink id="19e6-b0ff-a6ea-d4a0" name="Armoured Ceramite" hidden="false" targetId="2e87b8ca-7cd1-78b9-2116-246015e7935e" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
@@ -4442,8 +4442,8 @@ D3     Mutation
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="a372-ce99-d15d-e80a" hidden="false" targetId="ae6a-c619-bf7c-1caf" type="profile"/>
-        <infoLink id="ccbd-e6e7-417c-444e" hidden="false" targetId="3448-7621-7c68-7eb9" type="profile"/>
+        <infoLink id="a372-ce99-d15d-e80a" name="Armoured Cockpit" hidden="false" targetId="06710a9d-a2a8-638f-91b0-2af2fb3e95c2" type="profile"/>
+        <infoLink id="ccbd-e6e7-417c-444e" name="Chaff/Flare Launchers" hidden="false" targetId="c3bb10b0-0ad1-3d7e-5b6e-20b2f57fbaba" type="profile"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="dede-7586-dc68-e605" name="New CategoryLink" hidden="false" targetId="8a8c-ed20-7427-ddff" primary="false"/>
@@ -4775,7 +4775,7 @@ D3     Mutation
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="131b-0ae8-805e-38ff" type="max"/>
                   </constraints>
                   <infoLinks>
-                    <infoLink id="07e0-caca-3bdc-7e31" hidden="false" targetId="ea8a-04f6-ae7c-f351" type="profile"/>
+                    <infoLink id="07e0-caca-3bdc-7e31" name="Hand Flamer" hidden="false" targetId="21b6-668e-d5ef-a8da" type="profile"/>
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="10.0"/>
@@ -4920,7 +4920,7 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bce4-be0d-b11e-b188" type="min"/>
               </constraints>
               <infoLinks>
-                <infoLink id="a8d4-78f0-cc51-b829" name="Power Armour" hidden="false" targetId="341c-720f-2613-466f" type="profile"/>
+                <infoLink id="a8d4-78f0-cc51-b829" name="Power Armour" hidden="false" targetId="16b1-5d9f-cc76-f19d" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -5035,7 +5035,7 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b9b6-3058-da22-032d" type="max"/>
                   </constraints>
                   <infoLinks>
-                    <infoLink id="e02d-6cee-4533-16c3" hidden="false" targetId="d536-0e5a-f16b-7832" type="profile"/>
+                    <infoLink id="e02d-6cee-4533-16c3" name="Cyber-familiar" hidden="false" targetId="379b-7755-6264-0849" type="profile"/>
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="10.0"/>
@@ -5367,7 +5367,7 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f9fc-83fa-ebd1-f2d2" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="c6f9-dbb5-dab7-7fd4" name="Power Armour" hidden="false" targetId="341c-720f-2613-466f" type="profile"/>
+                <infoLink id="c6f9-dbb5-dab7-7fd4" name="Power Armour" hidden="false" targetId="16b1-5d9f-cc76-f19d" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
@@ -5441,7 +5441,7 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="cba8-f990-b4b8-2b17" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="4a35-7f72-5c05-1d71" hidden="false" targetId="30d4-b210-46ce-1af7" type="profile"/>
+                <infoLink id="4a35-7f72-5c05-1d71" name="Digital Lasers" hidden="false" targetId="1a12-3c84-f5a6-1c48" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
@@ -5463,7 +5463,7 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="231a-2fe8-d123-638b" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="31c5-e30f-8c21-d492" hidden="false" targetId="d536-0e5a-f16b-7832" type="profile"/>
+                <infoLink id="31c5-e30f-8c21-d492" name="Cyber-familiar" hidden="false" targetId="379b-7755-6264-0849" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
@@ -5566,7 +5566,7 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="83bf-cf02-619c-c353" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="e926-97a7-202d-f258" hidden="false" targetId="ea8a-04f6-ae7c-f351" type="profile"/>
+                <infoLink id="e926-97a7-202d-f258" name="Hand Flamer" hidden="false" targetId="21b6-668e-d5ef-a8da" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
@@ -5691,7 +5691,7 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="84f9-9962-c5e9-416e" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="a9e0-2e61-8def-c9bb" hidden="false" targetId="ea8a-04f6-ae7c-f351" type="profile"/>
+                <infoLink id="a9e0-2e61-8def-c9bb" name="Hand Flamer" hidden="false" targetId="21b6-668e-d5ef-a8da" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
@@ -6094,7 +6094,7 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0563-3a62-1d0a-26f6" type="max"/>
                       </constraints>
                       <infoLinks>
-                        <infoLink id="e3bb-5166-3854-e29b" hidden="false" targetId="ea8a-04f6-ae7c-f351" type="profile"/>
+                        <infoLink id="e3bb-5166-3854-e29b" name="Hand Flamer" hidden="false" targetId="21b6-668e-d5ef-a8da" type="profile"/>
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="10.0"/>
@@ -6189,7 +6189,7 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="274c-f4e1-5f26-7b54" type="max"/>
                       </constraints>
                       <infoLinks>
-                        <infoLink id="8384-e969-7fbd-1075" hidden="false" targetId="ea8a-04f6-ae7c-f351" type="profile"/>
+                        <infoLink id="8384-e969-7fbd-1075" name="Hand Flamer" hidden="false" targetId="21b6-668e-d5ef-a8da" type="profile"/>
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="10.0"/>
@@ -6613,7 +6613,7 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4fe3-55f3-aca2-c5ea" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="a847-a0a1-5153-eb47" name="Shotgun" hidden="false" targetId="6771-387a-b626-9f63" type="profile"/>
+                <infoLink id="a847-a0a1-5153-eb47" name="Shotgun" hidden="false" targetId="07cb-70d7-15c3-5117" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -7598,7 +7598,7 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e99f-dcae-f3d6-889b" type="max"/>
                   </constraints>
                   <infoLinks>
-                    <infoLink id="e1cf-ad62-fa9d-2dab" hidden="false" targetId="ea8a-04f6-ae7c-f351" type="profile"/>
+                    <infoLink id="e1cf-ad62-fa9d-2dab" name="Hand Flamer" hidden="false" targetId="21b6-668e-d5ef-a8da" type="profile"/>
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="10.0"/>
@@ -7668,7 +7668,7 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f797-2028-851a-dde8" type="max"/>
                   </constraints>
                   <infoLinks>
-                    <infoLink id="ad00-eccf-0fa7-8b6a" hidden="false" targetId="ea8a-04f6-ae7c-f351" type="profile"/>
+                    <infoLink id="ad00-eccf-0fa7-8b6a" name="Hand Flamer" hidden="false" targetId="21b6-668e-d5ef-a8da" type="profile"/>
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="10.0"/>
@@ -8142,7 +8142,7 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="092f-4e88-2ffe-9d40" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="4582-27a2-3d08-4419" hidden="false" targetId="537a-63f4-d939-c7f2" type="profile"/>
+                <infoLink id="4582-27a2-3d08-4419" name="Autogun" hidden="false" targetId="01e2-722b-da0c-9ccd" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
@@ -8337,7 +8337,7 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
     </selectionEntry>
     <selectionEntry id="a05b-1aaf-314c-cbba" name="Reconnaissance Squad, Imperialis Militia" hidden="false" collective="false" import="true" type="unit">
       <infoLinks>
-        <infoLink id="6c5a-5772-a5f5-a450" hidden="false" targetId="6b07-5fa5-6a1d-b243" type="rule"/>
+        <infoLink id="6c5a-5772-a5f5-a450" name="Support Squad" hidden="false" targetId="6b07-5fa5-6a1d-b243" type="rule"/>
         <infoLink id="6184-2ada-cc5b-bcd7" name="scout" hidden="false" targetId="9b30-1da3-eb8d-ce7a" type="rule"/>
         <infoLink id="00ca-c4cf-8d89-089c" name="New InfoLink" hidden="false" targetId="6d06-5ea0-9a17-ca97" type="rule"/>
         <infoLink id="8576-ccf3-46dc-e293" name="Infiltrate" hidden="false" targetId="34c7-8b61-a5b8-a301" type="rule"/>
@@ -8599,7 +8599,7 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2d30-a8f9-2c3d-6313" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="1772-ef25-cde3-a1b1" hidden="false" targetId="6771-387a-b626-9f63" type="profile"/>
+                <infoLink id="1772-ef25-cde3-a1b1" name="Shotgun" hidden="false" targetId="07cb-70d7-15c3-5117" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
@@ -8621,7 +8621,7 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a763-9eab-90d5-81be" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="f761-eede-88d1-e971" name="Autogun" hidden="false" targetId="537a-63f4-d939-c7f2" type="profile"/>
+                <infoLink id="f761-eede-88d1-e971" name="Autogun" hidden="false" targetId="01e2-722b-da0c-9ccd" type="profile"/>
                 <infoLink id="0ed2-5d43-3ac8-4516" name="Lasgun" hidden="false" targetId="d174-eb55-aaa6-d032" type="profile"/>
               </infoLinks>
               <costs>
@@ -8814,7 +8814,7 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9eaf-991c-3ec4-8709" type="max"/>
                   </constraints>
                   <infoLinks>
-                    <infoLink id="dda2-f6fc-46b1-0095" hidden="false" targetId="ea8a-04f6-ae7c-f351" type="profile"/>
+                    <infoLink id="dda2-f6fc-46b1-0095" name="Hand Flamer" hidden="false" targetId="21b6-668e-d5ef-a8da" type="profile"/>
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="10.0"/>
@@ -8884,7 +8884,7 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e116-d05e-286c-3ba9" type="max"/>
                   </constraints>
                   <infoLinks>
-                    <infoLink id="08fd-beed-bb8f-3c18" hidden="false" targetId="ea8a-04f6-ae7c-f351" type="profile"/>
+                    <infoLink id="08fd-beed-bb8f-3c18" name="Hand Flamer" hidden="false" targetId="21b6-668e-d5ef-a8da" type="profile"/>
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="10.0"/>
@@ -9102,7 +9102,7 @@ If a Weapon Destroyed result is repaired, that weapon may be fired in the follow
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7164-e7b3-bc63-596c" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="6925-d429-9087-5ac8" hidden="false" targetId="537a-63f4-d939-c7f2" type="profile"/>
+                <infoLink id="6925-d429-9087-5ac8" name="Autogun" hidden="false" targetId="01e2-722b-da0c-9ccd" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
@@ -9487,7 +9487,7 @@ As such if you wish to use them in ZM there are a couple of &quot;House Rules&qu
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7d75-3ce8-d0f2-0550" type="max"/>
                   </constraints>
                   <infoLinks>
-                    <infoLink id="1f9b-d947-e653-2fba" hidden="false" targetId="ea8a-04f6-ae7c-f351" type="profile"/>
+                    <infoLink id="1f9b-d947-e653-2fba" name="Hand Flamer" hidden="false" targetId="21b6-668e-d5ef-a8da" type="profile"/>
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="10.0"/>
@@ -9550,7 +9550,7 @@ As such if you wish to use them in ZM there are a couple of &quot;House Rules&qu
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="82f4-180e-4f6d-59fd" type="max"/>
                   </constraints>
                   <infoLinks>
-                    <infoLink id="5dd9-6476-f4e7-722f" hidden="false" targetId="ea8a-04f6-ae7c-f351" type="profile"/>
+                    <infoLink id="5dd9-6476-f4e7-722f" name="Hand Flamer" hidden="false" targetId="21b6-668e-d5ef-a8da" type="profile"/>
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="10.0"/>
@@ -9982,7 +9982,7 @@ As such if you wish to use them in ZM there are a couple of &quot;House Rules&qu
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ea99-bb80-8a1b-3e4e" type="max"/>
       </constraints>
       <infoLinks>
-        <infoLink id="3b37-c847-b26d-8c55" name="Extra Armour" hidden="false" targetId="5283-9b50-3dcd-78e4" type="rule"/>
+        <infoLink id="3b37-c847-b26d-8c55" name="Extra Armour" hidden="false" targetId="79c7-90f6-b453-e799" type="profile"/>
       </infoLinks>
       <costs>
         <cost name="pts" typeId="points" value="5.0"/>
@@ -10740,7 +10740,7 @@ A model may only use this weapon if it has successfully charged that player turn
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="82cf-656d-77c3-f584" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="9e3f-d100-605d-1361" hidden="false" targetId="537a-63f4-d939-c7f2" type="profile"/>
+                <infoLink id="9e3f-d100-605d-1361" name="Autogun" hidden="false" targetId="01e2-722b-da0c-9ccd" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
@@ -10841,7 +10841,7 @@ A model may only use this weapon if it has successfully charged that player turn
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="60c1-17fc-f21e-a8d9" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="176a-a15a-dd36-85d7" name="Hand Flamer" hidden="false" targetId="ea8a-04f6-ae7c-f351" type="profile"/>
+                <infoLink id="176a-a15a-dd36-85d7" name="Hand Flamer" hidden="false" targetId="21b6-668e-d5ef-a8da" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
@@ -11455,30 +11455,12 @@ A model may only use this weapon if it has successfully charged that player turn
     </rule>
   </sharedRules>
   <sharedProfiles>
-    <profile id="5585-9f3b-c886-36e2" name="Armoured Ceramite" publicationId="90aa-c2c8-pubN76431" page="88" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
-      <characteristics>
-        <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">A vehicle with this wargear is not subject to the additional D6 armour penetration caused by weapons with the Melta special rule.  </characteristic>
-      </characteristics>
-    </profile>
-    <profile id="ae6a-c619-bf7c-1caf" name="Armoured Cockpit" publicationId="90aa-c2c8-pubN76431" page="88" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
-      <characteristics>
-        <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">May ignore Crew shaken or stunned on a D6 roll of 4+</characteristic>
-      </characteristics>
-    </profile>
     <profile id="4c65-b01f-1491-555a" name="Augmented Weapon" publicationId="90aa-c2c8-pubN73486" page="180" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">4</characteristic>
         <characteristic name="AP" typeId="415023232344415441232323">-</characteristic>
         <characteristic name="Type" typeId="5479706523232344415441232323">Melee</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="537a-63f4-d939-c7f2" name="Autogun" publicationId="90aa-c2c8-pubN73486" page="179" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
-      <characteristics>
-        <characteristic name="Range" typeId="52616e676523232344415441232323">24&quot;</characteristic>
-        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">3</characteristic>
-        <characteristic name="AP" typeId="415023232344415441232323">-</characteristic>
-        <characteristic name="Type" typeId="5479706523232344415441232323">Rapid Fire</characteristic>
       </characteristics>
     </profile>
     <profile id="a7ca-04d9-b34d-d8cc" name="Auxilia Lascarbine" publicationId="90aa-c2c8-pubN73486" page="179" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
@@ -11505,11 +11487,6 @@ A model may only use this weapon if it has successfully charged that player turn
         <characteristic name="Type" typeId="5479706523232344415441232323">Pistol</characteristic>
       </characteristics>
     </profile>
-    <profile id="23af-6391-0bcf-9f10" name="Auxiliary Drive" publicationId="90aa-c2c8-pubN76431" page="88" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
-      <characteristics>
-        <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">A vehicle with an Auxiliary Drive may ignore Immobilised results it suffers on a D6 roll of a 4+</characteristic>
-      </characteristics>
-    </profile>
     <profile id="035e-17b5-4110-4726" name="Blast Pistol" publicationId="90aa-c2c8-pubN73486" page="179" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">6&quot;</characteristic>
@@ -11518,27 +11495,12 @@ A model may only use this weapon if it has successfully charged that player turn
         <characteristic name="Type" typeId="5479706523232344415441232323">Pistol, Twin-linked, Gets Hot</characteristic>
       </characteristics>
     </profile>
-    <profile id="3448-7621-7c68-7eb9" name="Chaff/Flare Launchers" publicationId="90aa-c2c8-pubN76431" page="90" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
-      <characteristics>
-        <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Gains 4++ invulnerable against damage caused by missile weapons. </characteristic>
-      </characteristics>
-    </profile>
     <profile id="0677-72ce-f493-574c" name="Charnabal Sabre" publicationId="90aa-c2c8-pubN73486" page="180" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">User</characteristic>
         <characteristic name="AP" typeId="415023232344415441232323">-</characteristic>
         <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Rending, Duellist&apos;s Edge</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="d536-0e5a-f16b-7832" name="Cyber-familiar" publicationId="90aa-c2c8-pubN76431" page="89" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
-      <characteristics>
-        <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">A Cyber-familiar adds +1 to its owners Invulnerable save (to a maximum of 3++) or provides an Invulnerable save of a 6++.   In addition they allow the owner to re-roll failed characteristic tests other than Leadership tests and failed Dangerous Terrain tests.  </characteristic>
-      </characteristics>
-    </profile>
-    <profile id="30d4-b210-46ce-1af7" name="Digital Lasers" publicationId="90aa-c2c8-pubN76431" page="87" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
-      <characteristics>
-        <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Provides +1 Attack in close combat</characteristic>
       </characteristics>
     </profile>
     <profile id="7f9f-8f71-e419-7cd2" name="Fireburst Grenade" publicationId="90aa-c2c8-pubN73486" page="180" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
@@ -11555,14 +11517,6 @@ A model may only use this weapon if it has successfully charged that player turn
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">-</characteristic>
         <characteristic name="AP" typeId="415023232344415441232323">5</characteristic>
         <characteristic name="Type" typeId="5479706523232344415441232323">Assault 1, Blast (3&quot;), Poison 4+, Ignores Cover</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="ea8a-04f6-ae7c-f351" name="Hand Flamer" publicationId="90aa-c2c8-pubN73486" page="179" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
-      <characteristics>
-        <characteristic name="Range" typeId="52616e676523232344415441232323">Template</characteristic>
-        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">3</characteristic>
-        <characteristic name="AP" typeId="415023232344415441232323">6</characteristic>
-        <characteristic name="Type" typeId="5479706523232344415441232323">Pistol</characteristic>
       </characteristics>
     </profile>
     <profile id="8d1e-6e6e-93c0-4885" name="Hellstrike Missiles" publicationId="ca571888--pubN66500" page="0" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
@@ -11602,19 +11556,6 @@ A model may only use this weapon if it has successfully charged that player turn
     <profile id="248f-7dc3-34af-a6df" name="Platoon Standard" publicationId="90aa-c2c8-pubN73486" page="183" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
       <characteristics>
         <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Confers benefits of a vexilla (+1 for combat resolution results, may always regroup even below 25%).  In addition, all units from the Imperialis Militia amy with models within 24&quot; ignore casualties when taking Morale Checks.  </characteristic>
-      </characteristics>
-    </profile>
-    <profile id="341c-720f-2613-466f" name="Power Armour" publicationId="90aa-c2c8-pubN73486" page="183" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
-      <characteristics>
-        <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Confers 3+ Armour Save</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="6771-387a-b626-9f63" name="Shotgun" publicationId="90aa-c2c8-pubN73486" page="179" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
-      <characteristics>
-        <characteristic name="Range" typeId="52616e676523232344415441232323">12&quot;</characteristic>
-        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">3</characteristic>
-        <characteristic name="AP" typeId="415023232344415441232323">-</characteristic>
-        <characteristic name="Type" typeId="5479706523232344415441232323">Assault 2</characteristic>
       </characteristics>
     </profile>
     <profile id="ca02-ea95-e9a0-aefc" name="Sub-flak Armour" publicationId="90aa-c2c8-pubN73486" page="182" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">

--- a/(HH) Mechanicum - Taghmata Army List.cat
+++ b/(HH) Mechanicum - Taghmata Army List.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="cf03-f607-41dc-7545" name="Mechanicum: Taghmata Army List" revision="109" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="132" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="cf03-f607-41dc-7545" name="Mechanicum: Taghmata Army List" revision="110" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="132" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="cf03-f607-pubN65537" name="Horus Heresy: Taghmata Army List"/>
     <publication id="cf03-f607-pubN65563" name="AoDRB"/>
@@ -1924,7 +1924,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
       <infoLinks>
         <infoLink id="67d4-e1ef-588a-47e9" name="Cybernetica Cortex" hidden="false" targetId="f6c9-cdb7-c695-5b6b" type="rule"/>
         <infoLink id="cba2-88ce-8788-ec9b" hidden="false" targetId="d5cf-bd98-2854-13cf" type="rule"/>
-        <infoLink id="5512-3146-04f4-9bc1" hidden="false" targetId="797e55b1-251e-6606-9cb3-64661b0b18a3" type="rule"/>
+        <infoLink id="5512-3146-04f4-9bc1" name="Lumbering Advance" hidden="false" targetId="797e55b1-251e-6606-9cb3-64661b0b18a3" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="4f52-7ec1-a77a-317b" name="New CategoryLink" hidden="false" targetId="8ec4-17b5-7fea-c682" primary="false"/>
@@ -1974,7 +1974,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f4c4-c740-465d-b739" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="5f88-598c-5639-90a4" hidden="false" targetId="6eb5b812-8b8b-9e7c-279e-c9e9c93fefe9" type="profile"/>
+                <infoLink id="5f88-598c-5639-90a4" name="Atomantic Shielding" hidden="false" targetId="13e0-4939-5232-8d85" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -2160,7 +2160,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5bc3-5606-70d8-cf5f" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="ff61-a84d-78e7-c4c0" hidden="false" targetId="6eb5b812-8b8b-9e7c-279e-c9e9c93fefe9" type="profile"/>
+                <infoLink id="ff61-a84d-78e7-c4c0" name="Atomantic Shielding" hidden="false" targetId="13e0-4939-5232-8d85" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -2757,7 +2757,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="bfe4-597b-6752-5116" type="max"/>
           </constraints>
           <infoLinks>
-            <infoLink id="c147-d5f9-3300-2cfa" hidden="false" targetId="6eb5b812-8b8b-9e7c-279e-c9e9c93fefe9" type="profile"/>
+            <infoLink id="c147-d5f9-3300-2cfa" name="Atomantic Shielding" hidden="false" targetId="13e0-4939-5232-8d85" type="profile"/>
           </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="0.0"/>
@@ -2902,7 +2902,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
     </selectionEntry>
     <selectionEntry id="3f38d321-12f2-5f34-726f-08b9e03eb50a" name="Charnabal Sabre" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
-        <infoLink id="669d83c8-2445-a5fe-6c36-ee1008d7bb2e" hidden="false" targetId="50707f97-ecd0-785e-cccc-8f866cac5ecb" type="profile"/>
+        <infoLink id="669d83c8-2445-a5fe-6c36-ee1008d7bb2e" name="Charnabal Sabre" hidden="false" targetId="d2b5-89d1-10e2-f3f0" type="profile"/>
         <infoLink id="678d24dd-4517-f2b3-6c6a-f9749310904b" name="Duelist&apos;s Edge" hidden="false" targetId="1a79-befa-05cf-ab0d" type="rule"/>
       </infoLinks>
       <costs>
@@ -3130,8 +3130,8 @@ A model equipped with a machinator array may make two additional attacks per tur
         <infoLink id="5ca0-977f-f7d1-b885" hidden="false" targetId="3a93202e-ac23-5508-2dda-248efcc8ff3d" type="rule"/>
         <infoLink id="934a-f7aa-54ad-2c84" name="Blessed Autosimulacra" hidden="false" targetId="6ce7-5e83-a2dd-571e" type="rule"/>
         <infoLink id="4ee4-be5f-74e5-a725" name="Extra Armour" hidden="false" targetId="5283-9b50-3dcd-78e4" type="rule"/>
-        <infoLink id="4131-5e01-05db-1efb" hidden="false" targetId="376f-adc9-b9bf-7fc9" type="profile"/>
-        <infoLink id="3e74-2746-8140-1ffc" name="Searchlight" hidden="false" targetId="2d8c-26b3-4336-1b66" type="profile"/>
+        <infoLink id="4131-5e01-05db-1efb" name="Augury Scanner" hidden="false" targetId="376f-adc9-b9bf-7fc9" type="profile"/>
+        <infoLink id="3e74-2746-8140-1ffc" name="Searchlight" hidden="false" targetId="9bb4-3833-5343-0dd9" type="profile"/>
         <infoLink id="dfa0-08b4-d543-5f0b" name="Smoke Launchers" hidden="false" targetId="6875-ee73-2a85-6a97" type="profile"/>
       </infoLinks>
       <categoryLinks>
@@ -3243,7 +3243,7 @@ Reduces transport capacity to 8.</description>
             </selectionEntry>
             <selectionEntry id="067b-1e05-f64b-dc52" name="Two irradiation engines" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <infoLinks>
-                <infoLink id="7ed7-11b7-65a0-6811" name="Irradiation Engine" hidden="false" targetId="926a370f-f4c1-b644-34f2-c348a5ce36c0" type="profile"/>
+                <infoLink id="7ed7-11b7-65a0-6811" name="Irradiation Engine" hidden="false" targetId="ffe1-35b1-65a5-cd5c" type="profile"/>
                 <infoLink id="9c2e-9cbd-9335-5806" name="Fleshbane" hidden="false" targetId="4575-0a0a-caaf-e4bf" type="rule"/>
                 <infoLink id="d18d-0a06-acbc-c008" name="Torrent" hidden="false" targetId="5039-18f0-a9ed-0938" type="rule"/>
                 <infoLink id="9dd7-c0e7-3f93-cd9f" name="Rad-phage" hidden="false" targetId="eefe-09e4-17aa-deb2" type="rule"/>
@@ -3273,7 +3273,7 @@ Reduces transport capacity to 8.</description>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="66db-70da-f418-0ac4" hidden="false" targetId="71ed050b-073d-852a-e50a-425b96eb71cd" type="profile"/>
+                <infoLink id="66db-70da-f418-0ac4" name="Phased-Plasma Fusil" hidden="false" targetId="306adc93-713f-8c18-71d3-6956c376e9e2" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
@@ -3284,7 +3284,7 @@ Reduces transport capacity to 8.</description>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="f819-b3b6-bac2-dded" name="Irad-cleanser" hidden="false" targetId="087e3cad-c849-204a-b83a-29093869a431" type="profile"/>
+                <infoLink id="f819-b3b6-bac2-dded" name="Irad-cleanser" hidden="false" targetId="7d03914a-f940-12e5-590b-822083dff647" type="profile"/>
                 <infoLink id="c0ef-aa2b-e9a8-b3b3" name="Fleshbane" hidden="false" targetId="4575-0a0a-caaf-e4bf" type="rule"/>
                 <infoLink id="ff6e-6016-c6d8-3946" name="Rad-phage" hidden="false" targetId="eefe-09e4-17aa-deb2" type="rule"/>
               </infoLinks>
@@ -3778,7 +3778,7 @@ Reduces transport capacity to 8.</description>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
                   </constraints>
                   <infoLinks>
-                    <infoLink id="ec83-6493-f332-44bb" hidden="false" targetId="9a458a3c-a9b5-db5e-a218-2041a3a49004" type="profile"/>
+                    <infoLink id="ec83-6493-f332-44bb" name="Nuncio-vox" hidden="false" targetId="2a0e-e1f0-5ea0-5799" type="profile"/>
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="10.0"/>
@@ -3842,7 +3842,7 @@ Reduces transport capacity to 8.</description>
                 </selectionEntry>
               </selectionEntries>
               <entryLinks>
-                <entryLink id="8692-e3c3-e8e4-9e57" name="New EntryLink" hidden="false" collective="false" import="true" targetId="2645-2048-de94-299c" type="selectionEntry"/>
+                <entryLink id="8692-e3c3-e8e4-9e57" name="Augury Scanner" hidden="false" collective="false" import="true" targetId="2645-2048-de94-299c" type="selectionEntry"/>
                 <entryLink id="ca7e-939a-3b3e-9f46" name="Melta Bombs" hidden="false" collective="false" import="true" targetId="4c62-8983-4a1b-d1c6" type="selectionEntry"/>
               </entryLinks>
             </selectionEntryGroup>
@@ -4058,7 +4058,7 @@ Reduces transport capacity to 8.</description>
                 <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="5e88-d33d-e0ed-5702" hidden="false" targetId="f4404a95-506e-bcef-1420-21d2d6e9013b" type="profile"/>
+                <infoLink id="5e88-d33d-e0ed-5702" name="Servo Arm" hidden="false" targetId="c3a5-c40c-b493-5cf6" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
@@ -5140,7 +5140,7 @@ Buildings and Fortifications D</description>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4a09-5a1f-301e-9cff" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="ef23-1f54-8db6-e531" name="New InfoLink" hidden="false" targetId="2d8c-26b3-4336-1b66" type="profile"/>
+                <infoLink id="ef23-1f54-8db6-e531" name="Searchlight" hidden="false" targetId="9bb4-3833-5343-0dd9" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -5874,7 +5874,7 @@ Buildings and Fortifications D</description>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e8df-ff5d-e2e3-1a12" type="max"/>
       </constraints>
       <infoLinks>
-        <infoLink id="ec73-99b6-4ea4-b281" name="Archaeotech Pistol" hidden="false" targetId="9045e242-71f8-6029-fc57-2b7cbedcc398" type="profile"/>
+        <infoLink id="ec73-99b6-4ea4-b281" name="Archaeotech Pistol" hidden="false" targetId="cf65-5d4c-24a3-92d2" type="profile"/>
         <infoLink id="53ee-f674-f92c-b40b" name="Master-crafted" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule"/>
       </infoLinks>
       <costs>
@@ -6015,7 +6015,7 @@ Buildings and Fortifications D</description>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7b60-432b-52b0-4727" type="max"/>
           </constraints>
           <infoLinks>
-            <infoLink id="d97e-4c71-3b86-cc96" name="Lightning Gun" hidden="false" targetId="ec450cd6-6dba-ca68-091c-9c48fcbc2112" type="profile"/>
+            <infoLink id="d97e-4c71-3b86-cc96" name="Lightning Gun" hidden="false" targetId="2850d06c-1eef-bae4-1314-6a3d9635193b" type="profile"/>
             <infoLink id="eeb3-a758-a9a3-ecbc" name="Rending" hidden="false" targetId="8269-2cd6-9236-16e7" type="rule"/>
             <infoLink id="7c4b-32db-91af-305a" name="Shred" hidden="false" targetId="89da-0cb5-bee4-8ec2" type="rule"/>
           </infoLinks>
@@ -6091,7 +6091,7 @@ Buildings and Fortifications D</description>
         </selectionEntryGroup>
         <selectionEntryGroup id="3bcb-13c2-48a2-0360" name="One in three may exchange their Lightning Gun for:" hidden="false" collective="false" import="true">
           <modifiers>
-            <modifier type="increment" field="e3b5-78c9-ed61-165b" value="1">
+            <modifier type="increment" field="e3b5-78c9-ed61-165b" value="1.0">
               <repeats>
                 <repeat field="selections" scope="b39b-9817-025c-62da" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
               </repeats>
@@ -6117,7 +6117,7 @@ Buildings and Fortifications D</description>
                 <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b6ea-d250-0de6-d80f" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="df9a-e2d3-7f93-02df" hidden="false" targetId="71ed050b-073d-852a-e50a-425b96eb71cd" type="profile"/>
+                <infoLink id="df9a-e2d3-7f93-02df" name="Phased-Plasma Fusil" hidden="false" targetId="306adc93-713f-8c18-71d3-6956c376e9e2" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
@@ -6128,7 +6128,7 @@ Buildings and Fortifications D</description>
                 <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d362-85fe-89a4-7f42" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="7933-8049-2150-0ead" name="Irad-cleanser" hidden="false" targetId="087e3cad-c849-204a-b83a-29093869a431" type="profile"/>
+                <infoLink id="7933-8049-2150-0ead" name="Irad-cleanser" hidden="false" targetId="7d03914a-f940-12e5-590b-822083dff647" type="profile"/>
                 <infoLink id="f117-15c5-7a40-307a" name="Fleshbane" hidden="false" targetId="4575-0a0a-caaf-e4bf" type="rule"/>
                 <infoLink id="8a73-0a5d-c854-2e72" name="Rad-phage" hidden="false" targetId="eefe-09e4-17aa-deb2" type="rule"/>
               </infoLinks>
@@ -6751,7 +6751,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3bfa-e233-7caf-04ab" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="12fb-8f2e-f1f5-ec35" hidden="false" targetId="9a458a3c-a9b5-db5e-a218-2041a3a49004" type="profile"/>
+                <infoLink id="12fb-8f2e-f1f5-ec35" name="Nuncio-vox" hidden="false" targetId="2a0e-e1f0-5ea0-5799" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
@@ -7221,7 +7221,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e10b-9d0f-c48a-27fd" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="4896-10e2-a4ad-9d11" hidden="false" targetId="6eb5b812-8b8b-9e7c-279e-c9e9c93fefe9" type="profile"/>
+                <infoLink id="4896-10e2-a4ad-9d11" name="Atomantic Shielding" hidden="false" targetId="13e0-4939-5232-8d85" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -7348,7 +7348,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
           </rules>
           <infoLinks>
             <infoLink id="64c9-1470-dc6a-2af8" name="Blessed Autosimulacra" hidden="false" targetId="6ce7-5e83-a2dd-571e" type="rule"/>
-            <infoLink id="0c33-12dd-6188-3e44" name="Searchlight" hidden="false" targetId="2d8c-26b3-4336-1b66" type="profile"/>
+            <infoLink id="0c33-12dd-6188-3e44" name="Searchlight" hidden="false" targetId="9bb4-3833-5343-0dd9" type="profile"/>
             <infoLink id="c0ff-6a7d-36aa-cb12" name="Smoke Launchers" hidden="false" targetId="6875-ee73-2a85-6a97" type="profile"/>
           </infoLinks>
           <selectionEntries>
@@ -7504,7 +7504,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="64de-28f8-9781-c26b" name="Searchlight" hidden="false" targetId="2d8c-26b3-4336-1b66" type="profile"/>
+            <infoLink id="64de-28f8-9781-c26b" name="Searchlight" hidden="false" targetId="9bb4-3833-5343-0dd9" type="profile"/>
             <infoLink id="47f3-ff6d-56c4-ffeb" name="Smoke Launchers" hidden="false" targetId="6875-ee73-2a85-6a97" type="profile"/>
           </infoLinks>
           <selectionEntryGroups>
@@ -8292,7 +8292,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="107b-c809-3244-cff1" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="6672-a89b-3b2a-21a4" hidden="false" targetId="f4404a95-506e-bcef-1420-21d2d6e9013b" type="profile"/>
+                <infoLink id="6672-a89b-3b2a-21a4" name="Servo Arm" hidden="false" targetId="c3a5-c40c-b493-5cf6" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
@@ -8400,7 +8400,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="31e2-50b3-d87d-51c7" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="3d5d-3e66-10cb-e78c" name="Irad-cleanser" hidden="false" targetId="087e3cad-c849-204a-b83a-29093869a431" type="profile"/>
+                <infoLink id="3d5d-3e66-10cb-e78c" name="Irad-cleanser" hidden="false" targetId="7d03914a-f940-12e5-590b-822083dff647" type="profile"/>
                 <infoLink id="e5e4-5f97-3791-6431" name="Fleshbane" hidden="false" targetId="4575-0a0a-caaf-e4bf" type="rule"/>
                 <infoLink id="b368-c2b6-5689-e6f1" name="Rad-phage" hidden="false" targetId="eefe-09e4-17aa-deb2" type="rule"/>
               </infoLinks>
@@ -8562,7 +8562,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a9cb-4107-6cf1-c8c0" type="max"/>
           </constraints>
           <infoLinks>
-            <infoLink id="c6c1-316e-c233-411c" hidden="false" targetId="6eb5b812-8b8b-9e7c-279e-c9e9c93fefe9" type="profile"/>
+            <infoLink id="c6c1-316e-c233-411c" name="Atomantic Shielding" hidden="false" targetId="13e0-4939-5232-8d85" type="profile"/>
           </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="0.0"/>
@@ -8755,7 +8755,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="98a2-0ce0-c7c9-bbac" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="5d06-f078-bc80-7892" hidden="false" targetId="6eb5b812-8b8b-9e7c-279e-c9e9c93fefe9" type="profile"/>
+                <infoLink id="5d06-f078-bc80-7892" name="Atomantic Shielding" hidden="false" targetId="13e0-4939-5232-8d85" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -8932,7 +8932,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ab43-6308-ad87-38ce" type="max"/>
           </constraints>
           <infoLinks>
-            <infoLink id="79d1-2df9-66ce-ff99" hidden="false" targetId="6eb5b812-8b8b-9e7c-279e-c9e9c93fefe9" type="profile"/>
+            <infoLink id="79d1-2df9-66ce-ff99" name="Atomantic Shielding" hidden="false" targetId="13e0-4939-5232-8d85" type="profile"/>
           </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="0.0"/>
@@ -9308,7 +9308,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
           <selectionEntries>
             <selectionEntry id="8b63-de7c-cc9a-7bb1" name="Servo-arm" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <infoLinks>
-                <infoLink id="8faa-be62-ef0b-511b" name="Servo-arm" hidden="false" targetId="f4404a95-506e-bcef-1420-21d2d6e9013b" type="profile"/>
+                <infoLink id="8faa-be62-ef0b-511b" name="Servo Arm" hidden="false" targetId="c3a5-c40c-b493-5cf6" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
@@ -9442,7 +9442,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e040-f22b-8036-d2b2" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="b8b4-af3a-1613-0631" hidden="false" targetId="71ed050b-073d-852a-e50a-425b96eb71cd" type="profile"/>
+                <infoLink id="b8b4-af3a-1613-0631" name="Phased-Plasma Fusil" hidden="false" targetId="306adc93-713f-8c18-71d3-6956c376e9e2" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
@@ -9467,7 +9467,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d8d4-44a9-0d4c-59a0" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="9071-895f-660a-cca5" name="Irad-cleanser" hidden="false" targetId="087e3cad-c849-204a-b83a-29093869a431" type="profile"/>
+                <infoLink id="9071-895f-660a-cca5" name="Irad-cleanser" hidden="false" targetId="7d03914a-f940-12e5-590b-822083dff647" type="profile"/>
                 <infoLink id="0d54-df05-8150-849e" name="Fleshbane" hidden="false" targetId="4575-0a0a-caaf-e4bf" type="rule"/>
                 <infoLink id="ef08-0eec-112f-f2fb" name="Rad-phage" hidden="false" targetId="eefe-09e4-17aa-deb2" type="rule"/>
               </infoLinks>
@@ -9793,7 +9793,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c259-e347-ee58-5b39" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="5297-73b9-99f8-4b9d" name="Phased-Plasma Fusil" hidden="false" targetId="71ed050b-073d-852a-e50a-425b96eb71cd" type="profile"/>
+                <infoLink id="5297-73b9-99f8-4b9d" name="Phased-Plasma Fusil" hidden="false" targetId="306adc93-713f-8c18-71d3-6956c376e9e2" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
@@ -9818,7 +9818,7 @@ Armour Value, an additional Hull point, on the same model. Invulnerable saves ma
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8b5c-9cfe-8c55-fbdf" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="dce9-8feb-0a52-ed40" name="Irad-cleanser" hidden="false" targetId="087e3cad-c849-204a-b83a-29093869a431" type="profile"/>
+                <infoLink id="dce9-8feb-0a52-ed40" name="Irad-cleanser" hidden="false" targetId="7d03914a-f940-12e5-590b-822083dff647" type="profile"/>
                 <infoLink id="02a8-c82f-fb14-6cef" name="Fleshbane" hidden="false" targetId="4575-0a0a-caaf-e4bf" type="rule"/>
                 <infoLink id="04a9-e6cc-e106-3cb4" name="Rad-phage" hidden="false" targetId="eefe-09e4-17aa-deb2" type="rule"/>
               </infoLinks>
@@ -10207,7 +10207,7 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6ac5-0786-8085-80cb" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="2998-00a1-419b-3a32" name="Irad-cleanser" hidden="false" targetId="087e3cad-c849-204a-b83a-29093869a431" type="profile"/>
+                <infoLink id="2998-00a1-419b-3a32" name="Irad-cleanser" hidden="false" targetId="7d03914a-f940-12e5-590b-822083dff647" type="profile"/>
                 <infoLink id="f7d3-2ea2-2420-0647" name="Fleshbane" hidden="false" targetId="4575-0a0a-caaf-e4bf" type="rule"/>
                 <infoLink id="87c9-24c7-5e99-9521" name="Rad-phage" hidden="false" targetId="eefe-09e4-17aa-deb2" type="rule"/>
               </infoLinks>
@@ -10246,7 +10246,7 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5050-bb61-9a14-e002" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="2b33-38ad-298c-b9ee" hidden="false" targetId="71ed050b-073d-852a-e50a-425b96eb71cd" type="profile"/>
+                <infoLink id="2b33-38ad-298c-b9ee" name="Phased-Plasma Fusil" hidden="false" targetId="306adc93-713f-8c18-71d3-6956c376e9e2" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
@@ -10421,7 +10421,7 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="65b5-1ee9-f2f4-89dd" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="3af5-aace-fce8-6e84" hidden="false" targetId="f4404a95-506e-bcef-1420-21d2d6e9013b" type="profile"/>
+                <infoLink id="3af5-aace-fce8-6e84" name="Servo Arm" hidden="false" targetId="c3a5-c40c-b493-5cf6" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
@@ -11325,8 +11325,8 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
                 </profile>
               </profiles>
               <infoLinks>
-                <infoLink id="3ae2-dd60-4cb5-d093" hidden="false" targetId="33e5-3347-0c00-4244" type="profile"/>
-                <infoLink id="7753-7a7d-6cd5-c35c" hidden="false" targetId="8bc8-94ff-73be-5959" type="profile"/>
+                <infoLink id="3ae2-dd60-4cb5-d093" name="Ion Shield" hidden="false" targetId="33e5-3347-0c00-4244" type="profile"/>
+                <infoLink id="7753-7a7d-6cd5-c35c" name="Reaper Chainsword" hidden="false" targetId="76191f60-ba9c-4e52-9faf-24b23e46c7a9" type="profile"/>
               </infoLinks>
               <categoryLinks>
                 <categoryLink id="57a7-b62a-516d-deda" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
@@ -11406,9 +11406,9 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
                 </profile>
               </profiles>
               <infoLinks>
-                <infoLink id="7523-16ab-7fbe-93b5" hidden="false" targetId="54b5-df3e-a811-b7b9" type="profile"/>
-                <infoLink id="9f59-b10c-313a-0310" hidden="false" targetId="0549fb57-3ec6-8bd4-830a-85fb240cb1d7" type="profile"/>
-                <infoLink id="6bfd-4f27-0aad-74ad" hidden="false" targetId="71ed050b-073d-852a-e50a-425b96eb71cd" type="profile"/>
+                <infoLink id="7523-16ab-7fbe-93b5" name="Ionic Flare Shield" hidden="false" targetId="54b5-df3e-a811-b7b9" type="profile"/>
+                <infoLink id="9f59-b10c-313a-0310" name="Lightning Cannon" hidden="false" targetId="418fbfed-277a-7376-dfd3-7d5a95fae9f5" type="profile"/>
+                <infoLink id="6bfd-4f27-0aad-74ad" name="Phased-Plasma Fusil" hidden="false" targetId="306adc93-713f-8c18-71d3-6956c376e9e2" type="profile"/>
                 <infoLink id="666d-d9bb-c12d-a074" name="Blessed Autosimulacra" hidden="false" targetId="6ce7-5e83-a2dd-571e" type="rule"/>
                 <infoLink id="cf59-ade0-6fd2-96f3" hidden="false" targetId="56c6-c38f-84c5-fb30" type="rule"/>
               </infoLinks>
@@ -11547,9 +11547,9 @@ Alternatively, instead of firing any weapons in the Shooting phase, the Magos/Ar
                 </profile>
               </profiles>
               <infoLinks>
-                <infoLink id="aae4-0252-c68f-377c" hidden="false" targetId="33e5-3347-0c00-4244" type="profile"/>
-                <infoLink id="505b-2992-36e1-6a1d" name="Heavy Stubber" hidden="false" targetId="012e-a738-c943-5c1d" type="profile"/>
-                <infoLink id="ddcb-6653-5b7b-138e" hidden="false" targetId="8bc8-94ff-73be-5959" type="profile"/>
+                <infoLink id="aae4-0252-c68f-377c" name="Ion Shield" hidden="false" targetId="33e5-3347-0c00-4244" type="profile"/>
+                <infoLink id="505b-2992-36e1-6a1d" name="Heavy Stubber" hidden="false" targetId="981c9d9e-9866-7245-ed4c-8d5e4f9b17f4" type="profile"/>
+                <infoLink id="ddcb-6653-5b7b-138e" name="Reaper Chainsword" hidden="false" targetId="76191f60-ba9c-4e52-9faf-24b23e46c7a9" type="profile"/>
               </infoLinks>
               <categoryLinks>
                 <categoryLink id="251d-2be9-9ed7-372f" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
@@ -11986,7 +11986,7 @@ In addition to its weapon attacks, units assaulting a model or unit with a gravi
     </selectionEntry>
     <selectionEntry id="5c5c-13cd-a75e-3b15" name="Servo-arm" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
-        <infoLink id="ff2d-6622-772d-06a9" name="Servo-arm" hidden="false" targetId="f4404a95-506e-bcef-1420-21d2d6e9013b" type="profile"/>
+        <infoLink id="ff2d-6622-772d-06a9" name="Servo Arm" hidden="false" targetId="c3a5-c40c-b493-5cf6" type="profile"/>
         <infoLink id="5dbb-3756-d8b8-6cf2" name="Unwieldy" hidden="false" targetId="5eea-958c-d623-c3c9" type="rule"/>
       </infoLinks>
       <costs>
@@ -12005,7 +12005,7 @@ In addition to its weapon attacks, units assaulting a model or unit with a gravi
     </selectionEntry>
     <selectionEntry id="3cd4-7aba-24a0-37b8" name="Irradiation engines" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
-        <infoLink id="258f-edfe-04f5-5205" name="Irradiation Engine" hidden="false" targetId="926a370f-f4c1-b644-34f2-c348a5ce36c0" type="profile"/>
+        <infoLink id="258f-edfe-04f5-5205" name="Irradiation Engine" hidden="false" targetId="ffe1-35b1-65a5-cd5c" type="profile"/>
         <infoLink id="bb65-2df2-825f-5044" name="Fleshbane" hidden="false" targetId="4575-0a0a-caaf-e4bf" type="rule"/>
         <infoLink id="8372-0df4-f914-df8b" name="Torrent" hidden="false" targetId="5039-18f0-a9ed-0938" type="rule"/>
         <infoLink id="40d1-4d04-3642-0a32" name="Rad-phage" hidden="false" targetId="eefe-09e4-17aa-deb2" type="rule"/>
@@ -12039,7 +12039,7 @@ In addition to its weapon attacks, units assaulting a model or unit with a gravi
     </selectionEntry>
     <selectionEntry id="d4ac-c006-b6fd-7901" name="Phased Plasma-fusil" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
-        <infoLink id="66a2-cd60-ecdc-b474" name="Phased-Plasma Fusil" hidden="false" targetId="71ed050b-073d-852a-e50a-425b96eb71cd" type="profile"/>
+        <infoLink id="66a2-cd60-ecdc-b474" name="Phased-Plasma Fusil" hidden="false" targetId="306adc93-713f-8c18-71d3-6956c376e9e2" type="profile"/>
       </infoLinks>
       <costs>
         <cost name="pts" typeId="points" value="20.0"/>
@@ -12137,7 +12137,7 @@ In addition to its weapon attacks, units assaulting a model or unit with a gravi
     </selectionEntry>
     <selectionEntry id="0cbc-ea7d-05e7-2d5c" name="Heavy Stubber" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
-        <infoLink id="9417-d368-6420-29f1" name="Heavy Stubber" hidden="false" targetId="012e-a738-c943-5c1d" type="profile"/>
+        <infoLink id="9417-d368-6420-29f1" name="Heavy Stubber" hidden="false" targetId="981c9d9e-9866-7245-ed4c-8d5e4f9b17f4" type="profile"/>
       </infoLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
@@ -12200,7 +12200,7 @@ In addition to its weapon attacks, units assaulting a model or unit with a gravi
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6117-03d9-c308-f90b" type="max"/>
           </constraints>
           <infoLinks>
-            <infoLink id="a475-d4c5-edaa-5966" name="Lightning Gun" hidden="false" targetId="ec450cd6-6dba-ca68-091c-9c48fcbc2112" type="profile"/>
+            <infoLink id="a475-d4c5-edaa-5966" name="Lightning Gun" hidden="false" targetId="2850d06c-1eef-bae4-1314-6a3d9635193b" type="profile"/>
             <infoLink id="c680-19ab-0a30-88c2" name="Rending" hidden="false" targetId="8269-2cd6-9236-16e7" type="rule"/>
             <infoLink id="1673-53f8-5e98-eebd" name="Shred" hidden="false" targetId="89da-0cb5-bee4-8ec2" type="rule"/>
           </infoLinks>
@@ -12302,7 +12302,7 @@ In addition to its weapon attacks, units assaulting a model or unit with a gravi
                 <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="93ba-0b95-0968-ced6" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="7f10-f073-47a5-a99f" hidden="false" targetId="71ed050b-073d-852a-e50a-425b96eb71cd" type="profile"/>
+                <infoLink id="7f10-f073-47a5-a99f" name="Phased-Plasma Fusil" hidden="false" targetId="306adc93-713f-8c18-71d3-6956c376e9e2" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
@@ -12313,7 +12313,7 @@ In addition to its weapon attacks, units assaulting a model or unit with a gravi
                 <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8ea3-5875-e944-8087" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="906a-282c-ff68-91a7" name="Irad-cleanser" hidden="false" targetId="087e3cad-c849-204a-b83a-29093869a431" type="profile"/>
+                <infoLink id="906a-282c-ff68-91a7" name="Irad-cleanser" hidden="false" targetId="7d03914a-f940-12e5-590b-822083dff647" type="profile"/>
                 <infoLink id="a028-a212-2ac7-ba7e" name="Fleshbane" hidden="false" targetId="4575-0a0a-caaf-e4bf" type="rule"/>
                 <infoLink id="5c4e-c08c-b876-7fc7" name="Rad-phage" hidden="false" targetId="eefe-09e4-17aa-deb2" type="rule"/>
               </infoLinks>
@@ -13525,7 +13525,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6dfe-b1c1-8095-54bf" type="max"/>
                   </constraints>
                   <infoLinks>
-                    <infoLink id="630c-7570-4e08-0c77" name="Irad-cleanser" hidden="false" targetId="087e3cad-c849-204a-b83a-29093869a431" type="profile">
+                    <infoLink id="630c-7570-4e08-0c77" name="Irad-cleanser" hidden="false" targetId="7d03914a-f940-12e5-590b-822083dff647" type="profile">
                       <modifiers>
                         <modifier type="append" field="5479706523232344415441232323" value="Master-crafted">
                           <conditions>
@@ -13544,7 +13544,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c557-5962-00f1-c3b6" type="max"/>
                   </constraints>
                   <infoLinks>
-                    <infoLink id="f0ef-c495-0e61-00ec" name="Phased-Plasma Fusil" hidden="false" targetId="71ed050b-073d-852a-e50a-425b96eb71cd" type="profile">
+                    <infoLink id="f0ef-c495-0e61-00ec" name="Phased-Plasma Fusil" hidden="false" targetId="306adc93-713f-8c18-71d3-6956c376e9e2" type="profile">
                       <modifiers>
                         <modifier type="append" field="5479706523232344415441232323" value="Master-crafted">
                           <conditions>
@@ -13742,7 +13742,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="41a1-7791-2f5f-3331" type="max"/>
                   </constraints>
                   <infoLinks>
-                    <infoLink id="0c5a-69df-952f-98c2" name="Archaeotech Pistol" hidden="false" targetId="9045e242-71f8-6029-fc57-2b7cbedcc398" type="profile"/>
+                    <infoLink id="0c5a-69df-952f-98c2" name="Archaeotech Pistol" hidden="false" targetId="cf65-5d4c-24a3-92d2" type="profile"/>
                     <infoLink id="420b-6bc9-e0ee-75b5" name="Master-crafted" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule"/>
                   </infoLinks>
                   <costs>
@@ -14292,7 +14292,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="17a0-ab58-5372-0a2a" type="max"/>
                   </constraints>
                   <infoLinks>
-                    <infoLink id="9a02-1850-8365-b8a1" name="Archaeotech Pistol" hidden="false" targetId="9045e242-71f8-6029-fc57-2b7cbedcc398" type="profile"/>
+                    <infoLink id="9a02-1850-8365-b8a1" name="Archaeotech Pistol" hidden="false" targetId="cf65-5d4c-24a3-92d2" type="profile"/>
                     <infoLink id="023e-e841-62e6-3f3e" name="Master-crafted" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule"/>
                   </infoLinks>
                   <costs>
@@ -14795,7 +14795,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed81-9877-962a-d7f9" type="max"/>
                   </constraints>
                   <infoLinks>
-                    <infoLink id="7c48-81ec-6bb2-64c2" name="Archaeotech Pistol" hidden="false" targetId="9045e242-71f8-6029-fc57-2b7cbedcc398" type="profile"/>
+                    <infoLink id="7c48-81ec-6bb2-64c2" name="Archaeotech Pistol" hidden="false" targetId="cf65-5d4c-24a3-92d2" type="profile"/>
                     <infoLink id="7ded-0604-00b1-0cc5" name="Master-crafted" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule"/>
                   </infoLinks>
                   <costs>
@@ -15240,7 +15240,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="33ea-7e59-8563-ab97" type="max"/>
                   </constraints>
                   <infoLinks>
-                    <infoLink id="f867-0e43-52e9-59bc" name="Irad-cleanser" hidden="false" targetId="087e3cad-c849-204a-b83a-29093869a431" type="profile">
+                    <infoLink id="f867-0e43-52e9-59bc" name="Irad-cleanser" hidden="false" targetId="7d03914a-f940-12e5-590b-822083dff647" type="profile">
                       <modifiers>
                         <modifier type="append" field="5479706523232344415441232323" value="Master-crafted">
                           <conditions>
@@ -15292,7 +15292,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2f71-b2cf-f93f-04d5" type="max"/>
                   </constraints>
                   <infoLinks>
-                    <infoLink id="311e-07b1-647b-a87f" name="Phased-Plasma Fusil" hidden="false" targetId="71ed050b-073d-852a-e50a-425b96eb71cd" type="profile">
+                    <infoLink id="311e-07b1-647b-a87f" name="Phased-Plasma Fusil" hidden="false" targetId="306adc93-713f-8c18-71d3-6956c376e9e2" type="profile">
                       <modifiers>
                         <modifier type="append" field="5479706523232344415441232323" value="Master-crafted">
                           <conditions>
@@ -15488,7 +15488,7 @@ Construct shields have an Armour value of 11. A Glancing or Penetrating hit (or 
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c256-fe22-4b7a-e58d" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="4c1b-3c8d-143c-73f1" name="Servo-arm" hidden="false" targetId="f4404a95-506e-bcef-1420-21d2d6e9013b" type="profile">
+                <infoLink id="4c1b-3c8d-143c-73f1" name="Servo Arm" hidden="false" targetId="c3a5-c40c-b493-5cf6" type="profile">
                   <modifiers>
                     <modifier type="append" field="5479706523232344415441232323" value=", Master-crafted">
                       <conditions>
@@ -18613,25 +18613,12 @@ A Unit may not use Counter Attack special rule if it used Reaction Fire.</descri
         <characteristic name="Type" typeId="5479706523232344415441232323">Melee, +1 Attack, Machine Destroyer</characteristic>
       </characteristics>
     </profile>
-    <profile id="6eb5b812-8b8b-9e7c-279e-c9e9c93fefe9" name="Atomantic Shielding" publicationId="cf03-f607-pubN76979" page="207" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
-      <characteristics>
-        <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Gains 5++ Invulnerable save from shooting attacks and explosions, and a 6++ Invulnerable save in close combat.  In addition, add +1 to the range of explosions from the Reactor Blast rule.  </characteristic>
-      </characteristics>
-    </profile>
     <profile id="99a47c75-0410-1c54-8124-3adcbd64aa7e" name="Breacher Charge" publicationId="cf03-f607-pubN80892" page="86" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">Special</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">8</characteristic>
         <characteristic name="AP" typeId="415023232344415441232323">2</characteristic>
         <characteristic name="Type" typeId="5479706523232344415441232323">Melee, One Use, Blast, Wrecker</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="50707f97-ecd0-785e-cccc-8f866cac5ecb" name="Charnabal Sabre" publicationId="cf03-f607-pubN80892" page="86" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
-      <characteristics>
-        <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
-        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">User</characteristic>
-        <characteristic name="AP" typeId="415023232344415441232323">-</characteristic>
-        <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Rending, Deullist&apos;s Edge</characteristic>
       </characteristics>
     </profile>
     <profile id="4687f5b1-f0b1-12bd-8cc7-27f9f25befaf" name="Cognis-signum" publicationId="cf03-f607-pubN80892" page="88" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
@@ -18682,14 +18669,6 @@ A Unit may not use Counter Attack special rule if it used Reaction Fire.</descri
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">+1</characteristic>
         <characteristic name="AP" typeId="415023232344415441232323">4</characteristic>
         <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Two-handed, Concussive, Haywire*</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="4e785d0e-85ad-2d40-bd57-9a3eab413431" name="Darkfire Cannon" publicationId="cf03-f607-pubN76979" page="209" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
-      <characteristics>
-        <characteristic name="Range" typeId="52616e676523232344415441232323">60&quot;</characteristic>
-        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">7</characteristic>
-        <characteristic name="AP" typeId="415023232344415441232323">2</characteristic>
-        <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 2, Lance, Blind, Gets Hot</characteristic>
       </characteristics>
     </profile>
     <profile id="2160e9dc-0bd4-805f-95ff-311ab8045e01" name="Double-barrelled Turbo-laser Destructor" publicationId="cf03-f607-pubN123006" page="274" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
@@ -18787,14 +18766,6 @@ A Unit may not use Counter Attack special rule if it used Reaction Fire.</descri
         <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 1, Large Blast, Firing Calibration</characteristic>
       </characteristics>
     </profile>
-    <profile id="012e-a738-c943-5c1d" name="Heavy Stubber" publicationId="cf03-f607-pubN99227" page="308" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
-      <characteristics>
-        <characteristic name="Range" typeId="52616e676523232344415441232323">36&quot;</characteristic>
-        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">4</characteristic>
-        <characteristic name="AP" typeId="415023232344415441232323">6</characteristic>
-        <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 3</characteristic>
-      </characteristics>
-    </profile>
     <profile id="ab4aca3e-a4f8-8057-5d15-6c93943a4d26" name="Hellstrike Missiles" publicationId="cf03-f607-pubN123006" page="0" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323"/>
@@ -18816,14 +18787,6 @@ A Unit may not use Counter Attack special rule if it used Reaction Fire.</descri
         <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">May drop a single flare per turn.  Fired just as bombs - flare is placed after scattering.  Leave in place until the end of the turn.  Any unit targeting an enemy within 12&quot; of the flare gains Night Vision for the shooting phase.  Split fire does not apply.  </characteristic>
       </characteristics>
     </profile>
-    <profile id="17c19758-29ee-7153-06bc-34e5091c7a5e" name="Inferno Cannon" publicationId="cf03-f607-pubN123006" page="274" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
-      <characteristics>
-        <characteristic name="Range" typeId="52616e676523232344415441232323">Hellstorm*</characteristic>
-        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">7</characteristic>
-        <characteristic name="AP" typeId="415023232344415441232323">3</characteristic>
-        <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 1</characteristic>
-      </characteristics>
-    </profile>
     <profile id="33e5-3347-0c00-4244" name="Ion Shield" publicationId="cf03-f607-pubN99227" page="301" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
       <characteristics>
         <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">When deployed, and at the start of each subsequent opposing side&apos;s shooting phase, the Knight&apos;s controlling player must declare a facing for the ion shield.  Choices are front, left, right, or rear.    The Knight has a 4+ invulnerable save  against all hits on that facing until the start of the opposing side&apos;s next shooting phase.  Ion shields are repositioned before any attacks are carried out and may not protect against close combat attacks.  </characteristic>
@@ -18832,22 +18795,6 @@ A Unit may not use Counter Attack special rule if it used Reaction Fire.</descri
     <profile id="54b5-df3e-a811-b7b9" name="Ionic Flare Shield" publicationId="cf03-f607-pubN99227" page="303" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
       <characteristics>
         <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">When deployed, and at the start of each subsequent opposing side&apos;s shooting phase, the Knight&apos;s controlling player must declare a facing for the ionic flare shield.  Choices are front, left, right, or rear.    The Knight has a 4+ invulnerable save  against all hits on that facing until the start of the opposing side&apos;s next shooting phase.  The strength of any shooting attack is reduced by -1, increasing to -2 if the weapon has the blast or template rule.  This does not effect Destroyer or Haywire attacks.  Ionic flare shields are repositioned before any attacks are carried out and may not protect against close combat attacks.  </characteristic>
-      </characteristics>
-    </profile>
-    <profile id="087e3cad-c849-204a-b83a-29093869a431" name="Irad-cleanser" publicationId="cf03-f607-pubN123006" page="240" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
-      <characteristics>
-        <characteristic name="Range" typeId="52616e676523232344415441232323">Template</characteristic>
-        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">2</characteristic>
-        <characteristic name="AP" typeId="415023232344415441232323">5</characteristic>
-        <characteristic name="Type" typeId="5479706523232344415441232323">Assault 1, Fleshbane, Rad-Phage</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="926a370f-f4c1-b644-34f2-c348a5ce36c0" name="Irradiation Engine" publicationId="cf03-f607-pubN123006" page="240" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
-      <characteristics>
-        <characteristic name="Range" typeId="52616e676523232344415441232323">Template</characteristic>
-        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">4</characteristic>
-        <characteristic name="AP" typeId="415023232344415441232323">3</characteristic>
-        <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 1, Fleshbane, Rad-Phage, Torrent</characteristic>
       </characteristics>
     </profile>
     <profile id="65bf6242-8fa0-55f7-92ac-71f4a8fba433" name="Las-lock" publicationId="cf03-f607-pubN76979" page="221" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
@@ -18882,22 +18829,6 @@ A Unit may not use Counter Attack special rule if it used Reaction Fire.</descri
         <characteristic name="Type" typeId="5479706523232344415441232323">Ordnance 1, Twin-linked</characteristic>
       </characteristics>
     </profile>
-    <profile id="0549fb57-3ec6-8bd4-830a-85fb240cb1d7" name="Lightning Cannon" publicationId="cf03-f607-pubN76979" page="228" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
-      <characteristics>
-        <characteristic name="Range" typeId="52616e676523232344415441232323">48&quot;</characteristic>
-        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">7</characteristic>
-        <characteristic name="AP" typeId="415023232344415441232323">3</characteristic>
-        <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 1, Rending, Shred, Large Blast</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="ec450cd6-6dba-ca68-091c-9c48fcbc2112" name="Lightning Gun" publicationId="cf03-f607-pubN123006" page="240" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
-      <characteristics>
-        <characteristic name="Range" typeId="52616e676523232344415441232323">18&quot;</characteristic>
-        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">7</characteristic>
-        <characteristic name="AP" typeId="415023232344415441232323">5</characteristic>
-        <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 1, Shred, Rending</characteristic>
-      </characteristics>
-    </profile>
     <profile id="405d3ced-c3a6-9f99-2018-9ab90162b6b1" name="Lorica Thallax" publicationId="cf03-f607-pubN123006" page="240" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
       <characteristics>
         <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Provides 4+ Armour and FNP 6+ but may not make Sweeping Advances</characteristic>
@@ -18919,36 +18850,12 @@ A Unit may not use Counter Attack special rule if it used Reaction Fire.</descri
         <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Unwieldy, Shred, Armourbane</characteristic>
       </characteristics>
     </profile>
-    <profile id="a037-b03b-2c2b-23c3" name="Macro-gatling Blaster" publicationId="cf03-f607-pubN80965" page="264" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
-      <characteristics>
-        <characteristic name="Range" typeId="52616e676523232344415441232323">72&quot;</characteristic>
-        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">10</characteristic>
-        <characteristic name="AP" typeId="415023232344415441232323">3</characteristic>
-        <characteristic name="Type" typeId="5479706523232344415441232323">Primary Weapon 6, Large Blast, Pinning</characteristic>
-      </characteristics>
-    </profile>
     <profile id="8043abca-b8b1-2694-0fc0-4e3d58910eca" name="Maxima Bolter" publicationId="cf03-f607-pubN76780" page="135" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">12&quot;</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">4</characteristic>
         <characteristic name="AP" typeId="415023232344415441232323">5</characteristic>
         <characteristic name="Type" typeId="5479706523232344415441232323">Assault 3</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="5bed8e68-c2db-1f09-9ea4-bfca1a3f3be3" name="Melta Cannon" publicationId="cf03-f607-pubN123006" page="274" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
-      <characteristics>
-        <characteristic name="Range" typeId="52616e676523232344415441232323">72&quot;</characteristic>
-        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">10</characteristic>
-        <characteristic name="AP" typeId="415023232344415441232323">2</characteristic>
-        <characteristic name="Type" typeId="5479706523232344415441232323">Ordnance 1, Apocalyptic Blast (10&quot;)</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="5090-b1d2-e9ae-ffa2" name="Melta Cannon" publicationId="cf03-f607-pubN123006" page="274" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
-      <characteristics>
-        <characteristic name="Range" typeId="52616e676523232344415441232323">72&quot;</characteristic>
-        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">10</characteristic>
-        <characteristic name="AP" typeId="415023232344415441232323">2</characteristic>
-        <characteristic name="Type" typeId="5479706523232344415441232323">Ordnance 1, Apocalyptic Blast (10&quot;)</characteristic>
       </characteristics>
     </profile>
     <profile id="47b334bb-cad7-a46c-c2eb-95ce7cd7bcd2" name="Mitralock" publicationId="cf03-f607-pubN76979" page="221" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
@@ -18959,35 +18866,9 @@ A Unit may not use Counter Attack special rule if it used Reaction Fire.</descri
         <characteristic name="Type" typeId="5479706523232344415441232323">Assault 1, Shred</characteristic>
       </characteristics>
     </profile>
-    <profile id="b4632691-8dcc-7fe7-b324-18b20f07c4ab" name="Narthecium" page="0" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
-      <characteristics>
-        <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323"/>
-      </characteristics>
-    </profile>
-    <profile id="7bc689cc-398d-f1f4-2359-ddbdf3af8968" name="Needle Pistol" publicationId="cf03-f607-pubN80892" page="84" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
-      <characteristics>
-        <characteristic name="Range" typeId="52616e676523232344415441232323">12&quot;</characteristic>
-        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">2</characteristic>
-        <characteristic name="AP" typeId="415023232344415441232323">5</characteristic>
-        <characteristic name="Type" typeId="5479706523232344415441232323">Pistol, Poisoned, Rending</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="9a458a3c-a9b5-db5e-a218-2041a3a49004" name="Nuncio-vox" publicationId="cf03-f607-pubN80892" page="91" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
-      <characteristics>
-        <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Units arriving via Deep Strike within 6&quot;  of a Nuncio-vox do not scatter.  When barrage weapons are used by the controlling player, line of sight may be drawn from any model equipped with a Nuncio-vox as well as the firing model itself. Range is still drawn from the firing model.  It may not be used inside a vehicle.   </characteristic>
-      </characteristics>
-    </profile>
     <profile id="1283-e198-796c-b406" name="Occular Augmetics" publicationId="cf03-f607-pubN99227" page="301" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
       <characteristics>
         <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Has Night Vision special rule, and may re-roll results of a 1 on the Vehicle Damage table and Destroyer Weapon Attack table which are inflicted by their shooting attacks at a range of 12&quot; or less.  </characteristic>
-      </characteristics>
-    </profile>
-    <profile id="71ed050b-073d-852a-e50a-425b96eb71cd" name="Phased-Plasma Fusil" publicationId="cf03-f607-pubN143916" page="232" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
-      <characteristics>
-        <characteristic name="Range" typeId="52616e676523232344415441232323">24&quot;</characteristic>
-        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">6</characteristic>
-        <characteristic name="AP" typeId="415023232344415441232323">3</characteristic>
-        <characteristic name="Type" typeId="5479706523232344415441232323">Salvo 2/3</characteristic>
       </characteristics>
     </profile>
     <profile id="2c169963-d356-aa63-60bd-eee2ee1afcc0" name="Plasma Blaster" publicationId="cf03-f607-pubN80892" page="84" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
@@ -18998,44 +18879,12 @@ A Unit may not use Counter Attack special rule if it used Reaction Fire.</descri
         <characteristic name="Type" typeId="5479706523232344415441232323">Assault 2, Gets Hot!</characteristic>
       </characteristics>
     </profile>
-    <profile id="0d83ac2f-7e3a-3363-98ed-320e3316b94c" name="Plasma Blastgun (Overload)" publicationId="cf03-f607-pubN80892" page="65" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
-      <characteristics>
-        <characteristic name="Range" typeId="52616e676523232344415441232323">96&quot;</characteristic>
-        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">10</characteristic>
-        <characteristic name="AP" typeId="415023232344415441232323">2</characteristic>
-        <characteristic name="Type" typeId="5479706523232344415441232323">Primary Weapon 1, Apocalyptic Blast (10&quot;)</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="d67c0bb3-8feb-6863-4d75-507b49d2ca86" name="Plasma Blastgun (Rapid)" publicationId="cf03-f607-pubN80892" page="65" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
-      <characteristics>
-        <characteristic name="Range" typeId="52616e676523232344415441232323">72&quot;</characteristic>
-        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">8</characteristic>
-        <characteristic name="AP" typeId="415023232344415441232323">2</characteristic>
-        <characteristic name="Type" typeId="5479706523232344415441232323">Primary Weapon 2, Massive Blast (7&quot;)</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="6e9c4f42-34a8-9253-3f68-8b582ee5830b" name="Power Blades" publicationId="cf03-f607-pubN76979" page="208" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
-      <characteristics>
-        <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
-        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">User</characteristic>
-        <characteristic name="AP" typeId="415023232344415441232323">2</characteristic>
-        <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Rending</characteristic>
-      </characteristics>
-    </profile>
     <profile id="3a3ff98f-d81d-ba25-797b-d88b293189c5" name="Pulsar-fusil" publicationId="cf03-f607-pubN76979" page="228" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">36&quot;</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">9</characteristic>
         <characteristic name="AP" typeId="415023232344415441232323">2</characteristic>
         <characteristic name="Type" typeId="5479706523232344415441232323">Ordnance 4, Pinning</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="6d02b74f-b832-0249-9ba0-01ac9c192099" name="Quad Mortar" publicationId="cf03-f607-pubN80892" page="83" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
-      <characteristics>
-        <characteristic name="Range" typeId="52616e676523232344415441232323">12&quot; - 60&quot;</characteristic>
-        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">5</characteristic>
-        <characteristic name="AP" typeId="415023232344415441232323">5</characteristic>
-        <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 4, Barrage, Blast, Shell Shock</characteristic>
       </characteristics>
     </profile>
     <profile id="69c7-9b79-399f-b7a9" name="Rad cleanser" publicationId="cf03-f607-pubN99227" page="308" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
@@ -19049,54 +18898,6 @@ A Unit may not use Counter Attack special rule if it used Reaction Fire.</descri
     <profile id="7f32-3376-7246-eeb0" name="Rad Furnace" publicationId="cf03-f607-pubN80965" page="223" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
       <characteristics>
         <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">All models locked in combat with this unit suffer -1 to their Toughness for the duration of the combat. Models equiped with Rad Furnace are immune to this effect as well as to Rad Grenades. Any weapon with Poison or Rad-phage only woulds a model with a Rad Furnace on a 6.</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="22d2c64e-3873-429f-5cf8-27e022bb1d6a" name="Reaper Autocannon" publicationId="cf03-f607-pubN80892" page="85" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
-      <characteristics>
-        <characteristic name="Range" typeId="52616e676523232344415441232323">36&quot;</characteristic>
-        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">7</characteristic>
-        <characteristic name="AP" typeId="415023232344415441232323">4</characteristic>
-        <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 2, Twin-linked</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="8bc8-94ff-73be-5959" name="Reaper Chainsword" publicationId="cf03-f607-pubN99227" page="308" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
-      <characteristics>
-        <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
-        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">D</characteristic>
-        <characteristic name="AP" typeId="415023232344415441232323">2</characteristic>
-        <characteristic name="Type" typeId="5479706523232344415441232323">Melee</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="ddb8-921a-2d03-af32" name="Saturnyne Lascutter (Assault)" publicationId="cf03-f607-pubN80965" page="264" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
-      <characteristics>
-        <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
-        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">D</characteristic>
-        <characteristic name="AP" typeId="415023232344415441232323">1</characteristic>
-        <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Machine Destroyer, Instant Death</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="711c-495a-28a6-5d64" name="Saturnyne Lascutter (Shooting)" publicationId="cf03-f607-pubN80965" page="264" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
-      <characteristics>
-        <characteristic name="Range" typeId="52616e676523232344415441232323">Hellstorm</characteristic>
-        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">9</characteristic>
-        <characteristic name="AP" typeId="415023232344415441232323">2</characteristic>
-        <characteristic name="Type" typeId="5479706523232344415441232323">Primary Weapon 1, Instant Death</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="067e9186-0fba-6430-507f-4fbaaecd0d17" name="Scorpius Bolt Shells" publicationId="cf03-f607-pubN80892" page="85" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
-      <characteristics>
-        <characteristic name="Range" typeId="52616e676523232344415441232323">24&quot;</characteristic>
-        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">4</characteristic>
-        <characteristic name="AP" typeId="415023232344415441232323">5</characteristic>
-        <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 1, Rending, Shred</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="f4404a95-506e-bcef-1420-21d2d6e9013b" name="Servo-arm" publicationId="cf03-f607-pubN76979" page="208" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
-      <characteristics>
-        <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
-        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">8</characteristic>
-        <characteristic name="AP" typeId="415023232344415441232323">2</characteristic>
-        <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Unwieldy</characteristic>
       </characteristics>
     </profile>
     <profile id="9458b91c-55d7-ac17-21a3-4235e153b328" name="Servo-automata" publicationId="cf03-f607-pubN80892" page="23" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
@@ -19113,67 +18914,9 @@ A Unit may not use Counter Attack special rule if it used Reaction Fire.</descri
         <characteristic name="Save" typeId="5361766523232344415441232323">5+</characteristic>
       </characteristics>
     </profile>
-    <profile id="6cda-9c8f-b85a-7b78" name="Sunfury Plasma Annihilator" publicationId="cf03-f607-pubN80965" page="264" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
-      <characteristics>
-        <characteristic name="Range" typeId="52616e676523232344415441232323">72&quot;</characteristic>
-        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">9</characteristic>
-        <characteristic name="AP" typeId="415023232344415441232323">2</characteristic>
-        <characteristic name="Type" typeId="5479706523232344415441232323">Primary Weapon 4, Apocalyptic Barrage, Plasma Wave</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="8da7d342-de6d-8cdc-4717-b1ca42c16400" name="Turbo-laser Destructor" publicationId="cf03-f607-pubN80892" page="73" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
-      <characteristics>
-        <characteristic name="Range" typeId="52616e676523232344415441232323">96&quot;</characteristic>
-        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">D</characteristic>
-        <characteristic name="AP" typeId="415023232344415441232323">2</characteristic>
-        <characteristic name="Type" typeId="5479706523232344415441232323">Primary Weapon 1,  Large Blast</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="e811e6ee-aa3f-fff6-9bba-513d01878fe3" name="Volkite Incinerator (Beam)" publicationId="cf03-f607-pubN76979" page="225" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
-      <characteristics>
-        <characteristic name="Range" typeId="52616e676523232344415441232323">10&quot;</characteristic>
-        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">5</characteristic>
-        <characteristic name="AP" typeId="415023232344415441232323">5</characteristic>
-        <characteristic name="Type" typeId="5479706523232344415441232323">Assault 2, Deflagrate</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="13b7b920-7b99-96b1-6c13-9de5323ecd83" name="Volkite Incinerator (Blast)" publicationId="cf03-f607-pubN76979" page="225" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
-      <characteristics>
-        <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
-        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">6</characteristic>
-        <characteristic name="AP" typeId="415023232344415441232323">2</characteristic>
-        <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Instant Death, Prisoned</characteristic>
-      </characteristics>
-    </profile>
     <profile id="bf17bd51-e354-8b3e-f047-c772e08346d4" name="Volkite Sentinels" publicationId="cf03-f607-pubN76979" page="224" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
       <characteristics>
         <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Each is a pintle-mounted Volkite Charger which can be fired in addition to any other weapons the vehicle is carrying without penalty and may target units separately from the vehicles main armament.  </characteristic>
-      </characteristics>
-    </profile>
-    <profile id="d4c95d4c-654b-618a-6543-3bb787d0cddb" name="Vortex Missile" publicationId="cf03-f607-pubN123006" page="274" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
-      <characteristics>
-        <characteristic name="Range" typeId="52616e676523232344415441232323">48&quot; - 480&quot;</characteristic>
-        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">*</characteristic>
-        <characteristic name="AP" typeId="415023232344415441232323">*</characteristic>
-        <characteristic name="Type" typeId="5479706523232344415441232323">Ordnance 1, Apocalyptic Blast (10&quot;), One Shot</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="e072-4756-f9c6-fdf0" name="Vortex Missile Bank" publicationId="cf03-f607-pubN80965" page="264" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
-      <characteristics>
-        <characteristic name="Range" typeId="52616e676523232344415441232323">12&quot; - 360&quot;</characteristic>
-        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">D</characteristic>
-        <characteristic name="AP" typeId="415023232344415441232323">1</characteristic>
-        <characteristic name="Type" typeId="5479706523232344415441232323">Primary Weapon 1, Large Blast, Vortex, 2x One Use</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="fd55-0814-ae39-764f" name="Shock chargers" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
-      <characteristics>
-        <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">A model equipped with shock chargers gains teh Concussive special rule added to all of their close combat attacks regardless of type (including Hammer of Wrath, Smash, etc.)  Shock chargers are not a weapon as such in themselves and so do not have a profile of their own, nor do they add additional attacks in conjunction with other weapons. </characteristic>
-      </characteristics>
-    </profile>
-    <profile id="2d8c-26b3-4336-1b66" name="Searchlight" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
-      <characteristics>
-        <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Searchlights are used when the Night Fighting rules are in effect. If a vehicle has a searchlight, it can, after firing all of its weapons, choose to illuminate its target with the searchlight. If it does so, it also illuminates itself. You may find it helpful to place coins, or other suitable counters, next to the units as reminders, and next to a vehicle to show it has used its searchlights this turn.  Illumination lasts until the end of the following turn. Illuminated units gain no benefit from the Night Fighting rule.</characteristic>
       </characteristics>
     </profile>
     <profile id="c1bc-dda3-fb87-e016" name="Secutarii" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
@@ -19375,28 +19118,12 @@ Each lightning-blaster sentinel may target units separately from the Karacnos&ap
         <characteristic name="Save" typeId="5361766523232344415441232323">3+/5++</characteristic>
       </characteristics>
     </profile>
-    <profile id="9045e242-71f8-6029-fc57-2b7cbedcc398" name="Archaeotech Pistol" publicationId="cf03-f607-pubN80892" page="82" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
-      <characteristics>
-        <characteristic name="Range" typeId="52616e676523232344415441232323">12&quot;</characteristic>
-        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">6</characteristic>
-        <characteristic name="AP" typeId="415023232344415441232323">3</characteristic>
-        <characteristic name="Type" typeId="5479706523232344415441232323">Pistol, Master-crafted</characteristic>
-      </characteristics>
-    </profile>
     <profile id="552f-c41a-a253-113e" name="Castellan Warhead" publicationId="cf03-f607-pubN107623" page="125" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">12&quot; - 48&quot;</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">4</characteristic>
         <characteristic name="AP" typeId="415023232344415441232323">5</characteristic>
         <characteristic name="Type" typeId="5479706523232344415441232323">Ordnance 1, Barrage, Large Blast, Ignores Cover</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="9130-2563-4eba-8ded" name="Vengeance Warhead" publicationId="cf03-f607-pubN107623" page="125" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
-      <characteristics>
-        <characteristic name="Range" typeId="52616e676523232344415441232323">12&quot; - 48&quot;</characteristic>
-        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">5</characteristic>
-        <characteristic name="AP" typeId="415023232344415441232323">4</characteristic>
-        <characteristic name="Type" typeId="5479706523232344415441232323">Ordnance 1, Barrage, Large Blast</characteristic>
       </characteristics>
     </profile>
     <profile id="c96b-c345-a620-5b2b" name="Djinn-skein" publicationId="cf03-f607-pubN76979" page="215" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">

--- a/(HH) Mornival Units.cat
+++ b/(HH) Mornival Units.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="9f87-b468-2001-5e3b" name="Mornival Units Legion Astartes (Fanmade)" revision="24" battleScribeVersion="2.03" authorName="Aus30K / Mourival Events" authorContact="" authorUrl="https://www.facebook.com/groups/190699548351507/" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="125" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="9f87-b468-2001-5e3b" name="Mornival Units Legion Astartes (Fanmade)" revision="25" battleScribeVersion="2.03" authorName="Aus30K / Mourival Events" authorContact="" authorUrl="https://www.facebook.com/groups/190699548351507/" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="133" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="0e6e-8c19-c436-39c4" name="Mournival Events 3.0 Digital Version"/>
     <publication id="cf75-540e-e446-ecd5" name="Mournival Events FAQ and Experimental Errata v3.1"/>
@@ -3505,10 +3505,10 @@ All models with psychic powers suffer a penalty to roll to manifest psychic powe
                     <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8f3e-30e1-1369-6dd4" type="max"/>
                   </constraints>
                 </entryLink>
-                <entryLink id="1ff1-a53c-03a9-2b99" name="Twin-linked Heavy Flamer (Salamanders)" hidden="false" collective="false" import="true" targetId="bf22e42c-d16a-d354-a7f2-f6aba925f510" type="selectionEntry">
-                  <modifiers>
-                    <modifier type="set" field="maxSelections" value="2.0"/>
-                  </modifiers>
+                <entryLink id="1ff1-a53c-03a9-2b99" name="Heavy Flamer" hidden="false" collective="false" import="true" targetId="9fef-d14e-0e9f-1cc8" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b48a-58ed-f809-0f0c" type="max"/>
+                  </constraints>
                 </entryLink>
                 <entryLink id="56eb-b326-9d1e-cac9" name="Twin-linked Autocannon" hidden="false" collective="false" import="true" targetId="62a9-03fb-a823-fc57" type="selectionEntry">
                   <modifiers>
@@ -10073,9 +10073,11 @@ A Unit may not use Counter Attack special rule if it used Reaction Fire.</descri
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0dd3-9eeb-63fc-c4b7" type="max"/>
                   </constraints>
-                  <infoLinks>
-                    <infoLink id="7e66-0ed1-9aba-c652" name="Onslaught" hidden="false" targetId="daed7458-7920-33c2-105e-face63889d1c" type="rule"/>
-                  </infoLinks>
+                  <rules>
+                    <rule id="deb0-d923-59e3-cce7" name="Onslaught" hidden="false">
+                      <description>In a turn in which a model with this rule charges into combat, it gains D3 extra attacks rather than the usual +1. In the case of a unit with multiple models with this rule, roll once and apply the result to each model in the entire unit each turn.</description>
+                    </rule>
+                  </rules>
                   <costs>
                     <cost name="pts" typeId="points" value="5.0"/>
                   </costs>
@@ -12523,7 +12525,7 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="78c8-83e5-a71f-5600" type="max"/>
                   </constraints>
                 </entryLink>
-                <entryLink id="aa3f-be93-02c6-c20f" name="Heavy Flamer (Salamander)" hidden="false" collective="false" import="true" targetId="f2d4a6e5-edf4-52b2-fa15-13b163113aa5" type="selectionEntry">
+                <entryLink id="aa3f-be93-02c6-c20f" name="Heavy Flamer" hidden="false" collective="false" import="true" targetId="9fef-d14e-0e9f-1cc8" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="points" value="0.0"/>
                     <modifier type="set" field="hidden" value="true">
@@ -18888,7 +18890,7 @@ The Centurion/Delegatus may take Terminator Armour as normal. If he does then th
                 <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9bcb-ad08-afe1-d80e" type="max"/>
               </constraints>
               <rules>
-                <rule id="d368-2b45-0394-5b83" name="Relics of the Dark Age of Technology" publicationId="839b6f2a--pubN132867" page="222" hidden="false">
+                <rule id="d368-2b45-0394-5b83" name="Relics of the Dark Age of Technology" publicationId="839b6f2a--pubN77395" page="222" hidden="false">
                   <description>Using Relics of the Dark Age of Technology
 Relics of the Dark Age of Technology may be purchased by Independent Characters at the points cost provided and within the limitations stated in each. They may not be taken by special characters (i.e., models with the Unique type). Only one of each relic may be
 chosen per army.
@@ -18915,7 +18917,7 @@ Void Shield Harness</description>
                 </rule>
               </rules>
               <entryLinks>
-                <entryLink id="2bb4-341e-e046-b8cc" hidden="false" collective="false" import="true" targetId="14271d3b-e836-f09c-2f16-6a2a293d95d1" type="selectionEntryGroup"/>
+                <entryLink id="2bb4-341e-e046-b8cc" name="Relics of the Dark Age of Technology" hidden="false" collective="false" import="true" targetId="14271d3b-e836-f09c-2f16-6a2a293d95d1" type="selectionEntryGroup"/>
               </entryLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -19824,7 +19826,7 @@ Void Shield Harness</description>
                 <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6774-14ef-a238-67a3" type="max"/>
               </constraints>
               <rules>
-                <rule id="332a-9c40-f1b1-cfd3" name="Relics of the Dark Age of Technology" publicationId="839b6f2a--pubN132867" page="222" hidden="false">
+                <rule id="332a-9c40-f1b1-cfd3" name="Relics of the Dark Age of Technology" publicationId="839b6f2a--pubN77395" page="222" hidden="false">
                   <description>Using Relics of the Dark Age of Technology
 Relics of the Dark Age of Technology may be purchased by Independent Characters at the points cost provided and within the limitations stated in each. They may not be taken by special characters (i.e., models with the Unique type). Only one of each relic may be
 chosen per army.
@@ -19851,7 +19853,7 @@ Void Shield Harness</description>
                 </rule>
               </rules>
               <entryLinks>
-                <entryLink id="f624-d345-98fa-c9ba" hidden="false" collective="false" import="true" targetId="14271d3b-e836-f09c-2f16-6a2a293d95d1" type="selectionEntryGroup"/>
+                <entryLink id="f624-d345-98fa-c9ba" name="Relics of the Dark Age of Technology" hidden="false" collective="false" import="true" targetId="14271d3b-e836-f09c-2f16-6a2a293d95d1" type="selectionEntryGroup"/>
               </entryLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -20575,7 +20577,7 @@ Void Shield Harness</description>
                 <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7d0f-b688-edc1-df7f" type="max"/>
               </constraints>
               <rules>
-                <rule id="5f15-dba4-c4fe-1dcc" name="Relics of the Dark Age of Technology" publicationId="839b6f2a--pubN132867" page="222" hidden="false">
+                <rule id="5f15-dba4-c4fe-1dcc" name="Relics of the Dark Age of Technology" publicationId="839b6f2a--pubN77395" page="222" hidden="false">
                   <description>Using Relics of the Dark Age of Technology
 Relics of the Dark Age of Technology may be purchased by Independent Characters at the points cost provided and within the limitations stated in each. They may not be taken by special characters (i.e., models with the Unique type). Only one of each relic may be
 chosen per army.
@@ -20602,7 +20604,7 @@ Void Shield Harness</description>
                 </rule>
               </rules>
               <entryLinks>
-                <entryLink id="b346-bea8-cb78-52af" hidden="false" collective="false" import="true" targetId="14271d3b-e836-f09c-2f16-6a2a293d95d1" type="selectionEntryGroup"/>
+                <entryLink id="b346-bea8-cb78-52af" name="Relics of the Dark Age of Technology" hidden="false" collective="false" import="true" targetId="14271d3b-e836-f09c-2f16-6a2a293d95d1" type="selectionEntryGroup"/>
               </entryLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>

--- a/(HH) Solar Auxilia - Crusade Army List.cat
+++ b/(HH) Solar Auxilia - Crusade Army List.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="7f243fc5-c5fd-8b2c-7b07-907bf684bb72" name="Solar Auxilia" revision="79" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="132" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="7f243fc5-c5fd-8b2c-7b07-907bf684bb72" name="Solar Auxilia" revision="80" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="132" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="7f243fc5--pubN65537" name="Crusade Imperialis"/>
     <publication id="7f243fc5--pubN65563" name="AoDRB"/>
@@ -1826,7 +1826,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="74e66001-4e2d-4a92-a349-b45592b98aaa" hidden="false" targetId="9e5daeb2-93d7-cac7-9d23-c85b81e46ea2" type="profile"/>
+                <infoLink id="74e66001-4e2d-4a92-a349-b45592b98aaa" name="Multi-laser" hidden="false" targetId="92be-1bfc-f355-f214" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
@@ -1873,7 +1873,8 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="db853c39-8ca9-433c-1df6-905ba1449d94" hidden="false" targetId="9e5daeb2-93d7-cac7-9d23-c85b81e46ea2" type="profile"/>
+                <infoLink id="db853c39-8ca9-433c-1df6-905ba1449d94" name="Twin-Linked Multi-laser" hidden="false" targetId="8010-122f-a8d0-0bf7" type="profile"/>
+                <infoLink id="17b4-77fd-c8b1-8027" name="Twin-linked" hidden="false" targetId="10a8-8d89-0bec-3e21" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
@@ -1947,7 +1948,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="8e856245-a032-a6d4-a195-e1bb444bdf5e" hidden="false" targetId="a7ee7212-6cb4-fca3-b31c-1bdd460878cf" type="profile"/>
+                <infoLink id="8e856245-a032-a6d4-a195-e1bb444bdf5e" name="Armoured Cockpit" hidden="false" targetId="06710a9d-a2a8-638f-91b0-2af2fb3e95c2" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
@@ -2193,7 +2194,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c5b3-5965-52a7-f96b" type="max"/>
       </constraints>
       <infoLinks>
-        <infoLink id="ca24-e774-cbd9-ce5f" hidden="false" targetId="b17f-2d29-e5e1-93ba" type="profile"/>
+        <infoLink id="ca24-e774-cbd9-ce5f" name="Auxiliary Drive" hidden="false" targetId="c5c3-cf81-76c6-b0c0" type="profile"/>
       </infoLinks>
       <costs>
         <cost name="pts" typeId="points" value="10.0"/>
@@ -2209,7 +2210,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
     </selectionEntry>
     <selectionEntry id="d3b4-93b8-3ccd-745e" name="Multi-laser" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
-        <infoLink id="0928-78e1-b083-2df8" name="Multi-laser" hidden="false" targetId="9e5daeb2-93d7-cac7-9d23-c85b81e46ea2" type="profile"/>
+        <infoLink id="0928-78e1-b083-2df8" name="Multi-laser" hidden="false" targetId="92be-1bfc-f355-f214" type="profile"/>
       </infoLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
@@ -2316,7 +2317,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b94a-fd65-f495-5195" type="max"/>
                       </constraints>
                       <infoLinks>
-                        <infoLink id="c7db-82d6-1e9a-338e" hidden="false" targetId="9e5daeb2-93d7-cac7-9d23-c85b81e46ea2" type="profile"/>
+                        <infoLink id="c7db-82d6-1e9a-338e" name="Multi-laser" hidden="false" targetId="92be-1bfc-f355-f214" type="profile"/>
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="10.0"/>
@@ -2442,7 +2443,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b9b5-0285-b96c-50ee" type="max"/>
                       </constraints>
                       <infoLinks>
-                        <infoLink id="6853-3e4e-3e1b-262c" hidden="false" targetId="9e5daeb2-93d7-cac7-9d23-c85b81e46ea2" type="profile"/>
+                        <infoLink id="6853-3e4e-3e1b-262c" name="Multi-laser" hidden="false" targetId="92be-1bfc-f355-f214" type="profile"/>
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="10.0"/>
@@ -2569,7 +2570,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="624f-2272-3759-25dd" type="max"/>
                       </constraints>
                       <infoLinks>
-                        <infoLink id="fa54-a51f-b70f-a572" hidden="false" targetId="9e5daeb2-93d7-cac7-9d23-c85b81e46ea2" type="profile"/>
+                        <infoLink id="fa54-a51f-b70f-a572" name="Multi-laser" hidden="false" targetId="92be-1bfc-f355-f214" type="profile"/>
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="10.0"/>
@@ -2746,7 +2747,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
                 </profile>
               </profiles>
               <infoLinks>
-                <infoLink id="c206-368e-32fb-0f1b" name="Auxiliary Drive" hidden="false" targetId="b17f-2d29-e5e1-93ba" type="profile"/>
+                <infoLink id="c206-368e-32fb-0f1b" name="Auxiliary Drive" hidden="false" targetId="c5c3-cf81-76c6-b0c0" type="profile"/>
                 <infoLink id="48dd-1d11-4954-8d60" hidden="false" targetId="11bec7a8-6060-53c9-572c-0df68bf9fa78" type="rule"/>
                 <infoLink id="8f7f-bbeb-61c6-5e31" hidden="false" targetId="574c2081-9a80-532f-6519-ef7cc15310e5" type="rule"/>
               </infoLinks>
@@ -2814,7 +2815,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
                 </profile>
               </profiles>
               <infoLinks>
-                <infoLink id="029b-f164-b79f-cfe8" name="Auxiliary Drive" hidden="false" targetId="b17f-2d29-e5e1-93ba" type="profile"/>
+                <infoLink id="029b-f164-b79f-cfe8" name="Auxiliary Drive" hidden="false" targetId="c5c3-cf81-76c6-b0c0" type="profile"/>
                 <infoLink id="6b0b-3a98-5c70-259a" hidden="false" targetId="11bec7a8-6060-53c9-572c-0df68bf9fa78" type="rule"/>
                 <infoLink id="9999-c4b0-ab41-5994" hidden="false" targetId="574c2081-9a80-532f-6519-ef7cc15310e5" type="rule"/>
                 <infoLink id="5aba-ac97-90c6-e530" name="Deflagrate" hidden="false" targetId="b46a-a3ec-91a5-5001" type="rule"/>
@@ -2882,7 +2883,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
                 </profile>
               </profiles>
               <infoLinks>
-                <infoLink id="e7bf-4430-8cb4-c2d7" name="Auxiliary Drive" hidden="false" targetId="b17f-2d29-e5e1-93ba" type="profile"/>
+                <infoLink id="e7bf-4430-8cb4-c2d7" name="Auxiliary Drive" hidden="false" targetId="c5c3-cf81-76c6-b0c0" type="profile"/>
                 <infoLink id="2bd8-b7bf-7397-f6a8" hidden="false" targetId="11bec7a8-6060-53c9-572c-0df68bf9fa78" type="rule"/>
                 <infoLink id="0cfd-1b2c-0bf6-158f" hidden="false" targetId="574c2081-9a80-532f-6519-ef7cc15310e5" type="rule"/>
               </infoLinks>
@@ -2965,10 +2966,10 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
                 </profile>
               </profiles>
               <infoLinks>
-                <infoLink id="ac69-6f11-6655-ba1e" hidden="false" targetId="b17f-2d29-e5e1-93ba" type="profile"/>
+                <infoLink id="ac69-6f11-6655-ba1e" name="Auxiliary Drive" hidden="false" targetId="c5c3-cf81-76c6-b0c0" type="profile"/>
                 <infoLink id="90f1-95ff-15a6-d4fc" hidden="false" targetId="11bec7a8-6060-53c9-572c-0df68bf9fa78" type="rule"/>
                 <infoLink id="0d52-dd33-d216-fbc8" hidden="false" targetId="de18-25a0-504b-74be" type="rule"/>
-                <infoLink id="6996-df6f-d8f7-f454" hidden="false" targetId="4a15e9b2-b47d-e765-ceb8-8b8aba0e708d" type="rule"/>
+                <infoLink id="6996-df6f-d8f7-f454" name="Induction Charger" hidden="false" targetId="4a15e9b2-b47d-e765-ceb8-8b8aba0e708d" type="rule"/>
               </infoLinks>
               <selectionEntries>
                 <selectionEntry id="1152-a557-3773-6384" name="Battlecannon" hidden="false" collective="false" import="true" type="upgrade">
@@ -3031,7 +3032,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
                 </profile>
               </profiles>
               <infoLinks>
-                <infoLink id="69e7-fb23-4d1a-86a2" hidden="false" targetId="b17f-2d29-e5e1-93ba" type="profile"/>
+                <infoLink id="69e7-fb23-4d1a-86a2" name="Auxiliary Drive" hidden="false" targetId="c5c3-cf81-76c6-b0c0" type="profile"/>
                 <infoLink id="b235-4c8f-f6ee-2c25" hidden="false" targetId="11bec7a8-6060-53c9-572c-0df68bf9fa78" type="rule"/>
                 <infoLink id="a429-62cc-8b1e-7685" hidden="false" targetId="de18-25a0-504b-74be" type="rule"/>
                 <infoLink id="e443-de0d-1719-4c98" hidden="false" targetId="4a15e9b2-b47d-e765-ceb8-8b8aba0e708d" type="rule"/>
@@ -3099,7 +3100,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
                 </profile>
               </profiles>
               <infoLinks>
-                <infoLink id="c888-59bb-b689-0f81" hidden="false" targetId="b17f-2d29-e5e1-93ba" type="profile"/>
+                <infoLink id="c888-59bb-b689-0f81" name="Auxiliary Drive" hidden="false" targetId="c5c3-cf81-76c6-b0c0" type="profile"/>
                 <infoLink id="4387-7229-b448-d832" hidden="false" targetId="11bec7a8-6060-53c9-572c-0df68bf9fa78" type="rule"/>
                 <infoLink id="fa2b-6695-1912-ac84" hidden="false" targetId="de18-25a0-504b-74be" type="rule"/>
                 <infoLink id="f0a8-00c7-e89c-90f0" hidden="false" targetId="4a15e9b2-b47d-e765-ceb8-8b8aba0e708d" type="rule"/>
@@ -3158,7 +3159,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
                 </profile>
               </profiles>
               <infoLinks>
-                <infoLink id="0ec9-6a0b-6cc2-da10" name="Auxiliary Drive" hidden="false" targetId="b17f-2d29-e5e1-93ba" type="profile"/>
+                <infoLink id="0ec9-6a0b-6cc2-da10" name="Auxiliary Drive" hidden="false" targetId="c5c3-cf81-76c6-b0c0" type="profile"/>
                 <infoLink id="ebac-1fd0-3459-595b" hidden="false" targetId="11bec7a8-6060-53c9-572c-0df68bf9fa78" type="rule"/>
                 <infoLink id="83e2-65d9-d6eb-eadb" hidden="false" targetId="de18-25a0-504b-74be" type="rule"/>
                 <infoLink id="b7b4-39fc-2064-7cb4" hidden="false" targetId="4a15e9b2-b47d-e765-ceb8-8b8aba0e708d" type="rule"/>
@@ -3263,7 +3264,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e92d-57e4-85e9-bef1" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="0c28-0a82-830d-eb5e" name="Multi-laser" hidden="false" targetId="9e5daeb2-93d7-cac7-9d23-c85b81e46ea2" type="profile"/>
+                <infoLink id="0c28-0a82-830d-eb5e" name="Multi-laser" hidden="false" targetId="92be-1bfc-f355-f214" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -3467,7 +3468,7 @@ but the tank loses the Fast special rule.</description>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d929-bd95-baa2-a4c5" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="9292-e4f6-a351-7cda" name="Multi-laser" hidden="false" targetId="9e5daeb2-93d7-cac7-9d23-c85b81e46ea2" type="profile"/>
+                <infoLink id="9292-e4f6-a351-7cda" name="Multi-laser" hidden="false" targetId="92be-1bfc-f355-f214" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -3726,7 +3727,7 @@ EDITORS NOTE... I think this rule is now redundant, as I think the rules for how
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="0890-58f6-ef63-ba43" name="Armoured Cockpit" hidden="false" targetId="a7ee7212-6cb4-fca3-b31c-1bdd460878cf" type="profile"/>
+        <infoLink id="0890-58f6-ef63-ba43" name="Armoured Cockpit" hidden="false" targetId="06710a9d-a2a8-638f-91b0-2af2fb3e95c2" type="profile"/>
         <infoLink id="3853-cfc0-5f7b-0835" name="Chaff/Flare Launchers" hidden="false" targetId="10c6f36c-5311-c691-21a7-44286f4fcbbc" type="profile"/>
         <infoLink id="9c37-63a0-7ba4-7c1b" name="New InfoLink" hidden="false" targetId="d219-2314-4834-c054" type="rule"/>
         <infoLink id="b427-c3af-ced4-1310" name="New InfoLink" hidden="false" targetId="2e96-21ae-353e-8742" type="rule"/>
@@ -4413,7 +4414,7 @@ EDITORS NOTE... I think this rule is now redundant, as I think the rules for how
                 <constraint field="selections" scope="parent" value="7.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d89b-40d5-53d0-a9af" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="a0b4-bc13-1f38-ef34" name="Multi-laser" hidden="false" targetId="9e5daeb2-93d7-cac7-9d23-c85b81e46ea2" type="profile"/>
+                <infoLink id="a0b4-bc13-1f38-ef34" name="Multi-laser" hidden="false" targetId="92be-1bfc-f355-f214" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -4563,7 +4564,7 @@ EDITORS NOTE... I think this rule is now redundant, as I think the rules for how
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="25c9-2778-7c18-1dfa" name="Nuncio-vox" hidden="false" targetId="2daecc7c-fbc8-6d50-001f-6f081243db44" type="profile"/>
+            <infoLink id="25c9-2778-7c18-1dfa" name="Nuncio-vox" hidden="false" targetId="2a0e-e1f0-5ea0-5799" type="profile"/>
           </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="0.0"/>
@@ -4773,8 +4774,8 @@ Precision Shots</description>
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="c8d2-d48e-845e-616f" hidden="false" targetId="a7ee7212-6cb4-fca3-b31c-1bdd460878cf" type="profile"/>
-        <infoLink id="c79f-4e4a-5cbe-1526" hidden="false" targetId="10c6f36c-5311-c691-21a7-44286f4fcbbc" type="profile"/>
+        <infoLink id="c8d2-d48e-845e-616f" name="Armoured Cockpit" hidden="false" targetId="06710a9d-a2a8-638f-91b0-2af2fb3e95c2" type="profile"/>
+        <infoLink id="c79f-4e4a-5cbe-1526" name="Chaff/Flare Launchers" hidden="false" targetId="10c6f36c-5311-c691-21a7-44286f4fcbbc" type="profile"/>
         <infoLink id="91cd-13d6-d43d-cc37" hidden="false" targetId="8419eb78-ea22-458d-2cf2-0fe53e265740" type="rule"/>
         <infoLink id="fa33-9d60-bf04-aba9" hidden="false" targetId="1012035b-91e1-dc4f-9870-79feacf53778" type="rule">
           <modifiers>
@@ -5137,7 +5138,7 @@ Precision Shots</description>
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="177f-0a8b-52ca-a8a5" hidden="false" targetId="09afc391-36b1-67bc-b975-9bf8d56e5465" type="rule"/>
+            <infoLink id="177f-0a8b-52ca-a8a5" name="Battlesmith" hidden="false" targetId="9edbc777-7d2b-011b-7488-335b14870be5" type="rule"/>
           </infoLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="4f07-74d2-d3f2-17a5" name="Any Adept may take:" hidden="false" collective="false" import="true">
@@ -5147,7 +5148,7 @@ Precision Shots</description>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6213-c693-6cb8-780a" type="max"/>
                   </constraints>
                   <infoLinks>
-                    <infoLink id="b096-228c-3d42-82ee" hidden="false" targetId="2daecc7c-fbc8-6d50-001f-6f081243db44" type="profile"/>
+                    <infoLink id="b096-228c-3d42-82ee" name="Nuncio-vox" hidden="false" targetId="2a0e-e1f0-5ea0-5799" type="profile"/>
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="10.0"/>
@@ -5169,7 +5170,7 @@ Precision Shots</description>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="56bb-041b-e380-7c5f" type="max"/>
                   </constraints>
                   <infoLinks>
-                    <infoLink id="26d8-7a59-9281-62ca" hidden="false" targetId="44d2260d-9431-a6d0-6ba3-de04b559ba5b" type="profile"/>
+                    <infoLink id="26d8-7a59-9281-62ca" name="Volkite Charger" hidden="false" targetId="c440-1f53-4d20-5cab" type="profile"/>
                     <infoLink id="78e9-25c0-a8c5-0f3c" name="Deflagrate" hidden="false" targetId="b46a-a3ec-91a5-5001" type="rule"/>
                   </infoLinks>
                   <costs>
@@ -5193,7 +5194,7 @@ Precision Shots</description>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="485d-5792-bd27-24ca" type="max"/>
                   </constraints>
                   <infoLinks>
-                    <infoLink id="2b79-9e9a-41a5-57f0" hidden="false" targetId="e426b32c-adcf-ddd3-8635-a9da6f895868" type="profile"/>
+                    <infoLink id="2b79-9e9a-41a5-57f0" name="Cyber-familiar" hidden="false" targetId="379b-7755-6264-0849" type="profile"/>
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="10.0"/>
@@ -5224,7 +5225,7 @@ Precision Shots</description>
               </selectionEntries>
               <entryLinks>
                 <entryLink id="7ad9-8dc2-2f53-d98a" hidden="false" collective="false" import="true" targetId="feca5998-1e05-c682-4f9d-207be0de75a7" type="selectionEntry"/>
-                <entryLink id="bd58-c932-2c8a-e1b9" name="New EntryLink" hidden="false" collective="false" import="true" targetId="5795-fa55-bf06-585f" type="selectionEntry"/>
+                <entryLink id="bd58-c932-2c8a-e1b9" name="Melta Bombs" hidden="false" collective="false" import="true" targetId="5795-fa55-bf06-585f" type="selectionEntry"/>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
@@ -5269,7 +5270,7 @@ Precision Shots</description>
                 <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6203-a8c4-8458-91ce" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="3d8a-e49d-3709-0e36" name="Servo-arm" hidden="false" targetId="29d0c857-4b9e-cb18-9bf4-e1b3a2f60284" type="profile"/>
+                <infoLink id="3d8a-e49d-3709-0e36" name="Servo Arm" hidden="false" targetId="c3a5-c40c-b493-5cf6" type="profile"/>
                 <infoLink id="27f8-8026-0e7b-691f" name="Unwieldy" hidden="false" targetId="5eea-958c-d623-c3c9" type="rule"/>
               </infoLinks>
               <costs>
@@ -5326,7 +5327,7 @@ Precision Shots</description>
                 <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="505e-583b-a3ed-5a6c" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="f1b2-6e99-fd11-0ac1" hidden="false" targetId="f4aa365c-8c58-5658-1b2e-4879848aae89" type="profile"/>
+                <infoLink id="f1b2-6e99-fd11-0ac1" name="Phased-Plasma Fusil" hidden="false" targetId="306adc93-713f-8c18-71d3-6956c376e9e2" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
@@ -5439,7 +5440,7 @@ Precision Shots</description>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0551-e95b-ad0e-e665" type="max"/>
                       </constraints>
                       <infoLinks>
-                        <infoLink id="1fb2-684e-2ebc-971f" hidden="false" targetId="9c538d14-da32-654d-21a0-ee4f0a3354f4" type="profile"/>
+                        <infoLink id="1fb2-684e-2ebc-971f" name="Charnabal Sabre" hidden="false" targetId="d2b5-89d1-10e2-f3f0" type="profile"/>
                         <infoLink id="177f-d59c-75f6-aea4" hidden="false" targetId="47879897-f297-6e79-1b9f-0e93e1a0bc13" type="rule"/>
                       </infoLinks>
                       <costs>
@@ -5553,7 +5554,7 @@ Precision Shots</description>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6d0e-3569-006b-8501" type="max"/>
                       </constraints>
                       <infoLinks>
-                        <infoLink id="ce73-1d8a-056e-bdc2" hidden="false" targetId="9c538d14-da32-654d-21a0-ee4f0a3354f4" type="profile"/>
+                        <infoLink id="ce73-1d8a-056e-bdc2" name="Charnabal Sabre" hidden="false" targetId="d2b5-89d1-10e2-f3f0" type="profile"/>
                         <infoLink id="3f86-6316-c737-a454" hidden="false" targetId="47879897-f297-6e79-1b9f-0e93e1a0bc13" type="rule"/>
                       </infoLinks>
                       <costs>
@@ -5693,7 +5694,7 @@ Precision Shots</description>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d4ab-ac0c-7c08-74b8" type="max"/>
                       </constraints>
                       <infoLinks>
-                        <infoLink id="ff1b-74e1-da97-4c1a" hidden="false" targetId="44d2260d-9431-a6d0-6ba3-de04b559ba5b" type="profile"/>
+                        <infoLink id="ff1b-74e1-da97-4c1a" name="Volkite Charger" hidden="false" targetId="c440-1f53-4d20-5cab" type="profile"/>
                         <infoLink id="8794-d0c0-f877-c796" name="Deflagrate" hidden="false" targetId="b46a-a3ec-91a5-5001" type="rule"/>
                       </infoLinks>
                       <costs>
@@ -5770,7 +5771,7 @@ Precision Shots</description>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="10af-1dc8-da3a-ec0f" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="e50a-ac7b-7727-82be" hidden="false" targetId="44d2260d-9431-a6d0-6ba3-de04b559ba5b" type="profile"/>
+                <infoLink id="e50a-ac7b-7727-82be" name="Volkite Charger" hidden="false" targetId="c440-1f53-4d20-5cab" type="profile"/>
                 <infoLink id="f93e-83d2-685b-983b" name="Deflagrate" hidden="false" targetId="b46a-a3ec-91a5-5001" type="rule"/>
               </infoLinks>
               <costs>
@@ -5786,7 +5787,7 @@ Precision Shots</description>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2b4f-50b6-95a9-84d3" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="84c2-1e53-fc78-111f" hidden="false" targetId="2daecc7c-fbc8-6d50-001f-6f081243db44" type="profile"/>
+                <infoLink id="84c2-1e53-fc78-111f" name="Nuncio-vox" hidden="false" targetId="2a0e-e1f0-5ea0-5799" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
@@ -6034,7 +6035,7 @@ Precision Shots</description>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="165c-15bb-d222-1c74" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="f65d-e790-ca6b-2a70" hidden="false" targetId="e426b32c-adcf-ddd3-8635-a9da6f895868" type="profile"/>
+                <infoLink id="f65d-e790-ca6b-2a70" name="Cyber-familiar" hidden="false" targetId="379b-7755-6264-0849" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
@@ -6821,7 +6822,8 @@ Precision Shots</description>
                 <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e74b-085c-950b-c592" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="7a3e-4f64-da06-0413" name="Multi-laser" hidden="false" targetId="9e5daeb2-93d7-cac7-9d23-c85b81e46ea2" type="profile"/>
+                <infoLink id="7a3e-4f64-da06-0413" name="Twin-Linked Multi-laser" hidden="false" targetId="8010-122f-a8d0-0bf7" type="profile"/>
+                <infoLink id="ae97-1f1c-fa47-0180" name="Twin-linked" hidden="false" targetId="10a8-8d89-0bec-3e21" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -6916,8 +6918,8 @@ Precision Shots</description>
         </modifier>
       </modifiers>
       <infoLinks>
-        <infoLink id="128b-6dcb-ac3a-15bc" hidden="false" targetId="ba12f018-1383-b401-42de-ae503de4fd71" type="profile"/>
-        <infoLink id="544b-4988-8058-8eea" hidden="false" targetId="82a49848-9eb1-305f-5f2a-fc8d08de7248" type="profile"/>
+        <infoLink id="128b-6dcb-ac3a-15bc" name="Lightning Gun" hidden="false" targetId="2850d06c-1eef-bae4-1314-6a3d9635193b" type="profile"/>
+        <infoLink id="544b-4988-8058-8eea" name="Lorica Thallax" hidden="false" targetId="82a49848-9eb1-305f-5f2a-fc8d08de7248" type="profile"/>
         <infoLink id="d226-83b5-5c34-f805" hidden="false" targetId="65f8cafb-0663-a321-3bd5-cd7fbb695ce1" type="rule"/>
         <infoLink id="26df-7b6d-f10a-1506" name="New InfoLink" hidden="false" targetId="7be5-30af-1a02-0a89" type="rule"/>
         <infoLink id="11cd-ca59-bc79-0845" name="New InfoLink" hidden="false" targetId="38d5-b6eb-bda8-2497" type="rule"/>
@@ -6991,7 +6993,7 @@ Precision Shots</description>
                 <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="483e-6c20-4197-df18" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="d059-eb42-14f8-bf45" name="Multi-laser" hidden="false" targetId="9e5daeb2-93d7-cac7-9d23-c85b81e46ea2" type="profile"/>
+                <infoLink id="d059-eb42-14f8-bf45" name="Multi-laser" hidden="false" targetId="92be-1bfc-f355-f214" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
@@ -7002,7 +7004,7 @@ Precision Shots</description>
                 <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ae2b-6121-4a98-21c8" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="38aa-1396-092b-d70e" hidden="false" targetId="f4aa365c-8c58-5658-1b2e-4879848aae89" type="profile"/>
+                <infoLink id="38aa-1396-092b-d70e" name="Phased-Plasma Fusil" hidden="false" targetId="306adc93-713f-8c18-71d3-6956c376e9e2" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
@@ -7013,7 +7015,7 @@ Precision Shots</description>
                 <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ed73-4c0d-fd42-d8de" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="a32f-e084-7add-5b2c" name="Irad-cleanser" hidden="false" targetId="e008aca1-b57a-5f7c-e41f-14519519fbee" type="profile"/>
+                <infoLink id="a32f-e084-7add-5b2c" name="Irad-cleanser" hidden="false" targetId="7d03914a-f940-12e5-590b-822083dff647" type="profile"/>
                 <infoLink id="f198-07e0-95ca-b6f7" name="Rad-phage" hidden="false" targetId="eefe-09e4-17aa-deb2" type="rule"/>
                 <infoLink id="4e0a-1cbc-70e4-27c8" name="Fleshbane" hidden="false" targetId="4575-0a0a-caaf-e4bf" type="rule"/>
               </infoLinks>
@@ -7038,7 +7040,7 @@ Precision Shots</description>
                 <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8a32-37b0-e7b1-0e0c" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="d005-87f2-47c1-032e" name="Photon Thruster" hidden="false" targetId="59fa4207-b5dc-94fd-ff43-37135c8ecb61" type="profile"/>
+                <infoLink id="d005-87f2-47c1-032e" name="Photon Thruster" hidden="false" targetId="77a5-6519-70ee-0414" type="profile"/>
                 <infoLink id="efd5-af33-8c6f-401a" name="Lance" hidden="false" targetId="98ed-3a29-c86b-455d" type="rule"/>
                 <infoLink id="7efb-8386-0f49-f95e" name="Blind" hidden="false" targetId="7dae-4d12-baba-e529" type="rule"/>
                 <infoLink id="3dbe-e7f1-9bc7-918c" name="Gets Hot" hidden="false" targetId="f4fd-d519-4769-5510" type="rule"/>
@@ -7158,7 +7160,7 @@ Precision Shots</description>
       </rules>
       <infoLinks>
         <infoLink id="c8a3-64c0-a45d-758f" hidden="false" targetId="aa451588-557c-7f81-2b3f-d17583985f38" type="rule"/>
-        <infoLink id="4b93-b009-2883-0fb5" hidden="false" targetId="0f466e26-4de9-d53c-5270-4c95dcf6867e" type="rule"/>
+        <infoLink id="4b93-b009-2883-0fb5" name="Hold the Line" hidden="false" targetId="0f466e26-4de9-d53c-5270-4c95dcf6867e" type="rule"/>
         <infoLink id="f720-d3b5-78ee-fd3f" hidden="false" targetId="470a38b3-ad69-52de-2996-36fa27f50e04" type="rule"/>
         <infoLink id="c126-b0f8-030d-269a" hidden="false" targetId="dff0089a-4273-26a0-d96f-b5a36d57a18f" type="profile"/>
         <infoLink id="c6bd-c7c4-a471-2817" name="New InfoLink" hidden="false" targetId="d890-1b84-bbd9-12d3" type="profile"/>
@@ -7233,7 +7235,7 @@ Precision Shots</description>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="228f-8922-b77e-f088" type="max"/>
                       </constraints>
                       <infoLinks>
-                        <infoLink id="7fe0-14f2-32db-40f0" hidden="false" targetId="9c538d14-da32-654d-21a0-ee4f0a3354f4" type="profile"/>
+                        <infoLink id="7fe0-14f2-32db-40f0" name="Charnabal Sabre" hidden="false" targetId="d2b5-89d1-10e2-f3f0" type="profile"/>
                         <infoLink id="ff50-e0a6-79f5-8179" hidden="false" targetId="47879897-f297-6e79-1b9f-0e93e1a0bc13" type="rule"/>
                       </infoLinks>
                       <costs>
@@ -7359,7 +7361,7 @@ Precision Shots</description>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="aac7-85eb-9d32-1fd7" type="max"/>
                       </constraints>
                       <infoLinks>
-                        <infoLink id="e38a-e063-343c-c2e5" hidden="false" targetId="9c538d14-da32-654d-21a0-ee4f0a3354f4" type="profile"/>
+                        <infoLink id="e38a-e063-343c-c2e5" name="Charnabal Sabre" hidden="false" targetId="d2b5-89d1-10e2-f3f0" type="profile"/>
                         <infoLink id="cbc5-c912-a7b2-7273" hidden="false" targetId="47879897-f297-6e79-1b9f-0e93e1a0bc13" type="rule"/>
                       </infoLinks>
                       <costs>
@@ -7529,7 +7531,7 @@ Precision Shots</description>
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="5c35-dbd3-0d0f-dd6b" hidden="false" targetId="aa451588-557c-7f81-2b3f-d17583985f38" type="rule"/>
+        <infoLink id="5c35-dbd3-0d0f-dd6b" name="Close Formation Fighting" hidden="false" targetId="aa451588-557c-7f81-2b3f-d17583985f38" type="rule"/>
         <infoLink id="72ff-ba57-25eb-9e56" hidden="false" targetId="470a38b3-ad69-52de-2996-36fa27f50e04" type="rule"/>
         <infoLink id="cadc-9598-a19e-13e6" hidden="false" targetId="0f466e26-4de9-d53c-5270-4c95dcf6867e" type="rule"/>
         <infoLink id="90aa-c16a-c5ff-b725" name="Void Armour" hidden="false" targetId="86f51528-f2ce-a3eb-15d1-9396cf0548c7" type="profile"/>
@@ -7606,8 +7608,8 @@ Precision Shots</description>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1c29-c400-98f4-7e86" type="max"/>
                       </constraints>
                       <infoLinks>
-                        <infoLink id="4db9-e5b7-b84f-36f3" name="Charnabal Sabre" hidden="false" targetId="9c538d14-da32-654d-21a0-ee4f0a3354f4" type="profile"/>
-                        <infoLink id="9155-aadd-3224-faf5" hidden="false" targetId="47879897-f297-6e79-1b9f-0e93e1a0bc13" type="rule"/>
+                        <infoLink id="4db9-e5b7-b84f-36f3" name="Charnabal Sabre" hidden="false" targetId="d2b5-89d1-10e2-f3f0" type="profile"/>
+                        <infoLink id="9155-aadd-3224-faf5" name="Duellist&apos;s Edge" hidden="false" targetId="47879897-f297-6e79-1b9f-0e93e1a0bc13" type="rule"/>
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="5.0"/>
@@ -7738,7 +7740,7 @@ Precision Shots</description>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="29d3-898c-e1e9-3b89" type="max"/>
                       </constraints>
                       <infoLinks>
-                        <infoLink id="1d66-70bf-bd77-3d68" hidden="false" targetId="9c538d14-da32-654d-21a0-ee4f0a3354f4" type="profile"/>
+                        <infoLink id="1d66-70bf-bd77-3d68" name="Charnabal Sabre" hidden="false" targetId="d2b5-89d1-10e2-f3f0" type="profile"/>
                         <infoLink id="9384-d47f-44e5-d148" hidden="false" targetId="47879897-f297-6e79-1b9f-0e93e1a0bc13" type="rule"/>
                       </infoLinks>
                       <costs>
@@ -7945,9 +7947,9 @@ Precision Shots</description>
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="7a9b-d4ef-0ffd-bc31" hidden="false" targetId="2daecc7c-fbc8-6d50-001f-6f081243db44" type="profile"/>
+            <infoLink id="7a9b-d4ef-0ffd-bc31" name="Nuncio-vox" hidden="false" targetId="2a0e-e1f0-5ea0-5799" type="profile"/>
             <infoLink id="e57a-bd39-f975-d7db" hidden="false" targetId="f7733b9f-53b3-fea6-a353-06c729deb699" type="profile"/>
-            <infoLink id="695d-e95d-d337-9691" hidden="false" targetId="a36164d1-02bb-16ed-19eb-65bc915bd832" type="profile"/>
+            <infoLink id="695d-e95d-d337-9691" name="Auxilia Lasrifle (Collimator)" hidden="false" targetId="a36164d1-02bb-16ed-19eb-65bc915bd832" type="profile"/>
           </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="0.0"/>
@@ -8087,7 +8089,7 @@ Precision Shots</description>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b3bd-f284-b002-64d5" type="max"/>
                       </constraints>
                       <infoLinks>
-                        <infoLink id="dadd-7f01-83db-d2f3" name="Charnabal Sabre" hidden="false" targetId="9c538d14-da32-654d-21a0-ee4f0a3354f4" type="profile"/>
+                        <infoLink id="dadd-7f01-83db-d2f3" name="Charnabal Sabre" hidden="false" targetId="d2b5-89d1-10e2-f3f0" type="profile"/>
                         <infoLink id="6ddb-dcf6-f0d6-1f12" hidden="false" targetId="47879897-f297-6e79-1b9f-0e93e1a0bc13" type="rule"/>
                       </infoLinks>
                       <costs>
@@ -8231,7 +8233,7 @@ Precision Shots</description>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="21eb-18be-0960-6957" type="max"/>
                       </constraints>
                       <infoLinks>
-                        <infoLink id="e0e6-1d98-90bb-f82a" hidden="false" targetId="9c538d14-da32-654d-21a0-ee4f0a3354f4" type="profile"/>
+                        <infoLink id="e0e6-1d98-90bb-f82a" name="Charnabal Sabre" hidden="false" targetId="d2b5-89d1-10e2-f3f0" type="profile"/>
                         <infoLink id="8472-f38b-ab51-0fda" hidden="false" targetId="47879897-f297-6e79-1b9f-0e93e1a0bc13" type="rule"/>
                       </infoLinks>
                       <costs>
@@ -8391,7 +8393,7 @@ Precision Shots</description>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7f5e-3277-fb4c-4265" type="max"/>
                   </constraints>
                   <infoLinks>
-                    <infoLink id="d822-638e-b2fd-4201" hidden="false" targetId="44d2260d-9431-a6d0-6ba3-de04b559ba5b" type="profile"/>
+                    <infoLink id="d822-638e-b2fd-4201" name="Volkite Charger" hidden="false" targetId="c440-1f53-4d20-5cab" type="profile"/>
                     <infoLink id="11ce-1a53-b183-eac1" name="Deflagrate" hidden="false" targetId="b46a-a3ec-91a5-5001" type="rule"/>
                   </infoLinks>
                   <costs>
@@ -8410,7 +8412,7 @@ Precision Shots</description>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0934-48c2-1b2a-00e9" type="max"/>
                   </constraints>
                   <infoLinks>
-                    <infoLink id="f9dd-7e16-1889-89dd" hidden="false" targetId="2daecc7c-fbc8-6d50-001f-6f081243db44" type="profile"/>
+                    <infoLink id="f9dd-7e16-1889-89dd" name="Nuncio-vox" hidden="false" targetId="2a0e-e1f0-5ea0-5799" type="profile"/>
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="10.0"/>
@@ -8494,7 +8496,7 @@ Precision Shots</description>
             </selectionEntry>
             <selectionEntry id="d68a-6dac-41ca-7d1d" name="Volkite Chargers" hidden="false" collective="false" import="true" type="upgrade">
               <infoLinks>
-                <infoLink id="fb8e-152e-ad96-0d09" name="Volkite Charger" hidden="false" targetId="44d2260d-9431-a6d0-6ba3-de04b559ba5b" type="profile"/>
+                <infoLink id="fb8e-152e-ad96-0d09" name="Volkite Charger" hidden="false" targetId="c440-1f53-4d20-5cab" type="profile"/>
                 <infoLink id="68da-fd33-af7b-fedb" name="Deflagrate" hidden="false" targetId="b46a-a3ec-91a5-5001" type="rule"/>
               </infoLinks>
               <costs>
@@ -8617,7 +8619,7 @@ Precision Shots</description>
     </selectionEntry>
     <selectionEntry id="9a72-5fd9-1981-bf71" name="Volkite Serpenta" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
-        <infoLink id="1776-ab38-f7a9-e628" name="Volkite Serpenta" hidden="false" targetId="7564129d-dc84-e237-d452-211f002e1e8e" type="profile"/>
+        <infoLink id="1776-ab38-f7a9-e628" name="Volkite Serpenta" hidden="false" targetId="477d-c630-7e79-8cf9" type="profile"/>
         <infoLink id="13ca-1068-e2de-b5cc" name="Deflagrate" hidden="false" targetId="b46a-a3ec-91a5-5001" type="rule"/>
       </infoLinks>
       <costs>
@@ -8670,7 +8672,7 @@ Precision Shots</description>
     </selectionEntry>
     <selectionEntry id="f4c2-70f0-1cb5-a00e" name="Charnabal sabre" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
-        <infoLink id="08aa-b4f0-6d6d-757e" name="Charnabal Sabre" hidden="false" targetId="9c538d14-da32-654d-21a0-ee4f0a3354f4" type="profile"/>
+        <infoLink id="08aa-b4f0-6d6d-757e" name="Charnabal Sabre" hidden="false" targetId="d2b5-89d1-10e2-f3f0" type="profile"/>
         <infoLink id="40cd-6134-4bc3-2a7e" name="Rending" hidden="false" targetId="8269-2cd6-9236-16e7" type="rule"/>
         <infoLink id="5665-6dbf-3bfe-2492" name="Duellist&apos;s Edge" hidden="false" targetId="47879897-f297-6e79-1b9f-0e93e1a0bc13" type="rule"/>
       </infoLinks>
@@ -8690,8 +8692,8 @@ Precision Shots</description>
     </selectionEntry>
     <selectionEntry id="9143-5f03-b6dc-395e" name="Paragon Blade" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
-        <infoLink id="ae0f-f2b7-26f9-a328" name="Paragon Blade" hidden="false" targetId="534a368d-08c3-0ed9-71a3-870e4ab5e7e3" type="profile"/>
-        <infoLink id="b914-38a5-5821-1823" name="Murderous Strike" hidden="false" targetId="ed795f28-cb75-87b2-c831-415f86e05c86" type="rule"/>
+        <infoLink id="ae0f-f2b7-26f9-a328" name="Paragon Blade" hidden="false" targetId="54c0-193a-65c8-03b3" type="profile"/>
+        <infoLink id="b914-38a5-5821-1823" name="Murderous Strike" hidden="false" targetId="b0c5-b980-95e5-b181" type="rule"/>
         <infoLink id="f5ec-b8f1-75c3-ac78" name="Specialist Weapon" hidden="false" targetId="7ee3-d437-bc44-3630" type="rule"/>
       </infoLinks>
       <costs>
@@ -8713,7 +8715,7 @@ Precision Shots</description>
     </selectionEntry>
     <selectionEntry id="ac42-b184-e3fe-a554" name="Volkite Charger" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
-        <infoLink id="fced-1990-b5de-1fa9" name="" hidden="false" targetId="44d2260d-9431-a6d0-6ba3-de04b559ba5b" type="profile"/>
+        <infoLink id="fced-1990-b5de-1fa9" name="Volkite Charger" hidden="false" targetId="c440-1f53-4d20-5cab" type="profile"/>
         <infoLink id="4f5f-0ee1-ddbc-8602" name="Deflagrate" hidden="false" targetId="b46a-a3ec-91a5-5001" type="rule"/>
       </infoLinks>
       <costs>
@@ -9036,7 +9038,7 @@ Precision Shots</description>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="32a8-2678-4ca1-c2a5" type="max"/>
                   </constraints>
                   <infoLinks>
-                    <infoLink id="b239-2408-b1db-193e" name="Multi-laser" hidden="false" targetId="9e5daeb2-93d7-cac7-9d23-c85b81e46ea2" type="profile"/>
+                    <infoLink id="b239-2408-b1db-193e" name="Multi-laser" hidden="false" targetId="92be-1bfc-f355-f214" type="profile"/>
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="5.0"/>
@@ -9103,7 +9105,7 @@ Precision Shots</description>
                   </constraints>
                   <infoLinks>
                     <infoLink id="5d6a-f1bf-6bf6-cea3" name="Twin-linked" hidden="false" targetId="10a8-8d89-0bec-3e21" type="rule"/>
-                    <infoLink id="32a9-4424-0878-4d91" name="Multi-laser" hidden="false" targetId="9e5daeb2-93d7-cac7-9d23-c85b81e46ea2" type="profile"/>
+                    <infoLink id="32a9-4424-0878-4d91" name="Twin-Linked Multi-laser" hidden="false" targetId="8010-122f-a8d0-0bf7" type="profile"/>
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="5.0"/>
@@ -9114,7 +9116,7 @@ Precision Shots</description>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e8e9-cab9-9c1d-e5ab" type="max"/>
                   </constraints>
                   <infoLinks>
-                    <infoLink id="d4d4-a64c-cb50-9c36" name="Volkite Culverin" hidden="false" targetId="13bbdf99-5b72-187e-9a9b-203ff8ab08ae" type="profile"/>
+                    <infoLink id="d4d4-a64c-cb50-9c36" name="Volkite Culverin" hidden="false" targetId="34d1-b4db-3e75-ccce" type="profile"/>
                     <infoLink id="82be-dd4f-9113-e366" name="Deflagrate" hidden="false" targetId="b46a-a3ec-91a5-5001" type="rule"/>
                   </infoLinks>
                   <costs>
@@ -9133,7 +9135,7 @@ Precision Shots</description>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6e5c-7231-0adc-3b36" type="max"/>
                   </constraints>
                   <infoLinks>
-                    <infoLink id="ffc9-78eb-9abe-f341" name="Multi-laser" hidden="false" targetId="9e5daeb2-93d7-cac7-9d23-c85b81e46ea2" type="profile"/>
+                    <infoLink id="ffc9-78eb-9abe-f341" name="Multi-laser" hidden="false" targetId="92be-1bfc-f355-f214" type="profile"/>
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="10.0"/>
@@ -9212,7 +9214,7 @@ Precision Shots</description>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <infoLinks>
-            <infoLink id="2ea4561a-322b-8620-fa2f-0598a4c08916" hidden="false" targetId="9e5daeb2-93d7-cac7-9d23-c85b81e46ea2" type="profile"/>
+            <infoLink id="2ea4561a-322b-8620-fa2f-0598a4c08916" name="Multi-laser" hidden="false" targetId="92be-1bfc-f355-f214" type="profile"/>
           </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="0.0"/>
@@ -9639,15 +9641,6 @@ Precision Shots</description>
     <rule id="648c98ba-d7db-2992-ecc5-0c57f82a638a" name="Battle Servitor Control" publicationId="7f243fc5--pubN74753" page="277" hidden="false">
       <description>Gains Tank Hunters</description>
     </rule>
-    <rule id="09afc391-36b1-67bc-b975-9bf8d56e5465" name="Battlesmith" publicationId="7f243fc5--pubN70233" page="81" hidden="false">
-      <description>If a Battlesmith is embarked on or in base contact with one or more damaged vehicles during the shooting phase, they may attempt to repair one of them instead of firing a weapon.  To attempt, roll a D6.  On a result of 5+ the Battlesmith may do one of the following:
-
-- Restore a lost Hull Point
-- Repair a Weapon Destroyed result
-- Repair an Immobilised result
-
-If a Weapon Destroyed result is repaired, that weapon may be fired in the following shooting phase.  The Battlesmith cannot use this ability if he has gone to ground or is falling back.</description>
-    </rule>
     <rule id="10be18c7-ffe3-1df3-0a8f-8ef1ad6200e1" name="Charger Burnout" publicationId="7f243fc5--pubN74753" page="247" hidden="false">
       <description>If a lasrifle is used with a Blast-charger, it may not be used again until at all until after the players next turn.  In addition, roll a D6.  On a 1, the blast-chargers may not be used again in this game.</description>
     </rule>
@@ -9698,9 +9691,6 @@ If your army contains none of the above, but does contain one or more Auxilia Ta
     <rule id="4a15e9b2-b47d-e765-ceb8-8b8aba0e708d" name="Induction Charger" publicationId="7f243fc5--pubN74753" page="274" hidden="false">
       <description>Once per game, declare use at the start of the controlling player&apos;s Movement Phase.  The squadron counts as having the Fast special rule for this player turn.</description>
     </rule>
-    <rule id="ed795f28-cb75-87b2-c831-415f86e05c86" name="Murderous Strike" page="0" hidden="false">
-      <description>Causes Instant Death on a To Wound roll of 6</description>
-    </rule>
     <rule id="8419eb78-ea22-458d-2cf2-0fe53e265740" name="Simulacra Repair" publicationId="7f243fc5--pubN74753" page="275" hidden="false">
       <description>When a vehicle suffers a glancing hit, roll a D6.  On a result of a 6, the damage is ignored.</description>
     </rule>
@@ -9716,11 +9706,6 @@ If your army contains none of the above, but does contain one or more Auxilia Ta
     </rule>
   </sharedRules>
   <sharedProfiles>
-    <profile id="a7ee7212-6cb4-fca3-b31c-1bdd460878cf" name="Armoured Cockpit" publicationId="7f243fc5--pubN70233" page="88" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
-      <characteristics>
-        <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">May ignore Crew shaken or stunned on a D6 roll of 4+</characteristic>
-      </characteristics>
-    </profile>
     <profile id="f7733b9f-53b3-fea6-a353-06c729deb699" name="Auxilia Lasrifle" publicationId="7f243fc5--pubN74753" page="247" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">30&quot;</characteristic>
@@ -9745,11 +9730,6 @@ If your army contains none of the above, but does contain one or more Auxilia Ta
         <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 2</characteristic>
       </characteristics>
     </profile>
-    <profile id="b17f-2d29-e5e1-93ba" name="Auxiliary Drive" publicationId="7f243fc5--pubN70233" page="88" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
-      <characteristics>
-        <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">A vehicle with an Auxiliary Drive may ignore Immobilised results it suffers on a D6 roll of a 4+</characteristic>
-      </characteristics>
-    </profile>
     <profile id="bf51be2a-da2c-b722-f0f4-d8be6779710e" name="Blast Pistol" publicationId="7f243fc5--pubN74753" page="247" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">6&quot;</characteristic>
@@ -9763,14 +9743,6 @@ If your army contains none of the above, but does contain one or more Auxilia Ta
         <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Gains 4++ invulnerable against damage caused by missile weapons. </characteristic>
       </characteristics>
     </profile>
-    <profile id="9c538d14-da32-654d-21a0-ee4f0a3354f4" name="Charnabal Sabre" publicationId="7f243fc5--pubN70233" page="86" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
-      <characteristics>
-        <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
-        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">User</characteristic>
-        <characteristic name="AP" typeId="415023232344415441232323">-</characteristic>
-        <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Rending, Deullist&apos;s Edge</characteristic>
-      </characteristics>
-    </profile>
     <profile id="27fa97b6-468d-4a4e-b83f-61efed13d795" name="Cognis-signum" publicationId="7f243fc5--pubN70233" page="88" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
       <characteristics>
         <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Model equipped with Cognis-sigum gains Night Vision special rule.  In addition, in lieu of firing a weapon in the Shooting phase, a single designated unit of the controlling player&apos;s choice withing 6&quot; of the signum-equipped model (excluding Independent Characters and Super-Heavies) gains a bonus of +1 to their BS for that shooting phase.  </characteristic>
@@ -9779,11 +9751,6 @@ If your army contains none of the above, but does contain one or more Auxilia Ta
     <profile id="3c05e6b4-5c43-4815-d0f3-28ee932d80f0" name="Cohort Vexilla" publicationId="7f243fc5--pubN74753" page="250" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
       <characteristics>
         <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">A unit that contains a model with a Troop Vexilla counts as scoring an additional wound for close combat results and may always attempt to regroup regardless of being below 25%.  Additionally, any friendly unit from the Soloar Auxilia army with models within 24&quot; of the Cohort Auxilia may ignore casualties when taking Morale checks.  </characteristic>
-      </characteristics>
-    </profile>
-    <profile id="e426b32c-adcf-ddd3-8635-a9da6f895868" name="Cyber-familiar" publicationId="7f243fc5--pubN70233" page="89" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
-      <characteristics>
-        <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">A Cyber-familiar adds +1 to its owners Invulnerable save (to a maximum of 3++) or provides an Invulnerable save of a 6++.   In addition they allow the owner to re-roll failed characteristic tests other than Leadership tests and failed Dangerous Terrain tests.  </characteristic>
       </characteristics>
     </profile>
     <profile id="cffa84fe-0304-a520-2662-461fa2f67e78" name="Darkfire Cannon" publicationId="7f243fc5--pubN94125" page="209" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
@@ -9841,22 +9808,6 @@ If your army contains none of the above, but does contain one or more Auxilia Ta
         <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">May drop a single flare per turn.  Fired just as bombs - flare is placed after scattering.  Leave in place until the end of the turn.  Any unit targeting an enemy within 12&quot; of the flare gains Night Vision for the shooting phase.  Split fire does not apply.  </characteristic>
       </characteristics>
     </profile>
-    <profile id="e008aca1-b57a-5f7c-e41f-14519519fbee" name="Irad-cleanser" publicationId="7f243fc5--pubN116331" page="240" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
-      <characteristics>
-        <characteristic name="Range" typeId="52616e676523232344415441232323">Template</characteristic>
-        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">2</characteristic>
-        <characteristic name="AP" typeId="415023232344415441232323">5</characteristic>
-        <characteristic name="Type" typeId="5479706523232344415441232323">Assault 1, Fleshbane, Rad-Phage</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="f30af14f-b0dc-3aec-51a6-3e12555e4a4a" name="Irradiation Engine" publicationId="7f243fc5--pubN116331" page="240" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
-      <characteristics>
-        <characteristic name="Range" typeId="52616e676523232344415441232323">Template</characteristic>
-        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">4</characteristic>
-        <characteristic name="AP" typeId="415023232344415441232323">3</characteristic>
-        <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 1, Fleshbane, Rad-Phage, Torrent</characteristic>
-      </characteristics>
-    </profile>
     <profile id="d1d6a67c-d459-abd8-5e7d-41900b3a84f4" name="Kinetic Grenade" publicationId="7f243fc5--pubN74753" page="247" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">24&quot;</characteristic>
@@ -9881,14 +9832,6 @@ If your army contains none of the above, but does contain one or more Auxilia Ta
         <characteristic name="Type" typeId="5479706523232344415441232323">Ordnance 1, Twin-linked</characteristic>
       </characteristics>
     </profile>
-    <profile id="ba12f018-1383-b401-42de-ae503de4fd71" name="Lightning Gun" publicationId="7f243fc5--pubN116331" page="240" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
-      <characteristics>
-        <characteristic name="Range" typeId="52616e676523232344415441232323">18&quot;</characteristic>
-        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">7</characteristic>
-        <characteristic name="AP" typeId="415023232344415441232323">5</characteristic>
-        <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 1, Shred, Rending</characteristic>
-      </characteristics>
-    </profile>
     <profile id="82a49848-9eb1-305f-5f2a-fc8d08de7248" name="Lorica Thallax" publicationId="7f243fc5--pubN116331" page="240" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
       <characteristics>
         <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Provides 4+ Armour and FNP 6+ but may not make Sweeping Advances</characteristic>
@@ -9902,73 +9845,12 @@ If your army contains none of the above, but does contain one or more Auxilia Ta
         <characteristic name="Type" typeId="5479706523232344415441232323">Pistol, Fleshbane, Rad-phage</characteristic>
       </characteristics>
     </profile>
-    <profile id="9e5daeb2-93d7-cac7-9d23-c85b81e46ea2" name="Multi-laser" publicationId="7f243fc5--pubN74753" page="247" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
-      <characteristics>
-        <characteristic name="Range" typeId="52616e676523232344415441232323">36&quot;</characteristic>
-        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">6</characteristic>
-        <characteristic name="AP" typeId="415023232344415441232323">6</characteristic>
-        <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 3</characteristic>
-      </characteristics>
-    </profile>
     <profile id="269c4711-8561-1d7b-0150-bbba32072f39" name="Needle Pistol" publicationId="7f243fc5--pubN70233" page="84" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">12&quot;</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">2</characteristic>
         <characteristic name="AP" typeId="415023232344415441232323">5</characteristic>
         <characteristic name="Type" typeId="5479706523232344415441232323">Pistol, Poisoned, Rending</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="2daecc7c-fbc8-6d50-001f-6f081243db44" name="Nuncio-vox" publicationId="7f243fc5--pubN70233" page="91" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
-      <characteristics>
-        <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Units arriving via Deep Strike within 6&quot;  of a Nuncio-vox do not scatter.  When barrage weapons are used by the controlling player, line of sight may be drawn from any model equipped with a Nuncio-vox as well as the firing model itself. Range is still drawn from the firing model.  It may not be used inside a vehicle.   </characteristic>
-      </characteristics>
-    </profile>
-    <profile id="534a368d-08c3-0ed9-71a3-870e4ab5e7e3" name="Paragon Blade" publicationId="7f243fc5--pubN116331" page="235" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
-      <characteristics>
-        <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
-        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">+1</characteristic>
-        <characteristic name="AP" typeId="415023232344415441232323">2</characteristic>
-        <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Murderous Strike, Specialist Weapon</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="f4aa365c-8c58-5658-1b2e-4879848aae89" name="Phased-Plasma Fusil" publicationId="7f243fc5--pubN116870" page="232" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
-      <characteristics>
-        <characteristic name="Range" typeId="52616e676523232344415441232323">24&quot;</characteristic>
-        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">6</characteristic>
-        <characteristic name="AP" typeId="415023232344415441232323">3</characteristic>
-        <characteristic name="Type" typeId="5479706523232344415441232323">Salvo 2/3</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="04924d19-1547-5aac-aeb9-b6a80feb20ef" name="Photon Gauntlet" publicationId="7f243fc5--pubN94125" page="209" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
-      <characteristics>
-        <characteristic name="Range" typeId="52616e676523232344415441232323">12&quot;</characteristic>
-        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">5</characteristic>
-        <characteristic name="AP" typeId="415023232344415441232323">2</characteristic>
-        <characteristic name="Type" typeId="5479706523232344415441232323">Assault 2, Blind, Gets Hot</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="59fa4207-b5dc-94fd-ff43-37135c8ecb61" name="Photon Thruster" publicationId="7f243fc5--pubN94125" page="209" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
-      <characteristics>
-        <characteristic name="Range" typeId="52616e676523232344415441232323">48&quot;</characteristic>
-        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">6</characteristic>
-        <characteristic name="AP" typeId="415023232344415441232323">2</characteristic>
-        <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 2, Lance, Blind, Gets Hot</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="6b9bde8d-7ce2-6098-cf5f-4d523609be9b" name="Plasma Blaster" publicationId="7f243fc5--pubN70233" page="84" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
-      <characteristics>
-        <characteristic name="Range" typeId="52616e676523232344415441232323">18&quot;</characteristic>
-        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">7</characteristic>
-        <characteristic name="AP" typeId="415023232344415441232323">2</characteristic>
-        <characteristic name="Type" typeId="5479706523232344415441232323">Assault 2, Gets Hot!</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="7ad65a49-98f4-549a-2904-ce9a67d0ccaa" name="Power Blades" publicationId="7f243fc5--pubN94125" page="208" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
-      <characteristics>
-        <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
-        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">User</characteristic>
-        <characteristic name="AP" typeId="415023232344415441232323">2</characteristic>
-        <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Rending</characteristic>
       </characteristics>
     </profile>
     <profile id="1c03eb3f-dd49-171f-e5eb-b22d40798be7" name="Psi-jammer" publicationId="7f243fc5--pubN74753" page="251" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
@@ -9995,14 +9877,6 @@ If your army contains none of the above, but does contain one or more Auxilia Ta
     <profile id="dff0089a-4273-26a0-d96f-b5a36d57a18f" name="Reinforced Void Armour" publicationId="7f243fc5--pubN74753" page="251" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
       <characteristics>
         <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Provides a 4+ save and counts as being Void Hardened in games of Zone Mortalis.  Additionally, wearer must re-roll failed saves against Template and Blast type weapons.  </characteristic>
-      </characteristics>
-    </profile>
-    <profile id="29d0c857-4b9e-cb18-9bf4-e1b3a2f60284" name="Servo-arm" publicationId="7f243fc5--pubN94125" page="208" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
-      <characteristics>
-        <characteristic name="Range" typeId="52616e676523232344415441232323">-</characteristic>
-        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">8</characteristic>
-        <characteristic name="AP" typeId="415023232344415441232323">2</characteristic>
-        <characteristic name="Type" typeId="5479706523232344415441232323">Melee, Unwieldy</characteristic>
       </characteristics>
     </profile>
     <profile id="5e5ca3a2-8a82-2700-39fa-acda4e7bf5fa" name="Servo-automata" publicationId="7f243fc5--pubN70233" page="23" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
@@ -10045,44 +9919,12 @@ If your army contains none of the above, but does contain one or more Auxilia Ta
         <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">Provides a 4+ save and counts as being Void Hardened in games of Zone Mortalis. Void Hardened Armour counts as Hardened Armour.</characteristic>
       </characteristics>
     </profile>
-    <profile id="c05be960-68eb-7adf-6123-856b93b3e9bd" name="Volkite Caliver" publicationId="7f243fc5--pubN70233" page="85" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
-      <characteristics>
-        <characteristic name="Range" typeId="52616e676523232344415441232323">30&quot;</characteristic>
-        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">6</characteristic>
-        <characteristic name="AP" typeId="415023232344415441232323">5</characteristic>
-        <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 2, Deflagrate</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="44d2260d-9431-a6d0-6ba3-de04b559ba5b" name="Volkite Charger" publicationId="7f243fc5--pubN70233" page="85" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
-      <characteristics>
-        <characteristic name="Range" typeId="52616e676523232344415441232323">15&quot;</characteristic>
-        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">5</characteristic>
-        <characteristic name="AP" typeId="415023232344415441232323">5</characteristic>
-        <characteristic name="Type" typeId="5479706523232344415441232323">Assault 2, Deflagrate</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="13bbdf99-5b72-187e-9a9b-203ff8ab08ae" name="Volkite Culverin" publicationId="7f243fc5--pubN70233" page="85" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
-      <characteristics>
-        <characteristic name="Range" typeId="52616e676523232344415441232323">45&quot;</characteristic>
-        <characteristic name="Strength" typeId="537472656e67746823232344415441232323"/>
-        <characteristic name="AP" typeId="415023232344415441232323">5</characteristic>
-        <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 4, Deflagrate</characteristic>
-      </characteristics>
-    </profile>
     <profile id="db3c0a52-5b40-6d35-15fc-5f8c9d4f4885" name="Volkite Demi-culverin" publicationId="7f243fc5--pubN74753" page="246" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">45&quot;</characteristic>
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">7</characteristic>
         <characteristic name="AP" typeId="415023232344415441232323">5</characteristic>
         <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 5, Deflagrate</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="7564129d-dc84-e237-d452-211f002e1e8e" name="Volkite Serpenta" publicationId="7f243fc5--pubN70233" page="85" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
-      <characteristics>
-        <characteristic name="Range" typeId="52616e676523232344415441232323">10&quot;</characteristic>
-        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">5</characteristic>
-        <characteristic name="AP" typeId="415023232344415441232323">5</characteristic>
-        <characteristic name="Type" typeId="5479706523232344415441232323">Pistol, Deflagrate</characteristic>
       </characteristics>
     </profile>
     <profile id="6563-97c5-620f-69bb" name="Quad Mortar (Frag)" publicationId="7f243fc5--pubN117639" page="179" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">

--- a/(HH) Talons of the Emperor Army List.cat
+++ b/(HH) Talons of the Emperor Army List.cat
@@ -2916,7 +2916,7 @@
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4190-c0c2-2ffe-d181" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="97b6-da94-7393-dbe5" name="New InfoLink" hidden="false" targetId="3138-683d-a9a0-570d" type="rule"/>
+                <infoLink id="97b6-da94-7393-dbe5" name="Armoured Ceramite" hidden="false" targetId="2e87b8ca-7cd1-78b9-2116-246015e7935e" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
@@ -2938,7 +2938,7 @@
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="91f0-11aa-07c3-8fc5" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="c432-9536-387a-c78d" name="New InfoLink" hidden="false" targetId="5283-9b50-3dcd-78e4" type="rule"/>
+                <infoLink id="c432-9536-387a-c78d" name="Extra Armour" hidden="false" targetId="79c7-90f6-b453-e799" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
@@ -2993,7 +2993,7 @@
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5250-bd43-559b-52b5" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="cc8e-1199-91d9-1489" name="New InfoLink" hidden="false" targetId="3138-683d-a9a0-570d" type="rule"/>
+                <infoLink id="cc8e-1199-91d9-1489" name="Armoured Ceramite" hidden="false" targetId="2e87b8ca-7cd1-78b9-2116-246015e7935e" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
@@ -3004,7 +3004,7 @@
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5dd6-b431-c7fc-af8e" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="8615-75cc-63a2-2f78" name="New InfoLink" hidden="false" targetId="5283-9b50-3dcd-78e4" type="rule"/>
+                <infoLink id="8615-75cc-63a2-2f78" name="Extra Armour" hidden="false" targetId="79c7-90f6-b453-e799" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
@@ -3432,7 +3432,7 @@
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1c76-cf88-eda5-6b6f" type="max"/>
                   </constraints>
                   <infoLinks>
-                    <infoLink id="50ad-14dc-4372-299d" name="New InfoLink" hidden="false" targetId="5283-9b50-3dcd-78e4" type="rule"/>
+                    <infoLink id="50ad-14dc-4372-299d" name="Extra Armour" hidden="false" targetId="79c7-90f6-b453-e799" type="profile"/>
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="5.0"/>
@@ -3872,10 +3872,10 @@
       <infoLinks>
         <infoLink id="fc19-b1ed-4626-7aa0" name="New InfoLink" hidden="false" targetId="69e5-fc02-1f9d-63c2" type="rule"/>
         <infoLink id="5a23-e549-8432-77f9" name="New InfoLink" hidden="false" targetId="6d06-5ea0-9a17-ca97" type="rule"/>
-        <infoLink id="9582-c203-28ed-0050" name="New InfoLink" hidden="false" targetId="0900-71d5-1937-aa96" type="rule"/>
+        <infoLink id="9582-c203-28ed-0050" name="Counter-attack" hidden="false" targetId="0900-71d5-1937-aa96" type="rule"/>
         <infoLink id="62d3-b774-21b0-3b2f" name="New InfoLink" hidden="false" targetId="6875-ee73-2a85-6a97" type="profile"/>
-        <infoLink id="e0f5-de7e-2c92-f99f" name="New InfoLink" hidden="false" targetId="5283-9b50-3dcd-78e4" type="rule"/>
-        <infoLink id="a7e7-7b01-1e64-9a6d" name="New InfoLink" hidden="false" targetId="9bb4-3833-5343-0dd9" type="profile"/>
+        <infoLink id="e0f5-de7e-2c92-f99f" name="Extra Armour" hidden="false" targetId="79c7-90f6-b453-e799" type="profile"/>
+        <infoLink id="a7e7-7b01-1e64-9a6d" name="Searchlight" hidden="false" targetId="9bb4-3833-5343-0dd9" type="profile"/>
         <infoLink id="dd6f-c4d4-2ad2-3e8c" name="Contemptor-Galatus Dreadnought" hidden="false" targetId="0b06-b727-909f-9126" type="profile"/>
       </infoLinks>
       <selectionEntries>
@@ -4842,11 +4842,11 @@ decided.</description>
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink id="a5f2-903a-5bb1-2ae1" name="Extra Armour" hidden="false" targetId="5283-9b50-3dcd-78e4" type="rule"/>
         <infoLink id="c874-1e29-dbdd-a8d3" name="Assault Vehicle" hidden="false" targetId="45cf-653a-4ff6-f22d" type="rule"/>
         <infoLink id="c639-4c38-4d68-7dfe" name="Grav-backwash" hidden="false" targetId="1254-9285-e876-010d" type="rule"/>
         <infoLink id="b532-2bdc-a230-1aaa" name="Deep Strike" hidden="false" targetId="d219-2314-4834-c054" type="rule"/>
-        <infoLink id="d5e4-db8d-4ea2-f1cc" name="Armoured Ceramite" hidden="false" targetId="3138-683d-a9a0-570d" type="rule"/>
+        <infoLink id="d5e4-db8d-4ea2-f1cc" name="Armoured Ceramite" hidden="false" targetId="2e87b8ca-7cd1-78b9-2116-246015e7935e" type="profile"/>
+        <infoLink id="5ef0-af83-30ab-fd48" name="Extra Armour" hidden="false" targetId="79c7-90f6-b453-e799" type="profile"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="abc7-60ba-9e6d-0cfd" name="Flyer" hidden="false" targetId="1638-5261-fd55-f53b" primary="false"/>
@@ -5076,10 +5076,10 @@ decided.</description>
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="1c31-aeff-f024-b832" name="Extra Armour" hidden="false" targetId="5283-9b50-3dcd-78e4" type="rule"/>
+        <infoLink id="1c31-aeff-f024-b832" name="Extra Armour" hidden="false" targetId="79c7-90f6-b453-e799" type="profile"/>
         <infoLink id="43e6-9a73-7db0-5b45" name="Grav-backwash" hidden="false" targetId="1254-9285-e876-010d" type="rule"/>
         <infoLink id="48af-c909-df68-7f2c" name="Deep Strike" hidden="false" targetId="d219-2314-4834-c054" type="rule"/>
-        <infoLink id="2170-334b-47f9-ca8a" name="Armoured Ceramite" hidden="false" targetId="3138-683d-a9a0-570d" type="rule"/>
+        <infoLink id="2170-334b-47f9-ca8a" name="Armoured Ceramite" hidden="false" targetId="2e87b8ca-7cd1-78b9-2116-246015e7935e" type="profile"/>
       </infoLinks>
       <selectionEntries>
         <selectionEntry id="61e7-7e45-be48-42aa" name="Macro Arae-shrike" hidden="false" collective="false" import="true" type="upgrade">

--- a/The Horus Heresy.gst
+++ b/The Horus Heresy.gst
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<gameSystem id="ca571888-56a9-c58e-ddaf-54f4713538bc" name="Warhammer 30,000 - The Horus Heresy" revision="132" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
+<gameSystem id="ca571888-56a9-c58e-ddaf-54f4713538bc" name="Warhammer 30,000 - The Horus Heresy" revision="133" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
   <publications>
     <publication id="ca571888--pubN65537" name="Forgeworld Horus Heresy Series"/>
     <publication id="ca571888--pubN66489" name="HH:MT"/>
@@ -6080,7 +6080,7 @@ or Gargantuan Creatures. </description>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5bcc-7fa0-1561-e7cb" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="6401-7ff6-388c-0121" name="Armoured Ceramite" hidden="false" targetId="3138-683d-a9a0-570d" type="rule"/>
+                <infoLink id="830b-9ea4-6555-1297" name="Armoured Ceramite" hidden="false" targetId="2e87b8ca-7cd1-78b9-2116-246015e7935e" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
@@ -7339,7 +7339,7 @@ Any abilities that allow the vehicle to fire multiple shots will use the same sh
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8d27-e190-3bc3-d3ba" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="d7f6-b0c8-f679-d0f7" name="Armoured Ceramite" hidden="false" targetId="3138-683d-a9a0-570d" type="rule"/>
+                <infoLink id="ed73-67fa-ea2b-eb37" name="Armoured Ceramite" hidden="false" targetId="2e87b8ca-7cd1-78b9-2116-246015e7935e" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
@@ -7493,7 +7493,7 @@ Any abilities that allow the vehicle to fire multiple shots will use the same sh
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f2cf-47a5-76b2-5bd6" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="6881-ec98-ec95-cbb5" name="Armoured Ceramite" hidden="false" targetId="3138-683d-a9a0-570d" type="rule"/>
+                <infoLink id="4fa2-133a-0e2f-8662" name="Armoured Ceramite" hidden="false" targetId="2e87b8ca-7cd1-78b9-2116-246015e7935e" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
@@ -10163,6 +10163,9 @@ Any abilities that allow the vehicle to fire multiple shots will use the same sh
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
@@ -10895,7 +10898,7 @@ Command Benefits:
             <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9a78-ae84-ef7c-c81b" type="min"/>
           </constraints>
           <infoLinks>
-            <infoLink id="3e26-8893-7b1a-8d5a" name="Armoured Ceramite" hidden="false" targetId="3138-683d-a9a0-570d" type="rule"/>
+            <infoLink id="3e26-8893-7b1a-8d5a" name="Armoured Ceramite" hidden="false" targetId="2e87b8ca-7cd1-78b9-2116-246015e7935e" type="profile"/>
           </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="20.0"/>
@@ -10960,7 +10963,7 @@ Command Benefits:
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6be5-dd8e-96da-604f" type="min"/>
           </constraints>
           <infoLinks>
-            <infoLink id="5bc4-80c5-f65a-828d" name="Armoured Ceramite" hidden="false" targetId="3138-683d-a9a0-570d" type="rule"/>
+            <infoLink id="4ddd-9747-a3c9-6433" name="Armoured Ceramite" hidden="false" targetId="2e87b8ca-7cd1-78b9-2116-246015e7935e" type="profile"/>
           </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="0.0"/>
@@ -10996,8 +10999,8 @@ Command Benefits:
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="680e-4bd9-603f-949f" type="min"/>
           </constraints>
           <infoLinks>
-            <infoLink id="1f26-867f-947b-1d2b" name="New InfoLink" hidden="false" targetId="0ac1-dfc1-295b-50a6" type="rule"/>
-            <infoLink id="119f-6b3b-5d89-aac7" name="New InfoLink" hidden="false" targetId="1578-d22a-060c-4700" type="profile"/>
+            <infoLink id="1f26-867f-947b-1d2b" name="Power of the Machine Spirit" hidden="false" targetId="0ac1-dfc1-295b-50a6" type="rule"/>
+            <infoLink id="119f-6b3b-5d89-aac7" name="Machine Spirit" hidden="false" targetId="1578-d22a-060c-4700" type="profile"/>
           </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="0.0"/>
@@ -12723,9 +12726,6 @@ D6 - Result
     <rule id="ca3e-e94e-58f6-75d9" name="Interceptor" publicationId="ca571888--pubN106502" page="167" hidden="false">
       <description>At the end of the enemy Movement phase, a weapon with the Interceptor special rule can be fired at any one unit that has arrived from Reserve within its range and line of sight. If this rule is used, the weapon cannot be fired in the next turn, but the firing model can shoot a different weapon if it has one.</description>
     </rule>
-    <rule id="3138-683d-a9a0-570d" name="Armoured Ceramite" publicationId="ca571888--pubN106780" page="131" hidden="false">
-      <description>A vehicle with this wargear is not subject to the additional D6 armour penetration caused by weapons with the Melta special rule.</description>
-    </rule>
     <rule id="d0b7-ed3f-25c8-1e63" name="Flare Shield" hidden="false">
       <description>A flare shield operates against shooting attacks that strike the vehicle&apos;s front arc.  It reduces the strength of attacks by weapons with the Templae or Blast type by -2, and other shooting attacks by -1.  A flare shield has no effect on attacks from close combat or with the Destroyer rule.</description>
     </rule>
@@ -14416,14 +14416,6 @@ Jetbikes can move over all other models and terrain freely. However, if a moving
         <characteristic name="Save" typeId="5361766523232344415441232323">3+</characteristic>
       </characteristics>
     </profile>
-    <profile id="6fbf4c0f-334f-844d-3d75-ce8a1da6c1fa" name="Darkfire Cannon" publicationId="ca571888--pubN85920" page="209" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
-      <characteristics>
-        <characteristic name="Range" typeId="52616e676523232344415441232323">60&quot;</characteristic>
-        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">7</characteristic>
-        <characteristic name="AP" typeId="415023232344415441232323">2</characteristic>
-        <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 2, Lance, Blind, Gets Hot</characteristic>
-      </characteristics>
-    </profile>
     <profile id="481b32ee-2904-c9e0-8612-35ff2bcab65a" name="Graviton Gun" publicationId="ca571888--pubN106502" page="177" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">18&quot;</characteristic>
@@ -14772,14 +14764,6 @@ Jetbikes can move over all other models and terrain freely. However, if a moving
         <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 2, Lance, Blind, Gets Hot</characteristic>
       </characteristics>
     </profile>
-    <profile id="4893-10c8-2718-bf24" name="Darkfire Cannon" publicationId="ca571888--pubN106502" page="179" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
-      <characteristics>
-        <characteristic name="Range" typeId="52616e676523232344415441232323">60&quot;</characteristic>
-        <characteristic name="Strength" typeId="537472656e67746823232344415441232323">7</characteristic>
-        <characteristic name="AP" typeId="415023232344415441232323">2</characteristic>
-        <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 2, Lance, Blind, Gets Hot</characteristic>
-      </characteristics>
-    </profile>
     <profile id="62c4-32da-84f2-5033" name="Phosphex Bomb" publicationId="ca571888--pubN106502" page="179" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
       <characteristics>
         <characteristic name="Range" typeId="52616e676523232344415441232323">6&quot;</characteristic>
@@ -15079,6 +15063,11 @@ Jetbikes can move over all other models and terrain freely. However, if a moving
         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">4</characteristic>
         <characteristic name="AP" typeId="415023232344415441232323">6</characteristic>
         <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 3, Twin-Linked</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="2e87b8ca-7cd1-78b9-2116-246015e7935e" name="Armoured Ceramite" publicationId="ca571888--pubN82424" page="88" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
+      <characteristics>
+        <characteristic name="Description" typeId="4465736372697074696f6e23232344415441232323">A vehicle with this wargear is not subject to the additional D6 armour penetration caused by weapons with the Melta special rule.  </characteristic>
       </characteristics>
     </profile>
   </sharedProfiles>


### PR DESCRIPTION
Thousand Sons Cult restrictions added. Did a bit of testing and seemed to be working.
Also fixed an issue with MOTL which was allowing one in lower than it should points values. Also the MOTL restriction is spread over all forces in roster, not each force individually.