### PR TITLE
Talons of Emperor #1912

### DIFF
--- a/(HH) Talons of the Emperor Army List.cat
+++ b/(HH) Talons of the Emperor Army List.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="a30a-7522-3343-553a" name="Talons of the Emperor" revision="109" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="137" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="a30a-7522-3343-553a" name="Talons of the Emperor" revision="110" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="137" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="a30a-7522-pubN65537" name="HH7 / HH8"/>
     <publication id="a30a-7522-pubN69988" name="Forgeworld.co.uk"/>
@@ -2845,14 +2845,10 @@
         </modifier>
       </modifiers>
       <infoLinks>
-        <infoLink id="06ee-92e6-c7a9-bab3" name="New InfoLink" hidden="false" targetId="6329-c318-322f-3690" type="profile"/>
-        <infoLink id="b3f8-7d3a-e7c0-ad7f" name="New InfoLink" hidden="false" targetId="6875-ee73-2a85-6a97" type="profile"/>
-        <infoLink id="2be2-6fd8-9149-5bbf" name="New InfoLink" hidden="false" targetId="0900-71d5-1937-aa96" type="rule"/>
+        <infoLink id="06ee-92e6-c7a9-bab3" name="Contemptor-Achillus Dreadnought" hidden="false" targetId="6329-c318-322f-3690" type="profile"/>
+        <infoLink id="2be2-6fd8-9149-5bbf" name="Counter-attack" hidden="false" targetId="0900-71d5-1937-aa96" type="rule"/>
         <infoLink id="e8ad-bb08-8e88-3e25" name="New InfoLink" hidden="false" targetId="6d06-5ea0-9a17-ca97" type="rule"/>
         <infoLink id="b3af-3a22-ff96-5629" name="New InfoLink" hidden="false" targetId="69e5-fc02-1f9d-63c2" type="rule"/>
-        <infoLink id="1833-dcab-6b7d-26a8" name="New InfoLink" hidden="false" targetId="79c7-90f6-b453-e799" type="profile"/>
-        <infoLink id="54c7-0ce0-a7b1-ac19" name="Refractor Field" hidden="false" targetId="4845-0bfe-2c22-883f" type="profile"/>
-        <infoLink id="0b98-3911-ffbf-9830" name="New InfoLink" hidden="false" targetId="9bb4-3833-5343-0dd9" type="profile"/>
       </infoLinks>
       <selectionEntries>
         <selectionEntry id="dc75-d782-32ec-f1d8" name="Two Dreadnought Close Combat Weapons" hidden="false" collective="false" import="true" type="upgrade">
@@ -2930,17 +2926,26 @@
           </costs>
         </selectionEntry>
       </selectionEntries>
+      <entryLinks>
+        <entryLink id="e381-ed91-2003-70d6" name="Refractor Field" hidden="false" collective="false" import="true" targetId="011a-b751-e773-6b90" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b04b-c98f-c0d9-4d28" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0a8e-1556-9fd0-8fcd" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="d2fe-4a15-0976-8fd6" name="Searchlight and Smoke Launchers" hidden="false" collective="false" import="true" targetId="1ecc-b3b6-1fe1-8bd5" type="selectionEntry"/>
+        <entryLink id="ed56-879a-be8c-c612" name="Extra Armour" hidden="false" collective="false" import="true" targetId="4167-42c8-42d8-1ce0" type="selectionEntry"/>
+      </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="215.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="52aa-6b05-24b3-d283" name="Legio Custodes Coronus Grav-Carrier" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
-        <infoLink id="e1c7-5859-b421-a94c" name="New InfoLink" hidden="false" targetId="d0b7-ed3f-25c8-1e63" type="rule"/>
         <infoLink id="c688-9996-9714-4fd5" name="New InfoLink" hidden="false" targetId="0ac1-dfc1-295b-50a6" type="rule"/>
-        <infoLink id="6e0b-c6a7-4ee7-ef65" name="New InfoLink" hidden="false" targetId="d219-2314-4834-c054" type="rule"/>
+        <infoLink id="6e0b-c6a7-4ee7-ef65" name="Deep Strike" hidden="false" targetId="d219-2314-4834-c054" type="rule"/>
         <infoLink id="f3ab-46e5-f3fa-95dd" name="New InfoLink" hidden="false" targetId="de18-25a0-504b-74be" type="rule"/>
-        <infoLink id="68ea-bd55-2e31-a356" name="New InfoLink" hidden="false" targetId="1254-9285-e876-010d" type="rule"/>
+        <infoLink id="68ea-bd55-2e31-a356" name="Grav-backwash" hidden="false" targetId="1254-9285-e876-010d" type="rule"/>
         <infoLink id="f4b0-9572-f331-95b0" name="Coronus Grav-Carrier" hidden="false" targetId="fb44-2178-c180-a450" type="profile"/>
         <infoLink id="34b2-68c4-f7c7-f6af" name="Coronus Grav-Carrier" hidden="false" targetId="e63f-762a-dde4-4c66" type="profile"/>
       </infoLinks>
@@ -3031,6 +3036,9 @@
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="7cd7-0e38-bfab-71ad" name="Flare Shield" hidden="false" collective="false" import="true" targetId="5627-96b7-0b67-5274" type="selectionEntry"/>
+      </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="175.0"/>
       </costs>
@@ -3533,9 +3541,8 @@
           </constraints>
           <infoLinks>
             <infoLink id="6864-0ab8-f79e-c3b9" name="Grav-backwash" hidden="false" targetId="1254-9285-e876-010d" type="rule"/>
-            <infoLink id="0b94-8bba-19b0-8c69" name="Flare Shield" hidden="false" targetId="cb4a-644f-bd8d-7d97" type="profile"/>
             <infoLink id="cc35-992f-3d9d-2136" name="New InfoLink" hidden="false" targetId="de18-25a0-504b-74be" type="rule"/>
-            <infoLink id="76ff-3be7-0eb2-08de" name="New InfoLink" hidden="false" targetId="d219-2314-4834-c054" type="rule"/>
+            <infoLink id="76ff-3be7-0eb2-08de" name="Deep Strike" hidden="false" targetId="d219-2314-4834-c054" type="rule"/>
             <infoLink id="c58d-335c-b0e6-0147" name="New InfoLink" hidden="false" targetId="0ac1-dfc1-295b-50a6" type="rule"/>
             <infoLink id="8820-165f-5199-fbc6" name="Pallas Grav-Attack" hidden="false" targetId="a222-27fb-496a-dc5e" type="profile"/>
           </infoLinks>
@@ -3595,6 +3602,9 @@
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="e9c8-a192-37aa-712a" name="Flare Shield" hidden="false" collective="false" import="true" targetId="5627-96b7-0b67-5274" type="selectionEntry"/>
+          </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="95.0"/>
           </costs>
@@ -3993,9 +4003,6 @@
         <infoLink id="fc19-b1ed-4626-7aa0" name="New InfoLink" hidden="false" targetId="69e5-fc02-1f9d-63c2" type="rule"/>
         <infoLink id="5a23-e549-8432-77f9" name="New InfoLink" hidden="false" targetId="6d06-5ea0-9a17-ca97" type="rule"/>
         <infoLink id="9582-c203-28ed-0050" name="Counter-attack" hidden="false" targetId="0900-71d5-1937-aa96" type="rule"/>
-        <infoLink id="62d3-b774-21b0-3b2f" name="New InfoLink" hidden="false" targetId="6875-ee73-2a85-6a97" type="profile"/>
-        <infoLink id="e0f5-de7e-2c92-f99f" name="Extra Armour" hidden="false" targetId="79c7-90f6-b453-e799" type="profile"/>
-        <infoLink id="a7e7-7b01-1e64-9a6d" name="Searchlight" hidden="false" targetId="9bb4-3833-5343-0dd9" type="profile"/>
         <infoLink id="dd6f-c4d4-2ad2-3e8c" name="Contemptor-Galatus Dreadnought" hidden="false" targetId="0b06-b727-909f-9126" type="profile"/>
       </infoLinks>
       <selectionEntries>
@@ -4039,6 +4046,8 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6288-eddb-7c8c-07d6" type="min"/>
           </constraints>
         </entryLink>
+        <entryLink id="05ea-5b05-050f-be9d" name="Searchlight and Smoke Launchers" hidden="false" collective="false" import="true" targetId="1ecc-b3b6-1fe1-8bd5" type="selectionEntry"/>
+        <entryLink id="5fa3-a959-03de-e947" name="Extra Armour" hidden="false" collective="false" import="true" targetId="4167-42c8-42d8-1ce0" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="250.0"/>
@@ -4893,10 +4902,7 @@ decided.</description>
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="24dc-5340-d47d-8553" name="Smoke Launchers" hidden="false" targetId="6875-ee73-2a85-6a97" type="profile"/>
         <infoLink id="a64c-1d2a-8262-4c89" name="Move Through Cover" hidden="false" targetId="6d06-5ea0-9a17-ca97" type="rule"/>
-        <infoLink id="ded8-3bdf-83fa-3d74" name="Extra Armour" hidden="false" targetId="79c7-90f6-b453-e799" type="profile"/>
-        <infoLink id="b75b-29a0-1060-3549" name="Searchlight" hidden="false" targetId="9bb4-3833-5343-0dd9" type="profile"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="4ec8-82c0-be2a-9601" name="New CategoryLink" hidden="false" targetId="486561767920537570706f727423232344415441232323" primary="true"/>
@@ -4941,6 +4947,8 @@ decided.</description>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e56e-2184-bb69-6468" type="min"/>
           </constraints>
         </entryLink>
+        <entryLink id="c398-0fbd-f7d2-7d40" name="Extra Armour" hidden="false" collective="false" import="true" targetId="4167-42c8-42d8-1ce0" type="selectionEntry"/>
+        <entryLink id="c896-f5e7-4831-1550" name="Searchlight and Smoke Launchers" hidden="false" collective="false" import="true" targetId="1ecc-b3b6-1fe1-8bd5" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="320.0"/>
@@ -4980,8 +4988,6 @@ decided.</description>
         <infoLink id="c874-1e29-dbdd-a8d3" name="Assault Vehicle" hidden="false" targetId="45cf-653a-4ff6-f22d" type="rule"/>
         <infoLink id="c639-4c38-4d68-7dfe" name="Grav-backwash" hidden="false" targetId="1254-9285-e876-010d" type="rule"/>
         <infoLink id="b532-2bdc-a230-1aaa" name="Deep Strike" hidden="false" targetId="d219-2314-4834-c054" type="rule"/>
-        <infoLink id="d5e4-db8d-4ea2-f1cc" name="Armoured Ceramite" hidden="false" targetId="2e87b8ca-7cd1-78b9-2116-246015e7935e" type="profile"/>
-        <infoLink id="5ef0-af83-30ab-fd48" name="Extra Armour" hidden="false" targetId="79c7-90f6-b453-e799" type="profile"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="abc7-60ba-9e6d-0cfd" name="Flyer" hidden="false" targetId="1638-5261-fd55-f53b" primary="false"/>
@@ -5062,6 +5068,8 @@ decided.</description>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="96ff-9c1a-00a5-aac5" type="min"/>
           </constraints>
         </entryLink>
+        <entryLink id="27e7-9fbf-d2a0-b48e" name="Extra Armour" hidden="false" collective="false" import="true" targetId="4167-42c8-42d8-1ce0" type="selectionEntry"/>
+        <entryLink id="957e-c95e-d0b8-62b5" name="Armoured Ceramite" hidden="false" collective="false" import="true" targetId="ca5e-98e3-dff7-fa49" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="615.0"/>
@@ -5229,10 +5237,8 @@ decided.</description>
         </rule>
       </rules>
       <infoLinks>
-        <infoLink id="1c31-aeff-f024-b832" name="Extra Armour" hidden="false" targetId="79c7-90f6-b453-e799" type="profile"/>
         <infoLink id="43e6-9a73-7db0-5b45" name="Grav-backwash" hidden="false" targetId="1254-9285-e876-010d" type="rule"/>
         <infoLink id="48af-c909-df68-7f2c" name="Deep Strike" hidden="false" targetId="d219-2314-4834-c054" type="rule"/>
-        <infoLink id="2170-334b-47f9-ca8a" name="Armoured Ceramite" hidden="false" targetId="2e87b8ca-7cd1-78b9-2116-246015e7935e" type="profile"/>
       </infoLinks>
       <selectionEntries>
         <selectionEntry id="61e7-7e45-be48-42aa" name="Macro Arae-shrike" hidden="false" collective="false" import="true" type="upgrade">
@@ -5340,6 +5346,8 @@ decided.</description>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c9d9-05aa-ef30-c13a" type="min"/>
           </constraints>
         </entryLink>
+        <entryLink id="0aee-fa69-3aa4-8d8c" name="Armoured Ceramite" hidden="false" collective="false" import="true" targetId="ca5e-98e3-dff7-fa49" type="selectionEntry"/>
+        <entryLink id="36bc-3957-e7a3-151b" name="Extra Armour" hidden="false" collective="false" import="true" targetId="4167-42c8-42d8-1ce0" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="640.0"/>
@@ -5762,9 +5770,9 @@ decided.</description>
             <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="011a-b751-e773-6b90" name="Refractor Feild" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="011a-b751-e773-6b90" name="Refractor Field" hidden="false" collective="false" import="true" type="upgrade">
           <infoLinks>
-            <infoLink id="5250-699f-a073-d16f" name="New InfoLink" hidden="false" targetId="4845-0bfe-2c22-883f" type="profile"/>
+            <infoLink id="5250-699f-a073-d16f" name="Refractor Field" hidden="false" targetId="4845-0bfe-2c22-883f" type="profile"/>
           </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="0.0"/>


### PR DESCRIPTION
Talons of Emperor #1912

Added Achillus refractor field and extra armour as mandatory selection options (so they show up better), it was just included in the blub. So I've cleared that up a bit and same with Armoured Ceremites and Flare shields on various other vehicles.
Corrected the spelling mistake on refractor fields. 