### PR TITLE
Chainswords on Tacts, Inferno Pistols on Assault and Despoilers

### DIFF
--- a/2022 - Legiones Astartes.cat
+++ b/2022 - Legiones Astartes.cat
@@ -14482,7 +14482,7 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="7.0"/>
               </costs>
             </entryLink>
-            <entryLink id="26f6-4c37-e6b9-43e7" name="Chainsword" hidden="true" collective="false" import="true" targetId="06e7-a6ae-ed1c-eb03" type="selectionEntry">
+            <entryLink id="26f6-4c37-e6b9-43e7" name="Chainsword" hidden="false" collective="false" import="true" targetId="06e7-a6ae-ed1c-eb03" type="selectionEntry">
               <modifiers>
                 <modifier type="increment" field="d2ee-04cb-5f8a-2642" value="5.0">
                   <repeats>
@@ -20524,7 +20524,7 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
             </entryLink>
             <entryLink id="5b82-d70a-2804-c462" name="Inferno Pistol" hidden="false" collective="false" import="true" targetId="dcd1-8b2a-9d97-40ef" type="selectionEntry">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
               </costs>
             </entryLink>
             <entryLink id="cd0e-dbe3-46a8-082c" name="Warpfire Pistol" hidden="false" collective="false" import="true" targetId="a94d-1f53-2902-0237" type="selectionEntry">
@@ -20834,7 +20834,7 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
             </entryLink>
             <entryLink id="9550-1090-6af4-87c0" name="Inferno Pistol" hidden="false" collective="false" import="true" targetId="dcd1-8b2a-9d97-40ef" type="selectionEntry">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
               </costs>
             </entryLink>
             <entryLink id="461b-837a-76f1-f097" name="Power Weapon" hidden="false" collective="false" import="true" targetId="8d9c-9f80-c0fd-adcf" type="selectionEntry">
@@ -21097,7 +21097,7 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
             </entryLink>
             <entryLink id="7021-c1ed-5f68-1525" name="Inferno Pistol" hidden="false" collective="false" import="true" targetId="dcd1-8b2a-9d97-40ef" type="selectionEntry">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
               </costs>
             </entryLink>
             <entryLink id="afd6-e234-b6e4-5891" name="Warpfire Pistol" hidden="false" collective="false" import="true" targetId="a94d-1f53-2902-0237" type="selectionEntry">
@@ -21378,7 +21378,7 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
             </entryLink>
             <entryLink id="cbc4-ee52-d7bd-2d9b" name="Inferno Pistol" hidden="false" collective="false" import="true" targetId="dcd1-8b2a-9d97-40ef" type="selectionEntry">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
               </costs>
             </entryLink>
             <entryLink id="b148-7410-c3ba-d298" name="Power Weapon" hidden="false" collective="false" import="true" targetId="8d9c-9f80-c0fd-adcf" type="selectionEntry">


### PR DESCRIPTION
## Fixed Units
Chainswords on Tactacal Squads where hidden
Inferno Pistols on Assault and Despoilers including sergeants were the wrong cost of 5 when they should have been 10.
