### PR TITLE
HH9 Errata fixes (mostly)

### DIFF
--- a/(HH) Craftworld Eldar - Asuryani Army List.cat
+++ b/(HH) Craftworld Eldar - Asuryani Army List.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="0798-288f-4f71-eab9" name="Asuryani Army List (Fanmade)" revision="9" battleScribeVersion="2.03" authorName="Dono Author / Maye Gelt the Battlescribbler" authorContact="Dono (for Content) / Maye Gelt (for Battlescibbling)" authorUrl="http://www.facebook.com/AUS30K" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="134" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="0798-288f-4f71-eab9" name="Asuryani Army List (Fanmade)" revision="10" battleScribeVersion="2.03" authorName="Dono Author / Maye Gelt the Battlescribbler" authorContact="Dono (for Content) / Maye Gelt (for Battlescibbling)" authorUrl="http://www.facebook.com/AUS30K" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="136" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="5c4c-bef9-9681-e0fc" name="30K Craftworld Aeldari - Asuryani Army List"/>
   </publications>
@@ -66,6 +66,7 @@
         <categoryLink id="30ad-7f0f-3ca1-9af5" name="Lords of War" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="false">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a2d9-279c-e0fc-c414" type="max"/>
+            <constraint field="limit::points" scope="roster" value="25.0" percentValue="true" shared="false" includeChildSelections="false" includeChildForces="false" id="d275-3d6a-a77f-66f5" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="c555-18ed-de23-d5fa" name="Use Playtest Rules" hidden="false" targetId="fdf4-0683-3e84-5a4b" primary="false">
@@ -180,6 +181,7 @@
         <categoryLink id="a64a-44e4-2684-1241" name="Lords of War" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="false">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="838b-51e0-d821-75d6" type="max"/>
+            <constraint field="limit::points" scope="roster" value="25.0" percentValue="true" shared="false" includeChildSelections="false" includeChildForces="false" id="b5a6-e4d7-135a-6d19" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="338b-f1be-29ae-6a86" name="Use Playtest Rules" hidden="false" targetId="fdf4-0683-3e84-5a4b" primary="false">
@@ -239,6 +241,7 @@
         <categoryLink id="df6e-5ea5-706c-96fc" name="Lords of War" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="false">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e09b-1faa-0dcb-90d1" type="max"/>
+            <constraint field="limit::points" scope="roster" value="25.0" percentValue="true" shared="false" includeChildSelections="false" includeChildForces="false" id="ae95-63bd-f130-a8a3" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="44e2-4340-8d6b-93a9" name="Use Playtest Rules" hidden="false" targetId="fdf4-0683-3e84-5a4b" primary="false">
@@ -470,6 +473,7 @@
         <categoryLink id="4818-cd44-881b-7023" name="Lords of War" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="false">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a27f-2ab6-6050-726f" type="max"/>
+            <constraint field="limit::points" scope="roster" value="25.0" percentValue="true" shared="false" includeChildSelections="false" includeChildForces="false" id="11ff-581f-c2d9-d3a9" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="c2f3-ee5e-a248-ac8c" name="Use Playtest Rules" hidden="false" targetId="fdf4-0683-3e84-5a4b" primary="false">

--- a/(HH) Daemons of the Ruinstorm Army List.cat
+++ b/(HH) Daemons of the Ruinstorm Army List.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="8700-b3bb-a471-a0ad" name="Daemons of the Ruinstorm" revision="20" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="132" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="8700-b3bb-a471-a0ad" name="Daemons of the Ruinstorm" revision="20" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="136" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="8700-b3bb-pubN65537" name="HH8: Malevolence"/>
     <publication id="8700-b3bb-pubN75780" name="BRB"/>
@@ -199,6 +199,7 @@
         <categoryLink id="8e55-c80a-0f2c-1be3" name="Lords of War" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="false">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1e66-5c0b-29b5-266a" type="max"/>
+            <constraint field="limit::points" scope="roster" value="25.0" percentValue="true" shared="false" includeChildSelections="false" includeChildForces="false" id="aa7d-a854-8d2c-2b3d" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="4486-01d5-c984-74a8" name="Use Playtest Rules" hidden="false" targetId="fdf4-0683-3e84-5a4b" primary="false">

--- a/(HH) Imperialis Militia and Cults Army List.cat
+++ b/(HH) Imperialis Militia and Cults Army List.cat
@@ -176,7 +176,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <categoryLink id="98db-b4ba-fbcd-3239-5297-7e0f-fa0b-3537" name="Allegiance" hidden="false" targetId="5297-7e0f-fa0b-3537" primary="false"/>
         <categoryLink id="98db-b4ba-fbcd-3239-1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" name="Lords of War" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="false">
           <constraints>
-            <constraint field="points" scope="parent" value="25.0" percentValue="true" shared="false" includeChildSelections="true" includeChildForces="false" id="a9d3-ce10-91f2-17f6" type="max"/>
+            <constraint field="points" scope="roster" value="25.0" percentValue="true" shared="false" includeChildSelections="false" includeChildForces="false" id="a9d3-ce10-91f2-17f6" type="max"/>
             <constraint field="selections" scope="parent" value="-1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6ef5-a7b1-2033-83f3" type="max"/>
           </constraints>
         </categoryLink>
@@ -241,7 +241,11 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <categoryLink id="80a2-7d5f-396f-352e-54726f6f707323232344415441232323" name="Troops" hidden="false" targetId="54726f6f707323232344415441232323" primary="false"/>
         <categoryLink id="80a2-7d5f-396f-352e-466173742041747461636b23232344415441232323" name="Fast Attack" hidden="false" targetId="466173742041747461636b23232344415441232323" primary="false"/>
         <categoryLink id="80a2-7d5f-396f-352e-486561767920537570706f727423232344415441232323" name="Heavy Support" hidden="false" targetId="486561767920537570706f727423232344415441232323" primary="false"/>
-        <categoryLink id="80a2-7d5f-396f-352e-1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" name="Lords of War" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="false"/>
+        <categoryLink id="80a2-7d5f-396f-352e-1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" name="Lords of War" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="false">
+          <constraints>
+            <constraint field="points" scope="roster" value="25.0" percentValue="true" shared="false" includeChildSelections="false" includeChildForces="false" id="172b-a2ca-c555-135d" type="max"/>
+          </constraints>
+        </categoryLink>
         <categoryLink id="80a2-7d5f-396f-352e-466f7274696669636174696f6e23232344415441232323" name="Fortification" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="false"/>
         <categoryLink id="80a2-7d5f-396f-352e-258478de-d031-8a7e-dcb0-7d56bee86952" name="Legion" hidden="false" targetId="258478de-d031-8a7e-dcb0-7d56bee86952" primary="false"/>
         <categoryLink id="80a2-7d5f-396f-352e-5297-7e0f-fa0b-3537" name="Allegiance" hidden="false" targetId="5297-7e0f-fa0b-3537" primary="false"/>
@@ -323,7 +327,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <categoryLink id="98db-b4ba-fbcd-3239-1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" name="Lords of War" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="false">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="70a0-1ebc-39cf-f0cc" type="max"/>
-            <constraint field="limit::points" scope="roster" value="25.0" percentValue="true" shared="true" includeChildSelections="false" includeChildForces="true" id="12a1-3a1f-5f6f-b56b" type="max"/>
+            <constraint field="limit::points" scope="roster" value="25.0" percentValue="true" shared="false" includeChildSelections="false" includeChildForces="false" id="12a1-3a1f-5f6f-b56b" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="98db-b4ba-fbcd-3239-466f7274696669636174696f6e23232344415441232323" name="Fortification" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="false">
@@ -762,6 +766,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <categoryLink id="1a2c-902b-cdb9-7640-1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" name="Lords of War" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="false">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="20a1-90d6-fb1d-2730" type="max"/>
+            <constraint field="points" scope="roster" value="25.0" percentValue="true" shared="false" includeChildSelections="false" includeChildForces="false" id="a79e-d10a-c45d-bf4b" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="b425-0e48-e198-066b" name="Use Playtest Rules" hidden="false" targetId="fdf4-0683-3e84-5a4b" primary="false">
@@ -809,6 +814,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <categoryLink id="8666-c0df-4dfa-08f1-1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" name="Lords of War" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="false">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="24cc-15d2-4bb6-8a0c" type="max"/>
+            <constraint field="points" scope="roster" value="25.0" percentValue="true" shared="false" includeChildSelections="false" includeChildForces="false" id="27b9-22e0-7b5c-cd2e" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="8666-c0df-4dfa-08f1-466f7274696669636174696f6e23232344415441232323" name="Fortification" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="false">

--- a/(HH) Imperialis Militia and Cults Army List.cat
+++ b/(HH) Imperialis Militia and Cults Army List.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="90aa-c2c8-ffb0-496e" name="Imperialis Militia and Cults Army List" revision="115" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="134" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="90aa-c2c8-ffb0-496e" name="Imperialis Militia and Cults Army List" revision="116" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="136" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="90aa-c2c8-pubN65537" name="Crusade Imperialis"/>
     <publication id="90aa-c2c8-pubN65563" name="AoDRB"/>
@@ -3684,7 +3684,7 @@ D3     Mutation
       </infoLinks>
       <categoryLinks>
         <categoryLink id="c336-61a6-6f47-52c4" name="New CategoryLink" hidden="false" targetId="8a8c-ed20-7427-ddff" primary="false"/>
-        <categoryLink id="8fe6-c586-aee6-6fbc" name="New CategoryLink" hidden="false" targetId="218b-fafd-986d-56ba" primary="false"/>
+        <categoryLink id="7780-d258-265d-292b" name="Tank" hidden="false" targetId="e59c-462e-9d9c-66dd" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="8ec5-210b-2b07-8a7c" name="May exchange traverse-mounted battlecannon for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="b37e-06d2-fb11-ed23">

--- a/(HH) Mechanicum - Taghmata Army List.cat
+++ b/(HH) Mechanicum - Taghmata Army List.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="cf03-f607-41dc-7545" name="Mechanicum: Taghmata Army List" revision="112" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="135" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="cf03-f607-41dc-7545" name="Mechanicum: Taghmata Army List" revision="113" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="136" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="cf03-f607-pubN65537" name="Horus Heresy: Taghmata Army List"/>
     <publication id="cf03-f607-pubN65563" name="AoDRB"/>
@@ -228,7 +228,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <categoryLink id="98db-b4ba-fbcd-3239-5297-7e0f-fa0b-3537" name="Allegiance" hidden="false" targetId="5297-7e0f-fa0b-3537" primary="false"/>
         <categoryLink id="98db-b4ba-fbcd-3239-1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" name="Lords of War" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="false">
           <constraints>
-            <constraint field="points" scope="parent" value="25.0" percentValue="true" shared="false" includeChildSelections="true" includeChildForces="false" id="a9d3-ce10-91f2-17f6" type="max"/>
+            <constraint field="points" scope="roster" value="25.0" percentValue="true" shared="false" includeChildSelections="false" includeChildForces="false" id="a9d3-ce10-91f2-17f6" type="max"/>
             <constraint field="selections" scope="parent" value="-1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6ef5-a7b1-2033-83f3" type="max"/>
           </constraints>
         </categoryLink>
@@ -352,7 +352,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <categoryLink id="0cb5-a583-e14f-2231-1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" name="Lords of War" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="false">
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f2da-0626-0d6d-78cf" type="max"/>
-            <constraint field="points" scope="parent" value="25.0" percentValue="true" shared="false" includeChildSelections="false" includeChildForces="false" id="9fad-8d73-4b51-62b0" type="max"/>
+            <constraint field="points" scope="roster" value="25.0" percentValue="true" shared="false" includeChildSelections="false" includeChildForces="false" id="9fad-8d73-4b51-62b0" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="0cb5-a583-e14f-2231-466f7274696669636174696f6e23232344415441232323" name="Fortification" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="false">
@@ -420,7 +420,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <categoryLink id="98db-b4ba-fbcd-3239-1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" name="Lords of War" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="false">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="70a0-1ebc-39cf-f0cc" type="max"/>
-            <constraint field="points" scope="parent" value="25.0" percentValue="true" shared="false" includeChildSelections="false" includeChildForces="false" id="12a1-3a1f-5f6f-b56b" type="max"/>
+            <constraint field="points" scope="roster" value="25.0" percentValue="true" shared="false" includeChildSelections="false" includeChildForces="false" id="12a1-3a1f-5f6f-b56b" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="98db-b4ba-fbcd-3239-466f7274696669636174696f6e23232344415441232323" name="Fortification" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="false"/>
@@ -817,7 +817,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <categoryLink id="d1ef-61e1-3d67-5a19-1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" name="Lords of War" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="false">
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8113-abb6-fd0c-2077" type="max"/>
-            <constraint field="points" scope="parent" value="25.0" percentValue="true" shared="false" includeChildSelections="false" includeChildForces="false" id="5231-3e8d-57cb-fcf5" type="max"/>
+            <constraint field="points" scope="roster" value="25.0" percentValue="true" shared="false" includeChildSelections="false" includeChildForces="false" id="5231-3e8d-57cb-fcf5" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="d1ef-61e1-3d67-5a19-5297-7e0f-fa0b-3537" name="Allegiance" hidden="false" targetId="5297-7e0f-fa0b-3537" primary="false"/>
@@ -867,7 +867,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <categoryLink id="3a6f-6d67-a8b2-e911-1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" name="Lords of War" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="false">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b33c-194d-0c8c-45e3" type="max"/>
-            <constraint field="points" scope="parent" value="25.0" percentValue="true" shared="false" includeChildSelections="false" includeChildForces="false" id="cb8f-4568-7b79-aa31" type="max"/>
+            <constraint field="points" scope="roster" value="25.0" percentValue="true" shared="false" includeChildSelections="false" includeChildForces="false" id="cb8f-4568-7b79-aa31" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="3a6f-6d67-a8b2-e911-466f7274696669636174696f6e23232344415441232323" name="Fortification" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="false">
@@ -941,7 +941,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <categoryLink id="1a2c-902b-cdb9-7640-1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" name="Lords of War" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="false">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="20a1-90d6-fb1d-2730" type="max"/>
-            <constraint field="points" scope="parent" value="25.0" percentValue="true" shared="false" includeChildSelections="false" includeChildForces="false" id="660a-74b3-37bd-764f" type="max"/>
+            <constraint field="points" scope="roster" value="25.0" percentValue="true" shared="false" includeChildSelections="false" includeChildForces="false" id="660a-74b3-37bd-764f" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="2cd4-0ba1-2d7a-3de8" name="Allegiance" hidden="false" targetId="5297-7e0f-fa0b-3537" primary="false"/>
@@ -990,7 +990,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <categoryLink id="8666-c0df-4dfa-08f1-1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" name="Lords of War" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="false">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="24cc-15d2-4bb6-8a0c" type="max"/>
-            <constraint field="points" scope="parent" value="25.0" percentValue="true" shared="false" includeChildSelections="false" includeChildForces="false" id="2478-041f-3d45-e25e" type="max"/>
+            <constraint field="points" scope="roster" value="25.0" percentValue="true" shared="false" includeChildSelections="false" includeChildForces="false" id="2478-041f-3d45-e25e" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="8666-c0df-4dfa-08f1-466f7274696669636174696f6e23232344415441232323" name="Fortification" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="false">
@@ -18022,6 +18022,9 @@ The second method of deployment for the Ordinatus Aktaeus is to deploy via Deep 
               </characteristics>
             </profile>
           </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="210d-c64a-aae1-8248" name="Terrebrax Rocket Battery" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
@@ -18038,6 +18041,9 @@ The second method of deployment for the Ordinatus Aktaeus is to deploy via Deep 
               </characteristics>
             </profile>
           </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -18074,6 +18080,9 @@ After deploying in this manner, the Ordinatus Aktaeus cannot move and counts as 
                 <infoLink id="492b-f5f5-b217-9b10" name="Deep Strike" hidden="false" targetId="d219-2314-4834-c054" type="rule"/>
                 <infoLink id="2fa9-da7e-8037-c1bf" name="Subterranean Assault" hidden="false" targetId="1679-b036-dc3a-c6a6" type="rule"/>
               </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="bcdb-ea77-ac6d-1023" name="Normal Deployment" hidden="false" collective="false" import="true" type="upgrade">
               <rules>
@@ -18090,6 +18099,9 @@ At the beginning of each of the controlling player’s Shooting phases for the r
 Should a vehicle suffer a penetrating hit from this attack, it immediately suffers from Crew Shaken in addition to any other effect. If a unit suffers any unsaved wounds from this attack, it must immediately make a number of Dangerous Terrain tests equal to the number of wounds suffered (wounds caused as a result of this test are allocated by the controlling player).</description>
                 </rule>
               </rules>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>

--- a/(HH) Mornival Units.cat
+++ b/(HH) Mornival Units.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="9f87-b468-2001-5e3b" name="Mornival Units Legion Astartes (Fanmade)" revision="30" battleScribeVersion="2.03" authorName="Aus30K / Mourival Events" authorContact="" authorUrl="https://www.facebook.com/groups/190699548351507/" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="135" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="9f87-b468-2001-5e3b" name="Mornival Units Legion Astartes (Fanmade)" revision="31" battleScribeVersion="2.03" authorName="Aus30K / Mourival Events" authorContact="" authorUrl="https://www.facebook.com/groups/190699548351507/" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="136" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="0e6e-8c19-c436-39c4" name="Mournival Events 3.3 Digital Version"/>
     <publication id="cf75-540e-e446-ecd5" name="Mournival Events FAQ and Experimental Errata v3.5"/>
@@ -240,7 +240,7 @@ Example 4: In a 2000 point army, a Daemon Lord is the Warlord (doesn’t count a
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="points" scope="parent" value="25.0" percentValue="true" shared="false" includeChildSelections="true" includeChildForces="false" id="1afa-92a0-362e-907d" type="max"/>
+            <constraint field="points" scope="roster" value="25.0" percentValue="true" shared="false" includeChildSelections="false" includeChildForces="false" id="1afa-92a0-362e-907d" type="max"/>
             <constraint field="selections" scope="parent" value="-1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1906-7564-22bc-2db4" type="max"/>
           </constraints>
         </categoryLink>

--- a/(HH) Mornival Units.cat
+++ b/(HH) Mornival Units.cat
@@ -252,9 +252,21 @@ Example 4: In a 2000 point army, a Daemon Lord is the Warlord (doesn’t count a
         <categoryLink id="8a2e-f45b-145a-ff91" name="Compulsory HQ" hidden="false" targetId="becd-7a6d-e80f-878e" primary="false">
           <modifiers>
             <modifier type="set" field="460b-968b-608f-83be" value="2.0">
-              <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e18e-3da1-b6d5-b6dc" type="equalTo"/>
-              </conditions>
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e18e-3da1-b6d5-b6dc" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="edd3-79ac-eb75-34b7" type="equalTo"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe16-7a9f-5ada-2bd8" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </conditionGroup>
+              </conditionGroups>
             </modifier>
           </modifiers>
           <constraints>
@@ -19126,6 +19138,9 @@ Crozius Arcanum (Location: Melee, Cost 15pts, Not Mandatory)</description>
                   <categoryLinks>
                     <categoryLink id="d399-8738-c16b-c5ad" name="Compulsory HQ" hidden="false" targetId="becd-7a6d-e80f-878e" primary="false"/>
                   </categoryLinks>
+                  <entryLinks>
+                    <entryLink id="271d-e180-2cb8-221c" name="Centurion or Chaplin" hidden="false" collective="false" import="true" targetId="5cac-698f-1ec3-411f" type="selectionEntry"/>
+                  </entryLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="0.0"/>
                   </costs>
@@ -19758,6 +19773,9 @@ Master of Cybernetica (Location: Specialisation &amp; Legion Special Rules, Cost
                   <categoryLinks>
                     <categoryLink id="64eb-a9be-6599-a421" name="Centurion or Delegatus" hidden="false" targetId="05c9-9e0d-c2e5-d62f" primary="false"/>
                   </categoryLinks>
+                  <entryLinks>
+                    <entryLink id="24f1-fe42-9baa-e940" name="Centurion or Chaplin" hidden="false" collective="false" import="true" targetId="5cac-698f-1ec3-411f" type="selectionEntry"/>
+                  </entryLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="0.0"/>
                   </costs>
@@ -21769,6 +21787,7 @@ Void Shield Harness</description>
                   </categoryLinks>
                   <entryLinks>
                     <entryLink id="860d-3c3a-7a7b-aecf" name="Wolf Lord/Claw Leader" hidden="false" collective="false" import="true" targetId="9546-c5b3-97d8-b0c1" type="selectionEntry"/>
+                    <entryLink id="cc53-b223-59ec-6f9f" name="Centurion or Chaplin" hidden="false" collective="false" import="true" targetId="5cac-698f-1ec3-411f" type="selectionEntry"/>
                   </entryLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="0.0"/>

--- a/(HH) Necron Army List.cat
+++ b/(HH) Necron Army List.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="b50f-0671-3aea-cf90" name="Necron Army List (Fanmade)" revision="7" battleScribeVersion="2.03" authorName="Dono Author / Maye Gelt the Battlescribbler" authorContact="Dono (for Content) / Maye Gelt (for Battlescibbling)" authorUrl="http://www.facebook.com/AUS30K" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="135" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="b50f-0671-3aea-cf90" name="Necron Army List (Fanmade)" revision="8" battleScribeVersion="2.03" authorName="Dono Author / Maye Gelt the Battlescribbler" authorContact="Dono (for Content) / Maye Gelt (for Battlescibbling)" authorUrl="http://www.facebook.com/AUS30K" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="136" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="6fc6-dd7c-7a39-b0c8" name="30K Necron Army List (Fanmade)"/>
   </publications>
@@ -156,6 +156,7 @@
           </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dad0-1a07-74d2-5344" type="max"/>
+            <constraint field="limit::points" scope="roster" value="25.0" percentValue="true" shared="false" includeChildSelections="false" includeChildForces="false" id="64f1-9b7d-4930-7ecf" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="ab78-1279-18e0-74a6" name="Use Playtest Rules" hidden="false" targetId="fdf4-0683-3e84-5a4b" primary="false">

--- a/(HH) Solar Auxilia - Crusade Army List.cat
+++ b/(HH) Solar Auxilia - Crusade Army List.cat
@@ -222,7 +222,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <categoryLink id="98db-b4ba-fbcd-3239-5297-7e0f-fa0b-3537" name="Allegiance" hidden="false" targetId="5297-7e0f-fa0b-3537" primary="false"/>
         <categoryLink id="98db-b4ba-fbcd-3239-1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" name="Lords of War" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="false">
           <constraints>
-            <constraint field="points" scope="parent" value="25.0" percentValue="true" shared="false" includeChildSelections="true" includeChildForces="false" id="a9d3-ce10-91f2-17f6" type="max"/>
+            <constraint field="points" scope="roster" value="25.0" percentValue="true" shared="false" includeChildSelections="false" includeChildForces="false" id="a9d3-ce10-91f2-17f6" type="max"/>
             <constraint field="selections" scope="parent" value="-1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6ef5-a7b1-2033-83f3" type="max"/>
           </constraints>
         </categoryLink>
@@ -333,7 +333,11 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <categoryLink id="4e06-f510-5de0-195b-54726f6f707323232344415441232323" name="Troops" hidden="false" targetId="54726f6f707323232344415441232323" primary="false"/>
         <categoryLink id="4e06-f510-5de0-195b-466173742041747461636b23232344415441232323" name="Fast Attack" hidden="false" targetId="466173742041747461636b23232344415441232323" primary="false"/>
         <categoryLink id="4e06-f510-5de0-195b-486561767920537570706f727423232344415441232323" name="Heavy Support" hidden="false" targetId="486561767920537570706f727423232344415441232323" primary="false"/>
-        <categoryLink id="4e06-f510-5de0-195b-1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" name="Lords of War" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="false"/>
+        <categoryLink id="4e06-f510-5de0-195b-1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" name="Lords of War" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="false">
+          <constraints>
+            <constraint field="limit::points" scope="roster" value="25.0" percentValue="true" shared="false" includeChildSelections="false" includeChildForces="false" id="4837-47bb-e52c-f3bc" type="max"/>
+          </constraints>
+        </categoryLink>
         <categoryLink id="4e06-f510-5de0-195b-466f7274696669636174696f6e23232344415441232323" name="Fortification" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="false"/>
         <categoryLink id="4e06-f510-5de0-195b-258478de-d031-8a7e-dcb0-7d56bee86952" name="Legion" hidden="false" targetId="258478de-d031-8a7e-dcb0-7d56bee86952" primary="false"/>
         <categoryLink id="4e06-f510-5de0-195b-5297-7e0f-fa0b-3537" name="Allegiance" hidden="false" targetId="5297-7e0f-fa0b-3537" primary="false"/>
@@ -385,7 +389,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <categoryLink id="98db-b4ba-fbcd-3239-1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" name="Lords of War" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="false">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="70a0-1ebc-39cf-f0cc" type="max"/>
-            <constraint field="limit::points" scope="roster" value="25.0" percentValue="true" shared="true" includeChildSelections="false" includeChildForces="true" id="12a1-3a1f-5f6f-b56b" type="max"/>
+            <constraint field="limit::points" scope="roster" value="25.0" percentValue="true" shared="false" includeChildSelections="false" includeChildForces="false" id="12a1-3a1f-5f6f-b56b" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="98db-b4ba-fbcd-3239-466f7274696669636174696f6e23232344415441232323" name="Fortification" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="false">
@@ -743,7 +747,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <categoryLink id="d1ef-61e1-3d67-5a19-1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" name="Lords of War" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="false">
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8113-abb6-fd0c-2077" type="max"/>
-            <constraint field="limit::points" scope="roster" value="25.0" percentValue="true" shared="true" includeChildSelections="false" includeChildForces="true" id="5231-3e8d-57cb-fcf5" type="max"/>
+            <constraint field="limit::points" scope="roster" value="25.0" percentValue="true" shared="false" includeChildSelections="false" includeChildForces="false" id="5231-3e8d-57cb-fcf5" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="d1ef-61e1-3d67-5a19-5297-7e0f-fa0b-3537" name="Allegiance" hidden="false" targetId="5297-7e0f-fa0b-3537" primary="false"/>
@@ -793,7 +797,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <categoryLink id="3a6f-6d67-a8b2-e911-1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" name="Lords of War" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="false">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b33c-194d-0c8c-45e3" type="max"/>
-            <constraint field="limit::points" scope="roster" value="25.0" percentValue="true" shared="true" includeChildSelections="false" includeChildForces="true" id="cb8f-4568-7b79-aa31" type="max"/>
+            <constraint field="limit::points" scope="roster" value="25.0" percentValue="true" shared="false" includeChildSelections="false" includeChildForces="false" id="cb8f-4568-7b79-aa31" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="3a6f-6d67-a8b2-e911-466f7274696669636174696f6e23232344415441232323" name="Fortification" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="false">
@@ -866,6 +870,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
         <categoryLink id="1a2c-902b-cdb9-7640-1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" name="Lords of War" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="false">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="20a1-90d6-fb1d-2730" type="max"/>
+            <constraint field="limit::points" scope="roster" value="25.0" percentValue="true" shared="false" includeChildSelections="false" includeChildForces="false" id="13a5-8a6d-ce2a-71b7" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="68b6-c2b3-6501-d55d" name="Use Playtest Rules" hidden="false" targetId="fdf4-0683-3e84-5a4b" primary="false">

--- a/(HH) Solar Auxilia - Crusade Army List.cat
+++ b/(HH) Solar Auxilia - Crusade Army List.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="7f243fc5-c5fd-8b2c-7b07-907bf684bb72" name="Solar Auxilia" revision="81" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="134" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="7f243fc5-c5fd-8b2c-7b07-907bf684bb72" name="Solar Auxilia" revision="82" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="136" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="7f243fc5--pubN65537" name="Crusade Imperialis"/>
     <publication id="7f243fc5--pubN65563" name="AoDRB"/>
@@ -3259,7 +3259,7 @@ Note this precludes some Rites of War and Army Lists from Centurion mode.</descr
       </infoLinks>
       <categoryLinks>
         <categoryLink id="9df9-f881-2c7a-e3cd" name="New CategoryLink" hidden="false" targetId="53bd-99e7-aba0-e79f" primary="false"/>
-        <categoryLink id="d612-a842-97fb-1777" name="New CategoryLink" hidden="false" targetId="218b-fafd-986d-56ba" primary="false"/>
+        <categoryLink id="2d64-0e52-2336-48fb" name="Tank" hidden="false" targetId="e59c-462e-9d9c-66dd" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="aee8-fdad-13bf-a8bd" name="May exchange traverse-mounted battlecannon for:" hidden="false" collective="false" import="true">
@@ -3465,7 +3465,7 @@ but the tank loses the Fast special rule.</description>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="7c47-9c87-6237-701f" name="New CategoryLink" hidden="false" targetId="53bd-99e7-aba0-e79f" primary="false"/>
-        <categoryLink id="8efa-f217-8c2d-10f7" name="New CategoryLink" hidden="false" targetId="218b-fafd-986d-56ba" primary="false"/>
+        <categoryLink id="0823-4db4-c960-67e1" name="Tank" hidden="false" targetId="e59c-462e-9d9c-66dd" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="10d4-557b-70f6-2d4e" name="Inferno Gun" hidden="false" collective="false" import="true" type="upgrade">

--- a/(HH) Talons of the Emperor Army List.cat
+++ b/(HH) Talons of the Emperor Army List.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="a30a-7522-3343-553a" name="Talons of the Emperor" revision="107" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="136" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="a30a-7522-3343-553a" name="Talons of the Emperor" revision="108" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="136" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="a30a-7522-pubN65537" name="HH7 / HH8"/>
     <publication id="a30a-7522-pubN69988" name="Forgeworld.co.uk"/>
@@ -61,7 +61,7 @@
         <categoryLink id="98db-b4ba-fbcd-3239-1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" name="Lords of War" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="false">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="70a0-1ebc-39cf-f0cc" type="max"/>
-            <constraint field="limit::points" scope="roster" value="25.0" percentValue="true" shared="true" includeChildSelections="false" includeChildForces="true" id="12a1-3a1f-5f6f-b56b" type="max"/>
+            <constraint field="limit::points" scope="roster" value="25.0" percentValue="true" shared="false" includeChildSelections="false" includeChildForces="false" id="12a1-3a1f-5f6f-b56b" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="98db-b4ba-fbcd-3239-466f7274696669636174696f6e23232344415441232323" name="Fortification" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="false">
@@ -380,7 +380,7 @@
         <categoryLink id="d1ef-61e1-3d67-5a19-1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" name="Lords of War" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="false">
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8113-abb6-fd0c-2077" type="max"/>
-            <constraint field="limit::points" scope="roster" value="25.0" percentValue="true" shared="true" includeChildSelections="false" includeChildForces="true" id="5231-3e8d-57cb-fcf5" type="max"/>
+            <constraint field="limit::points" scope="roster" value="25.0" percentValue="true" shared="false" includeChildSelections="false" includeChildForces="false" id="5231-3e8d-57cb-fcf5" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="d1ef-61e1-3d67-5a19-5297-7e0f-fa0b-3537" name="Allegiance" hidden="false" targetId="5297-7e0f-fa0b-3537" primary="false"/>
@@ -434,7 +434,7 @@
         <categoryLink id="3a6f-6d67-a8b2-e911-1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" name="Lords of War" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="false">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b33c-194d-0c8c-45e3" type="max"/>
-            <constraint field="limit::points" scope="roster" value="25.0" percentValue="true" shared="true" includeChildSelections="false" includeChildForces="true" id="cb8f-4568-7b79-aa31" type="max"/>
+            <constraint field="limit::points" scope="roster" value="25.0" percentValue="true" shared="false" includeChildSelections="false" includeChildForces="false" id="cb8f-4568-7b79-aa31" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="3a6f-6d67-a8b2-e911-466f7274696669636174696f6e23232344415441232323" name="Fortification" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="false">
@@ -510,6 +510,7 @@
         <categoryLink id="1a2c-902b-cdb9-7640-1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" name="Lords of War" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="false">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="20a1-90d6-fb1d-2730" type="max"/>
+            <constraint field="limit::points" scope="roster" value="25.0" percentValue="true" shared="false" includeChildSelections="false" includeChildForces="false" id="7129-88aa-e6b6-73cf" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="71aa-2bd1-473b-b803" name="Use Playtest Rules" hidden="false" targetId="fdf4-0683-3e84-5a4b" primary="false">
@@ -562,6 +563,7 @@
         <categoryLink id="8666-c0df-4dfa-08f1-1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" name="Lords of War" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="false">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="24cc-15d2-4bb6-8a0c" type="max"/>
+            <constraint field="limit::points" scope="roster" value="25.0" percentValue="true" shared="false" includeChildSelections="false" includeChildForces="false" id="b7d9-5599-e34a-e82f" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="8666-c0df-4dfa-08f1-466f7274696669636174696f6e23232344415441232323" name="Fortification" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="false">
@@ -618,7 +620,7 @@
         </categoryLink>
         <categoryLink id="9a8b-e037-92d7-6b85" name="Lords of War" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="false">
           <constraints>
-            <constraint field="points" scope="parent" value="25.0" percentValue="true" shared="false" includeChildSelections="true" includeChildForces="false" id="0978-7e89-374f-1bd1" type="max"/>
+            <constraint field="points" scope="roster" value="25.0" percentValue="true" shared="false" includeChildSelections="false" includeChildForces="false" id="0978-7e89-374f-1bd1" type="max"/>
             <constraint field="selections" scope="parent" value="-1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="abf5-52e3-9779-108b" type="max"/>
           </constraints>
         </categoryLink>


### PR DESCRIPTION
#1894 #1895 #1896 
HH9 Crusade Errata Updates #1894 #1895

Remove Land Raider Proteus option for Deathwing Companion Terminators, replace with Spartan transport option. (Left the Landraiders in, but only if Steel Fist RoW is in, as it would override their DT preferences)

Remove Hatred and add Preferred Enemy (characters) to Firewing Enigmatus Cabal.

Change Dreadwing Interemptors transport parameters to "10 models or less" rather than exactly 10

Add "This counts as a sword for the purposes of the Mastery of The Blade" to Corswain's The Blade's item description.

Remove the Inbuilt option for the Lion to take Deathwing Companions. Instead give him the same check that allows for Deathwing Companions and Deathwing Companion Terminators to be taken in the "Command Squads" section.

Updated rules and restrictions for the Storm of war to reflect changes.

Also fixed Malcadors from Solar and Militia still having the Superheavy Category.