### PR TITLE
RoW No More!

### DIFF
--- a/(HH) Mournival Units.cat
+++ b/(HH) Mournival Units.cat
@@ -521,10 +521,10 @@ Example 4: In a 2000 point army, a Daemon Lord is the Warlord (doesn’t count a
                 <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="974d-7438-c940-914b" repeats="1" roundUp="false"/>
               </repeats>
               <conditionGroups>
-                <conditionGroup type="or">
+                <conditionGroup type="and">
                   <conditions>
                     <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="83c2-692c-6560-3d68" type="equalTo"/>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ffe9-f112-4d9c-cd9b" type="equalTo"/>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe16-7a9f-5ada-2bd8" type="equalTo"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
@@ -543,10 +543,10 @@ Example 4: In a 2000 point army, a Daemon Lord is the Warlord (doesn’t count a
                 <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1b66-02c5-8ff6-bb14" repeats="1" roundUp="false"/>
               </repeats>
               <conditionGroups>
-                <conditionGroup type="or">
+                <conditionGroup type="and">
                   <conditions>
                     <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="83c2-692c-6560-3d68" type="equalTo"/>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ffe9-f112-4d9c-cd9b" type="equalTo"/>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe16-7a9f-5ada-2bd8" type="equalTo"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>

--- a/(HH) Varangian Heresy Legions.cat
+++ b/(HH) Varangian Heresy Legions.cat
@@ -227,10 +227,10 @@ LoW options are still visible, as despite the basic foc can&apos;t have them, Bo
                 <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1b66-02c5-8ff6-bb14" repeats="1" roundUp="false"/>
               </repeats>
               <conditionGroups>
-                <conditionGroup type="or">
+                <conditionGroup type="and">
                   <conditions>
                     <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="83c2-692c-6560-3d68" type="equalTo"/>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ffe9-f112-4d9c-cd9b" type="equalTo"/>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe16-7a9f-5ada-2bd8" type="equalTo"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
@@ -241,10 +241,10 @@ LoW options are still visible, as despite the basic foc can&apos;t have them, Bo
                 <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="974d-7438-c940-914b" repeats="1" roundUp="false"/>
               </repeats>
               <conditionGroups>
-                <conditionGroup type="or">
+                <conditionGroup type="and">
                   <conditions>
                     <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="83c2-692c-6560-3d68" type="equalTo"/>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ffe9-f112-4d9c-cd9b" type="equalTo"/>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe16-7a9f-5ada-2bd8" type="equalTo"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>


### PR DESCRIPTION
This should be the last of the RoW that are possible to fix without a major rework done.
XIX Legion - Raven Guard
Decapitation Strike
ERROR: all LA units gain Preferred Enemy (Independent Characters) FIXED 07/Sept/21 Part 2
ERROR: Max1 Consul FIXED 07/Sept/21 Part 2

XX Legion - Alpha Legion
Coils of the Hydra
ERROR: max1 Consul, except for Vigilator FIXED 07/Sept/21 Part 2

Shattered Legions
After Istvaan
ERROR: Legion Veteran Tactical Squads may be taken as non-compulsory Troops FIXED 07/Sept/21 Part 2

Hunter-Killer Mission
ERROR: Must contain units from at least two different Legions FIXED 07/Sept/21 Part 2
ERROR: Warlord must be from Emperor's Children FIXED 07/Sept/21 Part 2