### PR TITLE
More RoW fixes

### DIFF
--- a/(HH) Mournival Units.cat
+++ b/(HH) Mournival Units.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="9f87-b468-2001-5e3b" name="Mournival Units Legion Astartes (Fanmade)" revision="34" battleScribeVersion="2.03" authorName="Aus30K / Mournival Events" authorContact="" authorUrl="https://www.facebook.com/groups/190699548351507/" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="141" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="9f87-b468-2001-5e3b" name="Mournival Units Legion Astartes (Fanmade)" revision="35" battleScribeVersion="2.03" authorName="Aus30K / Mournival Events" authorContact="" authorUrl="https://www.facebook.com/groups/190699548351507/" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="141" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="0e6e-8c19-c436-39c4" name="Mournival Events 3.3 Digital Version"/>
     <publication id="cf75-540e-e446-ecd5" name="Mournival Events FAQ and Experimental Errata v3.5"/>
@@ -8230,7 +8230,6 @@ Hunter: Shot Gun, Chainblade, +1A and Acute Senses</description>
     <selectionEntry id="2b92-e606-8fb0-3117" name="Mars Pattern Land Speeder" page="0" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
         <categoryLink id="60d9-b50b-45d2-e365" name="Deep Strike" hidden="false" targetId="2d6f-e613-ab10-e55a" primary="false"/>
-        <categoryLink id="37f5-0da7-d60f-2349" name="Skimmer" hidden="false" targetId="9480-d3f6-fff1-7b35" primary="false"/>
         <categoryLink id="b753-59ef-4df7-9945" name="Vehicle" hidden="false" targetId="53bd-99e7-aba0-e79f" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -8266,6 +8265,7 @@ Hunter: Shot Gun, Chainblade, +1A and Acute Senses</description>
           </infoLinks>
           <categoryLinks>
             <categoryLink id="1ddf-ec67-26bb-8b6b" name="Vehicle" hidden="false" targetId="b2a4-14c8-52b5-41d9" primary="false"/>
+            <categoryLink id="5833-492a-6733-9d96" name="Skimmer" hidden="false" targetId="9480-d3f6-fff1-7b35" primary="false"/>
           </categoryLinks>
           <selectionEntries>
             <selectionEntry id="d7b2-de3b-e93d-094a" name="May take a Second Heavy Bolter" hidden="false" collective="false" import="true" type="upgrade">
@@ -8444,7 +8444,6 @@ Hunter: Shot Gun, Chainblade, +1A and Acute Senses</description>
       <categoryLinks>
         <categoryLink id="6841-b54f-c299-8be8" name="Transport" hidden="false" targetId="e4e0-c5d1-3430-f101" primary="false"/>
         <categoryLink id="b9e6-8014-c83d-f038" name="Vehicle" hidden="false" targetId="53bd-99e7-aba0-e79f" primary="false"/>
-        <categoryLink id="6403-e4c8-0ff8-c059" name="Skimmer" hidden="false" targetId="9480-d3f6-fff1-7b35" primary="false"/>
         <categoryLink id="f7ab-355f-0191-a74f" name="Deep Strike" hidden="false" targetId="2d6f-e613-ab10-e55a" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -8486,6 +8485,7 @@ Hunter: Shot Gun, Chainblade, +1A and Acute Senses</description>
           </infoLinks>
           <categoryLinks>
             <categoryLink id="b68c-5820-1a7b-86d5" name="Vehicle" hidden="false" targetId="b2a4-14c8-52b5-41d9" primary="false"/>
+            <categoryLink id="9883-5c4f-aa75-927f" name="Skimmer" hidden="false" targetId="9480-d3f6-fff1-7b35" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="585a-5e42-dad7-0e3d" name="Any model may exchange any Heavy Bolter (not including dual HB) for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="1002-463e-c6b2-9b66">
@@ -8575,7 +8575,6 @@ Hunter: Shot Gun, Chainblade, +1A and Acute Senses</description>
     <selectionEntry id="829f-26e6-6908-aa1f" name="Mars Pattern Javelin Attack Speeder Squadron" page="0" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
         <categoryLink id="8aac-26b8-06c4-4d7f" name="Deep Strike" hidden="false" targetId="2d6f-e613-ab10-e55a" primary="false"/>
-        <categoryLink id="e038-88f4-1532-6780" name="Skimmer" hidden="false" targetId="9480-d3f6-fff1-7b35" primary="false"/>
         <categoryLink id="f475-988b-c430-26b5" name="Vehicle" hidden="false" targetId="53bd-99e7-aba0-e79f" primary="false"/>
       </categoryLinks>
       <selectionEntries>
@@ -8611,6 +8610,7 @@ Hunter: Shot Gun, Chainblade, +1A and Acute Senses</description>
           </infoLinks>
           <categoryLinks>
             <categoryLink id="09b2-e285-b0f2-6ee2" name="Vehicle" hidden="false" targetId="b2a4-14c8-52b5-41d9" primary="false"/>
+            <categoryLink id="bdd4-66e4-8987-1769" name="Skimmer" hidden="false" targetId="9480-d3f6-fff1-7b35" primary="false"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="b8c0-29cf-506b-f311" name="Any model may exchange any Heavy Bolter (not including dual HB) for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="5ba0-1e4b-bc8b-7c4e">

--- a/The Horus Heresy.gst
+++ b/The Horus Heresy.gst
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<gameSystem id="ca571888-56a9-c58e-ddaf-54f4713538bc" name="Warhammer 30,000 - The Horus Heresy" revision="141" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
+<gameSystem id="ca571888-56a9-c58e-ddaf-54f4713538bc" name="Warhammer 30,000 - The Horus Heresy" revision="142" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
   <publications>
     <publication id="ca571888--pubN65537" name="Forgeworld Horus Heresy Series"/>
     <publication id="ca571888--pubN66489" name="HH:MT"/>
@@ -10901,7 +10901,7 @@ Command Benefits:
             <cost name="pts" typeId="points" value="15.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="4b1e-680b-1d39-e4f1" name="Chainsword/Combat Blade" hidden="false" collective="true" import="true" type="upgrade">
+        <selectionEntry id="4b1e-680b-1d39-e4f1" name="Chainsword/Combat Blade" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2adf-e0a8-708b-592c" type="max"/>
             <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="959a-1ceb-61ef-849d" type="min"/>


### PR DESCRIPTION
Angel's Wrath
Error: Jump Infantry Gains Hit&Run
FIXED by adding to category

Error: Storm Eagle and Fire Raptors gain Strafing Run
FIXED for Storm Eagle. The Fire Raptor must be a relic ROW thing as they come with it by default in current book.

Also Storm Eagles start without their Vengeance Launcher selected
FIXED all free options are now selected on both versions of the Storm Eagle

Only Units with Jump Infantry, Skimmer, and Jetbike type, as well as infantry that starts inside flyers or skimmers may be chosen as part of this list, with no more infantry then Flyer/Skimmers with transcap
NOT FIXABLE: Sadly that is one of the ones that you can remove some things from the lists, but it has to be manually checked for most as there are to many variables for adding units inside a a land raider which is brought in on a thunderhawk or whatever.

Error: No Tanks (Unless Skimmer/Flyer)
FIXED: Added the category of Non Flyer/Scimmer Vehicle to add of them (even though its tanks, it basically functions the same way, just didn't add it to the walkers and superheavy.

----
Pride of the Legion
Error: More Units with LA then without
FIXED: PotL Requirement Legiones Astartes added to Categories and force entries, linked to Units and Legiones Astartes

----
Armoured Breakthrough
Error: Tanks with 3HP or less gain Fast
FIXED: Added rule and append to profiles.

Error: All infantry units that can do so must be mounted in DT, and there must be greater than or equal to the number of Infantry units without DT options as Transport Vehicles (Tank or SHV)
NOT FIXABLE: Sadly not able to be done again due to limitations of BS.

Error: No more Skimmers then Flyers then it has Tank
FIXED: Added min requirement to tanks repeating based on skimmers and flyers. Also moved skimmer category to land speeder and javelin from unit.

----
Primarch's Chosen
Error: More Units with LA then without
FIXED: Same as PotL fix.

----
Orbital Assault
Error: Terminators gain Deep Strike
FIXED: Added to Terminators Category
    
Error: Must have Deep Strike tag, or have at least as many Vehicles with Deep Strike tag as it has Infantry that does not have Deep Strike tag
NOT FIXABLE: Due to BS limitations it makes it undoable as multiple units could for instance go in a Thunderhawk. So must be checked by players

----
Armoured Spearhead
Error: All units must take DT - no more units then vehicles with transcap
NOT FIXABLE: Due to BS limitations must be checked by player.

----
Brethren of Iron
Error: No more Automanta then units with LA
FIXED: Added new category

Error: No Paragon of Metal
FIXED: Changed link for Vorax

----
Outcast Sons
Error: More troops then Elites
FIXED: Same as some of the other ones above.

----
Sky hunter Phalanx
Error: Infantry must be mounted in flyers/Skimmers
NOT FIXABLE: Again issue of limitations of lots of variables.

Error: Otherwise, only jetbikes
NOT FIXABLE: Again issue of limitations of lots of variables.

----
Orphans of Betrayal
Error: More Troops then HS
FIXED: Same as some of the other ones above.

----
Drop Assault Vanguard
Error: Deep strikers or embarked on flyers only
NOT FIXABLE: Again issue of limitations of lots of variables.

----
Legion Recon Company
Error: must include additional compulsory legion recon squad
FIXED: Added a min requirement of 1 to the unit from Troops selection.

Error: Units limited to 15 marines at most.
FIXED: Added limitation on assault, breacher, immortals, phalanx, tacticals.

----
Sacrificial offering:
Error: Must Include Allied Militia detachment
NOT YET FIXABLE: This issue requires a huge rework.

Error: No units with Immobile or Slow and Purposeful rules
FIXED: Added to restricted list

No models that deploy via Deep Strike
NOT FIXABLE: Again issue of limitations of lots of variables.