### PR TITLE
More Loyalist Stuff Fafnir and Dominion & More

### DIFF
--- a/(HH) Talons of the Emperor Army List.cat
+++ b/(HH) Talons of the Emperor Army List.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="a30a-7522-3343-553a" name="Talons of the Emperor" revision="117" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="156" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="a30a-7522-3343-553a" name="Talons of the Emperor" revision="118" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" library="false" gameSystemId="ca571888-56a9-c58e-ddaf-54f4713538bc" gameSystemRevision="158" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <categoryEntries>
     <categoryEntry id="5297-7e0f-fa0b-3537" name="Allegiance" hidden="false"/>
     <categoryEntry id="1bcc0dc0-daee-dd60-6d6b-8510ffb8202f" name="Lords of War" hidden="false"/>
@@ -2002,22 +2002,24 @@
               </constraints>
             </entryLink>
             <entryLink id="5199-e559-8f26-0f02" name="Paragon Blade" hidden="false" collective="false" import="true" targetId="99f1-e166-4deb-ab11" type="selectionEntry">
-              <modifiers>
-                <modifier type="set" field="points" value="20"/>
-              </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1fa9-c8c3-34b2-323a" type="max"/>
               </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="20.0"/>
+              </costs>
             </entryLink>
             <entryLink id="7539-7e45-e4ac-5e94" name="Divining Blades" hidden="false" collective="false" import="true" targetId="7d90-3f3d-50e1-e295" type="selectionEntry">
               <modifiers>
-                <modifier type="set" field="points" value="50"/>
                 <modifier type="set" field="hidden" value="false">
                   <conditions>
                     <condition field="selections" scope="26dd-4eb2-fe70-ea73" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="56a8-62a7-0270-e718" type="equalTo"/>
                   </conditions>
                 </modifier>
               </modifiers>
+              <costs>
+                <cost name="pts" typeId="points" value="50.0"/>
+              </costs>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
@@ -3002,6 +3004,11 @@
               </modifiers>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="9bc6-d145-1091-af97" name="Divining Blades" hidden="false" collective="false" import="true" targetId="84c4-786f-c3c8-a450" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="points" value="55.0"/>
               </costs>
             </entryLink>
           </entryLinks>

--- a/The Horus Heresy.gst
+++ b/The Horus Heresy.gst
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<gameSystem id="ca571888-56a9-c58e-ddaf-54f4713538bc" name="Warhammer 30,000 - The Horus Heresy" revision="158" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
+<gameSystem id="ca571888-56a9-c58e-ddaf-54f4713538bc" name="Warhammer 30,000 - The Horus Heresy" revision="159" battleScribeVersion="2.03" authorName="https://github.com/BSData/horus-heresy/graphs/contributors" authorContact="Gitter: @BSData/horus-heresy" authorUrl="http://battlescribedata.appspot.com/#/repo/horus-heresy" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
   <publications>
     <publication id="ca571888--pubN65537" name="Forgeworld Horus Heresy Series"/>
     <publication id="ca571888--pubN106502" name="HH: Core Rule Book"/>
@@ -13907,6 +13907,9 @@ common enemy. These Factions cannot be part of the same army.</description>
     </rule>
     <rule id="797e55b1-251e-6606-9cb3-64661b0b18a3" name="Lumbering Advance" publicationId="ca571888--pubN85920" page="220" hidden="false">
       <description>May not Run or make sweeping advances</description>
+    </rule>
+    <rule id="56fd-77b4-e966-d11e" name="Gunslinger" hidden="false">
+      <description>All models with two pistols can fire both in the Shooting phase. This follows the normal rules for shooting.</description>
     </rule>
   </sharedRules>
   <sharedProfiles>


### PR DESCRIPTION
Fafnir and Dominion added
Closes #2036 Dark Heralds are back in Black-shields
Closes #2037 Hetaron Guard can take a Divining Blade (who knew)
Closes #2039 Burning Lore isn't as freely available as it was previously showing (should have only been Praetors, Chaplains, Diabolists and Centurion)