### PR TITLE
Raltac FOC for Varangian Heresy Events

### DIFF
--- a/(HH) Varangian Heresy Legions.cat
+++ b/(HH) Varangian Heresy Legions.cat
@@ -1,0 +1,553 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<catalogue id="026e-d6a9-3266-819f" name="Varangian Heresy Legions" revision="1" battleScribeVersion="2.03" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="140" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+  <forceEntries>
+    <forceEntry id="5e99-cad3-2c6c-dd09" name="Raltac" page="" hidden="false">
+      <rules>
+        <rule id="d1d4-9ab4-54c3-f546" name="Raltac Force Organisation Chart" hidden="false">
+          <description>HQ: 1 compulsory and 2 optional
+Elite: 3 optional
+Troop: 1 compulsory and 2 optional
+Fast: 2 optional
+Heavy: 2 optional
+Fortification: 1 optional
+
+No unit including dedicated transports may cost more than 350 points. THIS MUST BE CHECKED MANUALLY
+
+LoW options are still visible, as despite the basic foc can&apos;t have them, Bonus cards in the events can give access to a LoW choice.</description>
+        </rule>
+      </rules>
+      <categoryLinks>
+        <categoryLink id="eb64-2e81-3c8e-7a3d" name="HQ" hidden="false" targetId="485123232344415441232323" primary="false">
+          <modifiers>
+            <modifier type="increment" field="a32e-eb4d-0816-11a3" value="1.0">
+              <repeats>
+                <repeat field="points" scope="force" value="1000.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c91-a83b-8ca5-e5db" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="decrement" field="11cf-e01e-600d-6d0d" value="1.0">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="points" scope="force" value="2000.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="lessThan"/>
+                    <condition field="points" scope="force" value="999.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="greaterThan"/>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c91-a83b-8ca5-e5db" type="greaterThan"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="decrement" field="11cf-e01e-600d-6d0d" value="2.0">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="points" scope="force" value="1999.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="greaterThan"/>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c91-a83b-8ca5-e5db" type="greaterThan"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="increment" field="a32e-eb4d-0816-11a3" value="1.0">
+              <repeats>
+                <repeat field="points" scope="force" value="1000.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions>
+                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7c91-a83b-8ca5-e5db" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="a32e-eb4d-0816-11a3" value="2.0">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="23b2-72dc-7831-43d8" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="11cf-e01e-600d-6d0d" value="2.0">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="23b2-72dc-7831-43d8" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="a32e-eb4d-0816-11a3" value="1.0">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6d09-8d59-4508-75bd" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="11cf-e01e-600d-6d0d" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a32e-eb4d-0816-11a3" type="min"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="b31a-b89e-1896-cb95" name="Elites" hidden="false" targetId="456c6974657323232344415441232323" primary="false">
+          <modifiers>
+            <modifier type="decrement" field="f17b-455a-8ab4-e76a" value="1.0">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="aaa4-ac11-c309-e651" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="f17b-455a-8ab4-e76a" value="1.0">
+              <repeats>
+                <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="485123232344415441232323" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="aaa4-ac11-c309-e651" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="7214-cffa-a591-4e07" value="2.0">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6d09-8d59-4508-75bd" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f17b-455a-8ab4-e76a" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7214-cffa-a591-4e07" type="min"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="313d-0992-7966-7f71" name="Troops" hidden="false" targetId="54726f6f707323232344415441232323" primary="false">
+          <modifiers>
+            <modifier type="increment" field="f9f7-8fbf-87ed-d536" value="4.0">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="88e6-c803-528f-b603" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f9f7-8fbf-87ed-d536" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="8664-bcc8-a878-b069" name="Fast Attack" hidden="false" targetId="466173742041747461636b23232344415441232323" primary="false">
+          <modifiers>
+            <modifier type="set" field="e23e-fb93-f73b-847f" value="1.0">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0fff-2ab8-afae-2b0b" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="be69-a94b-555e-5990" value="1.0">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b66f-2c54-e1a3-57c7" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b575-2895-bcaa-9acf" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="set" field="e23e-fb93-f73b-847f" value="1.0">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5c66-2306-9285-8809" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="486561767920537570706f727423232344415441232323" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe16-7a9f-5ada-2bd8" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="set" field="e23e-fb93-f73b-847f" value="2.0">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5c66-2306-9285-8809" type="equalTo"/>
+                    <condition field="selections" scope="force" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="486561767920537570706f727423232344415441232323" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe16-7a9f-5ada-2bd8" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="be69-a94b-555e-5990" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e23e-fb93-f73b-847f" type="min"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="94ae-09af-2f4e-8d1b" name="Heavy Support" hidden="false" targetId="486561767920537570706f727423232344415441232323" primary="false">
+          <modifiers>
+            <modifier type="set" field="0cb2-1c07-093e-2e96" value="1.0">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a407-2a45-f198-77ac" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="0cb2-1c07-093e-2e96" value="1.0">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="90f1-7652-515e-c919" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0cb2-1c07-093e-2e96" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="fc8c-c345-c41e-2351" name="Allegiance" hidden="false" targetId="5297-7e0f-fa0b-3537" primary="false"/>
+        <categoryLink id="cf40-3603-2681-6229" name="Lords of War" hidden="false" targetId="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" primary="false">
+          <modifiers>
+            <modifier type="set" field="5fcf-bf3c-9f40-3e48" value="0.0">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0387-a3b9-3c08-0c80" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1006-e22e-3aa4-f79a" type="equalTo"/>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="485123232344415441232323" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="points" scope="roster" value="25.0" percentValue="true" shared="false" includeChildSelections="false" includeChildForces="false" id="e946-4ce4-20d3-8d09" type="max"/>
+            <constraint field="selections" scope="parent" value="-1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5fcf-bf3c-9f40-3e48" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="b079-c2eb-9061-bd03" name="Fortification" hidden="false" targetId="466f7274696669636174696f6e23232344415441232323" primary="false">
+          <modifiers>
+            <modifier type="set" field="12ad-b841-3b4d-e63d" value="0.0">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9ff3-ad55-3aee-0624" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e29d-a3c1-5481-9ae8" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="98e9-2a0d-2e40-bea5" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2e67-4ce3-498e-ab12" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e613-9ee7-7927-de41" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="28e7-5bc8-ee9f-c676" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5586-520e-c4cb-6679" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0fff-2ab8-afae-2b0b" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0ee5-3c01-65f0-f9eb" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b9c1-f183-1b64-3b65" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0e12-b313-b430-9a12" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e18e-3da1-b6d5-b6dc" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9d81-7da9-2ca0-1b20" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c4bb-71f9-9e2d-b8ce" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="06cf-1221-a38b-94d6" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e006-54b4-d151-4520" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="916d-646f-1e3f-aae5" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b12c-92e3-0561-c0e6" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1eee-6526-ab76-6bed" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1eee-6526-ab76-6bed" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7971-7a57-738e-f752" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8188-a2ce-a2ae-5ac4" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="98e9-2a0d-2e40-bea5" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="31e9-5295-2bd0-6b1c" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e2f9-2a17-919d-88b4" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab4a-3c81-317e-9ad3" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2e67-4ce3-498e-ab12" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7a4f-7aea-a254-c287" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4618-5a5e-08a7-8f19" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="set" field="01c3-6a92-6532-d7cf" value="1.0">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9f55-dc34-bba4-3545" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="12ad-b841-3b4d-e63d" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="01c3-6a92-6532-d7cf" type="min"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="2c57-0025-9016-d4d7" name="Compulsory HQ" hidden="false" targetId="becd-7a6d-e80f-878e" primary="false">
+          <modifiers>
+            <modifier type="set" field="6f84-9433-d0ad-8813" value="2.0">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e18e-3da1-b6d5-b6dc" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="edd3-79ac-eb75-34b7" type="equalTo"/>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe16-7a9f-5ada-2bd8" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="set" field="6f84-9433-d0ad-8813" value="3.0">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="23b2-72dc-7831-43d8" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6f84-9433-d0ad-8813" type="min"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="64e9-c484-93c8-f158" name="Compulsory Troops" hidden="false" targetId="219d-aefa-dfa5-44db" primary="false">
+          <modifiers>
+            <modifier type="increment" field="1e1f-1d7b-dbc3-0e6d" value="1.0">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="90f1-7652-515e-c919" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e54f-a96e-cbcc-8f8e" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0ee5-3c01-65f0-f9eb" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ac49-166d-aea9-5327" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7971-7a57-738e-f752" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="23b2-72dc-7831-43d8" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="aaa4-ac11-c309-e651" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1e1f-1d7b-dbc3-0e6d" type="min"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="5045-2c0e-673b-6f91" name="Deep Strike" hidden="false" targetId="2d6f-e613-ab10-e55a" primary="false">
+          <constraints>
+            <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a482-40b9-2aca-0a7c" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="6751-49d6-1b88-8ea8" name="Flyer" hidden="false" targetId="df44-81ea-e2ee-9849" primary="false">
+          <constraints>
+            <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="05e4-12bb-7644-68ce" type="min"/>
+            <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dff0-2009-2b82-5c89" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="f205-0cec-8937-d7b2" name="Immobile" hidden="false" targetId="18c5-559b-55e0-382e" primary="false"/>
+        <categoryLink id="da7c-f8ce-7c63-be10" name="Legiones Astartes" hidden="false" targetId="0c56-27b8-a737-c9fd" primary="false"/>
+        <categoryLink id="264f-45a0-254d-a334" name="Skimmer" hidden="false" targetId="9480-d3f6-fff1-7b35" primary="false">
+          <constraints>
+            <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ace7-a46d-fc7d-1e52" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="dfb0-84c8-63da-dec1" name="Drop Pod" hidden="false" targetId="51a3-45ca-ea32-7519" primary="false"/>
+        <categoryLink id="3ce1-3c0c-61ad-51b3" name="Sentry Gun" hidden="false" targetId="e448-6dab-e008-3247" primary="false"/>
+        <categoryLink id="ca0d-377c-0a77-513d" name="Walker" hidden="false" targetId="264d-166e-36c0-77b7" primary="false">
+          <modifiers>
+            <modifier type="set" field="6b93-e091-1cdf-6b95" value="2.0">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="98e9-2a0d-2e40-bea5" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="54726f6f707323232344415441232323" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6b93-e091-1cdf-6b95" type="min"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="bf9c-610b-d0e2-ae82" name="Vehicle (Unit)" hidden="false" targetId="53bd-99e7-aba0-e79f" primary="false"/>
+        <categoryLink id="8ec9-8d7e-52f4-7fde" name="Transport" hidden="false" targetId="e4e0-c5d1-3430-f101" primary="false">
+          <modifiers>
+            <modifier type="increment" field="f78e-0c87-c539-4795" value="1.0">
+              <repeats>
+                <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f74d-4679-75a6-1252" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a407-2a45-f198-77ac" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0fff-2ab8-afae-2b0b" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7971-7a57-738e-f752" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ab4a-3c81-317e-9ad3" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4618-5a5e-08a7-8f19" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f78e-0c87-c539-4795" type="min"/>
+            <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d4b7-7fd7-8ec7-8b94" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="f8d2-6df8-d2de-8104" name="Consul" hidden="false" targetId="287a-5939-2a29-9ccf" primary="false"/>
+        <categoryLink id="3892-e167-eb28-0a5b" name="Wolf Lord/Claw Leader" hidden="false" targetId="a5b5-33d4-9941-d832" primary="false"/>
+        <categoryLink id="c2e3-d6b8-ef7a-0d47" name="Cybernetica Cortex" hidden="false" targetId="7fdd-2a97-d0e9-6524" primary="false"/>
+        <categoryLink id="5fc0-60f1-a709-108c" name="Cortex Controlled" hidden="false" targetId="3f9d-27a5-969f-399b" primary="false"/>
+        <categoryLink id="23d9-dc93-9908-1f08" name="Infantry" hidden="false" targetId="f74d-4679-75a6-1252" primary="false"/>
+        <categoryLink id="504e-2026-713b-1c28" name="Bodyguard" hidden="false" targetId="73b6-4f0e-c013-b242" primary="false"/>
+        <categoryLink id="203c-97af-1ed1-85b2" name="Artillery" hidden="false" targetId="ce39-b313-7b57-ee8e" primary="false"/>
+        <categoryLink id="72eb-e86d-3c69-30fb" name="Use Playtest Rules" hidden="false" targetId="fdf4-0683-3e84-5a4b" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="a655-a769-a6c1-ecae" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="bbad-e7cb-1738-3e8c" name="Varangian Heresy" hidden="false" targetId="75dd-fb93-d6c7-1177" primary="false">
+          <constraints>
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="83ee-c296-ff82-4424" type="min"/>
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9506-fc6b-d92c-11de" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="263d-4f8a-57c4-40cc" name="Praetor" hidden="false" targetId="684a-be04-b069-3fe5" primary="false">
+          <modifiers>
+            <modifier type="increment" field="bac2-f3da-1745-b03c" value="1.0">
+              <repeats>
+                <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" childId="6c41-b70d-079b-c7cf" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="bac2-f3da-1745-b03c" type="min"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="eb47-0e62-64c6-0695" name="Compulsory Elite Infantry (Non-Termy)" hidden="false" targetId="6759-ec18-2d1c-dc88" primary="false">
+          <modifiers>
+            <modifier type="set" field="dd18-4711-5e27-3a18" value="2.0">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6d09-8d59-4508-75bd" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dd18-4711-5e27-3a18" type="min"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="f64e-8845-8a34-0b66" name="Compulsory Elite" hidden="false" targetId="196d-5b83-524b-4bdf" primary="false"/>
+        <categoryLink id="113a-98e8-7291-e416" name="Compulsory Scion Troops" hidden="false" targetId="7ebe-5d12-65e5-fd8f" primary="false">
+          <modifiers>
+            <modifier type="increment" field="2c2c-9e0e-9222-5bfc" value="1.0">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="88e6-c803-528f-b603" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0b50-ead3-74c3-6a1e" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4809-5e50-59aa-616e" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b8b4-f76f-3526-63ad" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2c2c-9e0e-9222-5bfc" type="min"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="b7d3-6e2f-3512-b118" name="Compulsory Scion Warlord" hidden="false" targetId="e7ba-324d-246c-dd6a" primary="false"/>
+        <categoryLink id="03ed-8fb9-4e25-0fa1" name="Allied Detachment" hidden="false" targetId="6077-281f-c55d-9bf0" primary="false">
+          <modifiers>
+            <modifier type="set" field="7654-3484-c87e-a4cb" value="0.0">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="88e6-c803-528f-b603" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3eb6-7bb4-f787-91c7" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0b50-ead3-74c3-6a1e" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e29d-a3c1-5481-9ae8" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3ff3-644e-6e21-bbc6" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4809-5e50-59aa-616e" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="98e9-2a0d-2e40-bea5" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ce46-4891-1810-33ba" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="iron-wing-protocol-rite" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0e12-b313-b430-9a12" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1576-0b33-8f6a-744f" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b8b4-f76f-3526-63ad" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e3d5-f5db-db79-4ff9" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fc24-e04e-2452-228e" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="06cf-1221-a38b-94d6" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="23b2-72dc-7831-43d8" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4618-5a5e-08a7-8f19" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2e67-4ce3-498e-ab12" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c4bb-71f9-9e2d-b8ce" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="916d-646f-1e3f-aae5" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="28e7-5bc8-ee9f-c676" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="da28-5c49-ae09-af64" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7654-3484-c87e-a4cb" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ccd2-43e4-d895-7a67" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="93fc-1256-1261-c142" name="Dreadnought Talon" hidden="false" targetId="8ba4-692c-1bf7-ca68" primary="false">
+          <constraints>
+            <constraint field="selections" scope="485123232344415441232323" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bd94-47b8-1860-de98" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="2d16-7867-070d-8c4f" name="Warlord Traits" hidden="false" targetId="baa4-80e4-c41d-6875" primary="false">
+          <constraints>
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9252-6a86-fd51-0e13" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="bd8e-fb45-6bc8-b573" name="Compulsory Cult Arcana" hidden="false" targetId="4024-a67a-3738-32d5" primary="false">
+          <modifiers>
+            <modifier type="increment" field="0fae-30ab-fe02-1e69" value="1.0">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e54f-a96e-cbcc-8f8e" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e77f-fb48-637d-11eb" type="equalTo"/>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dda4-2c88-6e85-325b" type="equalTo"/>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2b4f-4a30-0041-a892" type="equalTo"/>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="98da-03a8-32c3-317e" type="equalTo"/>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="233f-8198-8d36-98cf" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="increment" field="0fae-30ab-fe02-1e69" value="2.0">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e77f-fb48-637d-11eb" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dda4-2c88-6e85-325b" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2b4f-4a30-0041-a892" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="98da-03a8-32c3-317e" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="233f-8198-8d36-98cf" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0fae-30ab-fe02-1e69" type="min"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="e8f9-976c-c0ed-0b58" name="Dedicated Transport Restictions" hidden="false" targetId="a07b-3b90-3814-6c97" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="3aff-798b-9bcb-0ce3" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3395-6705-b507-0e18" type="min"/>
+          </constraints>
+        </categoryLink>
+      </categoryLinks>
+    </forceEntry>
+  </forceEntries>
+  <selectionEntries>
+    <selectionEntry id="0b48-f2a0-f486-2ccd" name="Varangian Heresy Rules" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6aae-08f2-4e23-1399" type="min"/>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9e2e-352e-f053-c5b5" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5501-b39d-c928-17c0" type="max"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="855f-9c2d-977a-d9e0" name="Varangian Heresy" hidden="false" targetId="75dd-fb93-d6c7-1177" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="f822-07b7-9e45-2976" name="Varangian Heresy Rules Active" hidden="false" collective="false" import="true" targetId="d13d-19a9-1519-3474" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3f53-eb27-e83b-c57c" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6dad-2f80-75a7-d687" type="max"/>
+          </constraints>
+          <categoryLinks>
+            <categoryLink id="51e5-e391-fa71-c23b" name="Varangian Heresy" hidden="false" targetId="75dd-fb93-d6c7-1177" primary="false"/>
+          </categoryLinks>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+  </selectionEntries>
+  <catalogueLinks>
+    <catalogueLink id="5a6a-9e7f-9df7-8489" name="Legiones Astartes: Age of Darkness Army List" targetId="839b6f2a-4041-398b-fc2d-dc6a31d5f75e" type="catalogue" importRootEntries="true"/>
+  </catalogueLinks>
+</catalogue>

--- a/The Horus Heresy.gst
+++ b/The Horus Heresy.gst
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<gameSystem id="ca571888-56a9-c58e-ddaf-54f4713538bc" name="Warhammer 30,000 - The Horus Heresy" revision="138" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
+<gameSystem id="ca571888-56a9-c58e-ddaf-54f4713538bc" name="Warhammer 30,000 - The Horus Heresy" revision="140" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
   <publications>
     <publication id="ca571888--pubN65537" name="Forgeworld Horus Heresy Series"/>
     <publication id="ca571888--pubN66489" name="HH:MT"/>
@@ -210,6 +210,12 @@
         <infoLink id="0436-90de-7b75-9c53" name="Deep Strike" hidden="false" targetId="d219-2314-4834-c054" type="rule"/>
         <infoLink id="398e-bbae-1013-3bef" name="Jump Unit" hidden="false" targetId="8cb0-ff25-22a2-d480" type="rule"/>
       </infoLinks>
+    </categoryEntry>
+    <categoryEntry id="75dd-fb93-d6c7-1177" name="Varangian Heresy" hidden="false">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e8a9-b4e7-9518-491c" type="max"/>
+        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fac7-0a52-aa75-4482" type="min"/>
+      </constraints>
     </categoryEntry>
   </categoryEntries>
   <forceEntries>
@@ -6451,7 +6457,7 @@ or Gargantuan Creatures. </description>
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="9a38-4736-87a7-0d55" name="Twin-linked Heavy Stubber" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="9a38-4736-87a7-0d55" name="Hull Mounted Twin-Linked Heavy Stubber" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="45c8-a2a0-92a4-2446" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="22b0-cbd2-bede-b1a4" type="max"/>
@@ -6827,6 +6833,22 @@ Any abilities that allow the vehicle to fire multiple shots will use the same sh
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
+            <selectionEntry id="bae4-fdd8-404f-5494" name="Hull Mounted Twin-Linked Heavy Stubber" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5116-23b4-d173-8d23" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cf87-c0ee-198a-8e9c" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="750d-70d0-f990-04a3" name="Heavy Stubber" hidden="false" targetId="981c9d9e-9866-7245-ed4c-8d5e4f9b17f4" type="profile">
+                  <modifiers>
+                    <modifier type="set" field="name" value="Twin-linked Heavy Stubber"/>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
           </selectionEntries>
           <selectionEntryGroups>
             <selectionEntryGroup id="d9dd-d953-dc6b-b648" name="May be given one pintle-mounted" page="" hidden="false" collective="false" import="true">
@@ -6962,7 +6984,7 @@ Any abilities that allow the vehicle to fire multiple shots will use the same sh
             </profile>
           </profiles>
           <selectionEntries>
-            <selectionEntry id="abc6-f014-bd8b-331c" name="Twin-linked Heavy Stubber" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="abc6-f014-bd8b-331c" name="Hull Mounted Twin-Linked Heavy Stubber" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="54bd-aa21-e1ea-7a14" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f3a6-8a12-2888-80f6" type="max"/>
@@ -7849,6 +7871,40 @@ Any abilities that allow the vehicle to fire multiple shots will use the same sh
                 </selectionEntryGroup>
               </selectionEntryGroups>
             </selectionEntryGroup>
+            <selectionEntryGroup id="b4cd-f62e-ce08-2b67" name="May Take" hidden="false" collective="false" import="true">
+              <selectionEntryGroups>
+                <selectionEntryGroup id="14c3-d38a-e774-df74" name="Pintle-Mounted Weapon" hidden="false" collective="false" import="true">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aac7-d7c8-1f43-bd5f" type="max"/>
+                  </constraints>
+                  <selectionEntries>
+                    <selectionEntry id="b63e-1772-da9d-1f69" name="Pintle-Mounted Heavy Stubber" hidden="false" collective="false" import="true" type="upgrade">
+                      <infoLinks>
+                        <infoLink id="7639-eaa4-bb63-5266" name="Heavy Stubber" hidden="false" targetId="981c9d9e-9866-7245-ed4c-8d5e4f9b17f4" type="profile"/>
+                      </infoLinks>
+                      <costs>
+                        <cost name="pts" typeId="points" value="10.0"/>
+                      </costs>
+                    </selectionEntry>
+                    <selectionEntry id="ad02-103f-69ca-a330" name="Pintle-Mounted Stormbolter" hidden="false" collective="false" import="true" type="upgrade">
+                      <infoLinks>
+                        <infoLink id="b5d9-6293-b64c-3903" name="Storm Bolter" hidden="false" targetId="505e-a5aa-edab-6d5b" type="profile"/>
+                      </infoLinks>
+                      <costs>
+                        <cost name="pts" typeId="points" value="10.0"/>
+                      </costs>
+                    </selectionEntry>
+                  </selectionEntries>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <entryLinks>
+                <entryLink id="ae70-7694-d5dc-88fe" name="Hunter-killer Missile" hidden="false" collective="false" import="true" targetId="0c28-bf1b-2964-f8eb" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks>
             <entryLink id="5d13-b209-f7a1-f22d" name="Searchlight and Smoke Launchers" hidden="false" collective="false" import="true" targetId="1ecc-b3b6-1fe1-8bd5" type="selectionEntry"/>
@@ -7940,57 +7996,140 @@ Any abilities that allow the vehicle to fire multiple shots will use the same sh
             </selectionEntry>
           </selectionEntries>
           <selectionEntryGroups>
-            <selectionEntryGroup id="6f76-f341-d330-4aad" name="Sponsons" hidden="false" collective="false" import="true">
+            <selectionEntryGroup id="a1d9-3ef3-a81a-e541" name="Sponsons" hidden="false" collective="false" import="true">
               <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c429-4e9d-9d5e-99c7" type="min"/>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a037-ef2a-0546-2654" type="max"/>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fc0d-d7f1-88b8-fd43" type="min"/>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d5ce-d5b9-cf6e-3e51" type="max"/>
               </constraints>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="43b3-624e-db28-f702" name="Front Left Sponsor" hidden="false" collective="false" import="true">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2f2b-3bde-8ec6-7f87" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a8c5-eeed-5110-7b03" type="max"/>
+                  </constraints>
+                  <selectionEntries>
+                    <selectionEntry id="01b2-e9f9-8559-b900" name="Lascannon Sponson" page="0" hidden="false" collective="false" import="true" type="upgrade">
+                      <infoLinks>
+                        <infoLink id="9311-3e3c-2c18-2106" name="Lascannon" hidden="false" targetId="1cce-972c-022a-2590" type="profile"/>
+                      </infoLinks>
+                      <costs>
+                        <cost name="pts" typeId="points" value="10.0"/>
+                      </costs>
+                    </selectionEntry>
+                    <selectionEntry id="5241-10e1-34ac-36f6" name="Heavy Flamer Sponson" page="0" hidden="false" collective="false" import="true" type="upgrade">
+                      <infoLinks>
+                        <infoLink id="e36d-702e-cedc-63ed" name="Heavy Flamer" hidden="false" targetId="c554-a05e-607c-5831" type="profile"/>
+                      </infoLinks>
+                      <costs>
+                        <cost name="pts" typeId="points" value="0.0"/>
+                      </costs>
+                    </selectionEntry>
+                    <selectionEntry id="8813-39b6-7eab-e713" name="Heavy Bolter Sponson" page="0" hidden="false" collective="false" import="true" type="upgrade">
+                      <infoLinks>
+                        <infoLink id="a3c2-0cfe-8f46-aa5c" name="Heavy Bolter" hidden="false" targetId="271e-6286-86cc-06dd" type="profile"/>
+                      </infoLinks>
+                      <costs>
+                        <cost name="pts" typeId="points" value="0.0"/>
+                      </costs>
+                    </selectionEntry>
+                    <selectionEntry id="46a5-7a63-accc-daf7" name="Autocannon Sponson" page="0" hidden="false" collective="false" import="true" type="upgrade">
+                      <infoLinks>
+                        <infoLink id="395e-0bbc-48a7-223f" name="Autocannon" hidden="false" targetId="d55f-eed0-800f-5789" type="profile"/>
+                      </infoLinks>
+                      <costs>
+                        <cost name="pts" typeId="points" value="5.0"/>
+                      </costs>
+                    </selectionEntry>
+                  </selectionEntries>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="f8f1-c441-0b61-64d9" name="Front Right Sponsor" hidden="false" collective="false" import="true">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="51e2-e355-0140-982d" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4fc3-3298-9f8c-455c" type="min"/>
+                  </constraints>
+                  <selectionEntries>
+                    <selectionEntry id="d02f-d6fb-e65d-d1e2" name="Lascannon Sponson" page="0" hidden="false" collective="false" import="true" type="upgrade">
+                      <infoLinks>
+                        <infoLink id="9650-6727-2170-63f7" name="Lascannon" hidden="false" targetId="1cce-972c-022a-2590" type="profile"/>
+                      </infoLinks>
+                      <costs>
+                        <cost name="pts" typeId="points" value="10.0"/>
+                      </costs>
+                    </selectionEntry>
+                    <selectionEntry id="7417-1b35-7946-d96b" name="Heavy Flamer Sponson" page="0" hidden="false" collective="false" import="true" type="upgrade">
+                      <infoLinks>
+                        <infoLink id="4963-f2f0-2f98-95a8" name="Heavy Flamer" hidden="false" targetId="c554-a05e-607c-5831" type="profile"/>
+                      </infoLinks>
+                      <costs>
+                        <cost name="pts" typeId="points" value="0.0"/>
+                      </costs>
+                    </selectionEntry>
+                    <selectionEntry id="d4cc-24f5-0681-14aa" name="Heavy Bolter Sponson" page="0" hidden="false" collective="false" import="true" type="upgrade">
+                      <infoLinks>
+                        <infoLink id="ceba-81ea-a3b9-07b4" name="Heavy Bolter" hidden="false" targetId="271e-6286-86cc-06dd" type="profile"/>
+                      </infoLinks>
+                      <costs>
+                        <cost name="pts" typeId="points" value="0.0"/>
+                      </costs>
+                    </selectionEntry>
+                    <selectionEntry id="8b48-7074-6848-fb44" name="Autocannon Sponson" page="0" hidden="false" collective="false" import="true" type="upgrade">
+                      <infoLinks>
+                        <infoLink id="8370-0059-0c2f-feb2" name="Autocannon" hidden="false" targetId="d55f-eed0-800f-5789" type="profile"/>
+                      </infoLinks>
+                      <costs>
+                        <cost name="pts" typeId="points" value="5.0"/>
+                      </costs>
+                    </selectionEntry>
+                  </selectionEntries>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="171b-51b7-a427-bb3d" name="May Take" hidden="false" collective="false" import="true">
               <selectionEntries>
-                <selectionEntry id="a03a-239c-484d-9851" name="Heavy Bolter" page="0" hidden="false" collective="false" import="true" type="upgrade">
+                <selectionEntry id="ef18-db51-0b7e-a3d2" name="Dozer Blade" page="0" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="30f5-2477-7d17-21f0" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5a95-c824-7614-9313" type="max"/>
                   </constraints>
                   <infoLinks>
-                    <infoLink id="3818-deae-f251-4ee6" name="Heavy Bolter" hidden="false" targetId="271e-6286-86cc-06dd" type="profile"/>
-                  </infoLinks>
-                  <costs>
-                    <cost name="pts" typeId="points" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="8fc2-3d21-a3a3-a9a2" name="Autocannon" page="0" hidden="false" collective="false" import="true" type="upgrade">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="859a-7c29-6232-908a" type="max"/>
-                  </constraints>
-                  <infoLinks>
-                    <infoLink id="149c-4168-f16e-85ba" name="Autocannon" hidden="false" targetId="d55f-eed0-800f-5789" type="profile"/>
-                  </infoLinks>
-                  <costs>
-                    <cost name="pts" typeId="points" value="5.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="c82d-59fe-ffe4-e41a" name="Lascannon" page="0" hidden="false" collective="false" import="true" type="upgrade">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6103-69f9-d13a-580e" type="max"/>
-                  </constraints>
-                  <infoLinks>
-                    <infoLink id="8676-0e18-da33-c5e0" name="Lascannon" hidden="false" targetId="1cce-972c-022a-2590" type="profile"/>
+                    <infoLink id="ba60-c694-ef80-b1fe" name="New InfoLink" hidden="false" targetId="35a2-2083-1522-cd61" type="profile"/>
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="10.0"/>
                   </costs>
                 </selectionEntry>
-                <selectionEntry id="31b0-047c-e421-9762" name="Heavy Flamer" page="0" hidden="false" collective="false" import="true" type="upgrade">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9192-b65b-6a7f-4ae4" type="max"/>
-                  </constraints>
-                  <infoLinks>
-                    <infoLink id="f6e6-cc1c-5e46-c1be" name="Heavy Flamer" hidden="false" targetId="c554-a05e-607c-5831" type="profile"/>
-                  </infoLinks>
-                  <costs>
-                    <cost name="pts" typeId="points" value="0.0"/>
-                  </costs>
-                </selectionEntry>
               </selectionEntries>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="9990-38fb-90f5-bc32" name="Pintle-Mounted Weapon" hidden="false" collective="false" import="true">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1d72-ed03-2b15-22b6" type="max"/>
+                  </constraints>
+                  <selectionEntries>
+                    <selectionEntry id="661b-7b37-f5e7-87ac" name="Pintle-Mounted Heavy Stubber" hidden="false" collective="false" import="true" type="upgrade">
+                      <infoLinks>
+                        <infoLink id="1f37-499e-6299-b39f" name="Heavy Stubber" hidden="false" targetId="981c9d9e-9866-7245-ed4c-8d5e4f9b17f4" type="profile"/>
+                      </infoLinks>
+                      <costs>
+                        <cost name="pts" typeId="points" value="10.0"/>
+                      </costs>
+                    </selectionEntry>
+                    <selectionEntry id="d238-b100-ff91-098d" name="Pintle-Mounted Stormbolter" hidden="false" collective="false" import="true" type="upgrade">
+                      <infoLinks>
+                        <infoLink id="a891-8da2-a4b8-dc51" name="Storm Bolter" hidden="false" targetId="505e-a5aa-edab-6d5b" type="profile"/>
+                      </infoLinks>
+                      <costs>
+                        <cost name="pts" typeId="points" value="10.0"/>
+                      </costs>
+                    </selectionEntry>
+                  </selectionEntries>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <entryLinks>
+                <entryLink id="9b4a-ec2a-3ae3-6193" name="Hunter-killer Missile" hidden="false" collective="false" import="true" targetId="0c28-bf1b-2964-f8eb" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="10.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks>
@@ -8190,6 +8329,40 @@ Any abilities that allow the vehicle to fire multiple shots will use the same sh
                   </selectionEntries>
                 </selectionEntryGroup>
               </selectionEntryGroups>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="93cc-ec4a-4ae0-9569" name="May Take" hidden="false" collective="false" import="true">
+              <selectionEntryGroups>
+                <selectionEntryGroup id="0a73-8301-d5e5-dcf2" name="Pintle-Mounted Weapon" hidden="false" collective="false" import="true">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="be6d-b2d7-5258-5482" type="max"/>
+                  </constraints>
+                  <selectionEntries>
+                    <selectionEntry id="8e22-4b59-8490-2775" name="Pintle-Mounted Heavy Stubber" hidden="false" collective="false" import="true" type="upgrade">
+                      <infoLinks>
+                        <infoLink id="d4c0-94d2-a2ef-905a" name="Heavy Stubber" hidden="false" targetId="981c9d9e-9866-7245-ed4c-8d5e4f9b17f4" type="profile"/>
+                      </infoLinks>
+                      <costs>
+                        <cost name="pts" typeId="points" value="10.0"/>
+                      </costs>
+                    </selectionEntry>
+                    <selectionEntry id="42c4-a33e-4a8c-961a" name="Pintle-Mounted Stormbolter" hidden="false" collective="false" import="true" type="upgrade">
+                      <infoLinks>
+                        <infoLink id="76b2-e78d-cc92-28d6" name="Storm Bolter" hidden="false" targetId="505e-a5aa-edab-6d5b" type="profile"/>
+                      </infoLinks>
+                      <costs>
+                        <cost name="pts" typeId="points" value="10.0"/>
+                      </costs>
+                    </selectionEntry>
+                  </selectionEntries>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <entryLinks>
+                <entryLink id="7a6f-d18a-7ab3-3505" name="Hunter-killer Missile" hidden="false" collective="false" import="true" targetId="0c28-bf1b-2964-f8eb" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks>
@@ -10478,6 +10651,11 @@ Any abilities that allow the vehicle to fire multiple shots will use the same sh
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7e97-5413-0c38-757d" type="max"/>
       </constraints>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="d13d-19a9-1519-3474" name="Varangian Heresy Rules Active" hidden="false" collective="false" import="true" type="upgrade">
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>


### PR DESCRIPTION
This is a first test of the Reltac FoC added to lists. If you are a player please test it and feedback. If it works or not let me know and it can be rolled out to the other force types (like mech, solar, militia...) if successful.

To access the list type you have to like with Mournival have a new Force type. Inside there you have all the regular stuff you can choose for legions, but also the Reltac FOC chart. Only thing to watch out for is that the 350pts cap is not enabled as I don't know how to make it work without a big rewrite of the LA file that could have many knock on effects which I do not which to do.

![image](https://user-images.githubusercontent.com/20280410/121352361-afc71e80-c924-11eb-8a26-33575e6d4cbb.png)
