### PR TITLE
Small fixes for 3 units

### DIFF
--- a/(HH) Mournival Units.cat
+++ b/(HH) Mournival Units.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="9f87-b468-2001-5e3b" name="Mournival Units Legion Astartes (Fanmade)" revision="36" battleScribeVersion="2.03" authorName="Aus30K / Mournival Events" authorContact="" authorUrl="https://www.facebook.com/groups/190699548351507/" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="143" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="9f87-b468-2001-5e3b" name="Mournival Units Legion Astartes (Fanmade)" revision="37" battleScribeVersion="2.03" authorName="Aus30K / Mournival Events" authorContact="" authorUrl="https://www.facebook.com/groups/190699548351507/" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="143" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="0e6e-8c19-c436-39c4" name="Mournival Events 3.3 Digital Version"/>
     <publication id="cf75-540e-e446-ecd5" name="Mournival Events FAQ and Experimental Errata v3.5"/>
@@ -2160,7 +2160,12 @@ If a Rogue Psyker who is the army’s Warlord becomes possessed, they are still 
               </constraints>
               <infoLinks>
                 <infoLink id="34d7-dad9-b6ed-57a7" name="Master-crafted" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule"/>
-                <infoLink id="2834-3750-41da-e4a4" name="Volkite Charger" hidden="false" targetId="c440-1f53-4d20-5cab" type="profile"/>
+                <infoLink id="2834-3750-41da-e4a4" name="Volkite Charger" hidden="false" targetId="c440-1f53-4d20-5cab" type="profile">
+                  <modifiers>
+                    <modifier type="set" field="name" value="Master-crafted Volkite Charger"/>
+                    <modifier type="append" field="5479706523232344415441232323" value=", Master-crafted"/>
+                  </modifiers>
+                </infoLink>
                 <infoLink id="44b6-b311-27f8-46f2" name="Deflagrate" hidden="false" targetId="b46a-a3ec-91a5-5001" type="rule"/>
               </infoLinks>
               <costs>
@@ -2173,7 +2178,12 @@ If a Rogue Psyker who is the army’s Warlord becomes possessed, they are still 
               </constraints>
               <infoLinks>
                 <infoLink id="0f00-5d13-06b2-a487" name="Master-crafted" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule"/>
-                <infoLink id="2eba-743c-57ff-b5c2" name="Volkite Caliver" hidden="false" targetId="626c-d79c-9bb7-3407" type="profile"/>
+                <infoLink id="2eba-743c-57ff-b5c2" name="Volkite Caliver" hidden="false" targetId="626c-d79c-9bb7-3407" type="profile">
+                  <modifiers>
+                    <modifier type="set" field="name" value="Master-crafted Volkite Caliver"/>
+                    <modifier type="append" field="5479706523232344415441232323" value=", Master-crafted"/>
+                  </modifiers>
+                </infoLink>
                 <infoLink id="da2a-30a9-3202-7538" name="Deflagrate" hidden="false" targetId="b46a-a3ec-91a5-5001" type="rule"/>
               </infoLinks>
               <costs>
@@ -2186,7 +2196,12 @@ If a Rogue Psyker who is the army’s Warlord becomes possessed, they are still 
               </constraints>
               <infoLinks>
                 <infoLink id="3d68-77cc-2502-9706" name="Master-crafted" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule"/>
-                <infoLink id="2ced-f2ce-eb1f-cd42" name="Meltagun" hidden="false" targetId="8ae4-74e5-7700-3804" type="profile"/>
+                <infoLink id="2ced-f2ce-eb1f-cd42" name="Meltagun" hidden="false" targetId="8ae4-74e5-7700-3804" type="profile">
+                  <modifiers>
+                    <modifier type="set" field="name" value="Master-crafted Meltagun"/>
+                    <modifier type="append" field="5479706523232344415441232323" value=", Master-crafted"/>
+                  </modifiers>
+                </infoLink>
                 <infoLink id="20f2-8de1-282f-d1c7" name="New InfoLink" hidden="false" targetId="21c0-62ff-3ed2-17a7" type="rule"/>
               </infoLinks>
               <costs>
@@ -2199,7 +2214,12 @@ If a Rogue Psyker who is the army’s Warlord becomes possessed, they are still 
               </constraints>
               <infoLinks>
                 <infoLink id="46f2-e061-8bc5-f606" name="Master-crafted" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule"/>
-                <infoLink id="5121-2d3b-6827-40f5" name="Plasma Gun" hidden="false" targetId="87c7-bd37-70f7-1933" type="profile"/>
+                <infoLink id="5121-2d3b-6827-40f5" name="Plasma Gun" hidden="false" targetId="87c7-bd37-70f7-1933" type="profile">
+                  <modifiers>
+                    <modifier type="set" field="name" value="Master-crafted Plasma Gun"/>
+                    <modifier type="append" field="5479706523232344415441232323" value=", Master-crafted"/>
+                  </modifiers>
+                </infoLink>
                 <infoLink id="0282-945f-27f9-704c" name="New InfoLink" hidden="false" targetId="f4fd-d519-4769-5510" type="rule"/>
               </infoLinks>
               <costs>
@@ -2212,7 +2232,12 @@ If a Rogue Psyker who is the army’s Warlord becomes possessed, they are still 
               </constraints>
               <infoLinks>
                 <infoLink id="ebea-7026-f3a0-0212" name="Master-crafted" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule"/>
-                <infoLink id="fcef-65a8-7951-223f" name="Heavy Flamer" hidden="false" targetId="c554-a05e-607c-5831" type="profile"/>
+                <infoLink id="fcef-65a8-7951-223f" name="Heavy Flamer" hidden="false" targetId="c554-a05e-607c-5831" type="profile">
+                  <modifiers>
+                    <modifier type="set" field="name" value="Master-crafted Heavy Flamer"/>
+                    <modifier type="append" field="5479706523232344415441232323" value=", Master-crafted"/>
+                  </modifiers>
+                </infoLink>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
@@ -2224,7 +2249,12 @@ If a Rogue Psyker who is the army’s Warlord becomes possessed, they are still 
               </constraints>
               <infoLinks>
                 <infoLink id="d35b-8e97-1c80-b081" name="Master-crafted" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule"/>
-                <infoLink id="d279-c5e8-66f2-33b5" name="Autocannon" hidden="false" targetId="d55f-eed0-800f-5789" type="profile"/>
+                <infoLink id="d279-c5e8-66f2-33b5" name="Autocannon" hidden="false" targetId="d55f-eed0-800f-5789" type="profile">
+                  <modifiers>
+                    <modifier type="set" field="name" value="Master-crafted Autocannon"/>
+                    <modifier type="append" field="5479706523232344415441232323" value=", Master-crafted"/>
+                  </modifiers>
+                </infoLink>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
@@ -2236,8 +2266,18 @@ If a Rogue Psyker who is the army’s Warlord becomes possessed, they are still 
               </constraints>
               <infoLinks>
                 <infoLink id="a604-aa64-f9b1-590d" name="Master-crafted" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule"/>
-                <infoLink id="eb4c-e535-207a-2ec8" name="Krak Missile" hidden="false" targetId="e2f7-5bdf-479c-8107" type="profile"/>
-                <infoLink id="d5f0-30c4-cb2b-7300" name="Frag Missile" hidden="false" targetId="40e6-c95c-7c8d-cf02" type="profile"/>
+                <infoLink id="eb4c-e535-207a-2ec8" name="Krak Missile" hidden="false" targetId="e2f7-5bdf-479c-8107" type="profile">
+                  <modifiers>
+                    <modifier type="set" field="name" value="Master-crafted Krak Missile"/>
+                    <modifier type="append" field="5479706523232344415441232323" value=", Master-crafted"/>
+                  </modifiers>
+                </infoLink>
+                <infoLink id="d5f0-30c4-cb2b-7300" name="Frag Missile" hidden="false" targetId="40e6-c95c-7c8d-cf02" type="profile">
+                  <modifiers>
+                    <modifier type="set" field="name" value="Master-crafted Frag Missile"/>
+                    <modifier type="append" field="5479706523232344415441232323" value=", Master-crafted"/>
+                  </modifiers>
+                </infoLink>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
@@ -2249,7 +2289,12 @@ If a Rogue Psyker who is the army’s Warlord becomes possessed, they are still 
               </constraints>
               <infoLinks>
                 <infoLink id="e92d-e000-3f41-60d4" name="Master-crafted" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule"/>
-                <infoLink id="2f73-246b-41be-dcca" name="Multi-Melta" hidden="false" targetId="4fc7-8b16-afe4-dad3" type="profile"/>
+                <infoLink id="2f73-246b-41be-dcca" name="Multi-Melta" hidden="false" targetId="4fc7-8b16-afe4-dad3" type="profile">
+                  <modifiers>
+                    <modifier type="set" field="name" value="Master-crafted Multi-Melta"/>
+                    <modifier type="append" field="5479706523232344415441232323" value=", Master-crafted"/>
+                  </modifiers>
+                </infoLink>
                 <infoLink id="9317-c811-482d-260f" name="New InfoLink" hidden="false" targetId="21c0-62ff-3ed2-17a7" type="rule"/>
               </infoLinks>
               <costs>
@@ -2262,7 +2307,12 @@ If a Rogue Psyker who is the army’s Warlord becomes possessed, they are still 
               </constraints>
               <infoLinks>
                 <infoLink id="38d9-50aa-7dbb-0c07" name="Master-crafted" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule"/>
-                <infoLink id="ba13-3489-7da6-5820" name="Plasma Cannon" hidden="false" targetId="13df-d6b0-3f33-bf9b" type="profile"/>
+                <infoLink id="ba13-3489-7da6-5820" name="Plasma Cannon" hidden="false" targetId="13df-d6b0-3f33-bf9b" type="profile">
+                  <modifiers>
+                    <modifier type="set" field="name" value="Master-crafted Plasma Cannon"/>
+                    <modifier type="append" field="5479706523232344415441232323" value=", Master-crafted"/>
+                  </modifiers>
+                </infoLink>
                 <infoLink id="f04d-217f-1a3f-4f05" name="New InfoLink" hidden="false" targetId="f4fd-d519-4769-5510" type="rule"/>
               </infoLinks>
               <costs>
@@ -2275,7 +2325,12 @@ If a Rogue Psyker who is the army’s Warlord becomes possessed, they are still 
               </constraints>
               <infoLinks>
                 <infoLink id="3605-5927-d086-c5d1" name="Master-crafted" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule"/>
-                <infoLink id="4b06-192d-69f5-7de6" name="Heavy Bolter" hidden="false" targetId="271e-6286-86cc-06dd" type="profile"/>
+                <infoLink id="4b06-192d-69f5-7de6" name="Heavy Bolter" hidden="false" targetId="271e-6286-86cc-06dd" type="profile">
+                  <modifiers>
+                    <modifier type="set" field="name" value="Master-crafted Heavy Bolter"/>
+                    <modifier type="append" field="5479706523232344415441232323" value=", Master-crafted"/>
+                  </modifiers>
+                </infoLink>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
@@ -2287,7 +2342,12 @@ If a Rogue Psyker who is the army’s Warlord becomes possessed, they are still 
               </constraints>
               <infoLinks>
                 <infoLink id="9af4-cb99-a272-dc2d" name="Master-crafted" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule"/>
-                <infoLink id="d3a4-79b8-9af1-30da" name="Volkite Culverin" hidden="false" targetId="34d1-b4db-3e75-ccce" type="profile"/>
+                <infoLink id="d3a4-79b8-9af1-30da" name="Volkite Culverin" hidden="false" targetId="34d1-b4db-3e75-ccce" type="profile">
+                  <modifiers>
+                    <modifier type="set" field="name" value="Master-crafted Volkite Culverin"/>
+                    <modifier type="append" field="5479706523232344415441232323" value=", Master-crafted"/>
+                  </modifiers>
+                </infoLink>
                 <infoLink id="91d6-fca7-1fd6-f027" name="Deflagrate" hidden="false" targetId="b46a-a3ec-91a5-5001" type="rule"/>
               </infoLinks>
               <costs>
@@ -2300,7 +2360,12 @@ If a Rogue Psyker who is the army’s Warlord becomes possessed, they are still 
               </constraints>
               <infoLinks>
                 <infoLink id="6cc2-8c1e-3338-e3bb" name="Master-crafted" hidden="false" targetId="f899-8f9d-fc7e-d855" type="rule"/>
-                <infoLink id="ed69-c3f8-28e9-b160" name="Lascannon" hidden="false" targetId="1cce-972c-022a-2590" type="profile"/>
+                <infoLink id="ed69-c3f8-28e9-b160" name="Lascannon" hidden="false" targetId="1cce-972c-022a-2590" type="profile">
+                  <modifiers>
+                    <modifier type="set" field="name" value="Master-crafted Lascannon"/>
+                    <modifier type="append" field="5479706523232344415441232323" value=", Master-crafted"/>
+                  </modifiers>
+                </infoLink>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
@@ -17129,7 +17194,7 @@ Owing to the massive expenditure of ammunition involved, once a squad has made a
                         <characteristic name="Range" typeId="52616e676523232344415441232323">45&quot;</characteristic>
                         <characteristic name="Strength" typeId="537472656e67746823232344415441232323">6</characteristic>
                         <characteristic name="AP" typeId="415023232344415441232323">5</characteristic>
-                        <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 4, Deflagrate</characteristic>
+                        <characteristic name="Type" typeId="5479706523232344415441232323">Heavy 4, Deflagrate, Master-crafted</characteristic>
                       </characteristics>
                     </profile>
                   </profiles>


### PR DESCRIPTION
Nullificators are not compulsory troops unless in pride of the legion.
Nullificators no longer get access to Mournival ammo without the rules being on.
Priests of Fenris now have access to Psyarkana which was previously missed.
Mournival Gunnery Centurion was missing Master-crafted from weapon names and stats.