### PR TITLE
Storm of War and lots of fixes

### DIFF
--- a/(HH) Craftworld Eldar - Asuryani Army List.cat
+++ b/(HH) Craftworld Eldar - Asuryani Army List.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="0798-288f-4f71-eab9" name="Asuryani Army List (Fanmade)" revision="8" battleScribeVersion="2.03" authorName="Dono Author / Maye Gelt the Battlescribbler" authorContact="Dono (for Content) / Maye Gelt (for Battlescibbling)" authorUrl="http://www.facebook.com/AUS30K" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="128" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="0798-288f-4f71-eab9" name="Asuryani Army List (Fanmade)" revision="9" battleScribeVersion="2.03" authorName="Dono Author / Maye Gelt the Battlescribbler" authorContact="Dono (for Content) / Maye Gelt (for Battlescibbling)" authorUrl="http://www.facebook.com/AUS30K" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="134" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="5c4c-bef9-9681-e0fc" name="30K Craftworld Aeldari - Asuryani Army List"/>
   </publications>
@@ -144,6 +144,414 @@
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c87c-ebde-2300-8fc5" type="min"/>
             <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2949-3ef9-2e84-a594" type="max"/>
+          </constraints>
+        </categoryLink>
+      </categoryLinks>
+    </forceEntry>
+    <forceEntry id="fb6a-8a59-41c6-1449" name=" Strategic Raid - Garrison" hidden="false">
+      <categoryLinks>
+        <categoryLink id="c589-62b0-78ab-e39a" name="Fast Attack" hidden="false" targetId="d968-07ca-4ac7-d474" primary="false">
+          <constraints>
+            <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="84fe-2b0e-5af1-767c" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="0350-30a9-8d3d-7bd8" name="HQ" hidden="false" targetId="f44f-8bb4-b946-f5ff" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f0a1-72e4-d7db-bcde" type="min"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c474-97f0-8f30-6518" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="49f8-7482-2fb6-1e3a" name="Troops" hidden="false" targetId="ec02-0f58-1161-7e31" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9842-0896-50e8-2481" type="min"/>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c9dd-88d3-61ee-71f5" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="6f55-b79d-e131-40ad" name="Heavy Support" hidden="false" targetId="8e98-e0fb-275c-1d1c" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9e22-a828-8674-2e88" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="fac2-633a-12c1-c3e0" name="Elites" hidden="false" targetId="2da8-675a-e742-5370" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0227-8722-abc8-8ada" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="a64a-44e4-2684-1241" name="Lords of War" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="838b-51e0-d821-75d6" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="338b-f1be-29ae-6a86" name="Use Playtest Rules" hidden="false" targetId="fdf4-0683-3e84-5a4b" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="ad80-ee46-9458-6fbb" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="0f4d-9c4d-fdc7-03ca" name="Craftworld Doctrines" hidden="false" targetId="07c2-ac27-e893-9f99" primary="false"/>
+        <categoryLink id="5c90-4445-e059-7113" name="Compulsory Troops" hidden="false" targetId="e75c-5ca5-7ae8-94ce" primary="false">
+          <constraints>
+            <constraint field="selections" scope="force" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b55d-e48c-ce36-9f7e" type="min"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="abda-297c-d24e-f34c" name="Fortification" hidden="false" targetId="857e-59aa-0b44-f48d" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="daa2-25d9-ebf7-92a4" type="min"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c2d6-8953-4406-47bb" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="c411-33ac-6ac9-df50" name="Aliens and Daemons" hidden="false" targetId="cd09-c1c6-237a-798e" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a048-fc3c-a584-bdcb" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d3c9-e3ba-598f-9eb0" type="min"/>
+          </constraints>
+        </categoryLink>
+      </categoryLinks>
+    </forceEntry>
+    <forceEntry id="c640-8d08-b61f-a776" name=" Strategic Raid - Raider" hidden="false">
+      <categoryLinks>
+        <categoryLink id="1fdc-514d-87e7-cc29" name="Fast Attack" hidden="false" targetId="d968-07ca-4ac7-d474" primary="false">
+          <constraints>
+            <constraint field="selections" scope="roster" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ae6b-f8e9-5501-f0ed" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="69ea-bd44-3e75-08a6" name="HQ" hidden="false" targetId="f44f-8bb4-b946-f5ff" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0528-3fbe-c21c-a997" type="min"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e24c-3785-a606-49f9" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="0f27-c8ee-6b7c-9968" name="Troops" hidden="false" targetId="ec02-0f58-1161-7e31" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="efb0-b50d-6b6d-76f7" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="b01d-b846-4bb2-54c6" name="Heavy Support" hidden="false" targetId="8e98-e0fb-275c-1d1c" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b5c7-17fe-2cee-224e" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="e699-c7dd-015b-1939" name="Elites" hidden="false" targetId="2da8-675a-e742-5370" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a1cc-3ce8-7924-698a" type="min"/>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="67ce-ea3f-9b09-4a15" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="df6e-5ea5-706c-96fc" name="Lords of War" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e09b-1faa-0dcb-90d1" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="44e2-4340-8d6b-93a9" name="Use Playtest Rules" hidden="false" targetId="fdf4-0683-3e84-5a4b" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="ec39-59b1-21df-d341" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="04ff-b491-b0b1-08e6" name="Craftworld Doctrines" hidden="false" targetId="07c2-ac27-e893-9f99" primary="false"/>
+        <categoryLink id="510d-f91f-4b0a-318b" name="Aliens and Daemons" hidden="false" targetId="cd09-c1c6-237a-798e" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="45c3-5fe4-928e-b97e" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="68fb-7e80-ef1a-d8ee" type="min"/>
+          </constraints>
+        </categoryLink>
+      </categoryLinks>
+    </forceEntry>
+    <forceEntry id="59ca-582e-8e5d-a299" name=" Zone Mortalis - Attacker" hidden="false">
+      <categoryLinks>
+        <categoryLink id="84b3-3f53-36c9-1d04" name="Fast Attack" hidden="false" targetId="d968-07ca-4ac7-d474" primary="false">
+          <constraints>
+            <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cdf9-b37d-fd84-0f84" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="6d0e-0c27-db9e-bb51" name="HQ" hidden="false" targetId="f44f-8bb4-b946-f5ff" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8d86-f53f-f4ae-065c" type="min"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8201-21b5-7466-a5db" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="2bff-a6b3-822d-b6c7" name="Troops" hidden="false" targetId="ec02-0f58-1161-7e31" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a405-4262-2db4-e72d" type="min"/>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0e6a-58ff-bfc4-5c16" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="fed5-cd5a-33e5-21d0" name="Heavy Support" hidden="false" targetId="8e98-e0fb-275c-1d1c" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6526-843f-0baf-7709" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="fe24-7f95-4059-337d" name="Elites" hidden="false" targetId="2da8-675a-e742-5370" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dfda-140c-fc32-f86a" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="603e-f56f-78e3-9876" name="Lords of War" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="23f1-4044-f256-0e2c" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="2dbf-75bc-f5ac-87b3" name="Use Playtest Rules" hidden="false" targetId="fdf4-0683-3e84-5a4b" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="d57d-a709-69ab-24ca" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="58bd-0970-cef3-64dc" name="Craftworld Doctrines" hidden="false" targetId="07c2-ac27-e893-9f99" primary="false"/>
+        <categoryLink id="717f-7b4b-4422-5707" name="Compulsory Troops" hidden="false" targetId="e75c-5ca5-7ae8-94ce" primary="false">
+          <modifiers>
+            <modifier type="set" field="name" value="0.0"/>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="force" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e91f-653c-897c-1141" type="min"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="4fe2-014b-5a60-f655" name="Fortification" hidden="false" targetId="857e-59aa-0b44-f48d" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e701-b4d0-1592-d93a" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="e2b1-80e9-8a26-0e81" name="Aliens and Daemons" hidden="false" targetId="cd09-c1c6-237a-798e" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a754-e992-59e4-37af" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af5a-4bb4-55a2-c76c" type="min"/>
+          </constraints>
+        </categoryLink>
+      </categoryLinks>
+    </forceEntry>
+    <forceEntry id="ba1b-c8fa-70b0-6daa" name=" Zone Mortalis - Combatant" hidden="false">
+      <categoryLinks>
+        <categoryLink id="8df9-7303-e7c2-4fea" name="Fast Attack" hidden="false" targetId="d968-07ca-4ac7-d474" primary="false">
+          <constraints>
+            <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7d01-98ed-52fb-f831" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="7206-50a1-fae9-8d12" name="HQ" hidden="false" targetId="f44f-8bb4-b946-f5ff" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="401d-f2bb-aaca-42d9" type="min"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5ee4-12b7-b0a3-219b" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="fe1a-f7a7-ea9c-91bc" name="Troops" hidden="false" targetId="ec02-0f58-1161-7e31" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="321b-1210-e221-810e" type="min"/>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e431-dc0f-959c-01ca" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="9c57-d7ea-d2aa-aae1" name="Heavy Support" hidden="false" targetId="8e98-e0fb-275c-1d1c" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4991-80a7-d942-aaa9" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="f957-5ed9-7653-d9d5" name="Elites" hidden="false" targetId="2da8-675a-e742-5370" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4129-9b54-3664-618f" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="b67f-487e-b094-ec1f" name="Lords of War" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a400-c3a1-fcee-58d1" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="9eab-7816-079f-8931" name="Use Playtest Rules" hidden="false" targetId="fdf4-0683-3e84-5a4b" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="4d79-90db-cab7-dc10" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="b175-c023-4a85-123b" name="Craftworld Doctrines" hidden="false" targetId="07c2-ac27-e893-9f99" primary="false"/>
+        <categoryLink id="463f-da3f-1332-b539" name="Compulsory Troops" hidden="false" targetId="e75c-5ca5-7ae8-94ce" primary="false">
+          <modifiers>
+            <modifier type="set" field="name" value="0.0"/>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="force" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2319-17aa-918f-3aae" type="min"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="c5ae-13e4-f2f3-5ad2" name="Fortification" hidden="false" targetId="857e-59aa-0b44-f48d" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c196-19d4-d15e-be54" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="44f4-b52c-3742-e435" name="Aliens and Daemons" hidden="false" targetId="cd09-c1c6-237a-798e" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="42c9-68eb-f2b2-0ad3" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5a51-8ffb-8f39-e4c2" type="min"/>
+          </constraints>
+        </categoryLink>
+      </categoryLinks>
+    </forceEntry>
+    <forceEntry id="ee92-ebf5-01e9-daaf" name=" Zone Mortalis - Defender" hidden="false">
+      <categoryLinks>
+        <categoryLink id="b612-0200-511e-bb1b" name="Fast Attack" hidden="false" targetId="d968-07ca-4ac7-d474" primary="false">
+          <constraints>
+            <constraint field="selections" scope="roster" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af4c-c476-9299-b012" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="6648-f3b9-1c02-9605" name="HQ" hidden="false" targetId="f44f-8bb4-b946-f5ff" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d226-4813-e4dc-d5f7" type="min"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7950-ab19-e2d0-6c71" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="a819-401f-b321-0e86" name="Troops" hidden="false" targetId="ec02-0f58-1161-7e31" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="32a3-91e8-9b4b-6acb" type="min"/>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c798-2f4c-d0ac-5db3" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="4891-324c-e0be-e3a3" name="Heavy Support" hidden="false" targetId="8e98-e0fb-275c-1d1c" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e638-640c-ea0e-6f71" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="0cdb-d60c-574a-a629" name="Elites" hidden="false" targetId="2da8-675a-e742-5370" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="20db-2c59-ca39-f10c" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="f542-6783-8212-b93e" name="Lords of War" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1029-95f1-8004-d57e" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="b490-6d51-0bc4-ddf1" name="Use Playtest Rules" hidden="false" targetId="fdf4-0683-3e84-5a4b" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="366a-c43c-a145-e4ce" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="f7ac-3c3d-362f-e8af" name="Craftworld Doctrines" hidden="false" targetId="07c2-ac27-e893-9f99" primary="false"/>
+        <categoryLink id="2af6-0b6d-b1c8-26c9" name="Compulsory Troops" hidden="false" targetId="e75c-5ca5-7ae8-94ce" primary="false">
+          <modifiers>
+            <modifier type="set" field="name" value="0.0"/>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="force" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e5b1-c4dd-42ec-f492" type="min"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="66dd-ae90-65cc-b1b1" name="Fortification" hidden="false" targetId="857e-59aa-0b44-f48d" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b536-b4ef-2c44-b07f" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="bd7f-5492-10dd-25a6" name="Aliens and Daemons" hidden="false" targetId="cd09-c1c6-237a-798e" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="041c-fe81-f2e0-8a00" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5b29-0682-1321-a5e7" type="min"/>
+          </constraints>
+        </categoryLink>
+      </categoryLinks>
+    </forceEntry>
+    <forceEntry id="22a6-394b-19ea-461e" name="Optional - Castellan" hidden="false">
+      <categoryLinks>
+        <categoryLink id="9af9-cf8a-8074-7134" name="Fast Attack" hidden="false" targetId="d968-07ca-4ac7-d474" primary="false">
+          <constraints>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2db0-bcd9-a8af-ac95" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="249a-e569-8def-52ec" name="HQ" hidden="false" targetId="f44f-8bb4-b946-f5ff" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a743-c46e-2ddd-462a" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="899f-9665-8baf-06ae" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="37d6-67c0-cdfc-d302" name="Troops" hidden="false" targetId="ec02-0f58-1161-7e31" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0981-1806-51ff-509b" type="min"/>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6601-b5eb-5bc0-0a3e" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="3a99-b809-1234-fc80" name="Heavy Support" hidden="false" targetId="8e98-e0fb-275c-1d1c" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5d7a-ca3b-d634-683c" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="1590-df64-6cdc-2e84" name="Elites" hidden="false" targetId="2da8-675a-e742-5370" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="518f-44c1-6e04-4d42" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="4818-cd44-881b-7023" name="Lords of War" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a27f-2ab6-6050-726f" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="c2f3-ee5e-a248-ac8c" name="Use Playtest Rules" hidden="false" targetId="fdf4-0683-3e84-5a4b" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="b066-d531-8ad1-c740" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="2e9f-3b05-462f-dfba" name="Craftworld Doctrines" hidden="false" targetId="07c2-ac27-e893-9f99" primary="false"/>
+        <categoryLink id="319e-3eb1-9a37-1df8" name="Compulsory Troops" hidden="false" targetId="e75c-5ca5-7ae8-94ce" primary="false">
+          <modifiers>
+            <modifier type="set" field="name" value="0.0"/>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="force" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5115-14cd-d785-93cc" type="min"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="f5c1-b279-1911-a9c1" name="Fortification" hidden="false" targetId="857e-59aa-0b44-f48d" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="768c-b2bc-a77a-687a" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cf98-c990-cd07-54d7" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="39bc-9acb-72a8-355e" name="Aliens and Daemons" hidden="false" targetId="cd09-c1c6-237a-798e" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9e1f-4950-226e-c8b5" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1491-ed73-3289-25a8" type="min"/>
+          </constraints>
+        </categoryLink>
+      </categoryLinks>
+    </forceEntry>
+    <forceEntry id="82c9-c1d2-f133-a2c7" name="Optional - Onslaught" hidden="false">
+      <categoryLinks>
+        <categoryLink id="0fbc-8036-66c3-cf53" name="Fast Attack" hidden="false" targetId="d968-07ca-4ac7-d474" primary="false">
+          <constraints>
+            <constraint field="selections" scope="roster" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9824-02c2-196e-6f79" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="b163-6119-1004-6393" name="HQ" hidden="false" targetId="f44f-8bb4-b946-f5ff" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b9bc-8156-41f5-1527" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="99b8-288a-f81d-bbb7" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="9b0b-1251-4140-3bb9" name="Troops" hidden="false" targetId="ec02-0f58-1161-7e31" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d838-1dea-1c98-97c2" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fd5d-b6bd-054d-76ee" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="48b6-f0fe-186e-78a0" name="Heavy Support" hidden="false" targetId="8e98-e0fb-275c-1d1c" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5024-6f34-b589-4474" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="1b52-bd39-9cfc-1a80" name="Elites" hidden="false" targetId="2da8-675a-e742-5370" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a791-f6d5-a89f-3baf" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="25d2-0604-17d1-b866" name="Lords of War" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e473-a50d-6946-f53a" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="3ff8-5d57-17ef-ae11" name="Use Playtest Rules" hidden="false" targetId="fdf4-0683-3e84-5a4b" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="7fa9-9bcf-8e5e-2073" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="b7d4-704f-e295-c1b1" name="Craftworld Doctrines" hidden="false" targetId="07c2-ac27-e893-9f99" primary="false"/>
+        <categoryLink id="aab3-d5e7-9c0c-f5a8" name="Compulsory Troops" hidden="false" targetId="e75c-5ca5-7ae8-94ce" primary="false">
+          <modifiers>
+            <modifier type="set" field="name" value="0.0"/>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="de26-47a9-ecb7-5b22" type="min"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="7e0c-80e2-611e-2025" name="Aliens and Daemons" hidden="false" targetId="cd09-c1c6-237a-798e" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="983c-81a0-c4b5-8cc2" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7396-aa8f-03be-1122" type="min"/>
           </constraints>
         </categoryLink>
       </categoryLinks>

--- a/(HH) Imperialis Militia and Cults Army List.cat
+++ b/(HH) Imperialis Militia and Cults Army List.cat
@@ -1186,8 +1186,8 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
     </entryLink>
     <entryLink id="6950-b9c9-a112-597a" name="Imperial Primus Redoubt" hidden="false" collective="false" import="true" targetId="c05d-2231-2481-4037" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="6950-b9c9-a112-597a-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
         <categoryLink id="fcce-2b2b-9749-8874" name="New CategoryLink" hidden="false" targetId="8a8c-ed20-7427-ddff" primary="false"/>
+        <categoryLink id="6c2a-8629-1e73-94ea" name="New CategoryLink" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="e6ba-816a-1c46-a20f" name="Manufactorum" hidden="false" collective="false" import="true" targetId="6140-dc64-5896-957f" type="selectionEntry">

--- a/(HH) Imperialis Militia and Cults Army List.cat
+++ b/(HH) Imperialis Militia and Cults Army List.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="90aa-c2c8-ffb0-496e" name="Imperialis Militia and Cults Army List" revision="114" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="132" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="90aa-c2c8-ffb0-496e" name="Imperialis Militia and Cults Army List" revision="115" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="134" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="90aa-c2c8-pubN65537" name="Crusade Imperialis"/>
     <publication id="90aa-c2c8-pubN65563" name="AoDRB"/>
@@ -858,6 +858,11 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
           </constraints>
         </entryLink>
         <entryLink id="f22a-c222-8e50-ea20" name="Additional Psychic Disciplines" hidden="false" collective="false" import="true" targetId="be86-7cb9-6f78-eb14" type="selectionEntry"/>
+        <entryLink id="c837-5d82-5ab8-b5ae" name="Mournival Experiemental Rules on" hidden="false" collective="false" import="true" targetId="8d39-af5d-fcc9-9c1f" type="selectionEntry">
+          <categoryLinks>
+            <categoryLink id="eb51-58a0-a4b8-e376" name="Mournival Rules" hidden="false" targetId="dbe0-716f-797c-66f7" primary="false"/>
+          </categoryLinks>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
@@ -3654,6 +3659,18 @@ D3     Mutation
           </characteristics>
         </profile>
       </profiles>
+      <rules>
+        <rule id="4529-ecce-dc2f-a07f" name="Lumbering Behemoth (Mournival)" hidden="true">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="8d39-af5d-fcc9-9c1f" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <description> If the tank only moves 6” or less it may fire all of its weapons at full BS (ignoring that Ordnance weapons cause snap shots).</description>
+        </rule>
+      </rules>
       <infoLinks>
         <infoLink id="932d-4781-c054-7148" name="Fast" hidden="false" targetId="f4f1-8772-1a1b-4f50" type="rule">
           <modifiers>

--- a/(HH) Mechanicum - Questoris Knight.cat
+++ b/(HH) Mechanicum - Questoris Knight.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="32d1ddc6-3187-cf6f-3bf8-9891e527a002" name="Questoris Knight Crusade Army" revision="55" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="132" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="32d1ddc6-3187-cf6f-3bf8-9891e527a002" name="Questoris Knight Crusade Army" revision="56" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="134" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="32d1ddc6--pubN65537" name="Age of Darkness Crusade Army List"/>
     <publication id="32d1ddc6--pubN66650" name="HH4: Conquest"/>
@@ -806,6 +806,13 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
       </costs>
     </selectionEntry>
     <selectionEntry id="48db-84ca-2bad-520f" name="Castellax Class Battle-Automata Maniple" page="" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="increment" field="points" value="25.0">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="c859-6b16-c533-7e97" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <infoLinks>
         <infoLink id="7678-ae60-16f2-e948" name="" hidden="false" targetId="988c-d4d0-9418-1165" type="rule"/>
         <infoLink id="a7f0-6bc1-ed4a-34dc" name="New InfoLink" hidden="false" targetId="d5cf-bd98-2854-13cf" type="rule"/>
@@ -832,6 +839,9 @@ If the Sword Enemy still remains in play at the end of the game, its owning play
               </characteristics>
             </profile>
           </profiles>
+          <infoLinks>
+            <infoLink id="a0cd-d1cd-0e3f-1a6c" name="Atomantic Shielding" hidden="false" targetId="13e0-4939-5232-8d85" type="profile"/>
+          </infoLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="6564-7afd-3cef-078a" name="May exchange its Mauler bolt cannon for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="4ed8-630f-8684-ebe1">
               <constraints>

--- a/(HH) Mechanicum - Taghmata Army List.cat
+++ b/(HH) Mechanicum - Taghmata Army List.cat
@@ -1376,7 +1376,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
     </entryLink>
     <entryLink id="2be9-5af0-6412-78d9" name="Imperial Primus Redoubt" hidden="false" collective="false" import="true" targetId="c05d-2231-2481-4037" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="2be9-5af0-6412-78d9-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
+        <categoryLink id="34d1-bb53-a1aa-ca7a" name="New CategoryLink" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="808e-b852-a76b-939f" name="Imperial Castelum Stronghold" hidden="false" collective="false" import="true" targetId="e40b-468f-f1d7-d05d" type="selectionEntry">

--- a/(HH) Mechanicum - Taghmata Army List.cat
+++ b/(HH) Mechanicum - Taghmata Army List.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="cf03-f607-41dc-7545" name="Mechanicum: Taghmata Army List" revision="110" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="132" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="cf03-f607-41dc-7545" name="Mechanicum: Taghmata Army List" revision="111" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="134" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="cf03-f607-pubN65537" name="Horus Heresy: Taghmata Army List"/>
     <publication id="cf03-f607-pubN65563" name="AoDRB"/>
@@ -1066,6 +1066,11 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7c9b-b61f-d477-0981" type="max"/>
           </constraints>
         </entryLink>
+        <entryLink id="0d01-7273-5f60-ea93" name="Mournival Experiemental Rules on" hidden="false" collective="false" import="true" targetId="8d39-af5d-fcc9-9c1f" type="selectionEntry">
+          <categoryLinks>
+            <categoryLink id="e018-0bd0-7762-3b8d" name="Mournival Rules" hidden="false" targetId="dbe0-716f-797c-66f7" primary="false"/>
+          </categoryLinks>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
@@ -1920,6 +1925,11 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
             </conditionGroup>
           </conditionGroups>
         </modifier>
+        <modifier type="increment" field="points" value="25.0">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="c859-6b16-c533-7e97" type="equalTo"/>
+          </conditions>
+        </modifier>
       </modifiers>
       <infoLinks>
         <infoLink id="67d4-e1ef-588a-47e9" name="Cybernetica Cortex" hidden="false" targetId="f6c9-cdb7-c695-5b6b" type="rule"/>
@@ -2100,6 +2110,11 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <modifier type="add" field="category" value="219d-aefa-dfa5-44db">
           <conditions>
             <condition field="selections" scope="48db-84ca-2bad-520f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0ee-a476-118f-2c11" type="equalTo"/>
+          </conditions>
+        </modifier>
+        <modifier type="increment" field="points" value="25.0">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="c859-6b16-c533-7e97" type="equalTo"/>
           </conditions>
         </modifier>
       </modifiers>
@@ -3388,6 +3403,13 @@ Reduces transport capacity to 8.</description>
       </costs>
     </selectionEntry>
     <selectionEntry id="314b-bec3-5501-a0aa" name="Scyllax Guardian-Automata Covenant" publicationId="cf03-f607-pubN76780" page="40" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="increment" field="points" value="15.0">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="8d39-af5d-fcc9-9c1f" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <constraints>
         <constraint field="selections" scope="parent" value="-1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
       </constraints>
@@ -3417,6 +3439,11 @@ Reduces transport capacity to 8.</description>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
+            </modifier>
+            <modifier type="set" field="points" value="25.0">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="8d39-af5d-fcc9-9c1f" type="equalTo"/>
+              </conditions>
             </modifier>
           </modifiers>
           <constraints>
@@ -4287,12 +4314,19 @@ Reduces transport capacity to 8.</description>
       </costs>
     </selectionEntry>
     <selectionEntry id="8190-e779-2c49-c564" name="Secutarii Peltast Phalanx" publicationId="cf03-f607-pubN89244" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="increment" field="points" value="25.0">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="c859-6b16-c533-7e97" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <infoLinks>
         <infoLink id="1918-cfef-52f5-3b04" hidden="false" targetId="85da-2f19-3756-44de" type="rule"/>
         <infoLink id="a4e8-10c8-92cf-2b75" hidden="false" targetId="a878-4168-e49f-1d06" type="rule"/>
         <infoLink id="b633-3729-d833-bcc5" hidden="false" targetId="7c0b-31e3-daa1-0d3a" type="rule"/>
         <infoLink id="c1a0-a48b-227e-9b98" hidden="false" targetId="3c7d-a1fa-c68b-caad" type="rule"/>
-        <infoLink id="b575-6604-804e-9991" name="New InfoLink" hidden="false" targetId="bd0a-ad49-6435-587e" type="rule"/>
+        <infoLink id="b575-6604-804e-9991" name="Secutarii Hazard Protocols" hidden="false" targetId="bd0a-ad49-6435-587e" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="c63e-9be3-05b4-db86" name="New CategoryLink" hidden="false" targetId="f74d-4679-75a6-1252" primary="false"/>
@@ -4614,6 +4648,13 @@ Reduces transport capacity to 8.</description>
       </costs>
     </selectionEntry>
     <selectionEntry id="4ff6-b526-4208-0d33" name="Secutarii Hoplite Phalanx" publicationId="cf03-f607-pubN89244" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="increment" field="points" value="25.0">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="c859-6b16-c533-7e97" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <infoLinks>
         <infoLink id="07c0-21d2-7a6c-e72e" name="" hidden="false" targetId="85da-2f19-3756-44de" type="rule"/>
         <infoLink id="197d-44b2-c886-348a" hidden="false" targetId="a878-4168-e49f-1d06" type="rule"/>
@@ -5005,6 +5046,13 @@ Buildings and Fortifications D</description>
       </costs>
     </selectionEntry>
     <selectionEntry id="972c-91a0-764b-3fe0" name="Vultarax Stratos-automata Maniple" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="increment" field="points" value="25.0">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="c859-6b16-c533-7e97" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="2c87-df97-9d45-cdb9" name="New CategoryLink" hidden="false" targetId="7fdd-2a97-d0e9-6524" primary="false"/>
       </categoryLinks>

--- a/(HH) Mornival Units.cat
+++ b/(HH) Mornival Units.cat
@@ -3079,7 +3079,7 @@ one Special Rule the unit possesses ceases to have any effect</description>
         <cost name="pts" typeId="points" value="115.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="693c-5450-e295-ce1f" name="Sisters of Silence Oblivion Knight-Centura" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="693c-5450-e295-ce1f" name="Sisters of Silence Oblivion Knight-Centura" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -3495,7 +3495,7 @@ All models with psychic powers suffer a penalty to roll to manifest psychic powe
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="1524-ecd3-80b0-453c" name="Cortus Class Dreadnought Talon" publicationId="0e6e-8c19-c436-39c4" page="27" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="1524-ecd3-80b0-453c" name="Cortus Class Dreadnought Talon" publicationId="0e6e-8c19-c436-39c4" page="27" hidden="false" collective="false" import="true" type="unit">
       <selectionEntries>
         <selectionEntry id="17cb-be38-c492-d766" name="Cortus Dreadnought" hidden="false" collective="false" import="true" type="model">
           <constraints>
@@ -3743,24 +3743,6 @@ All models with psychic powers suffer a penalty to roll to manifest psychic powe
               </constraints>
             </entryLink>
             <entryLink id="c0f2-c392-ef75-4fcf" name="Extra Armour" hidden="false" collective="false" import="true" targetId="4167-42c8-42d8-1ce0" type="selectionEntry"/>
-            <entryLink id="f492-5717-7714-64d0" name="Dreadnought CCW In-built:" hidden="false" collective="false" import="true" targetId="68cf-68c6-5017-156b" type="selectionEntryGroup">
-              <modifiers>
-                <modifier type="increment" field="c326-04d6-84f6-39f4" value="1.0">
-                  <repeats>
-                    <repeat field="selections" scope="17cb-be38-c492-d766" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="28f6-b43f-4914-4a29" repeats="1" roundUp="false"/>
-                    <repeat field="selections" scope="17cb-be38-c492-d766" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6e23-90c4-a3bf-030a" repeats="1" roundUp="false"/>
-                    <repeat field="selections" scope="17cb-be38-c492-d766" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e7d3-aa89-fb59-d733" repeats="1" roundUp="false"/>
-                  </repeats>
-                </modifier>
-                <modifier type="increment" field="a65e-55e7-3db7-acba" value="1.0">
-                  <repeats>
-                    <repeat field="selections" scope="17cb-be38-c492-d766" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="28f6-b43f-4914-4a29" repeats="1" roundUp="false"/>
-                    <repeat field="selections" scope="17cb-be38-c492-d766" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6e23-90c4-a3bf-030a" repeats="1" roundUp="false"/>
-                    <repeat field="selections" scope="17cb-be38-c492-d766" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e7d3-aa89-fb59-d733" repeats="1" roundUp="false"/>
-                  </repeats>
-                </modifier>
-              </modifiers>
-            </entryLink>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="115.0"/>
@@ -3783,7 +3765,7 @@ All models with psychic powers suffer a penalty to roll to manifest psychic powe
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="7d04-bb7c-cffb-f005" name="Independent Techmarines, Legion" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="7d04-bb7c-cffb-f005" name="Independent Techmarines, Legion" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
         <categoryLink id="25d9-7dcc-5792-5567" name="Character" hidden="false" targetId="eb92-48f9-9a1a-7bd1" primary="false"/>
       </categoryLinks>
@@ -5242,6 +5224,40 @@ Hunter: Shot Gun, Chainblade, +1A and Acute Senses</description>
       </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="d9cb-4510-3fef-1ded" name="All models may take:" hidden="false" collective="false" import="true">
+          <selectionEntries>
+            <selectionEntry id="c5c1-bd3d-19dd-f8e5" name="Sniper Rifles - Anti-Materiel Rounds" hidden="true" collective="false" import="true" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="points" value="5.0">
+                  <repeats>
+                    <repeat field="selections" scope="5aa7-c454-3656-3a3f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4cf5-3801-534a-b7e0" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+                <modifier type="set" field="hidden" value="false">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="8d39-af5d-fcc9-9c1f" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <profiles>
+                <profile id="6bff-7e13-b031-65b2" name="Sniper Rifle - Anti-Materiel Rounds" page="" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="52616e676523232344415441232323">36&quot;</characteristic>
+                    <characteristic name="Strength" typeId="537472656e67746823232344415441232323">7</characteristic>
+                    <characteristic name="AP" typeId="415023232344415441232323">6</characteristic>
+                    <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 1, Sniper</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules>
+                <rule id="5653-0fdb-48d2-74fb" name="Sniper Rifles - Anti-Materiel Rounds" hidden="false">
+                  <description>Sniper Rifles may be equipped with anti-materiel rounds for +5 points per model, increasing to Str 7. Due to the large amount of dust and debris kicked up, units containing models using these rounds suffer -1 to cover saves in the next turn.</description>
+                </rule>
+              </rules>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
           <entryLinks>
             <entryLink id="61e9-855e-7e07-2cd4" name="Cameleoline" hidden="false" collective="false" import="true" targetId="0d86175b-00bf-8a27-6964-d6eec7f81169" type="selectionEntry">
               <modifiers>
@@ -6909,6 +6925,29 @@ Hunter: Shot Gun, Chainblade, +1A and Acute Senses</description>
                 <modifier type="decrement" field="points" value="2.0"/>
               </modifiers>
             </entryLink>
+            <entryLink id="839c-2ae6-9619-fc07" name="Stasis Shells (grenade launcher)" hidden="false" collective="false" import="true" targetId="f118-45b2-9b94-d7f3" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="points" value="0.0"/>
+                <modifier type="increment" field="points" value="5.0">
+                  <repeats>
+                    <repeat field="selections" scope="0183-7594-8997-5b90" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+                <modifier type="set" field="hidden" value="false">
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e6fb-0e54-0be1-9ed1" type="equalTo"/>
+                        <condition field="selections" scope="0183-7594-8997-5b90" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a8e-da3f-59da-dc04" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a93e-06db-37ba-9b86" type="min"/>
+              </constraints>
+            </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="962f-4008-a4e6-e3b1" name="All members of the squad can equip their Bullock Jetcycles with:" hidden="false" collective="false" import="true">
@@ -6980,6 +7019,40 @@ Hunter: Shot Gun, Chainblade, +1A and Acute Senses</description>
                   </repeats>
                 </modifier>
               </modifiers>
+            </entryLink>
+            <entryLink id="cbaf-e835-bcfd-e0e9" name="Plasma Burners" hidden="false" collective="false" import="true" targetId="d650-2238-d718-9798" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e6fb-0e54-0be1-9ed1" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="points" value="15.0">
+                  <repeats>
+                    <repeat field="selections" scope="0183-7594-8997-5b90" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6cdc-effc-4271-45b0" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="ee45-f4b2-79c2-5861" name="Plasma Repeater" hidden="false" collective="false" import="true" targetId="d4e8-6e08-581a-79bd" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e6fb-0e54-0be1-9ed1" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="points" value="20.0">
+                  <repeats>
+                    <repeat field="selections" scope="0183-7594-8997-5b90" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="10b3-987f-d540-b7f7" type="max"/>
+              </constraints>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
@@ -7240,50 +7313,6 @@ Hunter: Shot Gun, Chainblade, +1A and Acute Senses</description>
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="50.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="bfa7-fc02-60e9-c200" name="Hurricane Bolter" hidden="false" collective="false" import="true" type="upgrade">
-      <profiles>
-        <profile id="c976-8bb0-93ee-d56a" name="Hurricane Bolter" publicationId="0e6e-8c19-c436-39c4" page="" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
-          <characteristics>
-            <characteristic name="Range" typeId="52616e676523232344415441232323">24&quot;</characteristic>
-            <characteristic name="Strength" typeId="537472656e67746823232344415441232323">4</characteristic>
-            <characteristic name="AP" typeId="415023232344415441232323">5</characteristic>
-            <characteristic name="Type" typeId="5479706523232344415441232323">Rapid Fire 3, Twin-linked</characteristic>
-          </characteristics>
-        </profile>
-      </profiles>
-      <infoLinks>
-        <infoLink id="74ad-2f65-7b84-aaf3" name="Twin-linked" hidden="false" targetId="10a8-8d89-0bec-3e21" type="rule"/>
-      </infoLinks>
-      <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="0a8e-da3f-59da-dc04" name="Twin-linked Grenade Launcher" hidden="false" collective="false" import="true" type="upgrade">
-      <profiles>
-        <profile id="aa61-660a-0704-ec1e" name="Twin-linked Grenade Launcher (Frag)" publicationId="ca571888--pubN106502" page="177" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
-          <characteristics>
-            <characteristic name="Range" typeId="52616e676523232344415441232323">24&quot;</characteristic>
-            <characteristic name="Strength" typeId="537472656e67746823232344415441232323">3</characteristic>
-            <characteristic name="AP" typeId="415023232344415441232323">6</characteristic>
-            <characteristic name="Type" typeId="5479706523232344415441232323">Rapid Fire, Blast (3&quot;), Twin-linked</characteristic>
-          </characteristics>
-        </profile>
-        <profile id="5432-581f-9d7c-a62f" name="Twin-linked Grenade Launcher (Krak)" publicationId="ca571888--pubN106502" page="177" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
-          <characteristics>
-            <characteristic name="Range" typeId="52616e676523232344415441232323">24&quot;</characteristic>
-            <characteristic name="Strength" typeId="537472656e67746823232344415441232323">6</characteristic>
-            <characteristic name="AP" typeId="415023232344415441232323">4</characteristic>
-            <characteristic name="Type" typeId="5479706523232344415441232323">Assault 1, Twin-linked</characteristic>
-          </characteristics>
-        </profile>
-      </profiles>
-      <infoLinks>
-        <infoLink id="de82-43ad-4183-d4ee" name="Twin-linked" hidden="false" targetId="10a8-8d89-0bec-3e21" type="rule"/>
-      </infoLinks>
-      <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="fd86-a3a0-adcc-63b5" name="Sky Stalker Jetbike Squad on Corvex Jetbikes, Legion" publicationId="0e6e-8c19-c436-39c4" page="" hidden="false" collective="false" import="true" type="unit">
@@ -7667,7 +7696,7 @@ Hunter: Shot Gun, Chainblade, +1A and Acute Senses</description>
         <cost name="pts" typeId="points" value="50.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="2b92-e606-8fb0-3117" name="Mars Pattern Land Speeder" page="0" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="2b92-e606-8fb0-3117" name="Mars Pattern Land Speeder" page="0" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
         <categoryLink id="60d9-b50b-45d2-e365" name="Deep Strike" hidden="false" targetId="2d6f-e613-ab10-e55a" primary="false"/>
         <categoryLink id="37f5-0da7-d60f-2349" name="Skimmer" hidden="false" targetId="9480-d3f6-fff1-7b35" primary="false"/>
@@ -7869,7 +7898,7 @@ Hunter: Shot Gun, Chainblade, +1A and Acute Senses</description>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="79c3-8891-b0e9-622a" name="Mars Cutter Pattern Land Speeder Squadron" page="0" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="79c3-8891-b0e9-622a" name="Mars Cutter Pattern Land Speeder Squadron" page="0" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
         <categoryLink id="6841-b54f-c299-8be8" name="Transport" hidden="false" targetId="e4e0-c5d1-3430-f101" primary="false"/>
         <categoryLink id="b9e6-8014-c83d-f038" name="Vehicle" hidden="false" targetId="53bd-99e7-aba0-e79f" primary="false"/>
@@ -7990,7 +8019,7 @@ Hunter: Shot Gun, Chainblade, +1A and Acute Senses</description>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="829f-26e6-6908-aa1f" name="Mars Pattern Javelin Attack Speeder Squadron" page="0" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="829f-26e6-6908-aa1f" name="Mars Pattern Javelin Attack Speeder Squadron" page="0" hidden="false" collective="false" import="true" type="unit">
       <selectionEntries>
         <selectionEntry id="8c5b-654a-d2d2-26d5" name="Mars Pattern Javelin Attack Speeder" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
@@ -9224,7 +9253,7 @@ Hunter: Shot Gun, Chainblade, +1A and Acute Senses</description>
         <cost name="pts" typeId="points" value="60.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="238b-3768-7dd7-7f81" name="Custom Legiones Astartes Character" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="238b-3768-7dd7-7f81" name="Custom Legiones Astartes Character" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="add" field="category" value="98da-03a8-32c3-317e">
           <conditionGroups>
@@ -19485,7 +19514,7 @@ Master of Cybernetica (Location: Specialisation &amp; Legion Special Rules, Cost
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="bfae-d4db-e184-7134" name="Legion Headquaters Company Command" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="bfae-d4db-e184-7134" name="Legion Headquaters Company Command" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="set" field="770e-4864-b33d-5955" value="1.0">
           <conditions>

--- a/(HH) Mornival Units.cat
+++ b/(HH) Mornival Units.cat
@@ -587,7 +587,6 @@ Example 4: In a 2000 point army, a Daemon Lord is the Warlord (doesn’t count a
       </modifiers>
       <categoryLinks>
         <categoryLink id="ccb5-3304-1dfe-0424" name="New CategoryLink" hidden="false" targetId="54726f6f707323232344415441232323" primary="true"/>
-        <categoryLink id="da8e-2b71-ea7e-6eec" name="Compulsory Troops" hidden="false" targetId="219d-aefa-dfa5-44db" primary="false"/>
         <categoryLink id="dc5e-80da-08f7-44f7" name="Mournival Centurion Restricted Unit" hidden="false" targetId="0617-4e0c-126d-17f3" primary="false"/>
       </categoryLinks>
     </entryLink>
@@ -1504,44 +1503,6 @@ If a Rogue Psyker who is the army’s Warlord becomes possessed, they are still 
         <categoryLink id="3aeb-5521-86d6-3477" name="Infantry" hidden="false" targetId="f74d-4679-75a6-1252" primary="false"/>
         <categoryLink id="05cd-eb8d-0880-76c4" name="Legiones Astartes" hidden="false" targetId="0c56-27b8-a737-c9fd" primary="false"/>
       </categoryLinks>
-      <selectionEntries>
-        <selectionEntry id="e6b1-1bc7-9baa-8dcb" name="Munitions (Any unit equiped with weapons listed may take upgrade at 2 points per model)" hidden="false" collective="false" import="true" type="upgrade">
-          <profiles>
-            <profile id="535d-8dbb-62e3-5bd8" name="Heavy Bolter: Splinter" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
-              <characteristics>
-                <characteristic name="Range" typeId="52616e676523232344415441232323">35&quot;</characteristic>
-                <characteristic name="Strength" typeId="537472656e67746823232344415441232323">2</characteristic>
-                <characteristic name="AP" typeId="415023232344415441232323">4</characteristic>
-                <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 3, Rending</characteristic>
-              </characteristics>
-            </profile>
-            <profile id="3786-8c46-f032-b393" name="Missile Launcher: Sabot" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
-              <characteristics>
-                <characteristic name="Range" typeId="52616e676523232344415441232323">36&quot;</characteristic>
-                <characteristic name="Strength" typeId="537472656e67746823232344415441232323"/>
-                <characteristic name="AP" typeId="415023232344415441232323">2</characteristic>
-                <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 1, Sunder</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <rules>
-            <rule id="f1d8-b221-8722-1536" name="Munitions" hidden="false">
-              <description>Any units in the same detachment may be equipped, for +2 pts per model, with:
-Autocannon: Sabot: 36” S8 AP2 Heavy 1 Sunder
-Missile Launcher: Sabot: 36” S8 AP2 Heavy 1 Sunder
-Heavy Bolter: Splinter: 36” S2 AP4 Heavy 3 Rending</description>
-            </rule>
-          </rules>
-          <infoLinks>
-            <infoLink id="c045-e082-5986-1b28" name="Rending" hidden="false" targetId="8269-2cd6-9236-16e7" type="rule"/>
-            <infoLink id="32ca-0a5c-4a94-229a" name="Sunder" hidden="false" targetId="841f-9119-9f9d-5058" type="rule"/>
-            <infoLink id="e108-c202-948f-851a" name="Autocannon: Sabot" hidden="false" targetId="d706-b010-f97a-ff5e" type="profile"/>
-          </infoLinks>
-          <costs>
-            <cost name="pts" typeId="points" value="2.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="586c-2b17-ffdc-41fd" name="May Exchange his Master-Crafted Bolt Gun for a Master-Crafted:" hidden="false" collective="false" import="true" defaultSelectionEntryId="e5b6-1360-ef4f-8bb3">
           <constraints>
@@ -1919,6 +1880,58 @@ Heavy Bolter: Splinter: 36” S2 AP4 Heavy 3 Rending</description>
               </costs>
             </entryLink>
           </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="92d2-d3c9-9166-09d0" name="Munitions" hidden="false" collective="false" import="true">
+          <selectionEntries>
+            <selectionEntry id="dc79-f330-ac4b-d443" name="Heavy Bolter Munitions (Any unit equiped with Heavy Bolter (or variant of) may take upgrade, at 2pts per model)" hidden="false" collective="false" import="true" type="upgrade">
+              <profiles>
+                <profile id="faba-450b-bc40-e001" name="Heavy Bolter: Splinter" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="52616e676523232344415441232323">35&quot;</characteristic>
+                    <characteristic name="Strength" typeId="537472656e67746823232344415441232323">2</characteristic>
+                    <characteristic name="AP" typeId="415023232344415441232323">4</characteristic>
+                    <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 3, Rending</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink id="a131-7d63-9967-8e14" name="Rending" hidden="false" targetId="8269-2cd6-9236-16e7" type="rule"/>
+                <infoLink id="ce8c-7f9c-5b68-6905" name="Munitions" hidden="false" targetId="0eaf-31da-5081-636f" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="2.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="8503-f675-11df-50ba" name="Missile Launcher Munitions (Any unit equiped with Missile Launcher (or variant of) may take upgrade, at 5pts per model)" hidden="false" collective="false" import="true" type="upgrade">
+              <profiles>
+                <profile id="a3e1-4339-9361-f1a6" name="Missile Launcher: Sabot" hidden="false" typeId="576561706f6e23232344415441232323" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="52616e676523232344415441232323">36&quot;</characteristic>
+                    <characteristic name="Strength" typeId="537472656e67746823232344415441232323"/>
+                    <characteristic name="AP" typeId="415023232344415441232323">2</characteristic>
+                    <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 1, Sunder</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink id="e158-2287-818a-346c" name="Sunder" hidden="false" targetId="841f-9119-9f9d-5058" type="rule"/>
+                <infoLink id="4846-f42f-cc0b-a37b" name="Munitions" hidden="false" targetId="0eaf-31da-5081-636f" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="2.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="c58f-29a5-68a5-434f" name="Autocannon Munitions (Any unit equiped with Autocannon (or variant of) may take upgrade, at 2pts per model)" hidden="false" collective="false" import="true" type="upgrade">
+              <infoLinks>
+                <infoLink id="5a39-425f-7692-a6d7" name="Sunder" hidden="false" targetId="841f-9119-9f9d-5058" type="rule"/>
+                <infoLink id="3c53-8197-c28d-5007" name="Autocannon: Sabot" hidden="false" targetId="d706-b010-f97a-ff5e" type="profile"/>
+                <infoLink id="7e7c-1f9f-a935-5f03" name="Munitions" hidden="false" targetId="0eaf-31da-5081-636f" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="2.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
@@ -3773,9 +3786,14 @@ All models with psychic powers suffer a penalty to roll to manifest psychic powe
         <selectionEntry id="bd53-9cb3-68e0-3f14" name="Legion Independent Techmarines" publicationId="0e6e-8c19-c436-39c4" hidden="false" collective="false" import="true" type="unit">
           <modifiers>
             <modifier type="remove" field="category" value="f74d-4679-75a6-1252">
-              <conditions>
-                <condition field="selections" scope="bd53-9cb3-68e0-3f14" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="db95-0c14-c334-4453" type="equalTo"/>
-              </conditions>
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="bd53-9cb3-68e0-3f14" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="db95-0c14-c334-4453" type="equalTo"/>
+                    <condition field="selections" scope="bd53-9cb3-68e0-3f14" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="023e-8d89-f61b-c1b9" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
             </modifier>
             <modifier type="increment" field="f139-0622-c255-2d75" value="1.0">
               <repeats>
@@ -3813,12 +3831,11 @@ All models with psychic powers suffer a penalty to roll to manifest psychic powe
             <rule id="3347-6c01-2010-59bf" name="Supernumerary" hidden="false">
               <description>0-1 Legion Techmarines may be taken for each full 500 points in the detachment. These models use a single Elites Force Organisation slot. Each Legion Techmarine must be deployed as either:
 ♦ A separate unit which may be joined by Servo-automata and may be equipped with a Rhino as a Dedicated Transport, or
-♦ Assigned to one of your squads during deployment and may not voluntarily leave it during the game. Only
-squads entirely comprising models with the Infantry type and the Legiones Astartes special rule are eligible
-to be joined, and squads equipped with Terminator armour may not be joined.
+♦ Assigned to one of your squads during deployment and may not voluntarily leave it during the game. Only squads entirely comprising models with the Infantry type and the Legiones Astartes special rule are eligible to be joined, and squads equipped with Terminator armour may not be joined.
 
-If equipped with a Jump Pack then they may only join eligible squads with the Jump Infantry type. If equipped with a Legion Space Marine Bike then they may only join eligible squads with the Bike type instead.
-</description>
+♦ If equipped with a Jump Pack then they may only join eligible squads with the Jump Infantry type. If equipped with a Legion Space Marine Bike then they may only join eligible squads with the Bike type instead.
+
+♦ Techmarines on Bullock Jetcycles can only join Astartes squads equipped with Bullock Jetcycles. Armorium can be used with all types of the weapons named, e.g. Biocorrosive ammunition can be used with heavy and snub rotor cannon.</description>
             </rule>
           </rules>
           <infoLinks>
@@ -3895,6 +3912,17 @@ If equipped with a Jump Pack then they may only join eligible squads with the Ju
                   </categoryLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="023e-8d89-f61b-c1b9" name="Bullock Jetcycle" hidden="false" collective="false" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6ac5-cae4-d2a0-a302" type="max"/>
+                  </constraints>
+                  <categoryLinks>
+                    <categoryLink id="2eea-e6a6-8099-8d52" name="Jetbike" hidden="false" targetId="1640-3081-13eb-b1cf" primary="false"/>
+                  </categoryLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="20.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -4041,6 +4069,7 @@ If equipped with a Jump Pack then they may only join eligible squads with the Ju
                           <conditions>
                             <condition field="selections" scope="bd53-9cb3-68e0-3f14" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="db95-0c14-c334-4453" type="equalTo"/>
                             <condition field="selections" scope="bd53-9cb3-68e0-3f14" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="25e5-7eb1-8938-0d67" type="equalTo"/>
+                            <condition field="selections" scope="bd53-9cb3-68e0-3f14" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="023e-8d89-f61b-c1b9" type="equalTo"/>
                           </conditions>
                         </conditionGroup>
                       </conditionGroups>
@@ -4192,6 +4221,93 @@ If equipped with a Jump Pack then they may only join eligible squads with the Ju
                   </costs>
                 </selectionEntry>
               </selectionEntries>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="6d0e-dfcc-30bc-3bc9" name="Bullock Jetcycles Weapon" hidden="true" collective="false" import="true">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <conditions>
+                    <condition field="selections" scope="bd53-9cb3-68e0-3f14" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="023e-8d89-f61b-c1b9" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c807-8276-9c9b-9b5a" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="eae3-e57d-d63e-53b1" name="Twin-linked Plasma gun" hidden="false" collective="false" import="true" targetId="e22c-8213-f142-f2fe" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="20.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="4fb9-e35d-5dbf-cc1e" name="Hurricane Bolter" hidden="false" collective="false" import="true" targetId="bfa7-fc02-60e9-c200" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0689-f637-707a-4c92" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="da21-f281-420d-710e" name="Heavy Bolter" hidden="false" collective="false" import="true" targetId="a161-76b3-9ef1-da7b" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4a1c-ad20-f9c7-c4e2" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="8ace-b83e-5305-2d74" name="Twin-linked Grenade Launcher" hidden="false" collective="false" import="true" targetId="0a8e-da3f-59da-dc04" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="8.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="9470-e294-7b0d-5fb7" name="Twin-linked Bolter" hidden="false" collective="false" import="true" targetId="30c2c848-c1d3-e61f-6632-a91bcee1fdc4" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="1.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="5292-df54-cef8-22ed" name="Heavy Flamer" hidden="true" collective="false" import="true" targetId="ead9-305c-a7e7-323e" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9c29-e6cd-2167-ce90" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="21b2-8d7e-f6ed-b454" name="Plasma Repeater" hidden="false" collective="false" import="true" targetId="d4e8-6e08-581a-79bd" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e6fb-0e54-0be1-9ed1" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f399-5c98-4526-74b1" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="20.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="f922-aecb-6592-c06a" name="Plasma Burners" hidden="false" collective="false" import="true" targetId="d650-2238-d718-9798" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e6fb-0e54-0be1-9ed1" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="72e7-3d43-3235-af12" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="15.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks>
@@ -6775,9 +6891,53 @@ Hunter: Shot Gun, Chainblade, +1A and Acute Senses</description>
       </costs>
     </selectionEntry>
     <selectionEntry id="0183-7594-8997-5b90" name="Sky Stalker Jetbike Squad on Bullock Jetcycles, Legion" publicationId="0e6e-8c19-c436-39c4" page="" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="add" field="category" value="219d-aefa-dfa5-44db">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2e67-4ce3-498e-ab12" type="equalTo"/>
+              </conditions>
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="0183-7594-8997-5b90" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0d60-2ba2-5f2b-ad3b" type="equalTo"/>
+                    <condition field="selections" scope="0183-7594-8997-5b90" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ead9-305c-a7e7-323e" type="equalTo"/>
+                    <condition field="selections" scope="0183-7594-8997-5b90" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d650-2238-d718-9798" type="equalTo"/>
+                    <condition field="selections" scope="0183-7594-8997-5b90" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a161-76b3-9ef1-da7b" type="equalTo"/>
+                    <condition field="selections" scope="0183-7594-8997-5b90" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e22c-8213-f142-f2fe" type="equalTo"/>
+                    <condition field="selections" scope="0183-7594-8997-5b90" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d4e8-6e08-581a-79bd" type="equalTo"/>
+                    <condition field="selections" scope="0183-7594-8997-5b90" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a8e-da3f-59da-dc04" type="equalTo"/>
+                    <condition field="selections" scope="0183-7594-8997-5b90" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="30c2c848-c1d3-e61f-6632-a91bcee1fdc4" type="equalTo"/>
+                    <condition field="selections" scope="0183-7594-8997-5b90" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bfa7-fc02-60e9-c200" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="set-primary" field="category" value="486561767920537570706f727423232344415441232323">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2e67-4ce3-498e-ab12" type="equalTo"/>
+              </conditions>
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="0183-7594-8997-5b90" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e5d2-e10d-1552-c5c6" type="equalTo"/>
+                    <condition field="selections" scope="0183-7594-8997-5b90" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3cb9-7ef8-c6cd-aab4" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <infoLinks>
         <infoLink id="b93e-41b3-712a-db1e" name="Deep Strike" hidden="false" targetId="d219-2314-4834-c054" type="rule"/>
         <infoLink id="d11e-89a3-2adb-8d2e" name="Space Marine Jetbike" hidden="false" targetId="3c28-4994-00ed-bbe5" type="profile"/>
+        <infoLink id="277b-0e33-7609-2ae1" name="Scout" hidden="false" targetId="9b30-1da3-eb8d-ce7a" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="5d07-3695-1c2c-82ec" name="Jetbike" hidden="false" targetId="1640-3081-13eb-b1cf" primary="false"/>
@@ -7054,6 +7214,53 @@ Hunter: Shot Gun, Chainblade, +1A and Acute Senses</description>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="10b3-987f-d540-b7f7" type="max"/>
               </constraints>
             </entryLink>
+            <entryLink id="5b73-6b45-0985-2d56" name="Heavy Rotor Cannon" hidden="false" collective="false" import="true" targetId="0d60-2ba2-5f2b-ad3b" type="selectionEntry">
+              <modifiers>
+                <modifier type="increment" field="points" value="2.0">
+                  <repeats>
+                    <repeat field="selections" scope="0183-7594-8997-5b90" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+            </entryLink>
+            <entryLink id="298b-18c3-cd5b-9ac3" name="Graviton Gun" hidden="false" collective="false" import="true" targetId="0d3c-2b57-247d-548d" type="selectionEntry">
+              <modifiers>
+                <modifier type="decrement" field="points" value="15.0"/>
+                <modifier type="increment" field="points" value="10.0">
+                  <repeats>
+                    <repeat field="selections" scope="0183-7594-8997-5b90" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+                <modifier type="set" field="name" value="Graviton Gun*"/>
+              </modifiers>
+            </entryLink>
+            <entryLink id="5f43-2934-d056-4333" name="Meltagun" hidden="false" collective="false" import="true" targetId="a22d-ceac-5063-54e1" type="selectionEntry">
+              <modifiers>
+                <modifier type="decrement" field="points" value="15.0"/>
+                <modifier type="set" field="name" value="Meltagun*"/>
+              </modifiers>
+            </entryLink>
+            <entryLink id="458b-2030-314a-adaa" name="Missile Launcher" hidden="false" collective="false" import="true" targetId="e5d2-e10d-1552-c5c6" type="selectionEntry">
+              <modifiers>
+                <modifier type="increment" field="points" value="10.0">
+                  <repeats>
+                    <repeat field="selections" scope="0183-7594-8997-5b90" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+                <modifier type="set" field="name" value="Missile Launcher (Frag and Krak)**"/>
+              </modifiers>
+            </entryLink>
+            <entryLink id="a4c7-938e-f72e-cec3" name="Reaper Autocannon" hidden="false" collective="false" import="true" targetId="3cb9-7ef8-c6cd-aab4" type="selectionEntry">
+              <modifiers>
+                <modifier type="decrement" field="points" value="15.0"/>
+                <modifier type="increment" field="points" value="10.0">
+                  <repeats>
+                    <repeat field="selections" scope="0183-7594-8997-5b90" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+                <modifier type="set" field="name" value="Reaper Autocannon**"/>
+              </modifiers>
+            </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="2de5-8427-10a2-a1ac" name="All members may be equipped wit:" hidden="false" collective="false" import="true">
@@ -7086,6 +7293,54 @@ Hunter: Shot Gun, Chainblade, +1A and Acute Senses</description>
             <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4541-062a-7d22-ac20" type="max"/>
             <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0df8-43e6-ebab-5f24" type="min"/>
           </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="88d8-869f-6f02-1687" name="One in three models may be equipped with Power Weapons" hidden="false" collective="false" import="true">
+              <modifiers>
+                <modifier type="increment" field="c85b-720e-5f97-8862" value="1.0">
+                  <repeats>
+                    <repeat field="selections" scope="0183-7594-8997-5b90" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c85b-720e-5f97-8862" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="fdf9-6a51-1560-e65e" name="Power Axe" hidden="false" collective="false" import="true" targetId="7b92-ab87-86a1-ab2e" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b7ac-212c-2231-6903" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="a095-1d8f-7fab-bb6c" name="Power Lance" hidden="false" collective="false" import="true" targetId="233d-238b-6940-2740" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="de64-2c22-a616-4d78" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="5ad7-0bc5-9e18-283b" name="Power Maul" hidden="false" collective="false" import="true" targetId="e8a2-42e8-82a7-8dd9" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1fef-f5cf-5230-8f26" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="fd33-41fa-e135-ac7d" name="Power Sword" hidden="false" collective="false" import="true" targetId="3e90-5ca1-8abe-0275" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0da1-d0eb-eae0-7198" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
           <entryLinks>
             <entryLink id="6d69-00a6-c7f7-3179" name="Chainsword/Combat Blade" hidden="false" collective="false" import="true" targetId="4b1e-680b-1d39-e4f1" type="selectionEntry">
               <modifiers>
@@ -7096,38 +7351,6 @@ Hunter: Shot Gun, Chainblade, +1A and Acute Senses</description>
               <constraints>
                 <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="32e0-d3ad-3121-712a" type="max"/>
               </constraints>
-            </entryLink>
-            <entryLink id="9cdf-7ec2-4d4e-feb7" name="Power Axe" hidden="false" collective="false" import="true" targetId="7b92-ab87-86a1-ab2e" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8319-e54a-423d-7641" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="ee88-7a68-273e-3841" name="Power Lance" hidden="false" collective="false" import="true" targetId="233d-238b-6940-2740" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f23f-4266-67df-79b6" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="31aa-e512-8562-e48a" name="Power Maul" hidden="false" collective="false" import="true" targetId="e8a2-42e8-82a7-8dd9" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1f21-f507-5a0b-f9e0" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="b899-56bc-ca0c-4b15" name="Power Sword" hidden="false" collective="false" import="true" targetId="3e90-5ca1-8abe-0275" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4862-1764-3ee3-330b" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-              </costs>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
@@ -7319,6 +7542,7 @@ Hunter: Shot Gun, Chainblade, +1A and Acute Senses</description>
       <infoLinks>
         <infoLink id="2766-8b93-38ac-d07c" name="Deep Strike" hidden="false" targetId="d219-2314-4834-c054" type="rule"/>
         <infoLink id="1c6f-65b2-96e8-cf15" name="Space Marine Jetbike" hidden="false" targetId="3c28-4994-00ed-bbe5" type="profile"/>
+        <infoLink id="44ad-12cd-d4af-3131" name="Scout" hidden="false" targetId="9b30-1da3-eb8d-ce7a" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="9d7c-0dab-2cbb-e5c8" name="Deep Strike" hidden="false" targetId="2d6f-e613-ab10-e55a" primary="false"/>
@@ -8011,7 +8235,7 @@ Hunter: Shot Gun, Chainblade, +1A and Acute Senses</description>
             <entryLink id="67dd-0bc0-e183-e036" name="Searchlight" hidden="false" collective="false" import="true" targetId="7b19-0e33-9c8d-e56a" type="selectionEntry"/>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="55.0"/>
+            <cost name="pts" typeId="points" value="45.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -11773,6 +11997,7 @@ A Unit may not use Counter Attack special rule if it used Reaction Fire.</descri
                             <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="dace-8f0f-e696-8179" type="equalTo"/>
                           </conditions>
                         </modifier>
+                        <modifier type="append" field="description" value=" A Moritat cannot benefit from Special rules such as Preferred Enemy or Fatal Strike while performing a Chainfire or Mag Rip attack on the roll to hit, however, the roll to wound may benefit."/>
                       </modifiers>
                     </infoLink>
                     <infoLink id="9fb8-35c5-942b-f100" name="Chain Fire" hidden="false" targetId="ba3f96a8-c144-ec70-9f5e-7e428598c16c" type="rule">
@@ -11782,6 +12007,7 @@ A Unit may not use Counter Attack special rule if it used Reaction Fire.</descri
                             <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="dace-8f0f-e696-8179" type="equalTo"/>
                           </conditions>
                         </modifier>
+                        <modifier type="append" field="description" value=" A Moritat cannot benefit from Special rules such as Preferred Enemy or Fatal Strike while performing a Chainfire or Mag Rip attack on the roll to hit, however, the roll to wound may benefit."/>
                       </modifiers>
                     </infoLink>
                   </infoLinks>
@@ -11820,6 +12046,59 @@ A Unit may not use Counter Attack special rule if it used Reaction Fire.</descri
                   </constraints>
                   <infoLinks>
                     <infoLink id="e32a-2a81-179f-e832" name="Keeper of the Dead" hidden="false" targetId="2bea-0d4d-380f-8992" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="b321-84c8-3680-2925" name="Bloody Murder" hidden="true" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cf56-aabc-9977-728d" type="greaterThan"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2e9e-6f3a-dcc9-1113" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a37c-7dc6-43ca-0073" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="26f8-8b29-041b-a768" name="Bloody Murder" hidden="false" targetId="caff-0ad5-1bab-14c5" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="becd-4331-3e7d-b8ed" name="Raptor Strike (Jump Infantry only)" hidden="true" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3afd-ac93-1a99-4de9" type="equalTo"/>
+                          </conditions>
+                          <conditionGroups>
+                            <conditionGroup type="or">
+                              <conditions>
+                                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cf56-aabc-9977-728d" type="greaterThan"/>
+                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2e9e-6f3a-dcc9-1113" type="equalTo"/>
+                              </conditions>
+                            </conditionGroup>
+                          </conditionGroups>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9743-5b52-0e8b-460a" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="51a0-7fed-2298-1ce8" name="Raptor Strike" hidden="false" targetId="d4af-61e0-fa3c-f3c6" type="rule"/>
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="5.0"/>
@@ -13129,6 +13408,120 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                     <cost name="pts" typeId="points" value="25.0"/>
                   </costs>
                 </entryLink>
+                <entryLink id="f636-6df2-3439-358d" name="Plasma Burners" hidden="false" collective="false" import="true" targetId="d650-2238-d718-9798" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e6fb-0e54-0be1-9ed1" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a733-8a62-0d94-3ff1" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="20.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="5e76-8180-e3c7-f039" name="Plasma Repeater" hidden="false" collective="false" import="true" targetId="d4e8-6e08-581a-79bd" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e6fb-0e54-0be1-9ed1" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3623-50fb-1dda-3cf8" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="25.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="4b61-0789-6543-333a" name="Plasma-Casters" hidden="true" collective="false" import="true" targetId="9529-231b-eb48-f276" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e6fb-0e54-0be1-9ed1" type="equalTo"/>
+                          </conditions>
+                          <conditionGroups>
+                            <conditionGroup type="or">
+                              <conditions>
+                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ba6-dda6-d587-3da7" type="equalTo"/>
+                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="28d4-97c4-3355-1b98" type="equalTo"/>
+                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b26e-ba33-ff55-3fd6" type="equalTo"/>
+                              </conditions>
+                            </conditionGroup>
+                          </conditionGroups>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f0c2-e5ce-b9af-ab50" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="20.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="105f-b69d-0ef9-1ca0" name="Volkite Cavitor" hidden="false" collective="false" import="true" targetId="e329-1b58-7c33-335f" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cf56-aabc-9977-728d" type="equalTo"/>
+                          </conditions>
+                          <conditionGroups>
+                            <conditionGroup type="or">
+                              <conditions>
+                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ba6-dda6-d587-3da7" type="equalTo"/>
+                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="28d4-97c4-3355-1b98" type="equalTo"/>
+                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b26e-ba33-ff55-3fd6" type="equalTo"/>
+                              </conditions>
+                            </conditionGroup>
+                          </conditionGroups>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="710f-7fcd-790d-78f7" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="20.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="5cb7-bf16-77ba-ae10" name="Coriolis Pattern Power Shield" hidden="true" collective="false" import="true" targetId="2ba5-ac49-bedd-ba60" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d97b-d19f-4972-8e7f" type="equalTo"/>
+                          </conditions>
+                          <conditionGroups>
+                            <conditionGroup type="or">
+                              <conditions>
+                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ba6-dda6-d587-3da7" type="equalTo"/>
+                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="28d4-97c4-3355-1b98" type="equalTo"/>
+                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b26e-ba33-ff55-3fd6" type="equalTo"/>
+                              </conditions>
+                            </conditionGroup>
+                          </conditionGroups>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fac1-9135-b4e3-de1d" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </entryLink>
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="7722-f24c-fa61-c96b" name="Bike or Jetbike Weapon" hidden="true" collective="false" import="true">
@@ -13139,6 +13532,7 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                       <conditions>
                         <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="84ea-ada4-abe0-f064" type="equalTo"/>
                         <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a6cc-561c-56f9-a051" type="equalTo"/>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="015d-3e99-93a2-83f4" type="equalTo"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
@@ -13149,6 +13543,8 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                       <conditions>
                         <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="84ea-ada4-abe0-f064" type="equalTo"/>
                         <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a6cc-561c-56f9-a051" type="equalTo"/>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="015d-3e99-93a2-83f4" type="equalTo"/>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fd54-10f7-c05c-6f4f" type="equalTo"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
@@ -13197,10 +13593,24 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                 </entryLink>
                 <entryLink id="8306-d785-fea8-9def" name="Heavy Bolter" hidden="false" collective="false" import="true" targetId="a161-76b3-9ef1-da7b" type="selectionEntry">
                   <modifiers>
-                    <modifier type="set" field="points" value="0.0"/>
-                    <modifier type="set" field="hidden" value="true">
+                    <modifier type="set" field="points" value="0.0">
                       <conditions>
-                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a6cc-561c-56f9-a051" type="equalTo"/>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a6cc-561c-56f9-a051" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="015d-3e99-93a2-83f4" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a6cc-561c-56f9-a051" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                    <modifier type="set" field="points" value="15.0">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="015d-3e99-93a2-83f4" type="equalTo"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -13210,10 +13620,24 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                 </entryLink>
                 <entryLink id="aa3f-be93-02c6-c20f" name="Heavy Flamer" hidden="false" collective="false" import="true" targetId="9fef-d14e-0e9f-1cc8" type="selectionEntry">
                   <modifiers>
-                    <modifier type="set" field="points" value="0.0"/>
                     <modifier type="set" field="hidden" value="true">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="015d-3e99-93a2-83f4" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a6cc-561c-56f9-a051" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                    <modifier type="set" field="points" value="15.0">
                       <conditions>
-                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a6cc-561c-56f9-a051" type="equalTo"/>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="015d-3e99-93a2-83f4" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="set" field="points" value="0.0">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a6cc-561c-56f9-a051" type="equalTo"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -13221,9 +13645,15 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                 <entryLink id="2c83-03ba-17c4-a737" name="Twin-linked Bolter" hidden="false" collective="false" import="true" targetId="30c2c848-c1d3-e61f-6632-a91bcee1fdc4" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="hidden" value="true">
-                      <conditions>
-                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="84ea-ada4-abe0-f064" type="equalTo"/>
-                      </conditions>
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fd54-10f7-c05c-6f4f" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="84ea-ada4-abe0-f064" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="015d-3e99-93a2-83f4" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
                     </modifier>
                   </modifiers>
                   <costs>
@@ -13257,8 +13687,18 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                 <entryLink id="2264-e7ab-e6aa-2ea1" name="Twin-linked Plasma gun" hidden="false" collective="false" import="true" targetId="e22c-8213-f142-f2fe" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="hidden" value="true">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="015d-3e99-93a2-83f4" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="84ea-ada4-abe0-f064" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                    <modifier type="set" field="points" value="25.0">
                       <conditions>
-                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="84ea-ada4-abe0-f064" type="equalTo"/>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="015d-3e99-93a2-83f4" type="equalTo"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -13279,6 +13719,112 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                       </conditionGroups>
                     </modifier>
                   </modifiers>
+                  <costs>
+                    <cost name="pts" typeId="points" value="15.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="7a66-c06a-5c49-1258" name="Twin-linked Snub Rotor Cannon" hidden="false" collective="false" import="true" targetId="8a9e-4d7f-139b-221f" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fd54-10f7-c05c-6f4f" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="1aa8-49f4-0b3b-9e08" name="Graviton Gun" hidden="false" collective="false" import="true" targetId="0d3c-2b57-247d-548d" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="015d-3e99-93a2-83f4" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <costs>
+                    <cost name="pts" typeId="points" value="15.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="6042-a190-1244-f655" name="Heavy Rotor Cannon" hidden="false" collective="false" import="true" targetId="0d60-2ba2-5f2b-ad3b" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="015d-3e99-93a2-83f4" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="71c8-2458-d097-a324" name="Hurricane Bolter" hidden="false" collective="false" import="true" targetId="bfa7-fc02-60e9-c200" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="015d-3e99-93a2-83f4" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="53af-ed30-3872-ee63" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="797e-5f51-7a0c-a980" name="Plasma Burners" hidden="false" collective="false" import="true" targetId="d650-2238-d718-9798" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e6fb-0e54-0be1-9ed1" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="015d-3e99-93a2-83f4" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2259-a62b-8135-5594" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="20.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="aea1-c686-770c-321e" name="Plasma Repeater" hidden="false" collective="false" import="true" targetId="d4e8-6e08-581a-79bd" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e6fb-0e54-0be1-9ed1" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="015d-3e99-93a2-83f4" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e98f-4d18-52d9-79e1" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="25.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="18e7-240d-7d42-4022" name="Grenade Launcher" hidden="false" collective="false" import="true" targetId="a6d9-5db2-b234-d2fc" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="015d-3e99-93a2-83f4" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <costs>
+                    <cost name="pts" typeId="points" value="15.0"/>
+                  </costs>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
@@ -13605,6 +14151,42 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="8c7e-0a81-7450-d2b4" name="Equinox Power blade Case" hidden="true" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d97b-d19f-4972-8e7f" type="equalTo"/>
+                          </conditions>
+                          <conditionGroups>
+                            <conditionGroup type="or">
+                              <conditions>
+                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3afd-ac93-1a99-4de9" type="equalTo"/>
+                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c347-ce4a-f9f6-48ec" type="equalTo"/>
+                              </conditions>
+                            </conditionGroup>
+                          </conditionGroups>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2c1d-2965-71a2-952e" type="max"/>
+                  </constraints>
+                  <rules>
+                    <rule id="d19a-58bf-bdc4-e9b7" name="Equinox Power blade Case" hidden="false">
+                      <description>An Equinox power blade case is a pair of Melee weapons, each with a different profile as listed below. In any given Assault phase, the wielder must choose one of the following two profiles before making any Attacks in that phase will use the chosen profile and gain the additional attack for using two combat weapons.</description>
+                    </rule>
+                  </rules>
+                  <entryLinks>
+                    <entryLink id="4614-4c49-9edc-ee6c" name="Sunrise Blade" hidden="false" collective="false" import="true" targetId="8a7d-fbf8-ae0b-8a52" type="selectionEntry"/>
+                    <entryLink id="716d-0c26-af45-f057" name="Sunset Blade" hidden="false" collective="false" import="true" targetId="0753-20e1-fd80-3b3e" type="selectionEntry"/>
+                  </entryLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="20.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -13979,11 +14561,6 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                     <cost name="pts" typeId="points" value="30.0"/>
                   </costs>
                 </entryLink>
-                <entryLink id="2997-8290-3437-0f06" name="Nostraman Chainglaive" hidden="false" collective="false" import="true" targetId="c31253d0-d1b9-35ac-6435-f1a06611e356" type="selectionEntry">
-                  <costs>
-                    <cost name="pts" typeId="points" value="15.0"/>
-                  </costs>
-                </entryLink>
                 <entryLink id="4790-110b-a66a-85e1" name="Blade of Perdition" hidden="false" collective="false" import="true" targetId="e5be-2b36-334f-e2e8" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="hidden" value="true">
@@ -14165,6 +14742,105 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                     <cost name="pts" typeId="points" value="15.0"/>
                   </costs>
                 </entryLink>
+                <entryLink id="99d7-269a-3f37-d11d" name="Power Lance" hidden="false" collective="false" import="true" targetId="a368-9d56-9d0f-4a3f" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="136c-41e0-c2b4-e6ee" name="Kontos Power Lance" hidden="false" collective="false" import="true" targetId="ddb3-faca-d36e-fb09" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5c66-2306-9285-8809" type="equalTo"/>
+                          </conditions>
+                          <conditionGroups>
+                            <conditionGroup type="or">
+                              <conditions>
+                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="015d-3e99-93a2-83f4" type="equalTo"/>
+                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a6cc-561c-56f9-a051" type="equalTo"/>
+                              </conditions>
+                            </conditionGroup>
+                          </conditionGroups>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                  <costs>
+                    <cost name="pts" typeId="points" value="15.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="47a0-39a1-7d00-b03c" name="Headsman&apos;s Axe" hidden="false" collective="false" import="true" targetId="e694-a971-ba9a-77b2" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cf56-aabc-9977-728d" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </entryLink>
+                <entryLink id="98a9-589f-ecf5-b3e7" name="Nostraman Chainblade" hidden="true" collective="false" import="true" targetId="afb1-c199-0893-fe53" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cf56-aabc-9977-728d" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </entryLink>
+                <entryLink id="6d74-9c90-7639-24a5" name="Escaton Power Claw" hidden="true" collective="false" import="true" targetId="cbb3-2de0-13c2-89ec" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditionGroups>
+                            <conditionGroup type="or">
+                              <conditions>
+                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ba6-dda6-d587-3da7" type="equalTo"/>
+                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="28d4-97c4-3355-1b98" type="equalTo"/>
+                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b26e-ba33-ff55-3fd6" type="equalTo"/>
+                              </conditions>
+                            </conditionGroup>
+                            <conditionGroup type="or">
+                              <conditions>
+                                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cf56-aabc-9977-728d" type="equalTo"/>
+                                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cf2e-9aed-ccc5-5696" type="equalTo"/>
+                              </conditions>
+                            </conditionGroup>
+                          </conditionGroups>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                </entryLink>
+                <entryLink id="3240-a00f-de28-9979" name="Fallen-star Pattern Power Spear" hidden="true" collective="false" import="true" targetId="29e0-947f-81c6-af75" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d97b-d19f-4972-8e7f" type="equalTo"/>
+                          </conditions>
+                          <conditionGroups>
+                            <conditionGroup type="or">
+                              <conditions>
+                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3afd-ac93-1a99-4de9" type="equalTo"/>
+                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c347-ce4a-f9f6-48ec" type="equalTo"/>
+                              </conditions>
+                            </conditionGroup>
+                          </conditionGroups>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b84a-87b5-048d-fccd" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="20.0"/>
+                  </costs>
+                </entryLink>
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="cbff-0bff-a3f9-427c" name="Ammo" hidden="false" collective="false" import="true">
@@ -14226,7 +14902,7 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                     </profile>
                   </profiles>
                   <costs>
-                    <cost name="pts" typeId="points" value="10.0"/>
+                    <cost name="pts" typeId="points" value="5.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="a3c9-1990-74a0-0442" name="Special Issue Ammunition" hidden="true" collective="false" import="true" type="upgrade">
@@ -18778,7 +19454,7 @@ Master of Cybernetica (Location: Specialisation &amp; Legion Special Rules, Cost
               <infoLinks>
                 <infoLink id="5c44-afaf-50e0-55db" name="Space Marine Bike" hidden="false" targetId="0434-8c4b-9614-73dd" type="profile"/>
                 <infoLink id="2d60-b39b-6458-e429" name="Hammer of Wrath" hidden="false" targetId="6f66-b417-6004-0916" type="rule"/>
-                <infoLink id="9d51-291e-9643-cfde" name="New InfoLink" hidden="false" targetId="d3e5-b43d-a89c-3bd8" type="rule"/>
+                <infoLink id="9d51-291e-9643-cfde" name="Jink" hidden="false" targetId="d3e5-b43d-a89c-3bd8" type="rule"/>
                 <infoLink id="c06c-d698-4267-8092" name="Relentless" hidden="false" targetId="3c7d-a1fa-c68b-caad" type="rule"/>
                 <infoLink id="1983-9909-35b1-f9b7" name="Very Bulky" hidden="false" targetId="abc9-8566-bb61-4b7c" type="rule"/>
                 <infoLink id="398a-f069-00f2-5e42" name="Scout" hidden="false" targetId="9b30-1da3-eb8d-ce7a" type="rule"/>
@@ -18861,6 +19537,108 @@ Master of Cybernetica (Location: Specialisation &amp; Legion Special Rules, Cost
               </categoryLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="fd54-10f7-c05c-6f4f" name="Space Marine Bike (Hussar) + Hit and Run#" page="0" hidden="false" collective="false" import="true" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="631d-c6b6-1f7d-a4b7" type="equalTo"/>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a2d0-d202-f0ce-d081" type="equalTo"/>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="aabc-93f7-1ae0-6bfe" type="equalTo"/>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c94-33f2-87e2-3fd0" type="equalTo"/>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f077-2e90-ccd2-f3ad" type="equalTo"/>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="26a6-7250-f7b3-d0cd" type="equalTo"/>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b26e-ba33-ff55-3fd6" type="equalTo"/>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="28d4-97c4-3355-1b98" type="equalTo"/>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ba6-dda6-d587-3da7" type="equalTo"/>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c904-7d1f-f3ce-d04b" type="equalTo"/>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0d32-4399-cd60-62be" type="equalTo"/>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe8b-2145-2541-9062" type="equalTo"/>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4652-e768-5037-5cc4" type="equalTo"/>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="af34-c67e-eef6-024d" type="equalTo"/>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="72c0-6528-3386-1e2d" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+                <modifier type="add" field="category" value="6585-9fd7-6b8d-5106">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a407-2a45-f198-77ac" type="equalTo"/>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f3ce-93fe-445b-b5aa" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="aa54-efc6-829d-9b1b" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="d811-7c0e-0c85-9bb9" name="Space Marine Bike" hidden="false" targetId="0434-8c4b-9614-73dd" type="profile"/>
+                <infoLink id="3529-98e1-98b7-603a" name="Hammer of Wrath" hidden="false" targetId="6f66-b417-6004-0916" type="rule"/>
+                <infoLink id="5bf6-e5d4-cd8b-8fe0" name="New InfoLink" hidden="false" targetId="d3e5-b43d-a89c-3bd8" type="rule"/>
+                <infoLink id="aa97-258c-3a6d-131a" name="Relentless" hidden="false" targetId="3c7d-a1fa-c68b-caad" type="rule"/>
+                <infoLink id="11a7-44ac-8621-29b6" name="Very Bulky" hidden="false" targetId="abc9-8566-bb61-4b7c" type="rule"/>
+              </infoLinks>
+              <categoryLinks>
+                <categoryLink id="8575-9110-6743-a073" name="New CategoryLink" hidden="false" targetId="c2ec-0327-8667-0a81" primary="false"/>
+                <categoryLink id="a4fe-bd3e-37cf-d6eb" name="# Restiction" hidden="false" targetId="c821-d9f2-5684-64fa" primary="false"/>
+              </categoryLinks>
+              <entryLinks>
+                <entryLink id="fdda-6337-1353-ffc1" name="Legiones Astartes" hidden="false" collective="false" import="true" targetId="4014-7d86-22e9-5d96" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="015d-3e99-93a2-83f4" name="Bullock Jetcycle# + Scout + Deepstrike" hidden="true" collective="false" import="true" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="631d-c6b6-1f7d-a4b7" type="equalTo"/>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a2d0-d202-f0ce-d081" type="equalTo"/>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="aabc-93f7-1ae0-6bfe" type="equalTo"/>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c94-33f2-87e2-3fd0" type="equalTo"/>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f077-2e90-ccd2-f3ad" type="equalTo"/>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="26a6-7250-f7b3-d0cd" type="equalTo"/>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b26e-ba33-ff55-3fd6" type="equalTo"/>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="28d4-97c4-3355-1b98" type="equalTo"/>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ba6-dda6-d587-3da7" type="equalTo"/>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c904-7d1f-f3ce-d04b" type="equalTo"/>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0d32-4399-cd60-62be" type="equalTo"/>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe8b-2145-2541-9062" type="equalTo"/>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="af34-c67e-eef6-024d" type="equalTo"/>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4652-e768-5037-5cc4" type="equalTo"/>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="72c0-6528-3386-1e2d" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2d22-9028-b085-d9ff" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="e13b-acce-8e2b-6e8b" name="Scout" hidden="false" targetId="9b30-1da3-eb8d-ce7a" type="rule"/>
+                <infoLink id="d97a-576f-c561-9def" name="Deep Strike" hidden="false" targetId="d219-2314-4834-c054" type="rule"/>
+                <infoLink id="ce5c-91b5-27f8-6792" name="Hammer of Wrath" hidden="false" targetId="6f66-b417-6004-0916" type="rule"/>
+                <infoLink id="abd4-9efb-7720-e390" name="Jink" hidden="false" targetId="d3e5-b43d-a89c-3bd8" type="rule"/>
+                <infoLink id="0c5d-cfb9-0be3-b02d" name="Relentless" hidden="false" targetId="3c7d-a1fa-c68b-caad" type="rule"/>
+                <infoLink id="6355-ba24-1233-eeed" name="Very Bulky" hidden="false" targetId="abc9-8566-bb61-4b7c" type="rule"/>
+              </infoLinks>
+              <categoryLinks>
+                <categoryLink id="68ae-17c9-b29f-9e26" name="Jetbike" hidden="false" targetId="1640-3081-13eb-b1cf" primary="false"/>
+                <categoryLink id="2b9f-ce0a-200f-0585" name="# Restiction" hidden="false" targetId="c821-d9f2-5684-64fa" primary="false"/>
+              </categoryLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="20.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -23592,6 +24370,14 @@ In a turn in which the vehicle neither moves Flat Out nor uses smoke launchers, 
     </rule>
     <rule id="5c68-573a-b2b6-3634" name="Psy-shock" publicationId="ca571888--pubN103311" page="" hidden="false">
       <description>If a unit containing at least one Daemon or Psyker (i.e., a model with the Psyker, Brotherhood of Psykers/Sorcerers, Psychic Pilot, Daemon or Daemon of the Ruinstorm special rule) is hit by a weapon with this Psi-shock special rule, one randomly determinded Psyker or Daemon model in the unit suffered Perils of the Warp in addition to any other damage.</description>
+    </rule>
+    <rule id="0eaf-31da-5081-636f" name="Munitions" hidden="false">
+      <description>Any units in the same detachment may be equipped at X per model, with:
+Autocannon: Sabot: 36” S8 AP2 Heavy 1 Sunder = 5pts per model
+Missile Launcher: Sabot: 36” S8 AP2 Heavy 1 Sunder = 5pts per model
+Heavy Bolter: Splinter: 36” S2 AP4 Heavy 3 Rending = 2pts per model
+
+Munitions can be used with all versions of these weapons (e.g. reaper and twin-linked autocannon) for models with a T value or Walkers (excluding Superheavies)</description>
     </rule>
   </sharedRules>
   <catalogueLinks>

--- a/(HH) Mornival Units.cat
+++ b/(HH) Mornival Units.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="9f87-b468-2001-5e3b" name="Mornival Units Legion Astartes (Fanmade)" revision="26" battleScribeVersion="2.03" authorName="Aus30K / Mourival Events" authorContact="" authorUrl="https://www.facebook.com/groups/190699548351507/" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="134" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="9f87-b468-2001-5e3b" name="Mornival Units Legion Astartes (Fanmade)" revision="27" battleScribeVersion="2.03" authorName="Aus30K / Mourival Events" authorContact="" authorUrl="https://www.facebook.com/groups/190699548351507/" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="134" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="0e6e-8c19-c436-39c4" name="Mournival Events 3.0 Digital Version"/>
     <publication id="cf75-540e-e446-ecd5" name="Mournival Events FAQ and Experimental Errata v3.1"/>
@@ -411,7 +411,7 @@ Example 4: In a 2000 point army, a Daemon Lord is the Warlord (doesn’t count a
         <categoryLink id="e01f-a11c-e359-2b82" name="New CategoryLink" hidden="false" targetId="dbe0-716f-797c-66f7" primary="true"/>
       </categoryLinks>
       <entryLinks>
-        <entryLink id="45fc-8bbd-8336-8ab6" name="Mornival Rules Active" hidden="false" collective="false" import="true" targetId="c859-6b16-c533-7e97" type="selectionEntry">
+        <entryLink id="45fc-8bbd-8336-8ab6" name="Mournival Rules Active" hidden="false" collective="false" import="true" targetId="c859-6b16-c533-7e97" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5685-aafb-1898-43c6" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2091-b9d7-8292-a025" type="max"/>
@@ -426,6 +426,11 @@ Example 4: In a 2000 point army, a Daemon Lord is the Warlord (doesn’t count a
           </constraints>
           <categoryLinks>
             <categoryLink id="6d25-d65e-8980-737e" name="Mournival Rules" hidden="false" targetId="dbe0-716f-797c-66f7" primary="false"/>
+          </categoryLinks>
+        </entryLink>
+        <entryLink id="9f36-9cbd-17f3-1d07" name="Mournival Experiemental Rules on" hidden="false" collective="false" import="true" targetId="8d39-af5d-fcc9-9c1f" type="selectionEntry">
+          <categoryLinks>
+            <categoryLink id="f1d3-fc7a-841f-e692" name="Mournival Rules" hidden="false" targetId="dbe0-716f-797c-66f7" primary="false"/>
           </categoryLinks>
         </entryLink>
       </entryLinks>
@@ -1762,7 +1767,6 @@ Heavy Bolter: Splinter: 36” S2 AP4 Heavy 3 Rending</description>
                 <cost name="pts" typeId="points" value="2.0"/>
               </costs>
             </entryLink>
-            <entryLink id="5ad5-a575-8fad-b688" name="Caedere Weapons" hidden="false" collective="false" import="true" targetId="bc0f78af-a75f-e3b4-b48f-af5df2bc8207" type="selectionEntryGroup"/>
             <entryLink id="4c4b-5c30-8068-bddf" name="Nostraman Chainglaive" hidden="false" collective="false" import="true" targetId="c31253d0-d1b9-35ac-6435-f1a06611e356" type="selectionEntry">
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
@@ -1789,6 +1793,10 @@ Heavy Bolter: Splinter: 36” S2 AP4 Heavy 3 Rending</description>
               </costs>
             </entryLink>
             <entryLink id="a9b0-8bac-e354-ab66" name="Legatine Axe" hidden="false" collective="false" import="true" targetId="f2b4-83cd-492c-d495" type="selectionEntry"/>
+            <entryLink id="41f8-dee6-747a-728a" name="Barb-hook Lash" hidden="false" collective="false" import="true" targetId="ca97e7b7-6f10-cd1c-17be-8d56aa708770" type="selectionEntry"/>
+            <entryLink id="96b2-775f-079a-a2e6" name="Excoriator Chainaxe" hidden="false" collective="false" import="true" targetId="c668914a-edb4-6b51-13b1-b1b4542eed6f" type="selectionEntry"/>
+            <entryLink id="9093-9e23-c031-16a5" name="Twin Falax Blades" hidden="false" collective="false" import="true" targetId="4b74a48f-4b50-01c0-53b2-f88c01fc0306" type="selectionEntry"/>
+            <entryLink id="ab12-53ea-9e59-1a23" name="Meteor Hammer" hidden="false" collective="false" import="true" targetId="19aadb8a-b814-c2c0-0198-223c038c1950" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="0a3e-c80a-618c-7c0c" name="May exchange Bolt Pistol for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="1878-ead4-5155-50eb">
@@ -1844,6 +1852,15 @@ Heavy Bolter: Splinter: 36” S2 AP4 Heavy 3 Rending</description>
           </modifiers>
         </entryLink>
         <entryLink id="66f9-b732-83dc-aca8" name="Legion-specific upgrade:" hidden="false" collective="false" import="true" targetId="8b059b74-0029-efeb-ecc0-98a21dded43a" type="selectionEntryGroup"/>
+        <entryLink id="fdda-748c-c397-6a53" name="Warlord" hidden="false" collective="false" import="true" targetId="5964-0582-8752-9fc8" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b25-1b90-4e6f-f991" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="95.0"/>
@@ -6369,6 +6386,35 @@ Hunter: Shot Gun, Chainblade, +1A and Acute Senses</description>
         <selectionEntryGroup id="120e-0893-9033-2001" name="Dedicated Transport" hidden="false" collective="false" import="true">
           <entryLinks>
             <entryLink id="c276-5c38-5bf4-de29" name="Land Raider Proteus" hidden="false" collective="false" import="true" targetId="8cc05fec-8274-bea3-5d54-d249b36a3209" type="selectionEntry"/>
+            <entryLink id="06ea-44df-441e-634e" name="Land Raider Phobos" hidden="false" collective="false" import="true" targetId="a8eda173-f749-cfb6-fd0e-3d6fb35cad3b" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="8d39-af5d-fcc9-9c1f" type="equalTo"/>
+                            <condition field="selections" scope="34da-0cfb-85e5-1573" value="9.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c16-9d68-7d62-7a51" type="greaterThan"/>
+                          </conditions>
+                        </conditionGroup>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="8d39-af5d-fcc9-9c1f" type="equalTo"/>
+                            <condition field="selections" scope="34da-0cfb-85e5-1573" value="9.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c16-9d68-7d62-7a51" type="greaterThan"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <categoryLinks>
+                <categoryLink id="fb38-6802-6ea2-019a" name="New CategoryLink" hidden="false" targetId="e4e0-c5d1-3430-f101" primary="false"/>
+                <categoryLink id="19b7-3da0-1e5e-433a" name="New CategoryLink" hidden="false" targetId="e59c-462e-9d9c-66dd" primary="false"/>
+                <categoryLink id="87fd-185d-491d-52fb" name="New CategoryLink" hidden="false" targetId="53bd-99e7-aba0-e79f" primary="false"/>
+              </categoryLinks>
+            </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="55bb-7c13-784f-301b" name="For every 5 models in the squad, one can exchange their Chainaxe for a:" hidden="false" collective="false" import="true">
@@ -8805,6 +8851,113 @@ Hunter: Shot Gun, Chainblade, +1A and Acute Senses</description>
       </costs>
     </selectionEntry>
     <selectionEntry id="238b-3768-7dd7-7f81" name="Custom Legiones Astartes Character" hidden="false" collective="false" import="true" type="upgrade">
+      <modifiers>
+        <modifier type="add" field="category" value="98da-03a8-32c3-317e">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dc6f-0a2e-718d-bf3e" type="equalTo"/>
+                <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5964-0582-8752-9fc8" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="add" field="category" value="0576-dccf-8819-731f">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5964-0582-8752-9fc8" type="equalTo"/>
+              </conditions>
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="28d4-97c4-3355-1b98" type="equalTo"/>
+                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ba6-dda6-d587-3da7" type="equalTo"/>
+                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c904-7d1f-f3ce-d04b" type="equalTo"/>
+                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b26e-ba33-ff55-3fd6" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="add" field="category" value="e77f-fb48-637d-11eb">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="647b-a501-6342-b7e5" type="equalTo"/>
+                <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5964-0582-8752-9fc8" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="add" field="category" value="233f-8198-8d36-98cf">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c34f-8a89-7e8a-0817" type="equalTo"/>
+                <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5964-0582-8752-9fc8" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="add" field="category" value="dda4-2c88-6e85-325b">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e0bf-3826-c3a9-e46d" type="equalTo"/>
+                <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5964-0582-8752-9fc8" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="add" field="category" value="2b4f-4a30-0041-a892">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ad06-a534-79cd-4c7c" type="equalTo"/>
+                <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5964-0582-8752-9fc8" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="add" field="category" value="e7ba-324d-246c-dd6a">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4809-5e50-59aa-616e" type="equalTo"/>
+                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5964-0582-8752-9fc8" type="equalTo"/>
+                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1b99-0ead-04f6-eb8c" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0b50-ead3-74c3-6a1e" type="equalTo"/>
+                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5964-0582-8752-9fc8" type="equalTo"/>
+                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6f4a-c5f9-3c88-e787" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b8b4-f76f-3526-63ad" type="equalTo"/>
+                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cbbb-ae40-bea6-35e0" type="equalTo"/>
+                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5964-0582-8752-9fc8" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="88e6-c803-528f-b603" type="equalTo"/>
+                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8b65-a822-ed2c-5567" type="equalTo"/>
+                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5964-0582-8752-9fc8" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile id="f406-1e57-3ccf-a9f7" name="Custom Legion Character" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
           <modifiers>
@@ -8952,14 +9105,6 @@ Hunter: Shot Gun, Chainblade, +1A and Acute Senses</description>
         <categoryLink id="16c1-ea88-42d5-64d9" name="Legiones Astartes" hidden="false" targetId="0c56-27b8-a737-c9fd" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="f374-e95e-892b-2655" name="Warlord" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9cfc-f1e9-9378-c331" type="max"/>
-          </constraints>
-          <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
         <selectionEntry id="c790-b10d-8028-b3df" name="Stat Upgrades" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d4d5-ea05-6b64-bfa8" type="min"/>
@@ -9482,7 +9627,7 @@ A Unit may not use Counter Attack special rule if it used Reaction Fire.</descri
                   <modifiers>
                     <modifier type="set" field="hidden" value="false">
                       <conditions>
-                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f374-e95e-892b-2655" type="equalTo"/>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5964-0582-8752-9fc8" type="equalTo"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -11437,6 +11582,104 @@ A Unit may not use Counter Attack special rule if it used Reaction Fire.</descri
                     </selectionEntry>
                   </selectionEntries>
                 </selectionEntryGroup>
+                <selectionEntryGroup id="153c-6498-0048-8fac" name="Scions of the Hexagrammaton" publicationId="690c-3e82-3080-6bc0" page="158" hidden="true" collective="false" import="true">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e6fb-0e54-0be1-9ed1" type="greaterThan"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f6e-f509-60ae-6a10" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="de6a-62a2-0071-6f58" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b572-07d6-4204-7494" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="2d08-8f05-9b5d-3d89" name="Deathwing" hidden="false" collective="false" import="true" targetId="cbbb-ae40-bea6-35e0" type="selectionEntry">
+                      <modifiers>
+                        <modifier type="set" field="f97e-75ee-fd49-235b" value="1.0">
+                          <conditionGroups>
+                            <conditionGroup type="and">
+                              <conditions>
+                                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b8b4-f76f-3526-63ad" type="equalTo"/>
+                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5964-0582-8752-9fc8" type="equalTo"/>
+                              </conditions>
+                            </conditionGroup>
+                          </conditionGroups>
+                        </modifier>
+                      </modifiers>
+                      <costs>
+                        <cost name="pts" typeId="points" value="20.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="c418-e4c9-0129-d930" name="Dreadwing" hidden="false" collective="false" import="true" targetId="1b99-0ead-04f6-eb8c" type="selectionEntry">
+                      <modifiers>
+                        <modifier type="set" field="7772-7012-ac19-2e98" value="1.0">
+                          <conditionGroups>
+                            <conditionGroup type="and">
+                              <conditions>
+                                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4809-5e50-59aa-616e" type="equalTo"/>
+                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5964-0582-8752-9fc8" type="equalTo"/>
+                              </conditions>
+                            </conditionGroup>
+                          </conditionGroups>
+                        </modifier>
+                      </modifiers>
+                      <costs>
+                        <cost name="pts" typeId="points" value="20.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="b761-95ca-6bb4-2540" name="Firewing" hidden="false" collective="false" import="true" targetId="6f4a-c5f9-3c88-e787" type="selectionEntry">
+                      <modifiers>
+                        <modifier type="set" field="5e05-8435-b11d-31d6" value="1.0">
+                          <conditionGroups>
+                            <conditionGroup type="and">
+                              <conditions>
+                                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0b50-ead3-74c3-6a1e" type="equalTo"/>
+                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5964-0582-8752-9fc8" type="equalTo"/>
+                              </conditions>
+                            </conditionGroup>
+                          </conditionGroups>
+                        </modifier>
+                      </modifiers>
+                      <costs>
+                        <cost name="pts" typeId="points" value="20.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="bfa3-11aa-2bce-df1e" name="Stormwing" hidden="false" collective="false" import="true" targetId="8b65-a822-ed2c-5567" type="selectionEntry">
+                      <modifiers>
+                        <modifier type="set" field="f6ba-512c-5bdd-539a" value="1.0">
+                          <conditionGroups>
+                            <conditionGroup type="and">
+                              <conditions>
+                                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="88e6-c803-528f-b603" type="equalTo"/>
+                                <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5964-0582-8752-9fc8" type="equalTo"/>
+                              </conditions>
+                            </conditionGroup>
+                          </conditionGroups>
+                        </modifier>
+                      </modifiers>
+                      <costs>
+                        <cost name="pts" typeId="points" value="20.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="8a9b-ddda-3176-8416" name="Ravenwing" hidden="false" collective="false" import="true" targetId="c012-d713-e2d1-7f96" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="points" value="20.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="c87e-0c15-4251-539d" name="Ironwing" hidden="false" collective="false" import="true" targetId="53fa-02f8-8d60-01ba" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="points" value="20.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
               </selectionEntryGroups>
               <entryLinks>
                 <entryLink id="873b-ff72-9f0f-bab1" name="Unlock Phosphex Medusa (Mourn)" hidden="true" collective="false" import="true" targetId="cdfa-cd0f-26aa-a872" type="selectionEntry">
@@ -11547,6 +11790,23 @@ A Unit may not use Counter Attack special rule if it used Reaction Fire.</descri
                       <conditions>
                         <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c74-f4c8-3bb2-7108" type="equalTo"/>
                       </conditions>
+                    </modifier>
+                  </modifiers>
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="c46d-6639-7749-3ae9" name="Scions of Hekatonystika" hidden="true" collective="false" import="true" targetId="4c40-bdff-264e-8997" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e6fb-0e54-0be1-9ed1" type="greaterThan"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f6e-f509-60ae-6a10" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
                     </modifier>
                   </modifiers>
                   <costs>
@@ -15085,7 +15345,7 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f374-e95e-892b-2655" type="equalTo"/>
+                <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5964-0582-8752-9fc8" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -18771,6 +19031,15 @@ Master of Cybernetica (Location: Specialisation &amp; Legion Special Rules, Cost
             </modifier>
           </modifiers>
         </entryLink>
+        <entryLink id="24fc-b0b0-3031-37b4" name="Warlord" hidden="false" collective="false" import="true" targetId="5964-0582-8752-9fc8" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b25-1b90-4e6f-f991" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
@@ -18804,7 +19073,7 @@ The Centurion/Delegatus may take Terminator Armour as normal. If he does then th
         </rule>
       </rules>
       <selectionEntries>
-        <selectionEntry id="eacb-6f76-d165-5160" name="Centurion or Delegatus" publicationId="ca571888--pubN82424" page="18" hidden="false" collective="false" import="true" type="unit">
+        <selectionEntry id="eacb-6f76-d165-5160" name="Centurion or Delegatus" publicationId="ca571888--pubN82424" page="18" hidden="false" collective="false" import="true" type="model">
           <modifiers>
             <modifier type="set" field="name" value="Delegatus">
               <conditions>
@@ -18830,6 +19099,74 @@ The Centurion/Delegatus may take Terminator Armour as normal. If he does then th
               <conditions>
                 <condition field="selections" scope="bfae-d4db-e184-7134" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3907-f781-c7be-4fcb" type="equalTo"/>
               </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="0576-dccf-8819-731f">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="eacb-6f76-d165-5160" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5964-0582-8752-9fc8" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="eacb-6f76-d165-5160" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e48-47c8-48c4-6162" type="equalTo"/>
+                        <condition field="selections" scope="eacb-6f76-d165-5160" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3171-830d-40f0-dca5" type="equalTo"/>
+                        <condition field="selections" scope="eacb-6f76-d165-5160" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8603-ec36-3283-576d" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="add" field="category" value="98da-03a8-32c3-317e">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="eacb-6f76-d165-5160" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dc6f-0a2e-718d-bf3e" type="equalTo"/>
+                    <condition field="selections" scope="eacb-6f76-d165-5160" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5964-0582-8752-9fc8" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="add" field="category" value="dda4-2c88-6e85-325b">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="eacb-6f76-d165-5160" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e0bf-3826-c3a9-e46d" type="equalTo"/>
+                    <condition field="selections" scope="eacb-6f76-d165-5160" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5964-0582-8752-9fc8" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="add" field="category" value="e77f-fb48-637d-11eb">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="eacb-6f76-d165-5160" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="647b-a501-6342-b7e5" type="equalTo"/>
+                    <condition field="selections" scope="eacb-6f76-d165-5160" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5964-0582-8752-9fc8" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="add" field="category" value="233f-8198-8d36-98cf">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="eacb-6f76-d165-5160" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c34f-8a89-7e8a-0817" type="equalTo"/>
+                    <condition field="selections" scope="eacb-6f76-d165-5160" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5964-0582-8752-9fc8" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="add" field="category" value="2b4f-4a30-0041-a892">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="eacb-6f76-d165-5160" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ad06-a534-79cd-4c7c" type="equalTo"/>
+                    <condition field="selections" scope="eacb-6f76-d165-5160" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5964-0582-8752-9fc8" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
             </modifier>
           </modifiers>
           <constraints>
@@ -19385,7 +19722,7 @@ Void Shield Harness</description>
                       <modifiers>
                         <modifier type="set" field="points" value="2.0">
                           <conditions>
-                            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c859-6b16-c533-7e97" type="equalTo"/>
+                            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8d39-af5d-fcc9-9c1f" type="equalTo"/>
                           </conditions>
                         </modifier>
                       </modifiers>
@@ -19755,12 +20092,21 @@ Void Shield Harness</description>
             <entryLink id="7c50-2646-58c5-1b57" name="Shattered Legion" hidden="false" collective="false" import="true" targetId="c487-be13-ea53-917e" type="selectionEntryGroup"/>
             <entryLink id="76db-65b2-b155-9659" name="Cult Arcana" hidden="false" collective="false" import="true" targetId="e096-a034-c3dc-ea24" type="selectionEntryGroup"/>
             <entryLink id="3562-e937-9613-1ca6" name="Rad Grenades (Destroyer Company)" hidden="false" collective="false" import="true" targetId="6b20-1187-bc72-1a45" type="selectionEntry"/>
+            <entryLink id="04a9-9a93-b267-291d" name="Warlord" hidden="false" collective="false" import="true" targetId="5964-0582-8752-9fc8" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b25-1b90-4e6f-f991" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </entryLink>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="50.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="ea69-747a-a648-daae" name="Herald" publicationId="ca571888--pubN82424" page="18" hidden="false" collective="false" import="true" type="unit">
+        <selectionEntry id="ea69-747a-a648-daae" name="Herald" publicationId="ca571888--pubN82424" page="18" hidden="false" collective="false" import="true" type="model">
           <modifiers>
             <modifier type="set" field="838b-feef-eab5-cfa1" value="0.0">
               <conditions>
@@ -20511,7 +20857,7 @@ Void Shield Harness</description>
             <cost name="pts" typeId="points" value="50.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="6817-44ed-9e65-d5e1" name="Master of Signal" publicationId="ca571888--pubN82424" page="18" hidden="false" collective="false" import="true" type="unit">
+        <selectionEntry id="6817-44ed-9e65-d5e1" name="Master of Signal" publicationId="ca571888--pubN82424" page="18" hidden="false" collective="false" import="true" type="model">
           <modifiers>
             <modifier type="set" field="f234-1f54-4fbe-ca23" value="0.0">
               <conditions>
@@ -21277,15 +21623,17 @@ cognis-signum.</description>
                 <modifier type="set" field="hidden" value="true">
                   <conditionGroups>
                     <conditionGroup type="or">
-                      <conditions>
-                        <condition field="selections" scope="bfae-d4db-e184-7134" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d2bb-19ab-3872-70b0" type="greaterThan"/>
-                      </conditions>
                       <conditionGroups>
                         <conditionGroup type="and">
                           <conditions>
-                            <condition field="selections" scope="bfae-d4db-e184-7134" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d2bb-19ab-3872-70b0" type="greaterThan"/>
-                            <condition field="selections" scope="bfae-d4db-e184-7134" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" childId="0826-5e24-e3a6-4b66" type="equalTo"/>
-                            <condition field="selections" scope="bfae-d4db-e184-7134" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" childId="32e0-759c-e2eb-bbcb" type="equalTo"/>
+                            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="8d39-af5d-fcc9-9c1f" type="equalTo"/>
+                            <condition field="selections" scope="bfae-d4db-e184-7134" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d2bb-19ab-3872-70b0" type="atLeast"/>
+                          </conditions>
+                        </conditionGroup>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="8d39-af5d-fcc9-9c1f" type="equalTo"/>
+                            <condition field="selections" scope="bfae-d4db-e184-7134" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d2bb-19ab-3872-70b0" type="atLeast"/>
                           </conditions>
                         </conditionGroup>
                       </conditionGroups>
@@ -21649,12 +21997,7 @@ cognis-signum.</description>
                 </selectionEntryGroup>
                 <selectionEntryGroup id="1633-68b6-d552-3d6d" name="Chosen may exchange Combi-bolter for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="6cc7-4aea-2f51-3a05">
                   <modifiers>
-                    <modifier type="decrement" field="f0c3-554e-6be5-fdb1" value="1.0">
-                      <repeats>
-                        <repeat field="selections" scope="7216-b0d6-77f2-58f7" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2e3f-3ccb-8f68-0f80" repeats="1" roundUp="false"/>
-                      </repeats>
-                    </modifier>
-                    <modifier type="decrement" field="f0c3-554e-6be5-fdb1" value="1.0">
+                    <modifier type="decrement" field="952b-e159-139e-d6e0" value="1.0">
                       <repeats>
                         <repeat field="selections" scope="7216-b0d6-77f2-58f7" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2e3f-3ccb-8f68-0f80" repeats="1" roundUp="false"/>
                       </repeats>
@@ -21664,9 +22007,14 @@ cognis-signum.</description>
                         <repeat field="selections" scope="7216-b0d6-77f2-58f7" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d2bb-19ab-3872-70b0" repeats="1" roundUp="false"/>
                       </repeats>
                     </modifier>
-                    <modifier type="increment" field="952b-e159-139e-d6e0" value="1.0">
+                    <modifier type="increment" field="f0c3-554e-6be5-fdb1" value="1.0">
                       <repeats>
                         <repeat field="selections" scope="7216-b0d6-77f2-58f7" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d2bb-19ab-3872-70b0" repeats="1" roundUp="false"/>
+                      </repeats>
+                    </modifier>
+                    <modifier type="decrement" field="f0c3-554e-6be5-fdb1" value="1.0">
+                      <repeats>
+                        <repeat field="selections" scope="7216-b0d6-77f2-58f7" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2e3f-3ccb-8f68-0f80" repeats="1" roundUp="false"/>
                       </repeats>
                     </modifier>
                   </modifiers>
@@ -22590,7 +22938,7 @@ cognis-signum.</description>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cca7-76a3-de0b-c897" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="ae76-0da4-f0cd-2a24" name="Herald" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="ae76-0da4-f0cd-2a24" name="Herald" hidden="false" collective="false" import="true" type="model">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0839-7a62-d951-cb3c" type="max"/>
               </constraints>
@@ -22598,7 +22946,7 @@ cognis-signum.</description>
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="0208-9207-7481-6ed1" name="Master of Signal" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="0208-9207-7481-6ed1" name="Master of Signal" hidden="false" collective="false" import="true" type="model">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8755-a3af-02c5-5d86" type="max"/>
               </constraints>

--- a/(HH) Mornival Units.cat
+++ b/(HH) Mornival Units.cat
@@ -1109,26 +1109,30 @@ If a Rogue Psyker who is the army’s Warlord becomes possessed, they are still 
           <entryLinks>
             <entryLink id="3ef1-963b-ec3e-8f63" name="Frost Axe" hidden="false" collective="false" import="true" targetId="5a40-b58d-ed9b-62cd" type="selectionEntry">
               <modifiers>
-                <modifier type="set" field="points" value="0.0"/>
                 <modifier type="set" field="c752-0f32-add2-9251" value="10.0"/>
+                <modifier type="set" field="points" value="0.0"/>
+                <modifier type="set" field="hidden" value="false"/>
               </modifiers>
             </entryLink>
             <entryLink id="2bef-ba36-449e-83b2" name="Frost Blade" hidden="false" collective="false" import="true" targetId="6e02-488e-39f9-47b4" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="points" value="0.0"/>
                 <modifier type="set" field="6d88-acb1-1f6f-a79e" value="10.0"/>
+                <modifier type="set" field="hidden" value="false"/>
               </modifiers>
             </entryLink>
             <entryLink id="b4bc-7f2b-adbf-85af" name="Frost Claw" hidden="false" collective="false" import="true" targetId="63ef-e326-2f90-961d" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="points" value="0.0"/>
                 <modifier type="set" field="1d20-59c1-b66d-6e92" value="10.0"/>
+                <modifier type="set" field="hidden" value="false"/>
               </modifiers>
             </entryLink>
             <entryLink id="e87f-41d5-68ee-0464" name="Frost Maul" hidden="false" collective="false" import="true" targetId="9543-d500-7629-8cc9" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="points" value="0.0"/>
                 <modifier type="set" field="9912-107c-2133-2c10" value="10.0"/>
+                <modifier type="set" field="hidden" value="false"/>
               </modifiers>
             </entryLink>
           </entryLinks>
@@ -6307,7 +6311,7 @@ Hunter: Shot Gun, Chainblade, +1A and Acute Senses</description>
                 </entryLink>
                 <entryLink id="25a1-f19d-6532-b45f" name="Power Axe" hidden="false" collective="false" import="true" targetId="7b92-ab87-86a1-ab2e" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="de22-3ee0-9524-2a3f" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="de22-3ee0-9524-2a3f" type="max"/>
                   </constraints>
                   <costs>
                     <cost name="pts" typeId="points" value="10.0"/>
@@ -6315,7 +6319,7 @@ Hunter: Shot Gun, Chainblade, +1A and Acute Senses</description>
                 </entryLink>
                 <entryLink id="ed91-94f9-97d0-ffe5" name="Power Lance" hidden="false" collective="false" import="true" targetId="233d-238b-6940-2740" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3701-8f05-af73-05c8" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3701-8f05-af73-05c8" type="max"/>
                   </constraints>
                   <costs>
                     <cost name="pts" typeId="points" value="10.0"/>
@@ -6323,7 +6327,7 @@ Hunter: Shot Gun, Chainblade, +1A and Acute Senses</description>
                 </entryLink>
                 <entryLink id="2043-dccb-0771-13e7" name="Power Maul" hidden="false" collective="false" import="true" targetId="e8a2-42e8-82a7-8dd9" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b006-7f00-67f5-29c4" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b006-7f00-67f5-29c4" type="max"/>
                   </constraints>
                   <costs>
                     <cost name="pts" typeId="points" value="10.0"/>
@@ -6331,7 +6335,7 @@ Hunter: Shot Gun, Chainblade, +1A and Acute Senses</description>
                 </entryLink>
                 <entryLink id="d69b-91d2-1d3e-7eed" name="Power Sword" hidden="false" collective="false" import="true" targetId="3e90-5ca1-8abe-0275" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e2cb-77be-d0a0-cf7a" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e2cb-77be-d0a0-cf7a" type="max"/>
                   </constraints>
                   <costs>
                     <cost name="pts" typeId="points" value="10.0"/>
@@ -6441,6 +6445,38 @@ Hunter: Shot Gun, Chainblade, +1A and Acute Senses</description>
               <modifiers>
                 <modifier type="set" field="5f3e-444b-2315-5e66" value="4.0"/>
               </modifiers>
+            </entryLink>
+            <entryLink id="fca2-aed9-c66c-cc1d" name="Power Axe" hidden="false" collective="false" import="true" targetId="7b92-ab87-86a1-ab2e" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2eb7-3a2e-a6e7-8916" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="f6b3-a0f3-b1ac-f4e8" name="Power Lance" hidden="false" collective="false" import="true" targetId="233d-238b-6940-2740" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c8f1-30df-24c2-dd51" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="d5d6-dd2c-5a79-8ee8" name="Power Maul" hidden="false" collective="false" import="true" targetId="e8a2-42e8-82a7-8dd9" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c8bf-0f17-7310-81e0" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="f0df-a27e-5d15-d5ab" name="Power Sword" hidden="false" collective="false" import="true" targetId="3e90-5ca1-8abe-0275" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="49ca-d357-61ec-51da" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>

--- a/(HH) Mornival Units.cat
+++ b/(HH) Mornival Units.cat
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <catalogue id="9f87-b468-2001-5e3b" name="Mornival Units Legion Astartes (Fanmade)" revision="27" battleScribeVersion="2.03" authorName="Aus30K / Mourival Events" authorContact="" authorUrl="https://www.facebook.com/groups/190699548351507/" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="134" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
-    <publication id="0e6e-8c19-c436-39c4" name="Mournival Events 3.0 Digital Version"/>
-    <publication id="cf75-540e-e446-ecd5" name="Mournival Events FAQ and Experimental Errata v3.1"/>
+    <publication id="0e6e-8c19-c436-39c4" name="Mournival Events 3.3 Digital Version"/>
+    <publication id="cf75-540e-e446-ecd5" name="Mournival Events FAQ and Experimental Errata v3.5"/>
   </publications>
   <categoryEntries>
     <categoryEntry id="1fb0-1499-5637-4715" name="Additional Ammunition, Weapons, Psychic Disciplines" hidden="false"/>
@@ -1704,6 +1704,26 @@ Heavy Bolter: Splinter: 36” S2 AP4 Heavy 3 Rending</description>
           </selectionEntries>
           <entryLinks>
             <entryLink id="e5b6-1360-ef4f-8bb3" name="Master-Crafted Bolter" hidden="false" collective="false" import="true" targetId="baaf-8622-e173-2b64" type="selectionEntry"/>
+            <entryLink id="07e6-bc72-8e1b-673d" name="Plasma Incinerator" hidden="false" collective="false" import="true" targetId="d332-1f89-3c9d-7a45" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="a38d-bc4d-7016-cf8d" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1b99-0ead-04f6-eb8c" type="equalTo"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4809-5e50-59aa-616e" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fc7d-1d7e-09df-dd8c" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="25.0"/>
+              </costs>
+            </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="8f37-b0f2-31e4-f52b" name="May select the following" hidden="false" collective="false" import="true">
@@ -1743,6 +1763,60 @@ Heavy Bolter: Splinter: 36” S2 AP4 Heavy 3 Rending</description>
             <entryLink id="6c48-fdbf-ee33-38d1" name="Melta Bombs" hidden="false" collective="false" import="true" targetId="4c62-8983-4a1b-d1c6" type="selectionEntry"/>
             <entryLink id="dbbe-96c1-2406-1c3d" name="Sonic Shrieker" hidden="false" collective="false" import="true" targetId="b09c9167-26b6-3d8b-b864-8d1f8d5cfbd9" type="selectionEntry"/>
             <entryLink id="de78-0583-e392-71f9" name="Rad Grenades (Destroyer Company)" hidden="false" collective="false" import="true" targetId="6b20-1187-bc72-1a45" type="selectionEntry"/>
+            <entryLink id="f371-594d-1d2a-71d1" name="Rad Grenades (Eskaton Imperative)" hidden="true" collective="false" import="true" targetId="4019-673a-148a-3aba" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4809-5e50-59aa-616e" type="equalTo"/>
+                        <condition field="selections" scope="a38d-bc4d-7016-cf8d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1b99-0ead-04f6-eb8c" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+                <modifier type="set" field="points" value="10.0">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="8d39-af5d-fcc9-9c1f" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </entryLink>
+            <entryLink id="8683-f973-63a5-6eae" name="Scions of the Hexagrammaton" hidden="false" collective="false" import="true" targetId="7a6e-57c9-6532-a746" type="selectionEntryGroup"/>
+            <entryLink id="cdc6-8367-3875-e9a5" name="Scions of Hekatonystika" hidden="false" collective="false" import="true" targetId="4c40-bdff-264e-8997" type="selectionEntry"/>
+            <entryLink id="dfaa-6306-3d5d-af36" name="Stasis Grenades (Eskaton Imperative)" hidden="true" collective="false" import="true" targetId="6018-78af-1232-e274" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4809-5e50-59aa-616e" type="equalTo"/>
+                        <condition field="selections" scope="a38d-bc4d-7016-cf8d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1b99-0ead-04f6-eb8c" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+            </entryLink>
+            <entryLink id="f49c-79fd-fc45-d4f3" name="Phosphex Bombs" hidden="true" collective="false" import="true" targetId="1de1f2d9-0857-67bf-d191-297d0f9f60bc" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4809-5e50-59aa-616e" type="equalTo"/>
+                        <condition field="selections" scope="a38d-bc4d-7016-cf8d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1b99-0ead-04f6-eb8c" type="equalTo"/>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="8d39-af5d-fcc9-9c1f" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+                <modifier type="set" field="maxSelections" value="1.0"/>
+              </modifiers>
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="e233-2b74-1a09-baed" name="May select one of the following:" hidden="false" collective="false" import="true">
@@ -2078,6 +2152,7 @@ Heavy Bolter: Splinter: 36” S2 AP4 Heavy 3 Rending</description>
             <entryLink id="3053-d51a-d9be-329a" name="Melta Bombs" hidden="false" collective="false" import="true" targetId="4c62-8983-4a1b-d1c6" type="selectionEntry"/>
             <entryLink id="6d3b-f713-9ec6-1b73" name="Legion-specific upgrade:" hidden="false" collective="false" import="true" targetId="8b059b74-0029-efeb-ecc0-98a21dded43a" type="selectionEntryGroup"/>
             <entryLink id="2d70-9646-f8b8-c51c" name="Rad Grenades (Destroyer Company)" hidden="false" collective="false" import="true" targetId="6b20-1187-bc72-1a45" type="selectionEntry"/>
+            <entryLink id="263a-e3f1-fb1a-e53d" name="Scions of the Hexagrammaton" hidden="false" collective="false" import="true" targetId="7a6e-57c9-6532-a746" type="selectionEntryGroup"/>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="95cf-fe00-7d11-d26a" name="Any model may exhange their Chainsword for" hidden="false" collective="false" import="true">
@@ -2319,6 +2394,34 @@ Heavy Bolter: Splinter: 36” S2 AP4 Heavy 3 Rending</description>
               </modifiers>
             </entryLink>
             <entryLink id="6ef5-595c-14ef-6a8b" name="Chem-munitions" hidden="false" collective="false" import="true" targetId="86e70545-ed1a-7cf4-5a3d-d60662a6b3be" type="selectionEntry"/>
+            <entryLink id="fb0e-81f4-fe7d-99f8" name="Rad Grenades (Eskaton Imperative)" hidden="true" collective="false" import="true" targetId="4019-673a-148a-3aba" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4809-5e50-59aa-616e" type="equalTo"/>
+                        <condition field="selections" scope="491a-9bf1-e9bd-b2f8" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1b99-0ead-04f6-eb8c" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+            </entryLink>
+            <entryLink id="db49-46c3-45df-f4e6" name="Stasis Grenades (Eskaton Imperative)" hidden="true" collective="false" import="true" targetId="6018-78af-1232-e274" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4809-5e50-59aa-616e" type="equalTo"/>
+                        <condition field="selections" scope="491a-9bf1-e9bd-b2f8" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1b99-0ead-04f6-eb8c" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+            </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="1783-d480-ffee-fdbf" name="Upgrade Bolt Pistol to Volkite Serpenta (DA Unification Only)" hidden="true" collective="false" import="true">
@@ -4918,6 +5021,7 @@ If equipped with a Jump Pack then they may only join eligible squads with the Ju
             </entryLink>
             <entryLink id="a255-7e0a-da54-da78" name="Legion-specific upgrade:" hidden="false" collective="false" import="true" targetId="8b059b74-0029-efeb-ecc0-98a21dded43a" type="selectionEntryGroup"/>
             <entryLink id="c04a-074f-8d87-96dc" name="Rad Grenades (Destroyer Company)" hidden="false" collective="false" import="true" targetId="6b20-1187-bc72-1a45" type="selectionEntry"/>
+            <entryLink id="0e69-2e7e-dcfc-5109" name="Scions of the Hexagrammaton" hidden="false" collective="false" import="true" targetId="7a6e-57c9-6532-a746" type="selectionEntryGroup"/>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="3b3a-9fb4-97d8-207b" name="Legion-specific upgrade:" hidden="false" collective="false" import="true">
@@ -4940,6 +5044,34 @@ If equipped with a Jump Pack then they may only join eligible squads with the Ju
             </entryLink>
             <entryLink id="1857-723a-c767-599e" name="Dark Channelling" hidden="false" collective="false" import="true" targetId="8e9aa9ef-7863-9522-7741-f7a3ebec8585" type="selectionEntry"/>
             <entryLink id="b6b3-f593-d5ba-fa5e" name="Chem-munitions" hidden="false" collective="false" import="true" targetId="86e70545-ed1a-7cf4-5a3d-d60662a6b3be" type="selectionEntry"/>
+            <entryLink id="fa6f-8419-eb50-64fb" name="Rad Grenades (Eskaton Imperative)" hidden="true" collective="false" import="true" targetId="4019-673a-148a-3aba" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4809-5e50-59aa-616e" type="equalTo"/>
+                        <condition field="selections" scope="eefe-b2cd-3f41-7c84" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1b99-0ead-04f6-eb8c" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+            </entryLink>
+            <entryLink id="1fa6-cc01-89a0-2f96" name="Stasis Grenades (Eskaton Imperative)" hidden="true" collective="false" import="true" targetId="6018-78af-1232-e274" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4809-5e50-59aa-616e" type="equalTo"/>
+                        <condition field="selections" scope="eefe-b2cd-3f41-7c84" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1b99-0ead-04f6-eb8c" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+            </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="7393-d14b-4211-7505" name="Additional Bolter Ammunition Types" hidden="false" collective="false" import="true">
@@ -5209,7 +5341,7 @@ Hunter: Shot Gun, Chainblade, +1A and Acute Senses</description>
                 <entryLink id="a8c6-8f23-f9e8-5502" name="Chainsword/Combat Blade" hidden="false" collective="false" import="true" targetId="4b1e-680b-1d39-e4f1" type="selectionEntry"/>
               </entryLinks>
             </selectionEntryGroup>
-            <selectionEntryGroup id="2fcd-f3dc-7a99-1147" name="Exchange Bolt Pistol for:" hidden="false" collective="false" import="true">
+            <selectionEntryGroup id="2fcd-f3dc-7a99-1147" name="Exchange Bolt Pistol for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="3ea7-c686-11af-e596">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4b7f-1e75-d411-843a" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a8b-1ae8-5276-8020" type="max"/>
@@ -5442,20 +5574,59 @@ Hunter: Shot Gun, Chainblade, +1A and Acute Senses</description>
                   <description>All attacks are Precision Shots (excluding Snap Shots). If the target unit suffers any casualties from such shots, that unit suffers a Pinning test.</description>
                 </rule>
               </rules>
-              <selectionEntries>
-                <selectionEntry id="0f3d-6ac9-95b9-f432" name="Sniper Rifle" page="0" hidden="false" collective="false" import="true" type="upgrade">
+              <selectionEntryGroups>
+                <selectionEntryGroup id="42cc-76d2-84ec-bffb" name="Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="4cf5-3801-534a-b7e0">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6373-77cf-e92a-5095" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ba98-3546-af84-d1e0" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a87b-7bfb-98e3-768f" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6ea9-eda7-d34f-376c" type="max"/>
                   </constraints>
-                  <infoLinks>
-                    <infoLink id="604f-d290-1eab-948c" name="Sniper Rifle" hidden="false" targetId="45a4-5982-7f8b-fb33" type="profile"/>
-                  </infoLinks>
-                  <costs>
-                    <cost name="pts" typeId="points" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
+                  <selectionEntries>
+                    <selectionEntry id="4cf5-3801-534a-b7e0" name="Sniper Rifle" page="0" hidden="false" collective="false" import="true" type="upgrade">
+                      <modifiers>
+                        <modifier type="set" field="5588-c766-488a-6247" value="0.0">
+                          <conditionGroups>
+                            <conditionGroup type="and">
+                              <conditions>
+                                <condition field="selections" scope="5aa7-c454-3656-3a3f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1b99-0ead-04f6-eb8c" type="equalTo"/>
+                                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4809-5e50-59aa-616e" type="equalTo"/>
+                              </conditions>
+                            </conditionGroup>
+                          </conditionGroups>
+                        </modifier>
+                      </modifiers>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ca3c-0a04-40e2-e7eb" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5588-c766-488a-6247" type="min"/>
+                      </constraints>
+                      <infoLinks>
+                        <infoLink id="511d-b1b5-d5e1-786d" name="Sniper Rifle" hidden="false" targetId="45a4-5982-7f8b-fb33" type="profile"/>
+                      </infoLinks>
+                      <costs>
+                        <cost name="pts" typeId="points" value="0.0"/>
+                      </costs>
+                    </selectionEntry>
+                  </selectionEntries>
+                  <entryLinks>
+                    <entryLink id="9d8c-cc13-dd87-55e8" name="Plasma Incinerator" hidden="false" collective="false" import="true" targetId="d332-1f89-3c9d-7a45" type="selectionEntry">
+                      <modifiers>
+                        <modifier type="set" field="hidden" value="true">
+                          <conditionGroups>
+                            <conditionGroup type="or">
+                              <conditions>
+                                <condition field="selections" scope="5aa7-c454-3656-3a3f" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1b99-0ead-04f6-eb8c" type="equalTo"/>
+                                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4809-5e50-59aa-616e" type="equalTo"/>
+                              </conditions>
+                            </conditionGroup>
+                          </conditionGroups>
+                        </modifier>
+                      </modifiers>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c0e2-662f-550c-1602" type="max"/>
+                      </constraints>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
@@ -5506,12 +5677,41 @@ Hunter: Shot Gun, Chainblade, +1A and Acute Senses</description>
                 <modifier type="decrement" field="points" value="2.0"/>
               </modifiers>
             </entryLink>
+            <entryLink id="75d3-e60d-2a6e-f46c" name="Rad Grenades (Eskaton Imperative)" hidden="true" collective="false" import="true" targetId="4019-673a-148a-3aba" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4809-5e50-59aa-616e" type="equalTo"/>
+                        <condition field="selections" scope="5aa7-c454-3656-3a3f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1b99-0ead-04f6-eb8c" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+            </entryLink>
+            <entryLink id="9c5c-d92d-e2c7-a210" name="Stasis Grenades (Eskaton Imperative)" hidden="true" collective="false" import="true" targetId="6018-78af-1232-e274" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4809-5e50-59aa-616e" type="equalTo"/>
+                        <condition field="selections" scope="5aa7-c454-3656-3a3f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1b99-0ead-04f6-eb8c" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+            </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="cfc6-33d5-9b24-a334" name="Sergeant may take:" hidden="false" collective="false" import="true">
           <entryLinks>
             <entryLink id="5859-2eeb-f1d2-f954" name="Legion-specific upgrade:" hidden="false" collective="false" import="true" targetId="8b059b74-0029-efeb-ecc0-98a21dded43a" type="selectionEntryGroup"/>
             <entryLink id="08dd-b54b-f758-a354" name="Rad Grenades (Destroyer Company)" hidden="false" collective="false" import="true" targetId="6b20-1187-bc72-1a45" type="selectionEntry"/>
+            <entryLink id="5f44-9c21-325e-539f" name="Scions of the Hexagrammaton" hidden="false" collective="false" import="true" targetId="7a6e-57c9-6532-a746" type="selectionEntryGroup"/>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="8979-7c9b-97fb-cefb" name="Additional Bolter Ammunition Types" hidden="false" collective="false" import="true">
@@ -5905,6 +6105,28 @@ Hunter: Shot Gun, Chainblade, +1A and Acute Senses</description>
                     </modifier>
                   </modifiers>
                 </entryLink>
+                <entryLink id="ee38-a0e9-6651-614d" name="Plasma Incinerator" hidden="false" collective="false" import="true" targetId="d332-1f89-3c9d-7a45" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="c5ba-7647-23ba-c728" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1b99-0ead-04f6-eb8c" type="equalTo"/>
+                            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4809-5e50-59aa-616e" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                    <modifier type="increment" field="points" value="25.0">
+                      <repeats>
+                        <repeat field="selections" scope="c5ba-7647-23ba-c728" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                      </repeats>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fd0f-85bd-343a-c099" type="max"/>
+                  </constraints>
+                </entryLink>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
@@ -6071,6 +6293,7 @@ Hunter: Shot Gun, Chainblade, +1A and Acute Senses</description>
             </entryLink>
             <entryLink id="9c07-9e6d-5c13-ecfc" name="Legion-specific upgrade:" hidden="false" collective="false" import="true" targetId="8b059b74-0029-efeb-ecc0-98a21dded43a" type="selectionEntryGroup"/>
             <entryLink id="e623-aaef-2d2a-0838" name="Rad Grenades (Destroyer Company)" hidden="false" collective="false" import="true" targetId="6b20-1187-bc72-1a45" type="selectionEntry"/>
+            <entryLink id="60d1-0b91-adce-7c31" name="Scions of the Hexagrammaton" hidden="false" collective="false" import="true" targetId="7a6e-57c9-6532-a746" type="selectionEntryGroup"/>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="313e-8843-0fe2-5f44" name="The squad can be equipped with one model with" hidden="false" collective="false" import="true">
@@ -6104,6 +6327,34 @@ Hunter: Shot Gun, Chainblade, +1A and Acute Senses</description>
               </costs>
             </entryLink>
             <entryLink id="9359-b4c0-c0e8-34d3" name="Cult Arcana" hidden="false" collective="false" import="true" targetId="e096-a034-c3dc-ea24" type="selectionEntryGroup"/>
+            <entryLink id="af30-329d-8535-8bef" name="Rad Grenades (Eskaton Imperative)" hidden="true" collective="false" import="true" targetId="4019-673a-148a-3aba" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4809-5e50-59aa-616e" type="equalTo"/>
+                        <condition field="selections" scope="c5ba-7647-23ba-c728" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1b99-0ead-04f6-eb8c" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+            </entryLink>
+            <entryLink id="80b1-9a19-c454-d0d5" name="Stasis Grenades (Eskaton Imperative)" hidden="true" collective="false" import="true" targetId="6018-78af-1232-e274" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4809-5e50-59aa-616e" type="equalTo"/>
+                        <condition field="selections" scope="c5ba-7647-23ba-c728" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1b99-0ead-04f6-eb8c" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+            </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="605c-b5a0-2d2a-ca62" name="Additional Bolter Ammunition Types" hidden="false" collective="false" import="true">
@@ -6570,6 +6821,7 @@ Hunter: Shot Gun, Chainblade, +1A and Acute Senses</description>
           <entryLinks>
             <entryLink id="a70f-6c8d-5281-9332" name="Rad Grenades (Destroyer Company)" hidden="false" collective="false" import="true" targetId="6b20-1187-bc72-1a45" type="selectionEntry"/>
             <entryLink id="cdb3-0d04-06da-20d3" name="Legion-specific upgrade:" hidden="false" collective="false" import="true" targetId="8b059b74-0029-efeb-ecc0-98a21dded43a" type="selectionEntryGroup"/>
+            <entryLink id="ea5a-e6ee-3f64-6583" name="Scions of the Hexagrammaton" hidden="false" collective="false" import="true" targetId="7a6e-57c9-6532-a746" type="selectionEntryGroup"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="15.0"/>
@@ -7097,6 +7349,7 @@ Hunter: Shot Gun, Chainblade, +1A and Acute Senses</description>
           <entryLinks>
             <entryLink id="5a3e-142d-6164-a71f" name="Rad Grenades (Destroyer Company)" hidden="false" collective="false" import="true" targetId="6b20-1187-bc72-1a45" type="selectionEntry"/>
             <entryLink id="f24e-89e9-c0e7-75d2" name="Legion-specific upgrade:" hidden="false" collective="false" import="true" targetId="8b059b74-0029-efeb-ecc0-98a21dded43a" type="selectionEntryGroup"/>
+            <entryLink id="92c2-08b5-2e51-97db" name="Scions of the Hexagrammaton" hidden="false" collective="false" import="true" targetId="7a6e-57c9-6532-a746" type="selectionEntryGroup"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="15.0"/>
@@ -8523,7 +8776,7 @@ Hunter: Shot Gun, Chainblade, +1A and Acute Senses</description>
                 </entryLink>
                 <entryLink id="097a-dcf3-7025-9d02" name="Power Axe" hidden="false" collective="false" import="true" targetId="7b92-ab87-86a1-ab2e" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5020-b54c-ea30-2497" type="max"/>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5020-b54c-ea30-2497" type="max"/>
                   </constraints>
                   <costs>
                     <cost name="pts" typeId="points" value="5.0"/>
@@ -8531,7 +8784,7 @@ Hunter: Shot Gun, Chainblade, +1A and Acute Senses</description>
                 </entryLink>
                 <entryLink id="d61d-14c5-1fcb-1527" name="Power Lance" hidden="false" collective="false" import="true" targetId="233d-238b-6940-2740" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ec55-a105-0ec3-e84b" type="max"/>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ec55-a105-0ec3-e84b" type="max"/>
                   </constraints>
                   <costs>
                     <cost name="pts" typeId="points" value="5.0"/>
@@ -8545,7 +8798,7 @@ Hunter: Shot Gun, Chainblade, +1A and Acute Senses</description>
                 </entryLink>
                 <entryLink id="af8d-6ce1-e5c1-768e" name="Power Maul" hidden="false" collective="false" import="true" targetId="e8a2-42e8-82a7-8dd9" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ff83-1aa1-97d6-99ec" type="max"/>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ff83-1aa1-97d6-99ec" type="max"/>
                   </constraints>
                   <costs>
                     <cost name="pts" typeId="points" value="5.0"/>
@@ -8553,7 +8806,7 @@ Hunter: Shot Gun, Chainblade, +1A and Acute Senses</description>
                 </entryLink>
                 <entryLink id="8bff-f760-c0a6-3813" name="Power Sword" hidden="false" collective="false" import="true" targetId="3e90-5ca1-8abe-0275" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="03f8-94d2-6332-2fc5" type="max"/>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="03f8-94d2-6332-2fc5" type="max"/>
                   </constraints>
                   <costs>
                     <cost name="pts" typeId="points" value="5.0"/>
@@ -8561,12 +8814,12 @@ Hunter: Shot Gun, Chainblade, +1A and Acute Senses</description>
                 </entryLink>
                 <entryLink id="f2d2-1858-e5a6-faea" name="Chainaxe" hidden="false" collective="false" import="true" targetId="a3a3-3a90-0c2a-cd81" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ba3c-2676-6d32-cf6c" type="max"/>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ba3c-2676-6d32-cf6c" type="max"/>
                   </constraints>
                 </entryLink>
                 <entryLink id="6fa5-5781-59f2-58bc" name="Irad-Cleanser" hidden="false" collective="false" import="true" targetId="32e0-80f7-982d-b29a" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d448-0bce-a45b-3941" type="max"/>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d448-0bce-a45b-3941" type="max"/>
                   </constraints>
                   <costs>
                     <cost name="pts" typeId="points" value="10.0"/>
@@ -8574,7 +8827,7 @@ Hunter: Shot Gun, Chainblade, +1A and Acute Senses</description>
                 </entryLink>
                 <entryLink id="f98f-c8a4-0a92-f229" name="Heavy Bolter" hidden="false" collective="false" import="true" targetId="a161-76b3-9ef1-da7b" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="12bb-7d31-2386-41f9" type="max"/>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="12bb-7d31-2386-41f9" type="max"/>
                   </constraints>
                   <costs>
                     <cost name="pts" typeId="points" value="7.0"/>
@@ -8582,11 +8835,28 @@ Hunter: Shot Gun, Chainblade, +1A and Acute Senses</description>
                 </entryLink>
                 <entryLink id="7e3e-84e9-944d-cac7" name="Toxiferran Flamer" hidden="false" collective="false" import="true" targetId="4440-dc83-bbd9-2a0f" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6765-4ac1-61c7-ff43" type="max"/>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6765-4ac1-61c7-ff43" type="max"/>
                   </constraints>
                   <costs>
                     <cost name="pts" typeId="points" value="5.0"/>
                   </costs>
+                </entryLink>
+                <entryLink id="51a9-3ca5-f41b-800f" name="Plasma Incinerator" hidden="false" collective="false" import="true" targetId="d332-1f89-3c9d-7a45" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="402b-5f71-93f2-d28f" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1b99-0ead-04f6-eb8c" type="equalTo"/>
+                            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4809-5e50-59aa-616e" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b187-62e1-42e8-77ae" type="max"/>
+                  </constraints>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
@@ -8622,6 +8892,7 @@ Hunter: Shot Gun, Chainblade, +1A and Acute Senses</description>
             <entryLink id="969d-2283-7c5c-289b" name="Phosphex Bombs" hidden="false" collective="false" import="true" targetId="1de1f2d9-0857-67bf-d191-297d0f9f60bc" type="selectionEntry"/>
             <entryLink id="cd3a-b5c4-29bb-b185" name="Rad Grenades (Destroyer Company)" hidden="false" collective="false" import="true" targetId="6b20-1187-bc72-1a45" type="selectionEntry"/>
             <entryLink id="3f34-5751-1abb-f8e5" name="Legion-specific upgrade:" hidden="false" collective="false" import="true" targetId="8b059b74-0029-efeb-ecc0-98a21dded43a" type="selectionEntryGroup"/>
+            <entryLink id="2620-276e-1144-31e9" name="Scions of the Hexagrammaton" hidden="false" collective="false" import="true" targetId="7a6e-57c9-6532-a746" type="selectionEntryGroup"/>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="74b8-5e2f-2e6c-4735" name="Dedicated Transport" hidden="false" collective="false" import="true">
@@ -8709,12 +8980,12 @@ Hunter: Shot Gun, Chainblade, +1A and Acute Senses</description>
             </entryLink>
             <entryLink id="41c8-187c-a763-5954" name="Chainaxe" hidden="false" collective="false" import="true" targetId="a3a3-3a90-0c2a-cd81" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="18.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="344d-a22f-d3f2-fd04" type="max"/>
+                <constraint field="selections" scope="parent" value="18.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="344d-a22f-d3f2-fd04" type="max"/>
               </constraints>
             </entryLink>
             <entryLink id="8213-1c33-1597-94c3" name="Heavy Bolter" hidden="false" collective="false" import="true" targetId="a161-76b3-9ef1-da7b" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="18.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="250d-c49f-9382-f403" type="max"/>
+                <constraint field="selections" scope="parent" value="18.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="250d-c49f-9382-f403" type="max"/>
               </constraints>
               <costs>
                 <cost name="pts" typeId="points" value="7.0"/>
@@ -8722,7 +8993,7 @@ Hunter: Shot Gun, Chainblade, +1A and Acute Senses</description>
             </entryLink>
             <entryLink id="81ad-cf15-cc95-1a2a" name="Irad-Cleanser" hidden="false" collective="false" import="true" targetId="32e0-80f7-982d-b29a" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="18.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="50ed-af30-c4ad-26b8" type="max"/>
+                <constraint field="selections" scope="parent" value="18.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="50ed-af30-c4ad-26b8" type="max"/>
               </constraints>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
@@ -8738,7 +9009,7 @@ Hunter: Shot Gun, Chainblade, +1A and Acute Senses</description>
             </entryLink>
             <entryLink id="0b29-faff-53ac-e09b" name="Power Axe" hidden="false" collective="false" import="true" targetId="7b92-ab87-86a1-ab2e" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="18.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2767-5c97-0aae-cd07" type="max"/>
+                <constraint field="selections" scope="parent" value="18.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2767-5c97-0aae-cd07" type="max"/>
               </constraints>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
@@ -8746,7 +9017,7 @@ Hunter: Shot Gun, Chainblade, +1A and Acute Senses</description>
             </entryLink>
             <entryLink id="7d3c-e6ef-9691-276a" name="Power Lance" hidden="false" collective="false" import="true" targetId="233d-238b-6940-2740" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="18.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3140-c5c0-2c55-62f5" type="max"/>
+                <constraint field="selections" scope="parent" value="18.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3140-c5c0-2c55-62f5" type="max"/>
               </constraints>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
@@ -8754,7 +9025,7 @@ Hunter: Shot Gun, Chainblade, +1A and Acute Senses</description>
             </entryLink>
             <entryLink id="6c04-4547-49ab-1de9" name="Power Maul" hidden="false" collective="false" import="true" targetId="e8a2-42e8-82a7-8dd9" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="18.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="359e-1b5c-65c2-4046" type="max"/>
+                <constraint field="selections" scope="parent" value="18.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="359e-1b5c-65c2-4046" type="max"/>
               </constraints>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
@@ -8762,7 +9033,7 @@ Hunter: Shot Gun, Chainblade, +1A and Acute Senses</description>
             </entryLink>
             <entryLink id="b7fd-a412-24a0-317a" name="Power Sword" hidden="false" collective="false" import="true" targetId="3e90-5ca1-8abe-0275" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="18.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cc51-f526-478f-3800" type="max"/>
+                <constraint field="selections" scope="parent" value="18.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="cc51-f526-478f-3800" type="max"/>
               </constraints>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
@@ -8770,11 +9041,28 @@ Hunter: Shot Gun, Chainblade, +1A and Acute Senses</description>
             </entryLink>
             <entryLink id="ff45-5606-1b2b-f65f" name="Toxiferran Flamer" hidden="false" collective="false" import="true" targetId="4440-dc83-bbd9-2a0f" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="18.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="21bb-1f15-796e-d0e5" type="max"/>
+                <constraint field="selections" scope="parent" value="18.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="21bb-1f15-796e-d0e5" type="max"/>
               </constraints>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
               </costs>
+            </entryLink>
+            <entryLink id="343a-3fda-7d66-236c" name="Plasma Incinerator" hidden="false" collective="false" import="true" targetId="d332-1f89-3c9d-7a45" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="402b-5f71-93f2-d28f" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1b99-0ead-04f6-eb8c" type="equalTo"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4809-5e50-59aa-616e" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="18.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c383-8bbf-7d40-d012" type="max"/>
+              </constraints>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
@@ -8842,6 +9130,56 @@ Hunter: Shot Gun, Chainblade, +1A and Acute Senses</description>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
               </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="405d-3bcc-39d2-3485" name="Legion-specific upgrade:" hidden="false" collective="false" import="true">
+          <entryLinks>
+            <entryLink id="ad43-fe3b-0199-5b2f" name="Chem-munitions" hidden="false" collective="false" import="true" targetId="86e70545-ed1a-7cf4-5a3d-d60662a6b3be" type="selectionEntry"/>
+            <entryLink id="bcfb-37af-fe9f-53a0" name="Dark Channelling" hidden="false" collective="false" import="true" targetId="8e9aa9ef-7863-9522-7741-f7a3ebec8585" type="selectionEntry"/>
+            <entryLink id="7878-9f51-4ee5-5183" name="Sonic Shriekers" hidden="false" collective="false" import="true" targetId="d8f4-1501-66fd-0477" type="selectionEntry">
+              <modifiers>
+                <modifier type="increment" field="points" value="2.0">
+                  <repeats>
+                    <repeat field="selections" scope="402b-5f71-93f2-d28f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+                <modifier type="decrement" field="points" value="2.0"/>
+              </modifiers>
+            </entryLink>
+            <entryLink id="e8fd-bad8-f404-3e74" name="Trophies of Judgement" hidden="false" collective="false" import="true" targetId="cea6be0e-460b-ce44-90f4-b1b0159ee33c" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="points" value="25.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="6b3d-d449-3be7-831c" name="Cult Arcana" hidden="false" collective="false" import="true" targetId="e096-a034-c3dc-ea24" type="selectionEntryGroup"/>
+            <entryLink id="848c-e870-73bc-089e" name="Rad Grenades (Eskaton Imperative)" hidden="true" collective="false" import="true" targetId="4019-673a-148a-3aba" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4809-5e50-59aa-616e" type="equalTo"/>
+                        <condition field="selections" scope="402b-5f71-93f2-d28f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1b99-0ead-04f6-eb8c" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+            </entryLink>
+            <entryLink id="4514-fe75-caad-ef38" name="Stasis Grenades (Eskaton Imperative)" hidden="true" collective="false" import="true" targetId="6018-78af-1232-e274" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4809-5e50-59aa-616e" type="equalTo"/>
+                        <condition field="selections" scope="402b-5f71-93f2-d28f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1b99-0ead-04f6-eb8c" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
@@ -12740,6 +13078,26 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                   </constraints>
                   <costs>
                     <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="e0b4-97b5-47d2-e701" name="Plasma Incinerator" hidden="false" collective="false" import="true" targetId="d332-1f89-3c9d-7a45" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1b99-0ead-04f6-eb8c" type="equalTo"/>
+                            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4809-5e50-59aa-616e" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c01c-9d02-3f75-ad13" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="25.0"/>
                   </costs>
                 </entryLink>
               </entryLinks>
@@ -18696,15 +19054,61 @@ Master of Cybernetica (Location: Specialisation &amp; Legion Special Rules, Cost
             <entryLink id="36fb-d255-2cb0-a29e" name="Phosphex Bombs" hidden="true" collective="false" import="true" targetId="1de1f2d9-0857-67bf-d191-297d0f9f60bc" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="hidden" value="false">
-                  <conditions>
-                    <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c94-33f2-87e2-3fd0" type="equalTo"/>
-                  </conditions>
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c94-33f2-87e2-3fd0" type="equalTo"/>
+                      </conditions>
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4809-5e50-59aa-616e" type="equalTo"/>
+                            <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1b99-0ead-04f6-eb8c" type="equalTo"/>
+                            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="8d39-af5d-fcc9-9c1f" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </conditionGroup>
+                  </conditionGroups>
                 </modifier>
                 <modifier type="set" field="maxSelections" value="1.0"/>
               </modifiers>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
               </costs>
+            </entryLink>
+            <entryLink id="5989-2658-3ce8-fbcf" name="Rad Grenades (Eskaton Imperative)" hidden="true" collective="false" import="true" targetId="4019-673a-148a-3aba" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4809-5e50-59aa-616e" type="equalTo"/>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1b99-0ead-04f6-eb8c" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+                <modifier type="set" field="points" value="10.0">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="8d39-af5d-fcc9-9c1f" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </entryLink>
+            <entryLink id="e592-ee06-ed82-579e" name="Stasis Grenades (Eskaton Imperative)" hidden="true" collective="false" import="true" targetId="6018-78af-1232-e274" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4809-5e50-59aa-616e" type="equalTo"/>
+                        <condition field="selections" scope="238b-3768-7dd7-7f81" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1b99-0ead-04f6-eb8c" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
@@ -19930,7 +20334,7 @@ Void Shield Harness</description>
             <selectionEntryGroup id="cf02-3124-8928-9cf0" name="Legion-specific upgrades" hidden="false" collective="false" import="true">
               <entryLinks>
                 <entryLink id="5c5d-c85d-3015-ffcc" hidden="false" collective="false" import="true" targetId="955bce92-a604-419f-0f2e-de6ce81af313" type="selectionEntry"/>
-                <entryLink id="2344-8707-6100-79a9" hidden="false" collective="false" import="true" targetId="63a55007-3c8c-21ea-41b0-85d8292c868f" type="selectionEntry"/>
+                <entryLink id="2344-8707-6100-79a9" name="Rad Grenades" hidden="false" collective="false" import="true" targetId="63a55007-3c8c-21ea-41b0-85d8292c868f" type="selectionEntry"/>
                 <entryLink id="f6f0-4423-8f3f-3fdf" hidden="false" collective="false" import="true" targetId="b09c9167-26b6-3d8b-b864-8d1f8d5cfbd9" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="points" value="5.0"/>
@@ -19996,6 +20400,8 @@ Void Shield Harness</description>
                     <modifier type="set" field="points" value="20"/>
                   </modifiers>
                 </entryLink>
+                <entryLink id="da92-be70-25e6-ee56" name="Scions of Hekatonystika" hidden="false" collective="false" import="true" targetId="4c40-bdff-264e-8997" type="selectionEntry"/>
+                <entryLink id="521a-d2a5-5db6-5177" name="Scions of the Hexagrammaton" hidden="false" collective="false" import="true" targetId="7a6e-57c9-6532-a746" type="selectionEntryGroup"/>
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="ec88-d1e5-4f4c-d4cb" name="Armour" hidden="false" collective="false" import="true" defaultSelectionEntryId="991b-d857-8217-2ef1">
@@ -20736,7 +21142,7 @@ Void Shield Harness</description>
             <selectionEntryGroup id="92b5-db37-41c9-7c4e" name="Legion-specific upgrades" hidden="false" collective="false" import="true">
               <entryLinks>
                 <entryLink id="5c1b-982d-c5ee-8efb" hidden="false" collective="false" import="true" targetId="955bce92-a604-419f-0f2e-de6ce81af313" type="selectionEntry"/>
-                <entryLink id="b5fb-2285-9530-8f46" hidden="false" collective="false" import="true" targetId="63a55007-3c8c-21ea-41b0-85d8292c868f" type="selectionEntry"/>
+                <entryLink id="b5fb-2285-9530-8f46" name="Rad Grenades" hidden="false" collective="false" import="true" targetId="63a55007-3c8c-21ea-41b0-85d8292c868f" type="selectionEntry"/>
                 <entryLink id="477d-fa45-3ec5-e203" name="Sonic Shrieker" hidden="false" collective="false" import="true" targetId="b09c9167-26b6-3d8b-b864-8d1f8d5cfbd9" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="points" value="5"/>
@@ -20802,6 +21208,8 @@ Void Shield Harness</description>
                     <modifier type="set" field="points" value="20"/>
                   </modifiers>
                 </entryLink>
+                <entryLink id="7437-dc43-7cc3-1be0" name="Scions of Hekatonystika" hidden="false" collective="false" import="true" targetId="4c40-bdff-264e-8997" type="selectionEntry"/>
+                <entryLink id="f867-52b0-c253-7cee" name="Scions of the Hexagrammaton" hidden="false" collective="false" import="true" targetId="7a6e-57c9-6532-a746" type="selectionEntryGroup"/>
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="0583-3770-af77-c765" name="Armour" hidden="false" collective="false" import="true" defaultSelectionEntryId="875c-200f-3299-f69a">
@@ -21373,7 +21781,7 @@ cognis-signum.</description>
             <selectionEntryGroup id="c94c-9948-cb77-0ae5" name="Legion-specific upgrades" hidden="false" collective="false" import="true">
               <entryLinks>
                 <entryLink id="f747-8927-c369-ae51" hidden="false" collective="false" import="true" targetId="955bce92-a604-419f-0f2e-de6ce81af313" type="selectionEntry"/>
-                <entryLink id="af53-673a-0ce6-8ee7" hidden="false" collective="false" import="true" targetId="63a55007-3c8c-21ea-41b0-85d8292c868f" type="selectionEntry"/>
+                <entryLink id="af53-673a-0ce6-8ee7" name="Rad Grenades" hidden="false" collective="false" import="true" targetId="63a55007-3c8c-21ea-41b0-85d8292c868f" type="selectionEntry"/>
                 <entryLink id="a060-3f33-529c-4554" hidden="false" collective="false" import="true" targetId="b09c9167-26b6-3d8b-b864-8d1f8d5cfbd9" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="points" value="5.0"/>
@@ -21439,6 +21847,8 @@ cognis-signum.</description>
                     <modifier type="set" field="points" value="20"/>
                   </modifiers>
                 </entryLink>
+                <entryLink id="2c66-7128-cadb-08ee" name="Scions of Hekatonystika" hidden="false" collective="false" import="true" targetId="4c40-bdff-264e-8997" type="selectionEntry"/>
+                <entryLink id="afcd-a2e9-580f-29e1" name="Scions of the Hexagrammaton" hidden="false" collective="false" import="true" targetId="7a6e-57c9-6532-a746" type="selectionEntryGroup"/>
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="464c-1b5b-49d9-2e2b" name="Armour" hidden="false" collective="false" import="true" defaultSelectionEntryId="ade2-55d0-0bce-31e0">

--- a/(HH) Solar Auxilia - Crusade Army List.cat
+++ b/(HH) Solar Auxilia - Crusade Army List.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="7f243fc5-c5fd-8b2c-7b07-907bf684bb72" name="Solar Auxilia" revision="80" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="132" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="7f243fc5-c5fd-8b2c-7b07-907bf684bb72" name="Solar Auxilia" revision="81" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="134" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="7f243fc5--pubN65537" name="Crusade Imperialis"/>
     <publication id="7f243fc5--pubN65563" name="AoDRB"/>
@@ -975,11 +975,16 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <categoryLink id="1327-2128-5341-3bdf" name="Mournival Rules" hidden="false" targetId="dbe0-716f-797c-66f7" primary="true"/>
       </categoryLinks>
       <entryLinks>
-        <entryLink id="ccc3-e3d8-64e7-4232" name="Mornival Rules Active" hidden="false" collective="false" import="true" targetId="c859-6b16-c533-7e97" type="selectionEntry">
+        <entryLink id="ccc3-e3d8-64e7-4232" name="Mournival Rules Active" hidden="false" collective="false" import="true" targetId="c859-6b16-c533-7e97" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d8bd-db23-bcee-58bd" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3d87-6feb-96d2-9473" type="max"/>
           </constraints>
+        </entryLink>
+        <entryLink id="4fd0-3420-d695-063f" name="Mournival Experiemental Rules on" hidden="false" collective="false" import="true" targetId="8d39-af5d-fcc9-9c1f" type="selectionEntry">
+          <categoryLinks>
+            <categoryLink id="8ae4-f128-5d2b-12dd" name="Mournival Rules" hidden="false" targetId="dbe0-716f-797c-66f7" primary="false"/>
+          </categoryLinks>
         </entryLink>
       </entryLinks>
       <costs>
@@ -1525,9 +1530,16 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
       </costs>
     </selectionEntry>
     <selectionEntry id="48db-84ca-2bad-520f" name="Castellax Class Battle-Automata Maniple" page="" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="increment" field="points" value="25.0">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="c859-6b16-c533-7e97" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <infoLinks>
         <infoLink id="7678-ae60-16f2-e948" name="" hidden="false" targetId="988c-d4d0-9418-1165" type="rule"/>
-        <infoLink id="a7f0-6bc1-ed4a-34dc" name="New InfoLink" hidden="false" targetId="d5cf-bd98-2854-13cf" type="rule"/>
+        <infoLink id="a7f0-6bc1-ed4a-34dc" name="Reactor Blast" hidden="false" targetId="d5cf-bd98-2854-13cf" type="rule"/>
       </infoLinks>
       <selectionEntries>
         <selectionEntry id="09ad-ef83-4a62-46fe" name="Castellax class Battle-automata" page="" hidden="false" collective="false" import="true" type="model">
@@ -3230,6 +3242,18 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
           </characteristics>
         </profile>
       </profiles>
+      <rules>
+        <rule id="32c5-7e31-c87b-6f30" name="Lumbering Behemoth (Mournival)" hidden="true">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="8d39-af5d-fcc9-9c1f" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <description> If the tank only moves 6” or less it may fire all of its weapons at full BS (ignoring that Ordnance weapons cause snap shots).</description>
+        </rule>
+      </rules>
       <infoLinks>
         <infoLink id="84d3-6e53-7d8f-cd37" name="Explorer Adaptation" hidden="false" targetId="11bec7a8-6060-53c9-572c-0df68bf9fa78" type="rule"/>
       </infoLinks>
@@ -3424,6 +3448,16 @@ but the tank loses the Fast special rule.</description>
       <rules>
         <rule id="b77d-3ed4-cd64-4a6e" name="Highly Flammable" publicationId="7f243fc5--pubN74753" page="281" hidden="false">
           <description>Adds +1 to any rolls made on the Catastrophic Damage table against it.</description>
+        </rule>
+        <rule id="006f-e356-d3e0-74a7" name="Lumbering Behemoth (Mournival)" hidden="true">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="8d39-af5d-fcc9-9c1f" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <description> If the tank only moves 6” or less it may fire all of its weapons at full BS (ignoring that Ordnance weapons cause snap shots).</description>
         </rule>
       </rules>
       <infoLinks>

--- a/(HH) Solar Auxilia - Crusade Army List.cat
+++ b/(HH) Solar Auxilia - Crusade Army List.cat
@@ -1237,7 +1237,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
     </entryLink>
     <entryLink id="075d-aaf8-c6cd-c6e9" name="Imperial Primus Redoubt" hidden="false" collective="false" import="true" targetId="c05d-2231-2481-4037" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="075d-aaf8-c6cd-c6e9-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
+        <categoryLink id="fe58-cbec-dc32-6364" name="New CategoryLink" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="9ebc-b85f-06a3-8a9e" name="Basilica Administratum" hidden="false" collective="false" import="true" targetId="e10f-7b90-ecd3-80a5" type="selectionEntry">

--- a/(HH) Talons of the Emperor Army List.cat
+++ b/(HH) Talons of the Emperor Army List.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="a30a-7522-3343-553a" name="Talons of the Emperor" revision="105" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="132" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="a30a-7522-3343-553a" name="Talons of the Emperor" revision="106" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="134" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="a30a-7522-pubN65537" name="HH7 / HH8"/>
     <publication id="a30a-7522-pubN69988" name="Forgeworld.co.uk"/>
@@ -936,6 +936,13 @@
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="dab7-cef6-7603-3be2" name="Legio Custodes Sentinel Guard Squad" hidden="false" collective="false" import="true" type="upgrade">
+      <modifiers>
+        <modifier type="increment" field="points" value="25.0">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="c859-6b16-c533-7e97" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <rules>
         <rule id="009e-3165-fcaf-6ae8" name="Shield Barricade" publicationId="a30a-7522-pubN69988" hidden="false">
           <description>Friendly Infantry units being targeted by ranged attacks which pass through the area occupied by a unit composed entirely of models with this special rule gain a 4+ cover save.</description>
@@ -1102,6 +1109,13 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="c6da-100a-a655-0e7d" name="Legio Custodes Custodian Guard Squad" hidden="false" collective="false" import="true" type="upgrade">
+      <modifiers>
+        <modifier type="increment" field="points" value="25.0">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="c859-6b16-c533-7e97" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <infoLinks>
         <infoLink id="0338-a6b2-1055-153f" name="New InfoLink" hidden="false" targetId="38d5-b6eb-bda8-2497" type="rule"/>
         <infoLink id="c02c-dce3-16fd-400d" name="New InfoLink" hidden="false" targetId="2b06-29a6-641a-b22e" type="rule"/>
@@ -1342,6 +1356,13 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="2973-f08c-8b34-5df5" name="Legio Custodes Caladius Grav-Tank" hidden="false" collective="false" import="true" type="upgrade">
+      <modifiers>
+        <modifier type="increment" field="points" value="25.0">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="c859-6b16-c533-7e97" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile id="2479-4bfa-1a6a-2ffe" name="Caladius Grav-Tank" publicationId="a30a-7522-pubN72320" hidden="false" typeId="56656869636c6523232344415441232323" typeName="Vehicle">
           <characteristics>
@@ -1465,6 +1486,13 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="5e4a-d122-6e76-2634" name="Legio Custodes Shield Captain" hidden="false" collective="false" import="true" type="upgrade">
+      <modifiers>
+        <modifier type="increment" field="points" value="25.0">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="c859-6b16-c533-7e97" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <infoLinks>
         <infoLink id="05ad-f44a-ac4d-887c" name="Bulky" hidden="false" targetId="38d5-b6eb-bda8-2497" type="rule"/>
         <infoLink id="2a42-1169-edd2-9b91" name="Crusader" hidden="false" targetId="2b06-29a6-641a-b22e" type="rule"/>
@@ -2365,6 +2393,13 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="6ced-0f69-b659-41da" name="Legio Custodes Aquilon Terminator Squad" hidden="false" collective="false" import="true" type="upgrade">
+      <modifiers>
+        <modifier type="increment" field="points" value="25.0">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="c859-6b16-c533-7e97" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <infoLinks>
         <infoLink id="2338-a096-d26d-88a9" name="New InfoLink" hidden="false" targetId="38d5-b6eb-bda8-2497" type="rule"/>
         <infoLink id="4f93-49c6-3dba-e017" name="New InfoLink" hidden="false" targetId="2b06-29a6-641a-b22e" type="rule"/>
@@ -2481,6 +2516,13 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="d290-734d-18b9-e387" name="Legio Custodes Hetaeron Guard Squad" hidden="false" collective="false" import="true" type="upgrade">
+      <modifiers>
+        <modifier type="increment" field="points" value="25.0">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="c859-6b16-c533-7e97" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <infoLinks>
         <infoLink id="36c6-17fc-4c9a-cf98" name="New InfoLink" hidden="false" targetId="38d5-b6eb-bda8-2497" type="rule"/>
         <infoLink id="def4-7a3c-839b-c526" name="New InfoLink" hidden="false" targetId="2b06-29a6-641a-b22e" type="rule"/>
@@ -2760,6 +2802,13 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="95b0-bc7c-b477-069b" name="Legio Custodes Contemptor-Achillus Dreadnought" hidden="false" collective="false" import="true" type="upgrade">
+      <modifiers>
+        <modifier type="increment" field="points" value="25.0">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="c859-6b16-c533-7e97" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <infoLinks>
         <infoLink id="06ee-92e6-c7a9-bab3" name="New InfoLink" hidden="false" targetId="6329-c318-322f-3690" type="profile"/>
         <infoLink id="b3f8-7d3a-e7c0-ad7f" name="New InfoLink" hidden="false" targetId="6875-ee73-2a85-6a97" type="profile"/>
@@ -3162,7 +3211,7 @@
             <infoLink id="993b-a6d0-e8fa-efd2" name="New InfoLink" hidden="false" targetId="7afd-4f57-4ff4-6545" type="profile"/>
           </infoLinks>
           <entryLinks>
-            <entryLink id="ed69-6021-57a5-db34" name="New EntryLink" hidden="false" collective="false" import="true" targetId="9ee5-e80d-e9cf-92c8" type="selectionEntry">
+            <entryLink id="ed69-6021-57a5-db34" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="9ee5-e80d-e9cf-92c8" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="715d-8422-38d9-19af" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d3aa-31a7-3f17-b193" type="max"/>
@@ -3250,7 +3299,7 @@
                       <modifiers>
                         <modifier type="set" field="hidden" value="false">
                           <conditions>
-                            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c859-6b16-c533-7e97" type="equalTo"/>
+                            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8d39-af5d-fcc9-9c1f" type="equalTo"/>
                           </conditions>
                         </modifier>
                       </modifiers>
@@ -3296,6 +3345,13 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="e5cb-9892-6a0d-9c40" name="Legio Custodes Agamatus Jetbike Squadron" hidden="false" collective="false" import="true" type="upgrade">
+      <modifiers>
+        <modifier type="increment" field="points" value="25.0">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="c859-6b16-c533-7e97" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <infoLinks>
         <infoLink id="9840-e429-8afd-7754" name="Deep Strike" hidden="false" targetId="d219-2314-4834-c054" type="rule"/>
         <infoLink id="3e00-2c01-ebd5-c171" name="New InfoLink" hidden="false" targetId="38ff-a919-70c4-aec4" type="rule"/>
@@ -3396,6 +3452,13 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="5ef4-118e-6aba-94a9" name="Legio Custodes Pallas Grav-Attack Squadron" hidden="false" collective="false" import="true" type="upgrade">
+      <modifiers>
+        <modifier type="increment" field="points" value="25.0">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="c859-6b16-c533-7e97" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <selectionEntries>
         <selectionEntry id="8236-3482-4a71-71ec" name="Pallas Grav-Attack" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
@@ -3680,7 +3743,7 @@
               <modifiers>
                 <modifier type="set" field="hidden" value="false">
                   <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c859-6b16-c533-7e97" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8d39-af5d-fcc9-9c1f" type="equalTo"/>
                   </conditions>
                 </modifier>
                 <modifier type="increment" field="points" value="5.0">
@@ -3707,6 +3770,13 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="5f2c-6d5f-60a2-c648" name="Legio Custodes Sagittarum Guard Squad" hidden="false" collective="false" import="true" type="upgrade">
+      <modifiers>
+        <modifier type="increment" field="points" value="25.0">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="c859-6b16-c533-7e97" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <selectionEntries>
         <selectionEntry id="19e0-ce3f-6d10-c15c" name="Sagittarum Guard" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
@@ -3869,6 +3939,13 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="335e-a873-5aa2-19e0" name="Legio Custodes Contemptor-Galatus Dreadnought" hidden="false" collective="false" import="true" type="upgrade">
+      <modifiers>
+        <modifier type="increment" field="points" value="25.0">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="c859-6b16-c533-7e97" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <infoLinks>
         <infoLink id="fc19-b1ed-4626-7aa0" name="New InfoLink" hidden="false" targetId="69e5-fc02-1f9d-63c2" type="rule"/>
         <infoLink id="5a23-e549-8432-77f9" name="New InfoLink" hidden="false" targetId="6d06-5ea0-9a17-ca97" type="rule"/>
@@ -4735,6 +4812,11 @@
             </conditionGroup>
           </conditionGroups>
         </modifier>
+        <modifier type="increment" field="points" value="25.0">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="c859-6b16-c533-7e97" type="equalTo"/>
+          </conditions>
+        </modifier>
       </modifiers>
       <profiles>
         <profile id="0dd1-7b8c-1e91-3fc7" name="Multi-Layer Refractor Field" hidden="false" typeId="57617267656172204974656d23232344415441232323" typeName="Wargear Item">
@@ -4961,6 +5043,13 @@ decided.</description>
       </costs>
     </selectionEntry>
     <selectionEntry id="702e-27bd-4148-e4e5" name="Legio Custodes Venatari Squad" publicationId="a30a-7522-pubN94337" hidden="false" collective="false" import="true" type="upgrade">
+      <modifiers>
+        <modifier type="increment" field="points" value="25.0">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="c859-6b16-c533-7e97" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <infoLinks>
         <infoLink id="7a14-cab3-a31f-d4b1" name="Bulky" hidden="false" targetId="38d5-b6eb-bda8-2497" type="rule"/>
         <infoLink id="d1cd-897f-a852-586c" name="Crusader" hidden="false" targetId="2b06-29a6-641a-b22e" type="rule"/>
@@ -5218,6 +5307,13 @@ decided.</description>
       </costs>
     </selectionEntry>
     <selectionEntry id="01e5-960d-a7b8-87fe" name="Legio Custodes Talon Master" hidden="false" collective="false" import="true" type="upgrade">
+      <modifiers>
+        <modifier type="increment" field="points" value="25.0">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="c859-6b16-c533-7e97" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile id="324c-4138-3540-2c9a" name="Legio Custodes Talon Master" hidden="false" typeId="556e697423232344415441232323" typeName="Unit">
           <characteristics>

--- a/(HH) Talons of the Emperor Army List.cat
+++ b/(HH) Talons of the Emperor Army List.cat
@@ -791,7 +791,7 @@
     </entryLink>
     <entryLink id="d6ad-e26f-6719-568c" name="Imperial Primus Redoubt" hidden="false" collective="false" import="true" targetId="c05d-2231-2481-4037" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="d6ad-e26f-6719-568c-466f7274696669636174696f6e23232344415441232323" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="true"/>
+        <categoryLink id="ef1c-3e37-e696-e951" name="New CategoryLink" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="7f84-41bd-8d98-965d" name="Imperial Castelum Stronghold" hidden="false" collective="false" import="true" targetId="e40b-468f-f1d7-d05d" type="selectionEntry">

--- a/The Horus Heresy.gst
+++ b/The Horus Heresy.gst
@@ -5983,7 +5983,7 @@ or Gargantuan Creatures. </description>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="c859-6b16-c533-7e97" name="Mornival Rules Active" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="c859-6b16-c533-7e97" name="Mournival Rules Active" hidden="false" collective="false" import="true" type="upgrade">
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
@@ -9301,6 +9301,9 @@ Any abilities that allow the vehicle to fire multiple shots will use the same sh
             <infoLink id="c263-101b-2994-8455" name="Master-crafted" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule"/>
             <infoLink id="0d0e-0316-cd74-d316" name="Bolt Pistol" hidden="false" targetId="ec83-0776-ef74-9cc2" type="profile"/>
           </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
@@ -9895,6 +9898,9 @@ Any abilities that allow the vehicle to fire multiple shots will use the same sh
             <infoLink id="2419-e29f-dc41-2206" name="Master-crafted" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule"/>
             <infoLink id="ee5d-527b-8504-6d25" name="Bolt Pistol" hidden="false" targetId="ec83-0776-ef74-9cc2" type="profile"/>
           </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="811f-ea3b-0ce4-3893" name="Force Sword" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
@@ -9914,6 +9920,9 @@ Any abilities that allow the vehicle to fire multiple shots will use the same sh
           <infoLinks>
             <infoLink id="d580-59d7-d8de-9b96" name="Force" hidden="false" targetId="f588-4e5a-a032-0aee" type="rule"/>
           </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
@@ -10194,6 +10203,21 @@ Any abilities that allow the vehicle to fire multiple shots will use the same sh
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="8d39-af5d-fcc9-9c1f" name="Mournival Experiemental Rules on" hidden="true" collective="false" import="true" type="upgrade">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c859-6b16-c533-7e97" type="atLeast"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7e97-5413-0c38-757d" type="max"/>
+      </constraints>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>

--- a/The Horus Heresy.gst
+++ b/The Horus Heresy.gst
@@ -2976,6 +2976,13 @@ In the event of enemy models embarking inside the Primus Redoubt, the Battle Cre
       </costs>
     </selectionEntry>
     <selectionEntry id="e40b-468f-f1d7-d05d" name="Imperial Castelum Stronghold" publicationId="ca571888--pubN82424" page="94" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="set-primary" field="category" value="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f">
+          <conditions>
+            <condition field="points" scope="e40b-468f-f1d7-d05d" value="500.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="any" type="atLeast"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <rules>
         <rule id="d307-b16a-5b89-9612" name="Shielded Gate Barriers" publicationId="ca571888--pubN82437" page="75" hidden="false">
           <description>The main entrances of the Castellum Stronghold are covered not by plascrete and adamantium, but crackling barriers of energy that can be raised or lowered at the will of the fortification’s controller.


### PR DESCRIPTION
Fixed Imperial Castellum Stronghold and Imperial Primus Redoubt.
Added more army list types for Eldar
Also added the Power Weapon options for Triarii

Fixing Storm of War (Hopefully)
The restrictions were broken for Storm of War RoW. Fixing it will impact many lists as Termites, Sicaran Battle Tanks, Venators, Anvillus, Khadbris, Stormeagle, Spartans taken as root entries (rather than dedicated transports) will have to be reselected in any list with them.

Fixed some issues such as Firedrakes not having weapon profiles for their default Combi-bolters or Power Weapons.

Finally finished adding changes

#1682 
#1842 
#1853  
#1854  
#1855 
#1857 
#1858 