### PR TITLE
More fixes for issues

### DIFF
--- a/(HH) Daemons of the Ruinstorm Army List.cat
+++ b/(HH) Daemons of the Ruinstorm Army List.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="8700-b3bb-a471-a0ad" name="Daemons of the Ruinstorm" revision="20" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="136" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="8700-b3bb-a471-a0ad" name="Daemons of the Ruinstorm" revision="21" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="142" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="8700-b3bb-pubN65537" name="HH8: Malevolence"/>
     <publication id="8700-b3bb-pubN75780" name="BRB"/>
@@ -43,14 +43,12 @@
     <categoryEntry id="12ca-5271-bc77-cd4f" name="Flying Monstrous Creature" publicationId="ca571888--pubN106502" hidden="false">
       <infoLinks>
         <infoLink id="03a7-38c5-cc0a-0269" name="Fear" hidden="false" targetId="52ff-4074-570b-4ea1" type="rule"/>
-        <infoLink id="b008-ad13-e989-0bf6" name="Fearless" hidden="false" targetId="dc70-e199-5525-e78c" type="rule"/>
         <infoLink id="f172-ab41-151c-1868" name="Hammer of Wrath" hidden="false" targetId="6f66-b417-6004-0916" type="rule"/>
         <infoLink id="ce27-c76f-dbda-99e0" name="Move Through Cover" hidden="false" targetId="6d06-5ea0-9a17-ca97" type="rule"/>
         <infoLink id="60ee-d9ba-a2ff-216f" name="Relentless" hidden="false" targetId="3c7d-a1fa-c68b-caad" type="rule"/>
         <infoLink id="8f4b-f55b-eab5-3dfa" name="Smash" hidden="false" targetId="4284-18a1-9844-a0bd" type="rule"/>
-        <infoLink id="7b2e-a074-31ad-7d1c" name="Strikedown" hidden="false" targetId="dd83-7fb9-6f58-0c96" type="rule"/>
         <infoLink id="12c7-360c-75f3-bf44" name="Vector Strike" hidden="false" targetId="5341-7110-d8d4-171a" type="rule"/>
-        <infoLink id="a37d-0c25-7aec-1b80" name="Feel No Pain" hidden="false" targetId="9bdd-5ec7-8dd6-63c0" type="rule"/>
+        <infoLink id="5bd2-19d9-acbb-0436" name="Jink" hidden="false" targetId="d3e5-b43d-a89c-3bd8" type="rule"/>
       </infoLinks>
     </categoryEntry>
     <categoryEntry id="3fd6-be25-ed1a-1799" name="Gargantuan Creature" publicationId="ca571888--pubN106502" page="" hidden="false">

--- a/(HH) Mechanicum - Taghmata Army List.cat
+++ b/(HH) Mechanicum - Taghmata Army List.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="cf03-f607-41dc-7545" name="Mechanicum: Taghmata Army List" revision="113" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="136" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="cf03-f607-41dc-7545" name="Mechanicum: Taghmata Army List" revision="113" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="142" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="cf03-f607-pubN65537" name="Horus Heresy: Taghmata Army List"/>
     <publication id="cf03-f607-pubN65563" name="AoDRB"/>
@@ -148,14 +148,11 @@ A wound cannot be re-allocated onto a gun model from a successful Look Out, Sir 
     <categoryEntry id="25d0-388c-dd16-af9a" name="Flying Monstrous Creature" hidden="false">
       <infoLinks>
         <infoLink id="f690-4338-67d6-1546" name="Fear" hidden="false" targetId="52ff-4074-570b-4ea1" type="rule"/>
-        <infoLink id="cda4-b713-7790-3e29" name="Fearless" hidden="false" targetId="dc70-e199-5525-e78c" type="rule"/>
-        <infoLink id="8df1-1326-9d28-aaec" name="Feel No Pain" hidden="false" targetId="9bdd-5ec7-8dd6-63c0" type="rule"/>
         <infoLink id="e118-0e47-9184-d155" name="Hammer of Wrath" hidden="false" targetId="6f66-b417-6004-0916" type="rule"/>
         <infoLink id="cbb9-3d52-7d1d-822f" name="Jink" hidden="false" targetId="d3e5-b43d-a89c-3bd8" type="rule"/>
         <infoLink id="5d43-b84b-5e65-934b" name="Move Through Cover" hidden="false" targetId="6d06-5ea0-9a17-ca97" type="rule"/>
         <infoLink id="6daf-a351-22f2-bf30" name="Relentless" hidden="false" targetId="3c7d-a1fa-c68b-caad" type="rule"/>
         <infoLink id="f174-7dcd-d9fb-da78" name="Smash" hidden="false" targetId="4284-18a1-9844-a0bd" type="rule"/>
-        <infoLink id="5799-4d21-f00f-5dea" name="Strikedown" hidden="false" targetId="dd83-7fb9-6f58-0c96" type="rule"/>
         <infoLink id="c3f8-9224-a6a2-1cc9" name="Vector Strike" hidden="false" targetId="5341-7110-d8d4-171a" type="rule"/>
       </infoLinks>
     </categoryEntry>


### PR DESCRIPTION
#1943 Bladeslaves had wrong points (seems like the plasma pistol was costing pts when it shouldn't
#1945 Mournival issue of Justarian no longer get those vigil shields
#1946 Flying Monstrous Creatures had been given rules they shouldn't have got. Looks like an issue of misallocation of rules.
#1947 Lancer and Castigator weren't showing up in legions LOW lists. They were available in the War Machine Detachment. But no reason not to be in both.

