### PR TITLE
WLTs and Shrapnel

### DIFF
--- a/2022 - Horus Heresy.gst
+++ b/2022 - Horus Heresy.gst
@@ -5304,7 +5304,7 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4c78-410a-98bc-ddd6" type="max"/>
       </constraints>
       <selectionEntryGroups>
-        <selectionEntryGroup id="75c8-9b24-b75b-b137" name="IV: Iron Warriors" hidden="true" collective="false" import="true">
+        <selectionEntryGroup id="75c8-9b24-b75b-b137" name="  IV: Iron Warriors" hidden="true" collective="false" import="true">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
@@ -5370,7 +5370,7 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="c064-819f-d9ef-1775" name="Generic Warlord Traits" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="c064-819f-d9ef-1775" name="    Generic Warlord Traits" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ad6a-4187-c90c-95a7" type="max"/>
             <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="65e6-9ba3-5bbf-efa0" type="max"/>
@@ -5426,7 +5426,7 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="fcc6-0dda-a0bd-8072" name="III: Emperor&apos;s Children (Placeholder)" hidden="true" collective="false" import="true">
+        <selectionEntryGroup id="fcc6-0dda-a0bd-8072" name="  III: Emperor&apos;s Children (Placeholder)" hidden="true" collective="false" import="true">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
@@ -5489,7 +5489,7 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="fa4e-9b26-7244-179d" name="V: White Scars (Placeholder)" hidden="true" collective="false" import="true">
+        <selectionEntryGroup id="fa4e-9b26-7244-179d" name="  V: White Scars (Placeholder)" hidden="true" collective="false" import="true">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
@@ -5552,7 +5552,7 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="0899-8b4b-2591-afac" name="X: Iron Hands (Placeholder)" hidden="true" collective="false" import="true">
+        <selectionEntryGroup id="0899-8b4b-2591-afac" name=" X: Iron Hands (Placeholder)" hidden="true" collective="false" import="true">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
@@ -5615,7 +5615,7 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="af62-dc9d-87c1-daf7" name="VII: Imperial Fists (Placeholder)" hidden="true" collective="false" import="true">
+        <selectionEntryGroup id="af62-dc9d-87c1-daf7" name="  VII: Imperial Fists (Placeholder)" hidden="true" collective="false" import="true">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
@@ -5678,7 +5678,7 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="9eb0-5436-0bce-5df2" name="VI: Space Wolves (Placeholder)" hidden="true" collective="false" import="true">
+        <selectionEntryGroup id="9eb0-5436-0bce-5df2" name="  VI: Space Wolves (Placeholder)" hidden="true" collective="false" import="true">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
@@ -5741,7 +5741,7 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="6cba-65a7-52c5-05e2" name="I: Dark Angels (Placeholder)" hidden="true" collective="false" import="true">
+        <selectionEntryGroup id="6cba-65a7-52c5-05e2" name="  I: Dark Angels (Placeholder)" hidden="true" collective="false" import="true">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
@@ -5804,7 +5804,7 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="655a-c3c6-380c-7d64" name="XII: World Eaters (Placeholder)" hidden="true" collective="false" import="true">
+        <selectionEntryGroup id="655a-c3c6-380c-7d64" name=" XII: World Eaters (Placeholder)" hidden="true" collective="false" import="true">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
@@ -5867,7 +5867,7 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="a8bf-22c3-6760-3f96" name="XIV: Death Guard (Placeholder)" hidden="true" collective="false" import="true">
+        <selectionEntryGroup id="a8bf-22c3-6760-3f96" name=" XIV: Death Guard (Placeholder)" hidden="true" collective="false" import="true">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
@@ -5930,7 +5930,7 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="e8b6-feff-5339-dda2" name="XIII: Ultramarines (Placeholder)" hidden="true" collective="false" import="true">
+        <selectionEntryGroup id="e8b6-feff-5339-dda2" name=" XIII: Ultramarines (Placeholder)" hidden="true" collective="false" import="true">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
@@ -5993,7 +5993,7 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="61ac-f6a6-6ae2-89c4" name="IX: Blood Angels (Placeholder)" hidden="true" collective="false" import="true">
+        <selectionEntryGroup id="61ac-f6a6-6ae2-89c4" name=" IX: Blood Angels (Placeholder)" hidden="true" collective="false" import="true">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
@@ -6056,7 +6056,7 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="4e7b-2af8-0383-644f" name="VIII: Night Lords (Placeholder)" hidden="true" collective="false" import="true">
+        <selectionEntryGroup id="4e7b-2af8-0383-644f" name="  VIII: Night Lords (Placeholder)" hidden="true" collective="false" import="true">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
@@ -6182,7 +6182,7 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="3377-34f2-e8f4-e84c" name="XVIII: Salamanders (Placeholder)" hidden="true" collective="false" import="true">
+        <selectionEntryGroup id="3377-34f2-e8f4-e84c" name=" XVIII: Salamanders (Placeholder)" hidden="true" collective="false" import="true">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
@@ -6245,7 +6245,7 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="050a-0b05-638b-d6ad" name="XIV: Word Bearers (Placeholder)" hidden="true" collective="false" import="true">
+        <selectionEntryGroup id="050a-0b05-638b-d6ad" name=" XVII: Word Bearers (Placeholder)" hidden="true" collective="false" import="true">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
@@ -6308,7 +6308,7 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="8fba-5b15-b959-4a17" name="XVI: Sons of Horus (Placeholder)" hidden="true" collective="false" import="true">
+        <selectionEntryGroup id="8fba-5b15-b959-4a17" name=" XVI: Sons of Horus (Placeholder)" hidden="true" collective="false" import="true">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>
@@ -6371,7 +6371,7 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="0402-be48-5bfc-9b31" name="XV: Thousand Sons (Placeholder)" hidden="true" collective="false" import="true">
+        <selectionEntryGroup id="0402-be48-5bfc-9b31" name=" XV: Thousand Sons (Placeholder)" hidden="true" collective="false" import="true">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <conditions>

--- a/2022 - Horus Heresy.gst
+++ b/2022 - Horus Heresy.gst
@@ -4953,9 +4953,9 @@ Thaumaturge’s Cleansing (Psychic Weapon)</description>
     </selectionEntry>
     <selectionEntry id="0176-56a3-d590-b103" name="Warlord" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5617-ada9-bf10-f9b0" type="max"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4024-fa03-dada-cc4b" type="max"/>
-        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0dff-37d2-448b-45a6" type="min"/>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="5617-ada9-bf10-f9b0" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4024-fa03-dada-cc4b" type="max"/>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="0dff-37d2-448b-45a6" type="min"/>
       </constraints>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
@@ -5300,14 +5300,27 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
     </selectionEntryGroup>
     <selectionEntryGroup id="dd08-dc56-c555-7e09" name="Warlord Traits" hidden="false" collective="false" import="true">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2214-d326-1005-c9c6" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2214-d326-1005-c9c6" type="max"/>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4c78-410a-98bc-ddd6" type="max"/>
       </constraints>
       <selectionEntryGroups>
-        <selectionEntryGroup id="75c8-9b24-b75b-b137" name="   IV: Iron Warriors" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="75c8-9b24-b75b-b137" name="IV: Iron Warriors" hidden="true" collective="false" import="true">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5f54-457a-fbb9-6730" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f2d4-4d01-dadd-1770" type="max"/>
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c966-c487-a925-6913" type="max"/>
+          </constraints>
           <selectionEntries>
             <selectionEntry id="16e5-b616-ae1c-7131" name="Tyrant of the Dodekathon" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2f5d-baf8-4f9b-c727" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2f5d-baf8-4f9b-c727" type="max"/>
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b14b-42f7-275a-7c2c" type="max"/>
               </constraints>
               <profiles>
                 <profile id="62d3-6c60-660f-c815" name="Tyrant of the Dodekathon" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
@@ -5322,7 +5335,8 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
             </selectionEntry>
             <selectionEntry id="e369-6ce6-212b-7420" name="Tyrant of the Lyssatra" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2d73-c45f-e61f-357f" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2d73-c45f-e61f-357f" type="max"/>
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2aa9-1ac3-0e05-4b2d" type="max"/>
               </constraints>
               <profiles>
                 <profile id="6139-ddbf-b9ec-f5da" name="Tyrant of the Lyssatra" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
@@ -5337,7 +5351,8 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
             </selectionEntry>
             <selectionEntry id="d4ac-f703-5add-8be4" name="Tyrant of the Apolokron" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="12df-eee8-fd51-f207" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="12df-eee8-fd51-f207" type="max"/>
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f078-194e-c439-e0a1" type="max"/>
               </constraints>
               <profiles>
                 <profile id="d5a6-b772-ce1b-a0b7" name="Tyrant of the Apolokron" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
@@ -5349,6 +5364,1133 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
               <infoLinks>
                 <infoLink id="2c31-8501-90cc-1180" name="Fearless" hidden="false" targetId="b48c-d7e1-2a83-2f5b" type="rule"/>
               </infoLinks>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="c064-819f-d9ef-1775" name="Generic Warlord Traits" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ad6a-4187-c90c-95a7" type="max"/>
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="65e6-9ba3-5bbf-efa0" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="dcbb-3e5a-e54e-239c" name="Stoic Defender" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7573-3e0a-40df-3581" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b308-b123-4e8a-e63b" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="2fa5-25dc-1496-8033" name="Stoic Defender" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                  <characteristics>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">When this Warlord or any friendly unit joined by a Warlord with this Trait makes a Shooting attack, the target unit must make a Pinning test if it suffers any unsaved Wounds. In addition, an army whose Warlord has this Trait may make an additional Reaction during their opponent’s Shooting phase as long as the Warlord has not been removed as a casualty.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="d636-9d61-631b-1650" name="Ever-vigilant" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9dc0-14c9-8e55-f2e4" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="511b-49f7-23e7-6ff4" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="fae0-5913-3ee9-a799" name="Ever-vigilant" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                  <characteristics>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">When this Warlord, and any unit it has joined, Runs during the Movement phase, it adds the value of the Warlord’s Initiative Characteristic, increased by 1, to the distance moved, rather than the lowest Initiative Characteristic in the unit. In addition, an army whose Warlord has this Trait may make an additional Reaction during their  opponent’s Movement phase as long as the Warlord has not been removed as a casualty.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="2b87-826d-22a1-682c" name="Bloody-handed" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1436-7b3c-d4c9-ef66" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="213d-5a79-675a-dc7f" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="f05c-2db3-6a88-bd4b" name="Bloody-handed" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                  <characteristics>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">Any combat with at least one friendly model within 12&quot; of this Warlord, or a combat which includes this Warlord, gains a bonus of +1 to the number of Wounds caused for the purposes of combat resolution. In addition, an army whose Warlord has this Trait may make an additional Reaction during their opponent’s Assault phase as long as the Warlord has not been removed as a casualty.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="fcc6-0dda-a0bd-8072" name="III: Emperor&apos;s Children (Placeholder)" hidden="true" collective="false" import="true">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3edc-a1b9-6dc6-b1ea" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="74bb-486e-c2a2-f6e1" type="max"/>
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="98e4-0f15-7203-d6e0" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="57ba-e2df-127d-dfd5" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6a71-3953-9cad-5d3e" type="max"/>
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bd99-108a-d9fb-1d41" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="5585-4c6e-1443-acf0" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                  <characteristics>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="ba2c-ab4d-9f97-e339" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="aa3c-c16e-8cf6-9d93" type="max"/>
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a4d5-c5e2-c084-b6f5" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="967d-7f09-6cd4-e04e" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                  <characteristics>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="0859-6b27-4a66-e937" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="934a-d656-ee1b-e39d" type="max"/>
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a19d-bab7-9822-86c5" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="6499-b0bb-25f5-5cbd" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                  <characteristics>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="fa4e-9b26-7244-179d" name="V: White Scars (Placeholder)" hidden="true" collective="false" import="true">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="581c-1302-230c-4216" type="max"/>
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3ee8-edaf-12ad-5ec2" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="fd20-efc4-b421-b8ef" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d766-2fb3-1383-5bd9" type="max"/>
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e21f-621d-e09b-96f3" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="ac80-1ea9-97e7-085d" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                  <characteristics>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="c503-afd4-ba91-0f41" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bd00-65e8-78b3-04bf" type="max"/>
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8f66-b93b-6188-2b83" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="7c21-0828-9bec-f4e0" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                  <characteristics>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="8a24-4c1b-ac43-5208" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ec2b-84e8-cc8a-195c" type="max"/>
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a403-bca4-9575-a70b" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="93ce-b682-fd06-6541" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                  <characteristics>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="0899-8b4b-2591-afac" name="X: Iron Hands (Placeholder)" hidden="true" collective="false" import="true">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bfc9-c99c-bf8a-3917" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f40f-7bf0-d8a5-effa" type="max"/>
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ffe2-18a4-e12e-01b4" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="53d2-df81-688e-0b8c" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f227-aaac-78c8-7739" type="max"/>
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8d3f-91f9-5b0a-7767" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="772c-511d-93c3-51a8" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                  <characteristics>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="0899-3ff6-2c7d-2070" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8ac2-88b3-15f9-f3de" type="max"/>
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3747-7d79-0b08-9f02" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="5c2c-d77b-2c48-5f3b" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                  <characteristics>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="b128-c1f2-ced0-2c0a" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b10a-fe95-c1da-6bf5" type="max"/>
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8d66-354a-ca64-1686" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="7f9f-c80f-bd1f-c90b" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                  <characteristics>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="af62-dc9d-87c1-daf7" name="VII: Imperial Fists (Placeholder)" hidden="true" collective="false" import="true">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a0e1-f2c4-8bcd-0723" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="37b7-e9ab-88ba-2c8e" type="max"/>
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8784-0bbd-bfdc-dea2" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="2c7c-efca-f9d3-c135" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="36ea-deb2-fbd2-78a6" type="max"/>
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b4fb-a5c3-9a8c-ca75" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="1c56-e4c0-57fe-6348" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                  <characteristics>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="e431-fb60-bc92-ac7a" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8fcb-14a9-d2b1-e7f2" type="max"/>
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2cd6-f952-7d06-01cd" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="f9bb-983d-694f-18ce" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                  <characteristics>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="e04f-f0cb-1033-2c7d" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="81c5-fb73-07ed-32ff" type="max"/>
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3b61-b48f-40d1-dd1f" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="4847-d189-f8d3-d4cb" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                  <characteristics>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="9eb0-5436-0bce-5df2" name="VI: Space Wolves (Placeholder)" hidden="true" collective="false" import="true">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4916-965e-8339-44f6" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7d5c-f0ed-1279-0b59" type="max"/>
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a40a-8469-a6cf-0cf7" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="af06-fd03-5bd5-5bb8" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fd0f-9949-0cf2-53de" type="max"/>
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5791-12e7-4011-d35c" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="6ac5-ba67-6277-9900" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                  <characteristics>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="0c77-14d6-b415-dc56" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a910-c1db-1d63-18d7" type="max"/>
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ad54-3ddb-e165-09d7" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="dc32-0a70-e63e-53a6" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                  <characteristics>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="99ae-5ddd-0342-51dc" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e9c2-4b03-9177-bf44" type="max"/>
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="43a3-5c41-241f-3100" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="29b9-7f6b-6720-b93b" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                  <characteristics>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="6cba-65a7-52c5-05e2" name="I: Dark Angels (Placeholder)" hidden="true" collective="false" import="true">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0792-c999-2bff-49a9" type="max"/>
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f96c-7788-b7be-899b" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="7e91-27d0-042e-23a2" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8f32-d2a8-ace8-ab17" type="max"/>
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d7b0-d70c-54c5-73ef" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="2010-3bb7-9a40-3b78" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                  <characteristics>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="b2c8-3b11-3f3e-7b7a" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1dfe-d786-e44a-c9b5" type="max"/>
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2fef-2fa5-2ea4-a6b6" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="4fa8-deac-a9a4-c426" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                  <characteristics>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="0133-b8f5-33a6-cfd4" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2752-5a8d-66ac-76ba" type="max"/>
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="480f-232e-9a2c-9da6" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="0bf8-9c06-d740-c4f1" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                  <characteristics>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="655a-c3c6-380c-7d64" name="XII: World Eaters (Placeholder)" hidden="true" collective="false" import="true">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="90ee-77dd-1b7f-ddfe" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3bdb-2249-980d-8eeb" type="max"/>
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4d83-b8f9-71e3-89c9" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="cf1a-36a8-19e8-8922" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8657-3675-d851-ce3b" type="max"/>
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e81e-9842-7322-ee95" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="aeaa-284d-8d0d-b8e6" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                  <characteristics>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="4ed5-30f0-7bea-dd86" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="53a3-3792-5487-3b08" type="max"/>
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8b17-f2d9-6c15-5f11" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="e277-863a-5618-0ade" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                  <characteristics>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="11b3-ac83-e1e4-1233" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b8de-ca32-11fd-b6d8" type="max"/>
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3ef9-d750-d2a8-3311" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="b191-c9c8-018d-be16" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                  <characteristics>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="a8bf-22c3-6760-3f96" name="XIV: Death Guard (Placeholder)" hidden="true" collective="false" import="true">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dd1f-1c51-706c-e5f7" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0d89-9db7-ab68-ae58" type="max"/>
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c934-c4ef-309e-caaf" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="45e8-8798-b2a0-5bd5" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2305-66ef-6e57-27c5" type="max"/>
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="25b0-9d79-8d10-a3a5" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="c6a5-da53-617f-783d" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                  <characteristics>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="85bb-05da-1a50-cdba" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8fb9-a2d7-be76-4d12" type="max"/>
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2890-0157-4a20-8f93" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="88fb-c5d9-60b3-7edf" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                  <characteristics>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="7f14-89b3-5e18-e522" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a417-3f4a-5141-16e4" type="max"/>
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9228-e026-1803-7185" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="5a51-f239-0ae5-23e2" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                  <characteristics>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="e8b6-feff-5339-dda2" name="XIII: Ultramarines (Placeholder)" hidden="true" collective="false" import="true">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e0f-3552-8842-f281" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d9fa-e912-a80a-1dd3" type="max"/>
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="04c5-8510-1cd2-b6bc" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="1c01-4039-4fcb-0bdd" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fd84-5b7b-5b93-a37e" type="max"/>
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9c25-23a3-c8b8-f809" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="cf7d-08c6-7dde-6236" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                  <characteristics>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="759e-de8a-912f-5c93" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3751-5e53-7119-e720" type="max"/>
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5539-1a68-3e62-1ee8" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="4ea5-efa5-5b49-1e08" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                  <characteristics>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="0935-10ca-2c5f-5c9a" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ae34-8d11-2cd4-469e" type="max"/>
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="766f-a1b6-bac4-c6ef" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="8b2e-cdb8-25b1-9f43" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                  <characteristics>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="61ac-f6a6-6ae2-89c4" name="IX: Blood Angels (Placeholder)" hidden="true" collective="false" import="true">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="296e-301e-3ce1-1c15" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2142-8ef5-d676-1636" type="max"/>
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="caf4-9860-3581-c2eb" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="be09-319c-faf7-0555" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9069-a422-5789-5f4e" type="max"/>
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="edc0-47aa-c98b-90df" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="ad05-1af3-a63c-cb64" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                  <characteristics>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="9c6a-574f-f70f-1df7" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="af21-1c08-34d0-44d5" type="max"/>
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="79d2-5269-bd38-79cb" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="f1bc-3993-b686-c353" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                  <characteristics>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="9211-63df-a5ec-b698" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="badd-fd72-9198-5f08" type="max"/>
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d78b-be73-bb8d-77fd" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="a08c-217e-089d-d31b" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                  <characteristics>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="4e7b-2af8-0383-644f" name="VIII: Night Lords (Placeholder)" hidden="true" collective="false" import="true">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b28b-71f7-e4f4-8f9c" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7d37-f586-392f-3b28" type="max"/>
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a588-2dfc-d56f-b4da" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="cb7d-eb31-f002-72c4" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4a0c-bf60-b6d2-6b50" type="max"/>
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="78c6-4648-7baf-8e43" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="71ea-b86f-e00f-86c1" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                  <characteristics>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="1d0c-7e32-b8e2-bc7d" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="282e-4f54-7511-aee8" type="max"/>
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0dc3-f399-8bb4-8136" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="24d3-3121-c902-30a7" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                  <characteristics>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="f0cd-3b80-db54-a061" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1b62-0dbe-b9e3-d2f9" type="max"/>
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4bdb-6754-ee5d-4276" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="374f-b35c-4dde-ffb6" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                  <characteristics>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="0bb7-5fa2-b765-d27d" name="XIX: Raven Guard (Placeholder)" hidden="true" collective="false" import="true">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dc34-fe08-dd44-fb99" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b042-2961-41ac-f7f9" type="max"/>
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2640-9d96-3aad-d699" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="bbb2-94d9-2474-4ff1" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="492e-4d60-b702-8c21" type="max"/>
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a47f-12de-f2e9-ba7c" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="fedf-2a24-a535-60a6" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                  <characteristics>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="7c70-1f95-e09b-40d9" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d1b6-321b-f2b0-796a" type="max"/>
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="aecb-929c-23b1-5f3b" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="bdda-a7f8-151b-5b25" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                  <characteristics>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="b660-b411-2493-231f" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b061-b4cd-b616-6c1e" type="max"/>
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5cbd-6f98-6834-54a4" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="ea28-63ef-bf6d-7af8" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                  <characteristics>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="3377-34f2-e8f4-e84c" name="XVIII: Salamanders (Placeholder)" hidden="true" collective="false" import="true">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c805-ca3a-ff93-5e2f" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="dbf0-a0a7-8160-acbe" type="max"/>
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6ba3-a81b-5760-72e6" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="7875-539f-85ce-34f6" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="cafc-dd05-e93a-1d7a" type="max"/>
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="08a7-bc5e-6472-02e7" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="414f-7d50-f292-a38d" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                  <characteristics>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="452c-a94f-9574-1f47" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8c26-e0ab-81df-3a08" type="max"/>
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d7d6-3f0f-d0f6-cdf3" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="69cf-d2ba-9d58-d998" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                  <characteristics>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="6ebb-9611-037a-a786" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1835-7ba2-8d09-4b59" type="max"/>
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3a13-93cd-4031-c6d6" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="3f26-a29c-d250-8318" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                  <characteristics>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="050a-0b05-638b-d6ad" name="XIV: Word Bearers (Placeholder)" hidden="true" collective="false" import="true">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9dbf-0760-d7ae-f125" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f101-4c3b-0ad2-468f" type="max"/>
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="192c-5cd9-49b9-4453" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="1feb-8835-0210-dd4f" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c323-8abb-95d7-1bba" type="max"/>
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c0f4-1ce9-a21d-8953" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="9ece-e772-07fa-1a5d" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                  <characteristics>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="d9e3-a0e9-492d-d45b" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c813-5bbe-4965-5620" type="max"/>
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e180-7d40-4700-529b" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="acd6-8152-e78b-6dcd" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                  <characteristics>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="2d93-454d-ea4f-5759" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="83fb-ad39-efb5-98f8" type="max"/>
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a504-cb4f-93cb-3c76" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="5c65-60cb-3e61-1559" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                  <characteristics>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="8fba-5b15-b959-4a17" name="XVI: Sons of Horus (Placeholder)" hidden="true" collective="false" import="true">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="01b4-57c7-bf61-2abf" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4e56-7ed1-1eb9-5ffa" type="max"/>
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="292d-8e60-a191-ffd8" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="989c-1089-47c6-60c4" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8dce-40e9-e4aa-7d43" type="max"/>
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5a74-5c91-9e1d-2f36" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="b6bd-4421-6d5b-0b73" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                  <characteristics>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="2a11-8ffa-623b-5f66" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7a60-9519-c96b-5623" type="max"/>
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ff28-4006-9ce4-d693" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="f3d7-0128-16db-b68c" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                  <characteristics>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="c7f9-9954-ac14-fee2" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="467a-583b-bff9-0ece" type="max"/>
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="86ac-2779-cc62-d210" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="6db0-85e5-85c2-18d5" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                  <characteristics>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="0402-be48-5bfc-9b31" name="XV: Thousand Sons (Placeholder)" hidden="true" collective="false" import="true">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="acf2-2ca6-0d5d-b7e7" type="max"/>
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fbb2-3451-5d7c-7fcd" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="3ebb-a8ef-429f-d050" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="25e4-4c50-7247-d8e9" type="max"/>
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="14af-b3dc-66d7-64e2" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="a8b4-6196-1d45-24d5" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                  <characteristics>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="d64d-37bc-905a-3e30" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4ba7-29a8-a010-e2c9" type="max"/>
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="cee3-4aca-b486-2bc6" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="3e72-239a-2dee-f9aa" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                  <characteristics>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="26aa-aeb8-133f-03c0" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6399-1be6-8139-6388" type="max"/>
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9633-a5f5-0018-e17b" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="d6a1-81c3-1908-b79d" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                  <characteristics>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="be90-69c4-929e-c852" name="XX: Alpha Legion (Placeholder)" hidden="true" collective="false" import="true">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c0df-c1fa-5ddc-9ee5" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d4fa-2939-8634-d4ef" type="max"/>
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="73e2-0e8e-bc95-bb94" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="47d2-7b7d-3818-5fdd" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9334-2e15-a1fe-912c" type="max"/>
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ec62-054b-2aa2-fd2a" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="6fdb-415d-d441-40a2" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                  <characteristics>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="7f8e-c94e-b089-3558" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7fac-2e7a-3ee4-347a" type="max"/>
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="60cb-bac7-55cf-b36b" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="b0c6-309d-2989-3008" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                  <characteristics>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="d7a5-4b0c-7fe1-2258" name="PLACEHOLDER" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bed6-eb06-b033-b04a" type="max"/>
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8664-0283-01f2-44c8" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="f0fa-29b9-780a-4a58" name="PLACEHOLDER" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+                  <characteristics>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca"/>
+                  </characteristics>
+                </profile>
+              </profiles>
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
               </costs>

--- a/2022 - Legiones Astartes.cat
+++ b/2022 - Legiones Astartes.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="6393-649c-7213-a327" name="(HH V2) Legions Astartes" revision="21" battleScribeVersion="2.03" authorName="Various" authorUrl="https://github.com/BSData/horus-heresy" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="7" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="6393-649c-7213-a327" name="(HH V2) Legions Astartes" revision="22" battleScribeVersion="2.03" authorName="Various" authorUrl="https://github.com/BSData/horus-heresy" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="7" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <categoryEntries>
     <categoryEntry id="11f2-472f-c1d1-9ae9" name="Legiones Astartes" hidden="false">
       <infoLinks>
@@ -9482,7 +9482,6 @@ When a model has two Raven’s Talons, that model gains +2 Attacks instead of th
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink id="9ce9-7a6e-7daa-2b81" name="Shred" hidden="false" targetId="5e7e-1628-8174-6f2c" type="rule"/>
         <infoLink id="edc9-b3a8-f32f-a281" name="Pinning" hidden="false" targetId="1c96-205c-59a0-3cf2" type="rule"/>
       </infoLinks>
       <costs>
@@ -9509,7 +9508,6 @@ When a model has two Raven’s Talons, that model gains +2 Attacks instead of th
       </profiles>
       <infoLinks>
         <infoLink id="3b45-9342-cb1b-5000" name="Pinning" hidden="false" targetId="1c96-205c-59a0-3cf2" type="rule"/>
-        <infoLink id="b383-23e3-bb4a-a768" name="Shred" hidden="false" targetId="5e7e-1628-8174-6f2c" type="rule"/>
       </infoLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
@@ -28851,6 +28849,9 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
                       </costs>
                     </entryLink>
                   </entryLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                  </costs>
                 </selectionEntry>
                 <selectionEntry id="6b87-884f-2fc1-02f0" name="Autocannons" hidden="false" collective="false" import="true" type="upgrade">
                   <entryLinks>
@@ -36674,6 +36675,9 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
                 </infoLink>
                 <infoLink id="9f10-0ad3-e8be-2c38" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
               </infoLinks>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="9cb7-f45a-8422-0f1b" name="Gunner" hidden="false" collective="true" import="true" type="model">
               <constraints>
@@ -36697,6 +36701,9 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
                   </characteristics>
                 </profile>
               </profiles>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
             </selectionEntry>
           </selectionEntries>
           <costs>
@@ -36886,6 +36893,9 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="954d-cf8e-eefd-27a6" name="Nullificator Squad" hidden="false" collective="false" import="true" type="unit">
       <constraints>
@@ -37385,6 +37395,9 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
           </constraints>
         </entryLink>
       </entryLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="bd58-7b96-a940-bd7f" name="Crysos Morturg" hidden="true" collective="false" import="true" type="unit">
       <modifiers>
@@ -37444,6 +37457,9 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
           <entryLinks>
             <entryLink id="c249-9165-df6e-fd08" name="Minor Combi-Weapon - Alchem Flamer" hidden="false" collective="false" import="true" targetId="b941-687c-c95e-31a6" type="selectionEntry"/>
           </entryLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="4bf6-846d-c017-425a" name="The Revenant&apos;s Aegis" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
@@ -37457,6 +37473,9 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
               </characteristics>
             </profile>
           </profiles>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="ec7b-4e8a-5c2b-828b" name="Two Disintegrator pistols" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
@@ -37471,6 +37490,9 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
               </constraints>
             </entryLink>
           </entryLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="8a7a-52e1-787e-bd9f" name="Death&apos;s Tally" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
@@ -37499,6 +37521,9 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
               </modifiers>
             </infoLink>
           </infoLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
@@ -37904,6 +37929,9 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
             <infoLink id="e3dd-9cb1-e8cd-3331" name="Specialist Weapon" hidden="false" targetId="1a1f-3c9b-b097-5886" type="rule"/>
             <infoLink id="7843-8908-8b98-82d2" name="Sunder" hidden="false" targetId="20e2-75cf-bc16-cd8f" type="rule"/>
           </infoLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
@@ -38351,6 +38379,9 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
           </characteristics>
         </profile>
       </profiles>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="da1a-85ed-813f-829a" name="Proteus assault cannon" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
@@ -38370,6 +38401,9 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
           </modifiers>
         </infoLink>
       </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="82b5-dbc8-0060-97a4" name="Proteus pattern storm shield" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
@@ -38379,6 +38413,9 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
           </characteristics>
         </profile>
       </profiles>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="c2b4-503b-5732-a8a2" name="Gravis Missile Launcher" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
@@ -38403,6 +38440,9 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
         <infoLink id="1cdd-ef6d-d419-cda7" name="Blast" hidden="false" targetId="1d9a-73ef-5f4f-8bd8" type="rule"/>
         <infoLink id="8beb-4fad-195b-1104" name="Pinning" hidden="false" targetId="1c96-205c-59a0-3cf2" type="rule"/>
       </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>

--- a/2022 - Legiones Astartes.cat
+++ b/2022 - Legiones Astartes.cat
@@ -14956,21 +14956,19 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
               </costs>
             </entryLink>
             <entryLink id="afed-7566-0c89-e748" name="Shrapnel Bolter" hidden="false" collective="false" import="true" targetId="1941-21b5-932c-74d6" type="selectionEntry">
-              <modifiers>
-                <modifier type="increment" field="4559-5233-c1d6-8a7c" value="1.0">
-                  <conditions>
-                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1941-21b5-932c-74d6" type="atLeast"/>
-                  </conditions>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4559-5233-c1d6-8a7c" type="min"/>
-              </constraints>
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
               </costs>
             </entryLink>
-            <entryLink id="a84f-1379-9c2a-b7e8" name="Bolter" hidden="false" collective="false" import="true" targetId="1ade-0c02-5612-252b" type="selectionEntry"/>
+            <entryLink id="a84f-1379-9c2a-b7e8" name="Bolter" hidden="false" collective="false" import="true" targetId="1ade-0c02-5612-252b" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="aa72-63e4-bc60-4611" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1941-21b5-932c-74d6" type="atLeast"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="0b7b-85d3-e994-5f28" name="Give all Legionaries additional Melee Weapons:" hidden="false" collective="false" import="true">
@@ -15117,22 +15115,12 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7d72-7f6d-6330-6871" type="equalTo"/>
+                    <condition field="selections" scope="aa72-63e4-bc60-4611" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7d72-7f6d-6330-6871" type="atLeast"/>
                   </conditions>
                 </modifier>
               </modifiers>
             </entryLink>
             <entryLink id="dbb0-a521-dcec-e244" name="Shrapnel Pistol" hidden="false" collective="false" import="true" targetId="7d72-7f6d-6330-6871" type="selectionEntry">
-              <modifiers>
-                <modifier type="set" field="hidden" value="true">
-                  <conditions>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7d72-7f6d-6330-6871" type="equalTo"/>
-                  </conditions>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bf8e-7891-eff8-0691" type="min"/>
-              </constraints>
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
               </costs>
@@ -15266,16 +15254,6 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
               </costs>
             </entryLink>
             <entryLink id="bb75-9f24-460e-f1eb" name="Shrapnel Pistol" hidden="false" collective="false" import="true" targetId="7d72-7f6d-6330-6871" type="selectionEntry">
-              <modifiers>
-                <modifier type="set" field="hidden" value="true">
-                  <conditions>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7d72-7f6d-6330-6871" type="equalTo"/>
-                  </conditions>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e925-c83e-2711-131e" type="min"/>
-              </constraints>
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
               </costs>
@@ -15284,7 +15262,7 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7d72-7f6d-6330-6871" type="equalTo"/>
+                    <condition field="selections" scope="aa72-63e4-bc60-4611" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7d72-7f6d-6330-6871" type="atLeast"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -15326,19 +15304,6 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
           </constraints>
           <entryLinks>
             <entryLink id="bf33-40bc-2a78-0c6b" name="Shrapnel Bolter" hidden="false" collective="false" import="true" targetId="1941-21b5-932c-74d6" type="selectionEntry">
-              <modifiers>
-                <modifier type="increment" field="baf3-8596-8ec0-19be" value="1.0">
-                  <repeats>
-                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
-                  </repeats>
-                  <conditions>
-                    <condition field="selections" scope="aa72-63e4-bc60-4611" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1941-21b5-932c-74d6" type="atLeast"/>
-                  </conditions>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="baf3-8596-8ec0-19be" type="min"/>
-              </constraints>
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
               </costs>
@@ -15348,7 +15313,15 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="1.0"/>
               </costs>
             </entryLink>
-            <entryLink id="cff8-b759-d545-c095" name="Bolter" hidden="false" collective="false" import="true" targetId="1ade-0c02-5612-252b" type="selectionEntry"/>
+            <entryLink id="cff8-b759-d545-c095" name="Bolter" hidden="false" collective="false" import="true" targetId="1ade-0c02-5612-252b" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="aa72-63e4-bc60-4611" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1941-21b5-932c-74d6" type="atLeast"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="89bf-b32d-f938-1896" name="Legiones Unit Upgrades:" hidden="false" collective="false" import="true">
@@ -15368,11 +15341,6 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
               </costs>
-            </entryLink>
-            <entryLink id="325c-7716-907c-bc13" name="Shrapnel Weaponry Options" hidden="false" collective="false" import="true" targetId="b26e-c64c-f86f-8351" type="selectionEntryGroup">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aaf1-7491-99ab-24de" type="max"/>
-              </constraints>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
@@ -16043,7 +16011,7 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="160b-c560-0115-432c" name="The Legion Tactical Support Sergeant may take (Melee Weapon):" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="160b-c560-0115-432c" name="Sergeant may take (Melee Weapon):" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3aca-ea36-7c02-a920" type="max"/>
           </constraints>
@@ -16113,7 +16081,7 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="5f20-d6b3-1c6e-85b7" name="The Legion Tactical Support Sergeant may take (Wargear):" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="5f20-d6b3-1c6e-85b7" name="Sergeant may take (Wargear):" hidden="false" collective="false" import="true">
           <selectionEntries>
             <selectionEntry id="a261-aaef-9ef9-cfa8" name="Master-craft a one weapon" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
@@ -16215,7 +16183,7 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
             <entryLink id="b209-a1e4-dc99-c1e3" name="Rhino Transport" hidden="false" collective="false" import="true" targetId="03f1-8ed9-9867-8d18" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="0209-3f35-6117-1af8" name="The Legion Tactical Support Sergeant may exchange his Bolt Pistol for:" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="0209-3f35-6117-1af8" name="Sergeant may exchange his Bolt Pistol for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="c1c4-98af-0f0b-3b3f">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1763-868d-c601-0a65" type="max"/>
           </constraints>
@@ -16270,6 +16238,30 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
               </costs>
             </entryLink>
+            <entryLink id="c1c4-98af-0f0b-3b3f" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7d72-7f6d-6330-6871" type="atLeast"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </entryLink>
+            <entryLink id="377d-717d-f840-4045" name="Shrapnel Pistol" hidden="false" collective="false" import="true" targetId="7d72-7f6d-6330-6871" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="2ba1-f39b-7c89-61a0" value="1.0">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7d72-7f6d-6330-6871" type="atLeast"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2ba1-f39b-7c89-61a0" type="min"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
+              </costs>
+            </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="6367-5d0e-8133-6a48" name="Legiones Unit Upgrades:" hidden="false" collective="false" import="true">
@@ -16292,14 +16284,45 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
+        <selectionEntryGroup id="fde5-1430-eeed-972d" name="Bolt Pistol Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="990f-1d8d-968e-1945">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af3b-4e7f-6591-b5ff" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9b57-ad1a-b27f-a7af" type="min"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="185d-6596-75aa-8100" name="Shrapnel Pistol" hidden="false" collective="false" import="true" targetId="7d72-7f6d-6330-6871" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="e397-4164-c58f-20d1" value="1.0">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7d72-7f6d-6330-6871" type="atLeast"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="d2ee-04cb-5f8a-2642" value="2.0">
+                  <repeats>
+                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e397-4164-c58f-20d1" type="min"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="-2.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="990f-1d8d-968e-1945" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7d72-7f6d-6330-6871" type="atLeast"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="3492-b5e4-5a29-a219" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eeda-5deb-2c22-04f2" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="39ab-a224-e2ff-a9ee" type="min"/>
-          </constraints>
-        </entryLink>
         <entryLink id="7e04-dbe8-fdb8-ee3f" name="Power Armour" hidden="false" collective="false" import="true" targetId="2d9d-480e-7c14-1a6f" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="21f5-d832-9dd6-e4a8" type="max"/>
@@ -16547,7 +16570,15 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
               </costs>
             </entryLink>
-            <entryLink id="00d6-a94a-1a51-20e2" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry"/>
+            <entryLink id="00d6-a94a-1a51-20e2" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="70eb-e4da-8b3f-f065" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7d72-7f6d-6330-6871" type="atLeast"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </entryLink>
             <entryLink id="69eb-aa7c-e084-2c7f" name="Hand Flamer" hidden="false" collective="false" import="true" targetId="e337-adf4-a11f-0280" type="selectionEntry">
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
@@ -16588,9 +16619,14 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
               </costs>
             </entryLink>
+            <entryLink id="c11d-8c38-93ba-6e18" name="Shrapnel Pistol" hidden="false" collective="false" import="true" targetId="7d72-7f6d-6330-6871" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
+              </costs>
+            </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="0b4e-c0ab-e8af-d518" name="All Outriders must choose one melee weapon from:" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="0b4e-c0ab-e8af-d518" name="All Outriders must choose one melee weapon from:" hidden="false" collective="false" import="true" defaultSelectionEntryId="465c-deee-249d-3394">
           <modifiers>
             <modifier type="increment" field="5e4e-d576-18ac-2c07" value="1.0">
               <repeats>
@@ -16602,10 +16638,11 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
                 <repeat field="selections" scope="70eb-e4da-8b3f-f065" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="97b6-65f8-df73-9551" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
+            <modifier type="decrement" field="cfd4-f753-e4dd-f6a1" value="2.0"/>
           </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5e4e-d576-18ac-2c07" type="max"/>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cfd4-f753-e4dd-f6a1" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cfd4-f753-e4dd-f6a1" type="min"/>
           </constraints>
           <entryLinks>
             <entryLink id="465c-deee-249d-3394" name="Chainsword" hidden="false" collective="false" import="true" targetId="06e7-a6ae-ed1c-eb03" type="selectionEntry"/>
@@ -16670,7 +16707,7 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="503c-a6d6-3b60-f4c7" name="All Outriders must choose one Pistol from:" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="503c-a6d6-3b60-f4c7" name="All Outriders must choose one Pistol from:" hidden="false" collective="false" import="true" defaultSelectionEntryId="02ee-7490-b9c4-32e0">
           <modifiers>
             <modifier type="increment" field="f463-3323-9485-b7ec" value="1.0">
               <repeats>
@@ -16682,13 +16719,22 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
                 <repeat field="selections" scope="70eb-e4da-8b3f-f065" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="97b6-65f8-df73-9551" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
+            <modifier type="decrement" field="cdfa-f35c-6762-3c0a" value="2.0"/>
           </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f463-3323-9485-b7ec" type="max"/>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cdfa-f35c-6762-3c0a" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cdfa-f35c-6762-3c0a" type="min"/>
           </constraints>
           <entryLinks>
-            <entryLink id="02ee-7490-b9c4-32e0" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry"/>
+            <entryLink id="02ee-7490-b9c4-32e0" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="70eb-e4da-8b3f-f065" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7d72-7f6d-6330-6871" type="atLeast"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </entryLink>
             <entryLink id="a898-6779-e1f2-8cc0" name="Hand Flamer" hidden="false" collective="false" import="true" targetId="e337-adf4-a11f-0280" type="selectionEntry">
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
@@ -16702,6 +16748,11 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
             <entryLink id="25f9-232e-920b-c59f" name="Dragon&apos;s Breath Pistol" hidden="false" collective="false" import="true" targetId="c1cb-0fa7-0d39-73ae" type="selectionEntry">
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="c330-0b02-6542-d136" name="Shrapnel Pistol" hidden="false" collective="false" import="true" targetId="7d72-7f6d-6330-6871" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
               </costs>
             </entryLink>
           </entryLinks>
@@ -18047,7 +18098,7 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="f6a5-151f-1d1c-62b6" name="Every Destroyer must choose one from:" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="f6a5-151f-1d1c-62b6" name="1) Every Destroyer must choose one from:" hidden="false" collective="false" import="true" defaultSelectionEntryId="2363-7a9d-30e4-8242">
           <modifiers>
             <modifier type="increment" field="44ad-2c17-c6e3-1198" value="1.0">
               <repeats>
@@ -18070,7 +18121,7 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7d72-7f6d-6330-6871" type="atLeast"/>
+                    <condition field="selections" scope="d30b-59bb-8ae0-36d1" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f37c-dd77-547b-29d0" type="atLeast"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -18134,15 +18185,14 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="829a-0315-ee4e-bf86" name="Two Shrapnel Pistols" hidden="false" collective="false" import="true" type="upgrade">
-              <entryLinks>
-                <entryLink id="0514-f470-b8fc-8996" name="Shrapnel Pistol" hidden="false" collective="false" import="true" targetId="7d72-7f6d-6330-6871" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4916-db1e-26c1-bcd9" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bff2-44dc-257f-6278" type="max"/>
-                  </constraints>
-                </entryLink>
-              </entryLinks>
+            <selectionEntry id="f37c-dd77-547b-29d0" name="Two Shrapnel Pistols" hidden="false" collective="false" import="true" type="upgrade">
+              <infoLinks>
+                <infoLink id="0775-31b4-fcdd-1daa" name="Shrapnel Pistol" hidden="false" targetId="237f-c069-a680-dfae" type="profile"/>
+                <infoLink id="e295-b9d0-990c-7982" name="Pinning" hidden="false" targetId="1c96-205c-59a0-3cf2" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="4.0"/>
+              </costs>
             </selectionEntry>
           </selectionEntries>
           <selectionEntryGroups>
@@ -18182,7 +18232,7 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
             </selectionEntryGroup>
           </selectionEntryGroups>
         </selectionEntryGroup>
-        <selectionEntryGroup id="77b2-0225-a601-9e6c" name="One Destroyer may take:" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="77b2-0225-a601-9e6c" name="3) One Destroyer may take:" hidden="false" collective="false" import="true">
           <entryLinks>
             <entryLink id="d51e-2905-1ec8-6c6e" name="Legion Vexilla" hidden="false" collective="false" import="true" targetId="21b1-2a90-9826-1782" type="selectionEntry">
               <constraints>
@@ -18210,7 +18260,7 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="4681-ef70-4a6c-889b" name="The Entire unit may take:" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="4681-ef70-4a6c-889b" name="4) The Entire unit may take:" hidden="false" collective="false" import="true">
           <entryLinks>
             <entryLink id="2d88-dacd-275c-7ffc" name="Meltabombs" hidden="false" collective="false" import="true" targetId="b9dd-3b21-f3f8-78e3" type="selectionEntry">
               <constraints>
@@ -18222,11 +18272,18 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="578c-7d59-601c-d25d" name="The Legion Destroyer Sergeant may take:" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="578c-7d59-601c-d25d" name="Sergeant may take:" hidden="false" collective="false" import="true">
           <selectionEntries>
-            <selectionEntry id="53b9-48c7-29ae-98ee" name="Master-craft a one weapon" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="53b9-48c7-29ae-98ee" name="Master-craft one weapon" hidden="true" collective="false" import="true" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c805-ca3a-ff93-5e2f" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1571-2a8b-b596-413a" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1571-2a8b-b596-413a" type="max"/>
               </constraints>
               <infoLinks>
                 <infoLink id="6784-c868-e017-fc50" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule"/>
@@ -18309,7 +18366,7 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
             <entryLink id="4f59-be80-a752-bfbb" name="Surgical Augement" hidden="false" collective="false" import="true" targetId="aeb3-6a73-da1d-2b90" type="selectionEntryGroup"/>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="1980-10c4-7bdf-bfe0" name="Destroyer Melee Weapons" hidden="false" collective="false" import="true" defaultSelectionEntryId="5c5b-dd53-e356-3c48">
+        <selectionEntryGroup id="1980-10c4-7bdf-bfe0" name="2) Destroyer Melee Weapons" hidden="false" collective="false" import="true" defaultSelectionEntryId="5c5b-dd53-e356-3c48">
           <modifiers>
             <modifier type="increment" field="5f0f-43c8-100f-ba92" value="1.0">
               <repeats>
@@ -18321,7 +18378,7 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
                 <repeat field="selections" scope="d30b-59bb-8ae0-36d1" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="532b-51a5-42d1-c133" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
-            <modifier type="set" field="9d1d-962a-75fb-77b2" value="0.0"/>
+            <modifier type="decrement" field="9d1d-962a-75fb-77b2" value="4.0"/>
           </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5f0f-43c8-100f-ba92" type="max"/>
@@ -18379,7 +18436,7 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
             <entryLink id="9118-e0b1-98b0-e40c" name="Fenrisian Axe" hidden="false" collective="false" import="true" targetId="72ba-d2df-d98b-8b5d" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="031e-adc8-ad3d-99c1" name="The Legion Destroyer Sergeant may exchange his Chainsword for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="8632-e799-a6a6-abbe">
+        <selectionEntryGroup id="031e-adc8-ad3d-99c1" name="Sergeant may exchange his Chainsword for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="8632-e799-a6a6-abbe">
           <entryLinks>
             <entryLink id="d4cf-c5f4-98e1-acc6" name="Power Fist" hidden="false" collective="false" import="true" targetId="a3e1-d633-dff9-028b" type="selectionEntry">
               <costs>
@@ -18972,7 +19029,15 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bdb3-31cc-6477-d06b" type="max"/>
               </constraints>
               <entryLinks>
-                <entryLink id="c67e-2f9b-d60f-3c99" name="Gravis Bolt Cannon" hidden="false" collective="false" import="true" targetId="3b5f-52ab-6534-94a3" type="selectionEntry"/>
+                <entryLink id="c67e-2f9b-d60f-3c99" name="Gravis Bolt Cannon" hidden="false" collective="false" import="true" targetId="3b5f-52ab-6534-94a3" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditions>
+                        <condition field="selections" scope="d664-5692-cd41-f9be" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ce7e-4548-10b5-8762" type="atLeast"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </entryLink>
                 <entryLink id="9923-ba47-3bc8-df9c" name="Gravis Melta Cannon" hidden="false" collective="false" import="true" targetId="ef6c-f656-171a-03e1" type="selectionEntry">
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
@@ -19039,7 +19104,15 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3c86-1ac1-20bf-b382" type="max"/>
               </constraints>
               <entryLinks>
-                <entryLink id="6950-5e3e-7dec-4d4b" name="Gravis Bolt Cannon" hidden="false" collective="false" import="true" targetId="3b5f-52ab-6534-94a3" type="selectionEntry"/>
+                <entryLink id="6950-5e3e-7dec-4d4b" name="Gravis Bolt Cannon" hidden="false" collective="false" import="true" targetId="3b5f-52ab-6534-94a3" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditions>
+                        <condition field="selections" scope="d664-5692-cd41-f9be" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ce7e-4548-10b5-8762" type="atLeast"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </entryLink>
                 <entryLink id="6359-61c1-8442-04b2" name="Gravis Melta Cannon" hidden="false" collective="false" import="true" targetId="ef6c-f656-171a-03e1" type="selectionEntry">
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
@@ -19077,12 +19150,12 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
                 </entryLink>
                 <entryLink id="3466-6815-279e-39bb" name="Gravis Power Fist" hidden="false" collective="false" import="true" targetId="08be-6994-6a63-6279" type="selectionEntry">
                   <modifiers>
-                    <modifier type="append" field="name" value=" with in-built combi-bolter"/>
+                    <modifier type="append" field="name" value=" with in-built ranged weapon"/>
                   </modifiers>
                 </entryLink>
                 <entryLink id="cabb-1e8d-feff-c9b9" name="Gravis Chainfist" hidden="false" collective="false" import="true" targetId="5ffe-2820-9b97-99db" type="selectionEntry">
                   <modifiers>
-                    <modifier type="append" field="name" value=" with in-built combi-bolter"/>
+                    <modifier type="append" field="name" value=" with in-built ranged weapon"/>
                   </modifiers>
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
@@ -19094,27 +19167,30 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
                   </costs>
                 </entryLink>
                 <entryLink id="8a5d-8302-b2dc-6d6a" name="Graviton Maul" hidden="false" collective="false" import="true" targetId="b254-abfc-a57f-ab28" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="append" field="name" value=" with in-built ranged weapon"/>
+                  </modifiers>
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
                   </costs>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
-            <selectionEntryGroup id="b666-9cce-4495-4eb2" name="May replace an in-built combi-bolter on either a Gravis power fist or Gravis chainfistwith one of the following:" hidden="false" collective="false" import="true" defaultSelectionEntryId="ba53-9b53-809b-705f">
+            <selectionEntryGroup id="b666-9cce-4495-4eb2" name="May replace an in-built combi-bolter with one of the following:" hidden="false" collective="false" import="true" defaultSelectionEntryId="ba53-9b53-809b-705f">
               <modifiers>
                 <modifier type="decrement" field="983a-9186-b28e-1e9f" value="1.0"/>
                 <modifier type="increment" field="983a-9186-b28e-1e9f" value="1.0">
                   <repeats>
                     <repeat field="selections" scope="20f9-af27-2d44-0021" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5ffe-2820-9b97-99db" repeats="1" roundUp="false"/>
                     <repeat field="selections" scope="20f9-af27-2d44-0021" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="08be-6994-6a63-6279" repeats="1" roundUp="false"/>
-                    <repeat field="selections" scope="20f9-af27-2d44-0021" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ce7e-4548-10b5-8762" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="20f9-af27-2d44-0021" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b254-abfc-a57f-ab28" repeats="1" roundUp="false"/>
                   </repeats>
                 </modifier>
                 <modifier type="increment" field="0633-35b7-f95b-9cac" value="1.0">
                   <repeats>
                     <repeat field="selections" scope="20f9-af27-2d44-0021" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5ffe-2820-9b97-99db" repeats="1" roundUp="false"/>
                     <repeat field="selections" scope="20f9-af27-2d44-0021" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="08be-6994-6a63-6279" repeats="1" roundUp="false"/>
-                    <repeat field="selections" scope="20f9-af27-2d44-0021" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ce7e-4548-10b5-8762" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="20f9-af27-2d44-0021" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b254-abfc-a57f-ab28" repeats="1" roundUp="false"/>
                   </repeats>
                 </modifier>
               </modifiers>
@@ -19622,7 +19698,7 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0"/>
                   </costs>
                 </entryLink>
-                <entryLink id="aa97-ec31-3423-a275" name="Thunder Hammer" hidden="false" collective="false" import="true" targetId="838c-4002-713d-d7c6" type="selectionEntry">
+                <entryLink id="aa97-ec31-3423-a275" name="Thunder Hammer" hidden="false" collective="false" import="true" targetId="e6cc-bfce-a4d9-301c" type="selectionEntry">
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0"/>
                   </costs>
@@ -19655,11 +19731,7 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
                   </costs>
                 </entryLink>
-                <entryLink id="22f1-1f9f-0146-3495" name="Shrapnel Pistol" hidden="false" collective="false" import="true" targetId="7d72-7f6d-6330-6871" type="selectionEntry">
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
-                  </costs>
-                </entryLink>
+                <entryLink id="22f1-1f9f-0146-3495" name="Shrapnel Pistol" hidden="false" collective="false" import="true" targetId="7d72-7f6d-6330-6871" type="selectionEntry"/>
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="fb94-51ab-dd77-b7a1" name="May take one of the following:" hidden="false" collective="false" import="true">
@@ -19749,7 +19821,7 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0"/>
                   </costs>
                 </entryLink>
-                <entryLink id="8a47-1c13-fe1e-d5c4" name="Thunder Hammer" hidden="false" collective="false" import="true" targetId="838c-4002-713d-d7c6" type="selectionEntry">
+                <entryLink id="8a47-1c13-fe1e-d5c4" name="Thunder Hammer" hidden="false" collective="false" import="true" targetId="e6cc-bfce-a4d9-301c" type="selectionEntry">
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0"/>
                   </costs>
@@ -19909,6 +19981,7 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
                   </costs>
                 </entryLink>
+                <entryLink id="b130-67c9-087f-7947" name="Shrapnel Bolter" hidden="false" collective="false" import="true" targetId="1941-21b5-932c-74d6" type="selectionEntry"/>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
@@ -20393,16 +20466,6 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
                   </costs>
                 </entryLink>
-                <entryLink id="419a-9eda-4140-a515" name="Charnabal Glaive" hidden="false" collective="false" import="true" targetId="c07c-35e6-4616-ef25" type="selectionEntry">
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
-                  </costs>
-                </entryLink>
-                <entryLink id="b42f-5e74-c2d8-dad4" name="Power Sword" hidden="false" collective="false" import="true" targetId="a3cd-aa97-a148-2309" type="selectionEntry">
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
-                  </costs>
-                </entryLink>
                 <entryLink id="6bed-cdae-f95b-a6d5" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="hidden" value="true">
@@ -20434,22 +20497,6 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
                     </modifier>
                   </modifiers>
                 </entryLink>
-                <entryLink id="06a3-8f73-222b-5633" name="Thunder Hammer" hidden="false" collective="false" import="true" targetId="838c-4002-713d-d7c6" type="selectionEntry">
-                  <modifiers>
-                    <modifier type="set" field="hidden" value="true">
-                      <conditionGroups>
-                        <conditionGroup type="or">
-                          <conditions>
-                            <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35ac-992e-97a7-1612" type="equalTo"/>
-                          </conditions>
-                        </conditionGroup>
-                      </conditionGroups>
-                    </modifier>
-                  </modifiers>
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0"/>
-                  </costs>
-                </entryLink>
                 <entryLink id="d2be-c567-3071-b775" name="Lightning Claw" hidden="false" collective="false" import="true" targetId="6923-4e42-5691-b13f" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="hidden" value="true">
@@ -20472,26 +20519,6 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
                   </costs>
                 </entryLink>
                 <entryLink id="b65c-f5fa-599c-cba1" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry"/>
-                <entryLink id="86cd-04c0-ea85-7ca0" name="Charnabal Sabre" hidden="false" collective="false" import="true" targetId="30c2-57eb-5bbe-be0b" type="selectionEntry">
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
-                  </costs>
-                </entryLink>
-                <entryLink id="6101-4eea-a61f-567a" name="Charnabal Tabar" hidden="false" collective="false" import="true" targetId="4611-c33e-f360-7246" type="selectionEntry">
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
-                  </costs>
-                </entryLink>
-                <entryLink id="8491-7a64-dcf6-6c43" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry">
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
-                  </costs>
-                </entryLink>
-                <entryLink id="bdce-df3b-14c2-9b01" name="Power Maul" hidden="false" collective="false" import="true" targetId="0df4-c67e-cf64-82e0" type="selectionEntry">
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
-                  </costs>
-                </entryLink>
                 <entryLink id="c248-3bbf-b234-977f" name="Raven&apos;s Talons" hidden="false" collective="false" import="true" targetId="09d8-64f5-1936-e8ab" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="hidden" value="true">
@@ -20506,74 +20533,6 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
                   </modifiers>
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
-                  </costs>
-                </entryLink>
-                <entryLink id="67e3-0016-35b5-168b" name="Force Axe" hidden="true" collective="false" import="true" targetId="40bb-c99e-b4b3-12c1" type="selectionEntry">
-                  <modifiers>
-                    <modifier type="set" field="hidden" value="false">
-                      <conditionGroups>
-                        <conditionGroup type="or">
-                          <conditions>
-                            <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8846-2f93-a2be-18dc" type="equalTo"/>
-                            <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d332-0e64-7ecf-6c35" type="equalTo"/>
-                          </conditions>
-                        </conditionGroup>
-                      </conditionGroups>
-                    </modifier>
-                  </modifiers>
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
-                  </costs>
-                </entryLink>
-                <entryLink id="81e2-2946-d675-055c" name="Force Maul" hidden="true" collective="false" import="true" targetId="da60-5978-bdd7-9c95" type="selectionEntry">
-                  <modifiers>
-                    <modifier type="set" field="hidden" value="false">
-                      <conditionGroups>
-                        <conditionGroup type="or">
-                          <conditions>
-                            <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8846-2f93-a2be-18dc" type="equalTo"/>
-                            <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d332-0e64-7ecf-6c35" type="equalTo"/>
-                          </conditions>
-                        </conditionGroup>
-                      </conditionGroups>
-                    </modifier>
-                  </modifiers>
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
-                  </costs>
-                </entryLink>
-                <entryLink id="7857-3d0d-1aa4-7e86" name="Force Staff" hidden="true" collective="false" import="true" targetId="5132-9034-5e79-13c8" type="selectionEntry">
-                  <modifiers>
-                    <modifier type="set" field="hidden" value="false">
-                      <conditionGroups>
-                        <conditionGroup type="or">
-                          <conditions>
-                            <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8846-2f93-a2be-18dc" type="equalTo"/>
-                            <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d332-0e64-7ecf-6c35" type="equalTo"/>
-                          </conditions>
-                        </conditionGroup>
-                      </conditionGroups>
-                    </modifier>
-                  </modifiers>
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
-                  </costs>
-                </entryLink>
-                <entryLink id="7465-9d30-a4ef-34a6" name="Force Sword" hidden="true" collective="false" import="true" targetId="6164-c01a-a879-37d7" type="selectionEntry">
-                  <modifiers>
-                    <modifier type="set" field="hidden" value="false">
-                      <conditionGroups>
-                        <conditionGroup type="or">
-                          <conditions>
-                            <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8846-2f93-a2be-18dc" type="equalTo"/>
-                            <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d332-0e64-7ecf-6c35" type="equalTo"/>
-                          </conditions>
-                        </conditionGroup>
-                      </conditionGroups>
-                    </modifier>
-                  </modifiers>
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
                   </costs>
                 </entryLink>
                 <entryLink id="0d97-ca8d-34b8-4002" name="Archaeotech Pistol" hidden="true" collective="false" import="true" targetId="c22a-ed4d-af68-bf00" type="selectionEntry">
@@ -20593,6 +20552,35 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
                   </costs>
                 </entryLink>
                 <entryLink id="8eea-fe96-ed04-4a39" name="Shrapnel Pistol" hidden="false" collective="false" import="true" targetId="7d72-7f6d-6330-6871" type="selectionEntry"/>
+                <entryLink id="6b1a-321d-f64e-9300" name="Thunder Hammer" hidden="false" collective="false" import="true" targetId="e6cc-bfce-a4d9-301c" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35ac-992e-97a7-1612" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                </entryLink>
+                <entryLink id="a675-5e87-f393-b12f" name="Power Weapon" hidden="false" collective="false" import="true" targetId="8d9c-9f80-c0fd-adcf" type="selectionEntry"/>
+                <entryLink id="5ce9-29b2-1b37-8053" name="Charnabal Weapon" hidden="false" collective="false" import="true" targetId="2376-af96-e101-e712" type="selectionEntry"/>
+                <entryLink id="ab03-027f-0f44-a367" name="Force Weapon" hidden="true" collective="false" import="true" targetId="a9c2-6881-3391-9622" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8846-2f93-a2be-18dc" type="equalTo"/>
+                            <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d332-0e64-7ecf-6c35" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                </entryLink>
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="525d-defc-1b29-0886" name="May take one of the following weapons:" hidden="false" collective="false" import="true">
@@ -20904,22 +20892,6 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
                     </modifier>
                   </modifiers>
                 </entryLink>
-                <entryLink id="4cf3-8711-c39a-106a" name="Thunder Hammer" hidden="false" collective="false" import="true" targetId="838c-4002-713d-d7c6" type="selectionEntry">
-                  <modifiers>
-                    <modifier type="set" field="hidden" value="true">
-                      <conditionGroups>
-                        <conditionGroup type="or">
-                          <conditions>
-                            <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35ac-992e-97a7-1612" type="equalTo"/>
-                          </conditions>
-                        </conditionGroup>
-                      </conditionGroups>
-                    </modifier>
-                  </modifiers>
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0"/>
-                  </costs>
-                </entryLink>
                 <entryLink id="cc07-940c-6707-6d42" name="Lightning Claw" hidden="false" collective="false" import="true" targetId="6923-4e42-5691-b13f" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="hidden" value="true">
@@ -20942,36 +20914,6 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
                   </costs>
                 </entryLink>
                 <entryLink id="4da1-7810-954d-3fcd" name="Chainsword" hidden="false" collective="false" import="true" targetId="06e7-a6ae-ed1c-eb03" type="selectionEntry"/>
-                <entryLink id="16b4-b530-9c81-837c" name="Charnabal Glaive" hidden="false" collective="false" import="true" targetId="c07c-35e6-4616-ef25" type="selectionEntry">
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
-                  </costs>
-                </entryLink>
-                <entryLink id="6865-e366-37c1-d6b2" name="Charnabal Sabre" hidden="false" collective="false" import="true" targetId="30c2-57eb-5bbe-be0b" type="selectionEntry">
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
-                  </costs>
-                </entryLink>
-                <entryLink id="6dc5-829c-6ec7-be80" name="Charnabal Tabar" hidden="false" collective="false" import="true" targetId="4611-c33e-f360-7246" type="selectionEntry">
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
-                  </costs>
-                </entryLink>
-                <entryLink id="2a78-9b96-f7cf-ef5a" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry">
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
-                  </costs>
-                </entryLink>
-                <entryLink id="0079-2ba9-83bc-e143" name="Power Maul" hidden="false" collective="false" import="true" targetId="0df4-c67e-cf64-82e0" type="selectionEntry">
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
-                  </costs>
-                </entryLink>
-                <entryLink id="c0bb-8b67-02a9-1d44" name="Power Sword" hidden="false" collective="false" import="true" targetId="a3cd-aa97-a148-2309" type="selectionEntry">
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
-                  </costs>
-                </entryLink>
                 <entryLink id="ed94-bc2b-adb8-a28c" name="Raven&apos;s Talons" hidden="false" collective="false" import="true" targetId="09d8-64f5-1936-e8ab" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="hidden" value="true">
@@ -20988,41 +20930,21 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
                   </costs>
                 </entryLink>
-                <entryLink id="7bef-372f-94f9-9e31" name="Force Axe" hidden="true" collective="false" import="true" targetId="40bb-c99e-b4b3-12c1" type="selectionEntry">
+                <entryLink id="d4e7-f227-b807-24ea" name="Thunder Hammer" hidden="false" collective="false" import="true" targetId="e6cc-bfce-a4d9-301c" type="selectionEntry">
                   <modifiers>
-                    <modifier type="set" field="hidden" value="false">
+                    <modifier type="set" field="hidden" value="true">
                       <conditionGroups>
                         <conditionGroup type="or">
                           <conditions>
-                            <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d332-0e64-7ecf-6c35" type="equalTo"/>
-                            <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8846-2f93-a2be-18dc" type="equalTo"/>
+                            <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="35ac-992e-97a7-1612" type="equalTo"/>
                           </conditions>
                         </conditionGroup>
                       </conditionGroups>
                     </modifier>
                   </modifiers>
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
-                  </costs>
                 </entryLink>
-                <entryLink id="8000-a62c-5ccd-7ebc" name="Force Maul" hidden="true" collective="false" import="true" targetId="da60-5978-bdd7-9c95" type="selectionEntry">
-                  <modifiers>
-                    <modifier type="set" field="hidden" value="false">
-                      <conditionGroups>
-                        <conditionGroup type="or">
-                          <conditions>
-                            <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8846-2f93-a2be-18dc" type="equalTo"/>
-                            <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d332-0e64-7ecf-6c35" type="equalTo"/>
-                          </conditions>
-                        </conditionGroup>
-                      </conditionGroups>
-                    </modifier>
-                  </modifiers>
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
-                  </costs>
-                </entryLink>
-                <entryLink id="5f7a-0fad-218f-50e4" name="Force Staff" hidden="true" collective="false" import="true" targetId="5132-9034-5e79-13c8" type="selectionEntry">
+                <entryLink id="c243-b391-1b6b-b698" name="Power Weapon" hidden="false" collective="false" import="true" targetId="8d9c-9f80-c0fd-adcf" type="selectionEntry"/>
+                <entryLink id="3270-d3dd-1ca2-99e3" name="Force Weapon" hidden="true" collective="false" import="true" targetId="a9c2-6881-3391-9622" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="hidden" value="false">
                       <conditionGroups>
@@ -21035,27 +20957,8 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
                       </conditionGroups>
                     </modifier>
                   </modifiers>
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
-                  </costs>
                 </entryLink>
-                <entryLink id="0798-c3c8-db80-7a32" name="Force Sword" hidden="true" collective="false" import="true" targetId="6164-c01a-a879-37d7" type="selectionEntry">
-                  <modifiers>
-                    <modifier type="set" field="hidden" value="false">
-                      <conditionGroups>
-                        <conditionGroup type="or">
-                          <conditions>
-                            <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8846-2f93-a2be-18dc" type="equalTo"/>
-                            <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d332-0e64-7ecf-6c35" type="equalTo"/>
-                          </conditions>
-                        </conditionGroup>
-                      </conditionGroups>
-                    </modifier>
-                  </modifiers>
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
-                  </costs>
-                </entryLink>
+                <entryLink id="3d3b-1303-1b7b-4599" name="Charnabal Weapon" hidden="false" collective="false" import="true" targetId="2376-af96-e101-e712" type="selectionEntry"/>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
@@ -21785,7 +21688,7 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="a0a1-1191-6346-bb87" name="For every five models in the unit, one Legionary may exchange their Bolt Pistol for:" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="a0a1-1191-6346-bb87" name="One in five may exchange their Bolt Pistol for:" hidden="false" collective="false" import="true">
           <modifiers>
             <modifier type="increment" field="762f-4f90-1983-6244" value="1.0">
               <repeats>
@@ -21871,14 +21774,9 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
               </costs>
             </entryLink>
-            <entryLink id="c41d-ca51-50c1-e8c1" name="Shrapnel Weaponry Options" hidden="false" collective="false" import="true" targetId="b26e-c64c-f86f-8351" type="selectionEntryGroup">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="472c-2d0a-5ba5-809d" type="max"/>
-              </constraints>
-            </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="81cc-ac6d-99da-2a39" name="The Legion Assault Sergeant may exchange his Bolt Pistol and Chainsword for:" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="81cc-ac6d-99da-2a39" name="Sergeant may exchange his Bolt Pistol and Chainsword for:" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4d3b-8472-7029-a792" type="max"/>
             <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b1d4-4a2c-7258-bef1" type="min"/>
@@ -21903,7 +21801,7 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="1ac3-5ffc-3179-17a1" name="The Legion Assault Sergeant may take:" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="1ac3-5ffc-3179-17a1" name="Sergeant may take:" hidden="false" collective="false" import="true">
           <selectionEntries>
             <selectionEntry id="6b11-7fb1-335b-93df" name="Master-craft a one weapon" hidden="true" collective="false" import="true" type="upgrade">
               <modifiers>
@@ -22000,7 +21898,7 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="b8b5-1b75-870e-d226" name="The Legion  Assault Sergeant must pick two:" hidden="false" collective="false" import="true" defaultSelectionEntryId="538f-2696-e9a0-fa7f">
+        <selectionEntryGroup id="b8b5-1b75-870e-d226" name="Sergeant must pick two:" hidden="false" collective="false" import="true" defaultSelectionEntryId="538f-2696-e9a0-fa7f">
           <modifiers>
             <modifier type="set" field="4f6e-c02f-c1ef-d06c" value="0.0">
               <conditions>
@@ -22076,8 +21974,15 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
               </costs>
             </entryLink>
             <entryLink id="538f-2696-e9a0-fa7f" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="a8e9-70e1-b8bc-8ee2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7d72-7f6d-6330-6871" type="atLeast"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5d33-d03f-3222-8db9" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5d33-d03f-3222-8db9" type="max"/>
               </constraints>
             </entryLink>
             <entryLink id="6f76-87d2-c247-3576" name="Fenrisian Axe" hidden="false" collective="false" import="true" targetId="72ba-d2df-d98b-8b5d" type="selectionEntry">
@@ -22098,11 +22003,6 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
             <entryLink id="bc56-96de-4bbd-7e87" name="Raven&apos;s Talons" hidden="false" collective="false" import="true" targetId="09d8-64f5-1936-e8ab" type="selectionEntry">
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="42f1-de4c-3e2d-9d5f" name="Shrapnel Pistol" hidden="false" collective="false" import="true" targetId="7d72-7f6d-6330-6871" type="selectionEntry">
-              <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
               </costs>
             </entryLink>
             <entryLink id="52e6-34a8-db4b-fa00" name="Chainaxe" hidden="true" collective="false" import="true" targetId="85b9-4e50-af11-c295" type="selectionEntry">
@@ -22145,6 +22045,14 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
             <entryLink id="461b-837a-76f1-f097" name="Power Weapon" hidden="false" collective="false" import="true" targetId="8d9c-9f80-c0fd-adcf" type="selectionEntry">
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="95a3-2658-7e2e-ce10" name="Shrapnel Pistol" hidden="false" collective="false" import="true" targetId="7d72-7f6d-6330-6871" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d6a8-b921-f80b-cfb0" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
               </costs>
             </entryLink>
           </entryLinks>
@@ -22231,6 +22139,40 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
               </costs>
             </entryLink>
             <entryLink id="603a-ccf8-f7bb-c9e1" name="Chainsword" hidden="false" collective="false" import="true" targetId="06e7-a6ae-ed1c-eb03" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="47a0-bbd7-a0d2-3a94" name="Bolt Pistol Options" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7976-ea21-7c06-a4b0" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="6f0f-6818-d5c8-c1c8" name="Shrapnel Pistol" hidden="false" collective="false" import="true" targetId="7d72-7f6d-6330-6871" type="selectionEntry">
+              <modifiers>
+                <modifier type="increment" field="d2ee-04cb-5f8a-2642" value="2.0">
+                  <repeats>
+                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f27-e636-6ed0-163f" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4930-389b-e19e-f1d8" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="0869-3d74-a320-fad7" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="a8e9-70e1-b8bc-8ee2" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7d72-7f6d-6330-6871" type="atLeast"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2292-a968-0418-3837" type="max"/>
+              </constraints>
+            </entryLink>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
@@ -22363,7 +22305,7 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="75ac-e7a8-0b7e-a019" name="For every five models in the unit, one  Despoiler may exchange their Bolt Pistol for:" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="75ac-e7a8-0b7e-a019" name="One in five may exchange their Bolt Pistol for:" hidden="false" collective="false" import="true">
           <modifiers>
             <modifier type="increment" field="87d2-9943-d6c1-883b" value="1.0">
               <repeats>
@@ -22435,11 +22377,6 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
               </costs>
             </entryLink>
-            <entryLink id="d80e-7874-dee8-554d" name="Shrapnel Weaponry Options" hidden="false" collective="false" import="true" targetId="b26e-c64c-f86f-8351" type="selectionEntryGroup">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a97c-4f42-b185-e8cd" type="max"/>
-              </constraints>
-            </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="ef54-aab4-53ae-d96c" name="Dedicated Transport:" hidden="false" collective="false" import="true">
@@ -22504,7 +22441,7 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
             <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aa1e-e1a7-da8f-bb3c" type="min"/>
           </constraints>
           <selectionEntryGroups>
-            <selectionEntryGroup id="db2f-247f-7b1a-5704" name="For every five models in the unit, one Despoiler may exchange their Chainsword for:" hidden="false" collective="false" import="true">
+            <selectionEntryGroup id="db2f-247f-7b1a-5704" name="One in five may exchange their Chainsword for:" hidden="false" collective="false" import="true">
               <modifiers>
                 <modifier type="increment" field="8a00-311f-5796-9a55" value="1.0">
                   <repeats>
@@ -22559,7 +22496,7 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="eb09-b1ac-20f5-0013" type="equalTo"/>
+                    <condition field="selections" scope="4357-930e-165a-a6e3" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7d72-7f6d-6330-6871" type="equalTo"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -22580,13 +22517,6 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
               </costs>
             </entryLink>
             <entryLink id="dc9f-dcde-09d2-c87c" name="Shrapnel Pistol" hidden="false" collective="false" import="true" targetId="7d72-7f6d-6330-6871" type="selectionEntry">
-              <modifiers>
-                <modifier type="set" field="hidden" value="true">
-                  <conditions>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="eb09-b1ac-20f5-0013" type="equalTo"/>
-                  </conditions>
-                </modifier>
-              </modifiers>
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
               </costs>
@@ -22656,7 +22586,7 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="eb09-b1ac-20f5-0013" type="equalTo"/>
+                    <condition field="selections" scope="4357-930e-165a-a6e3" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7d72-7f6d-6330-6871" type="atLeast"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -22685,13 +22615,6 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
               </costs>
             </entryLink>
             <entryLink id="9c86-9643-673b-eca1" name="Shrapnel Pistol" hidden="false" collective="false" import="true" targetId="7d72-7f6d-6330-6871" type="selectionEntry">
-              <modifiers>
-                <modifier type="set" field="hidden" value="true">
-                  <conditions>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="eb09-b1ac-20f5-0013" type="equalTo"/>
-                  </conditions>
-                </modifier>
-              </modifiers>
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
               </costs>
@@ -22857,19 +22780,12 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="eb09-b1ac-20f5-0013" type="equalTo"/>
+                    <condition field="selections" scope="4357-930e-165a-a6e3" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7d72-7f6d-6330-6871" type="atLeast"/>
                   </conditions>
                 </modifier>
               </modifiers>
             </entryLink>
             <entryLink id="b6cf-0d72-97b1-f934" name="Shrapnel Pistol" hidden="false" collective="false" import="true" targetId="7d72-7f6d-6330-6871" type="selectionEntry">
-              <modifiers>
-                <modifier type="set" field="hidden" value="true">
-                  <conditions>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="eb09-b1ac-20f5-0013" type="equalTo"/>
-                  </conditions>
-                </modifier>
-              </modifiers>
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
               </costs>
@@ -23001,7 +22917,7 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="6238-8c0e-c4f5-99ad" name="One Breacher may take:" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="6238-8c0e-c4f5-99ad" name="3) One Breacher may take:" hidden="false" collective="false" import="true">
           <entryLinks>
             <entryLink id="9a50-c4bc-749a-2a60" name="Nuncio-Vox" hidden="false" collective="false" import="true" targetId="005e-aae6-ddac-bb45" type="selectionEntry">
               <constraints>
@@ -23029,7 +22945,7 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="6b35-d3b4-2c92-b4bf" name="The Legion Breacher Sergeant may exchange his Bolter for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="7c3a-b82e-25ae-f620">
+        <selectionEntryGroup id="6b35-d3b4-2c92-b4bf" name="4) The Sergeant may exchange his Bolter for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="7c3a-b82e-25ae-f620">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3729-d036-6bb3-4f24" type="max"/>
           </constraints>
@@ -23079,10 +22995,18 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
               </costs>
             </entryLink>
-            <entryLink id="7c3a-b82e-25ae-f620" name="Bolter" hidden="false" collective="false" import="true" targetId="1ade-0c02-5612-252b" type="selectionEntry"/>
+            <entryLink id="7c3a-b82e-25ae-f620" name="Bolter" hidden="false" collective="false" import="true" targetId="1ade-0c02-5612-252b" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="ad97-c090-fa67-696f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1941-21b5-932c-74d6" type="atLeast"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="a7c0-9731-3b44-d9dd" name="The Legion Breacher Sergeant may take (Melee Weapon):" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="a7c0-9731-3b44-d9dd" name="6) The Sergeant may take (Melee Weapon):" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="43dc-5ca0-7c15-7631" type="max"/>
           </constraints>
@@ -23135,7 +23059,7 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="39b4-cf65-749b-8a40" name="The Legion Breacher Sergeant may exchange his Bolt Pistol for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="e714-9a7d-8597-3a53">
+        <selectionEntryGroup id="39b4-cf65-749b-8a40" name="5) The Sergeant may exchange his Bolt Pistol for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="e714-9a7d-8597-3a53">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="585a-2b23-bc49-428a" type="max"/>
           </constraints>
@@ -23195,10 +23119,18 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
               </costs>
             </entryLink>
-            <entryLink id="e714-9a7d-8597-3a53" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry"/>
+            <entryLink id="e714-9a7d-8597-3a53" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="ad97-c090-fa67-696f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7d72-7f6d-6330-6871" type="atLeast"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="fbe6-f5fc-581e-95a3" name="The Legion Breacher Sergeant may take (Wargear):" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="fbe6-f5fc-581e-95a3" name="7) The Sergeant may take (Wargear):" hidden="false" collective="false" import="true">
           <selectionEntries>
             <selectionEntry id="da47-aa6e-cd52-083d" name="Master-craft one weapon" hidden="true" collective="false" import="true" type="upgrade">
               <modifiers>
@@ -23207,14 +23139,9 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
                     <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c805-ca3a-ff93-5e2f" type="equalTo"/>
                   </conditions>
                 </modifier>
-                <modifier type="increment" field="7126-58fb-5a4e-07b6" value="1.0">
-                  <conditions>
-                    <condition field="selections" scope="ad97-c090-fa67-696f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a7c0-9731-3b44-d9dd" type="atLeast"/>
-                  </conditions>
-                </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7126-58fb-5a4e-07b6" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7126-58fb-5a4e-07b6" type="max"/>
               </constraints>
               <infoLinks>
                 <infoLink id="dccd-cfa5-e8f5-5ddb" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule"/>
@@ -23316,16 +23243,11 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
             <entryLink id="1277-6d8c-e33e-1ccf" name="Land Raider Proteus Carrier" hidden="false" collective="false" import="true" targetId="c123-bdc6-a6ba-79a2" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="b4da-f951-9b41-dbee" name="Any Breacher may replace their Bolter with:" hidden="false" collective="false" import="true" defaultSelectionEntryId="1de2-72ab-b1f6-b3a0">
+        <selectionEntryGroup id="b4da-f951-9b41-dbee" name="1) Any Breacher may replace their Bolter with:" hidden="false" collective="false" import="true" defaultSelectionEntryId="1de2-72ab-b1f6-b3a0">
           <modifiers>
             <modifier type="increment" field="257d-8b00-53c4-bfcf" value="1.0">
               <repeats>
                 <repeat field="selections" scope="ad97-c090-fa67-696f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3bfa-086f-26ea-0ade" repeats="1" roundUp="false"/>
-              </repeats>
-            </modifier>
-            <modifier type="decrement" field="257d-8b00-53c4-bfcf" value="1.0">
-              <repeats>
-                <repeat field="selections" scope="ad97-c090-fa67-696f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="479a-e42b-0093-c388" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="7d74-dcbb-f669-8d46" value="9.0"/>
@@ -23334,16 +23256,62 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
                 <repeat field="selections" scope="ad97-c090-fa67-696f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3bfa-086f-26ea-0ade" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
-            <modifier type="decrement" field="7d74-dcbb-f669-8d46" value="1.0">
-              <repeats>
-                <repeat field="selections" scope="ad97-c090-fa67-696f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="479a-e42b-0093-c388" repeats="1" roundUp="false"/>
-              </repeats>
-            </modifier>
           </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7d74-dcbb-f669-8d46" type="min"/>
             <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="257d-8b00-53c4-bfcf" type="max"/>
           </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="b79d-4492-9da8-8829" name="For every five models in the unit, one Breacher may exchange his Bolter for:" hidden="false" collective="false" import="true">
+              <modifiers>
+                <modifier type="increment" field="1c3d-95e4-51d0-4895" value="1.0">
+                  <repeats>
+                    <repeat field="selections" scope="ad97-c090-fa67-696f" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1c3d-95e4-51d0-4895" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="9e16-2820-3350-744b" name="Flamer" hidden="false" collective="false" import="true" targetId="9f41-82e2-90f6-973a" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="8c6a-2def-4682-ee52" name="Meltagun" hidden="false" collective="false" import="true" targetId="4ebd-57e0-3560-e568" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="3a07-65c5-6377-a9e5" name="Graviton Gun" hidden="false" collective="false" import="true" targetId="5303-5a3e-de51-1707" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="8c67-5007-6913-67e6" name="Lascutter" hidden="false" collective="false" import="true" targetId="6331-c1b9-bf0e-d0e5" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="a848-16d5-bd6d-22a0" name="Alchem Flamer" hidden="false" collective="false" import="true" targetId="0d08-eaaf-3793-0a70" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="9c5f-756f-c037-606c" name="Dragon&apos;s Breath Flamer" hidden="false" collective="false" import="true" targetId="d6c6-779a-0b83-fd15" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="57bb-c2f4-766a-de84" name="Graviton Shredder" hidden="false" collective="false" import="true" targetId="0849-b63b-0b1b-fd4f" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
           <entryLinks>
             <entryLink id="a175-7fd4-c1a0-7d3c" name="Shrapnel Bolter" hidden="false" collective="false" import="true" targetId="1941-21b5-932c-74d6" type="selectionEntry">
               <costs>
@@ -23360,10 +23328,18 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
               </costs>
             </entryLink>
-            <entryLink id="1de2-72ab-b1f6-b3a0" name="Bolter" hidden="false" collective="false" import="true" targetId="1ade-0c02-5612-252b" type="selectionEntry"/>
+            <entryLink id="1de2-72ab-b1f6-b3a0" name="Bolter" hidden="false" collective="false" import="true" targetId="1ade-0c02-5612-252b" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="ad97-c090-fa67-696f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1941-21b5-932c-74d6" type="atLeast"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="16b2-2bdd-6e01-1684" name="Legiones Unit Upgrades:" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="16b2-2bdd-6e01-1684" name="0) Legiones Unit Upgrades:" hidden="false" collective="false" import="true">
           <entryLinks>
             <entryLink id="8d90-a51c-d976-e82b" name="Preysight" hidden="false" collective="false" import="true" targetId="b905-4d78-c141-4e63" type="selectionEntry">
               <constraints>
@@ -23383,62 +23359,14 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="479a-e42b-0093-c388" name="For every five models in the unit, one Breacher may exchange his Bolter for:" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="566e-c048-afb3-7d10" name="2) Any Breacher may replace their Bolt Pistol with:" hidden="false" collective="false" import="true" defaultSelectionEntryId="b705-c3b2-edfa-a71c">
           <modifiers>
-            <modifier type="increment" field="95f3-4d11-4434-0978" value="1.0">
+            <modifier type="increment" field="a7dc-42f8-fe95-b79a" value="1.0">
               <repeats>
-                <repeat field="selections" scope="ad97-c090-fa67-696f" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="ad97-c090-fa67-696f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3bfa-086f-26ea-0ade" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="95f3-4d11-4434-0978" type="max"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="fbce-df8d-a7e4-d5f3" name="Flamer" hidden="false" collective="false" import="true" targetId="9f41-82e2-90f6-973a" type="selectionEntry">
-              <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="d553-1618-3470-3838" name="Meltagun" hidden="false" collective="false" import="true" targetId="4ebd-57e0-3560-e568" type="selectionEntry">
-              <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="158d-2fc9-fa5a-5186" name="Graviton Gun" hidden="false" collective="false" import="true" targetId="5303-5a3e-de51-1707" type="selectionEntry">
-              <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="328c-21c1-7cbd-a1dc" name="Lascutter" hidden="false" collective="false" import="true" targetId="6331-c1b9-bf0e-d0e5" type="selectionEntry">
-              <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="9e18-fbaa-5fbe-e86c" name="Alchem Flamer" hidden="false" collective="false" import="true" targetId="0d08-eaaf-3793-0a70" type="selectionEntry">
-              <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="14c8-21ba-a3fb-f102" name="Dragon&apos;s Breath Flamer" hidden="false" collective="false" import="true" targetId="d6c6-779a-0b83-fd15" type="selectionEntry">
-              <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="a900-2350-992d-d6dc" name="Graviton Shredder" hidden="false" collective="false" import="true" targetId="0849-b63b-0b1b-fd4f" type="selectionEntry">
-              <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
-              </costs>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="566e-c048-afb3-7d10" name="Any Breacher may replace their Bolt Pistol with:" hidden="true" collective="false" import="true">
-          <modifiers>
-            <modifier type="set" field="hidden" value="false">
-              <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
-              </conditions>
-            </modifier>
+            <modifier type="decrement" field="a7dc-42f8-fe95-b79a" value="9.0"/>
             <modifier type="increment" field="2661-0fce-ee4e-1bad" value="1.0">
               <repeats>
                 <repeat field="selections" scope="ad97-c090-fa67-696f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3bfa-086f-26ea-0ade" repeats="1" roundUp="false"/>
@@ -23447,6 +23375,7 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
           </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2661-0fce-ee4e-1bad" type="max"/>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a7dc-42f8-fe95-b79a" type="min"/>
           </constraints>
           <entryLinks>
             <entryLink id="fd93-e844-531e-ce45" name="Asphyx Bolt Pistol" hidden="false" collective="false" import="true" targetId="07f7-c486-f597-a1b9" type="selectionEntry">
@@ -23454,16 +23383,24 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="1.0"/>
               </costs>
             </entryLink>
+            <entryLink id="b705-c3b2-edfa-a71c" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="ad97-c090-fa67-696f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7d72-7f6d-6330-6871" type="atLeast"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </entryLink>
+            <entryLink id="62dc-e8f2-855b-0e76" name="Shrapnel Pistol" hidden="false" collective="false" import="true" targetId="7d72-7f6d-6330-6871" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
+              </costs>
+            </entryLink>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="c56e-8f2c-d177-5592" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fb01-9fa9-69df-f3f8" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0dc0-7417-19d6-d435" type="min"/>
-          </constraints>
-        </entryLink>
         <entryLink id="4b38-dd31-0cd5-605e" name="Power Armour" hidden="false" collective="false" import="true" targetId="2d9d-480e-7c14-1a6f" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="92c0-1f0c-0dd3-5b5b" type="max"/>
@@ -23673,7 +23610,7 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="8a4b-9c85-abbc-164a" name="The Legion Recon Sergeant may exchange his Bolter for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="4e3c-2b10-6333-c173">
+        <selectionEntryGroup id="8a4b-9c85-abbc-164a" name="Sergeant may exchange his Bolter for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="4e3c-2b10-6333-c173">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c0b8-4d49-0fe7-18b3" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2f65-eb42-7bed-1e5e" type="max"/>
@@ -23740,10 +23677,18 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
               </costs>
             </entryLink>
-            <entryLink id="4e3c-2b10-6333-c173" name="Bolter" hidden="false" collective="false" import="true" targetId="1ade-0c02-5612-252b" type="selectionEntry"/>
+            <entryLink id="4e3c-2b10-6333-c173" name="Bolter" hidden="false" collective="false" import="true" targetId="1ade-0c02-5612-252b" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="6db7-6e88-877e-35ca" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1941-21b5-932c-74d6" type="atLeast"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="c359-c526-a3c7-0322" name="The Legion Recon Sergeant may exchange his Bolt Pistol for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="ef80-e2ab-17b2-fcdd">
+        <selectionEntryGroup id="c359-c526-a3c7-0322" name="Sergeant may exchange his Bolt Pistol for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="ef80-e2ab-17b2-fcdd">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="df5c-33cb-2756-9ea9" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6536-56ee-6903-035a" type="max"/>
@@ -23804,7 +23749,15 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
               </costs>
             </entryLink>
-            <entryLink id="ef80-e2ab-17b2-fcdd" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry"/>
+            <entryLink id="ef80-e2ab-17b2-fcdd" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="6db7-6e88-877e-35ca" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7d72-7f6d-6330-6871" type="atLeast"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="03bf-3f23-6606-5740" name="The Legion Recon Sergeant may take (Wargear):" hidden="false" collective="false" import="true">
@@ -23922,7 +23875,15 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
               </costs>
             </entryLink>
-            <entryLink id="de01-818f-adcb-c086" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry"/>
+            <entryLink id="de01-818f-adcb-c086" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="6db7-6e88-877e-35ca" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7d72-7f6d-6330-6871" type="atLeast"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="77e9-4e14-63c6-fad7" name="Dedicated Transport:" hidden="false" collective="false" import="true">
@@ -23976,7 +23937,15 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
               </costs>
             </entryLink>
-            <entryLink id="f269-a037-e45e-1beb" name="Bolter" hidden="false" collective="false" import="true" targetId="1ade-0c02-5612-252b" type="selectionEntry"/>
+            <entryLink id="f269-a037-e45e-1beb" name="Bolter" hidden="false" collective="false" import="true" targetId="1ade-0c02-5612-252b" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="6db7-6e88-877e-35ca" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1941-21b5-932c-74d6" type="atLeast"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="7fa7-8ca5-d4be-f2af" name="Legiones Unit Upgrades:" hidden="false" collective="false" import="true">
@@ -24279,7 +24248,15 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
               </costs>
             </entryLink>
-            <entryLink id="a6eb-e1d3-6462-35d1" name="Bolter" hidden="false" collective="false" import="true" targetId="1ade-0c02-5612-252b" type="selectionEntry"/>
+            <entryLink id="a6eb-e1d3-6462-35d1" name="Bolter" hidden="false" collective="false" import="true" targetId="1ade-0c02-5612-252b" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="9b10-b657-a65a-9d60" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1941-21b5-932c-74d6" type="atLeast"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </entryLink>
             <entryLink id="acec-656b-6888-6279" name="Nemesis Bolter" hidden="false" collective="false" import="true" targetId="c10a-61f8-9c33-fe8a" type="selectionEntry">
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
@@ -24349,7 +24326,15 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
               </costs>
             </entryLink>
-            <entryLink id="c3c8-bfd7-40f3-eb07" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry"/>
+            <entryLink id="c3c8-bfd7-40f3-eb07" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="9b10-b657-a65a-9d60" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7d72-7f6d-6330-6871" type="atLeast"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="850c-322d-5c15-59fd" name="The Legion Tactical Sergeant may take (Wargear):" hidden="false" collective="false" import="true">
@@ -24467,7 +24452,15 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
               </costs>
             </entryLink>
-            <entryLink id="19e2-b55e-256f-1edd" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry"/>
+            <entryLink id="19e2-b55e-256f-1edd" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="9b10-b657-a65a-9d60" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7d72-7f6d-6330-6871" type="atLeast"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="7b90-31d7-3a64-772e" name="Dedicated Transport:" hidden="false" collective="false" import="true">
@@ -24549,7 +24542,15 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
               </costs>
             </entryLink>
-            <entryLink id="f0fd-094c-7992-1fee" name="Bolter" hidden="false" collective="false" import="true" targetId="1ade-0c02-5612-252b" type="selectionEntry"/>
+            <entryLink id="f0fd-094c-7992-1fee" name="Bolter" hidden="false" collective="false" import="true" targetId="1ade-0c02-5612-252b" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="9b10-b657-a65a-9d60" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1941-21b5-932c-74d6" type="atLeast"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="de73-b98a-9f1e-8688" name="The Legion Scout Sergeant may take (Melee Weapon):" hidden="false" collective="false" import="true">
@@ -24672,15 +24673,6 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="18.0"/>
           </costs>
-        </selectionEntry>
-        <selectionEntry id="d05f-2585-8e8d-00d9" name="Until this unit is completed, Legion-specific options can go here" hidden="true" collective="false" import="true" type="upgrade">
-          <entryLinks>
-            <entryLink id="af99-bcb9-1fc5-aba4" name="Shrapnel Pistol" hidden="false" collective="false" import="true" targetId="7d72-7f6d-6330-6871" type="selectionEntry">
-              <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
-              </costs>
-            </entryLink>
-          </entryLinks>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
@@ -24935,6 +24927,230 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
               </characteristics>
             </profile>
           </profiles>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="063e-9afc-8305-9eae" name="1) Bolt Pistol Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="6d19-aee4-d237-d50e">
+              <modifiers>
+                <modifier type="decrement" field="9800-655f-8ef4-330d" value="1.0">
+                  <repeats>
+                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a6d2-b3a9-6d2c-1f6f" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="08e4-5e02-da82-f296" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+                <modifier type="decrement" field="8e2b-0dfa-1b4a-67a9" value="1.0">
+                  <repeats>
+                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a6d2-b3a9-6d2c-1f6f" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="08e4-5e02-da82-f296" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8e2b-0dfa-1b4a-67a9" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9800-655f-8ef4-330d" type="min"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="e624-2095-4986-8ece" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="717f-cf0a-1593-4bd8" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="fdbd-e452-70dd-8cd7" name="Inferno Pistol" hidden="false" collective="false" import="true" targetId="dcd1-8b2a-9d97-40ef" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="7307-f7ee-c515-7f25" name="Graviton Pistol" hidden="false" collective="false" import="true" targetId="0087-19d3-eca0-cc75" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="a232-50f0-3e81-c085" name="Æther-Fire Pistol" hidden="false" collective="false" import="true" targetId="ae13-0ae8-a3ba-f6ff" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="df7d-bd5a-3fa3-343e" name="Warpfire Pistol" hidden="false" collective="false" import="true" targetId="a94d-1f53-2902-0237" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="07fe-e814-d1d1-b9c3" name="Shrapnel Pistol" hidden="false" collective="false" import="true" targetId="7d72-7f6d-6330-6871" type="selectionEntry"/>
+                <entryLink id="4490-f54f-c648-97ba" name="Alchem Pistol" hidden="false" collective="false" import="true" targetId="1899-9e9e-76dd-a7ba" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="744d-b3c7-566e-e337" name="Hand Flamer" hidden="false" collective="false" import="true" targetId="e337-adf4-a11f-0280" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="a96f-5528-1de3-5f59" name="Volkite Serpenta" hidden="false" collective="false" import="true" targetId="d535-1da8-290d-69a6" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="256b-1885-eb48-eea2" name="Asphyx Bolt Pistol" hidden="false" collective="false" import="true" targetId="07f7-c486-f597-a1b9" type="selectionEntry"/>
+                <entryLink id="6d19-aee4-d237-d50e" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditions>
+                        <condition field="selections" scope="a423-7dd8-3f1b-3e28" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7d72-7f6d-6330-6871" type="atLeast"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </entryLink>
+                <entryLink id="26bf-98f9-4da3-0f80" name="Dragon&apos;s Breath Pistol" hidden="false" collective="false" import="true" targetId="c1cb-0fa7-0d39-73ae" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="1f64-9747-ce08-7606" name="3) Wargear" hidden="false" collective="false" import="true">
+              <selectionEntries>
+                <selectionEntry id="ddb8-203b-36e3-39d6" name="Master-craft one weapon" hidden="true" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c805-ca3a-ff93-5e2f" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bd2c-dbe4-0aeb-48be" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="7d98-67c1-12dd-dddf" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <entryLinks>
+                <entryLink id="39ab-37f3-6770-e5a9" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aa46-bb84-f896-28a7" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="bd31-f812-fae2-7101" name="Cyber-Familiar" hidden="false" collective="false" import="true" targetId="6c85-4601-cf58-7b35" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditions>
+                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bfc9-c99c-bf8a-3917" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b47b-740d-5ba7-08ea" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="07d2-663b-4dd4-2fa5" name="Toxin Bombs" hidden="false" collective="false" import="true" targetId="987b-9177-dde0-bf9b" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="03f1-fb64-c0bb-16ac" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="f4b7-e8a0-b710-f44b" name="Infravisor" hidden="false" collective="false" import="true" targetId="bc5b-fcd7-aeed-e97c" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="767e-1726-dbd0-036d" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="3122-b730-bccd-5d4f" name="Venom Spheres" hidden="false" collective="false" import="true" targetId="82f5-cca1-51a0-31dd" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b535-7f26-e333-67e8" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="d863-ecf0-c220-bedd" name="Power Dagger" hidden="false" collective="false" import="true" targetId="8157-b77c-0dd3-85b2" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c2ea-7d6d-8e6a-9bc0" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="cc3d-8375-7918-a05e" name="Trophies of Judgement" hidden="false" collective="false" import="true" targetId="bde7-7c77-5973-cd52" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="51c9-717d-2c7d-c296" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="4f81-7825-89ff-e748" name="Cult Arcana:" hidden="false" collective="false" import="true" targetId="e6a0-3ea2-f7ca-411f" type="selectionEntryGroup"/>
+                <entryLink id="bfd8-9621-794b-6152" name="Surgical Augement" hidden="false" collective="false" import="true" targetId="aeb3-6a73-da1d-2b90" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="9ee2-f410-a0a3-24c9" name="2) Melee Options" hidden="false" collective="false" import="true">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f48a-563c-5de4-9db4" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="023c-d082-98aa-fee9" name="Thunder Hammer" hidden="false" collective="false" import="true" targetId="e6cc-bfce-a4d9-301c" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="bbbe-d24a-9414-c168" name="Power Fist" hidden="false" collective="false" import="true" targetId="a3e1-d633-dff9-028b" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="16da-3b9e-d257-591a" name="Pair of Lightning Claws" hidden="false" collective="false" import="true" targetId="a6d2-b3a9-6d2c-1f6f" type="selectionEntry"/>
+                <entryLink id="a4dc-f5a4-399d-b937" name="Pair of Raven&apos;s Talons" hidden="false" collective="false" import="true" targetId="08e4-5e02-da82-f296" type="selectionEntry"/>
+                <entryLink id="e176-91a9-d13a-b354" name="Chainaxe" hidden="false" collective="false" import="true" targetId="ed76-dace-31e4-b174" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="ded9-9fa6-bbba-100e" name="Chainsword" hidden="false" collective="false" import="true" targetId="06e7-a6ae-ed1c-eb03" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="8cfc-b8d5-26b0-3234" name="Heavy Chainsword" hidden="false" collective="false" import="true" targetId="ba92-3eda-3a71-dabb" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="4d78-ccb9-db90-f23e" name="Power Weapon" hidden="false" collective="false" import="true" targetId="8d9c-9f80-c0fd-adcf" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="df1e-d0d4-d64d-9d30" name="Fenrisian Axe" hidden="false" collective="false" import="true" targetId="72ba-d2df-d98b-8b5d" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="4.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="bc34-42ea-b4e1-de3a" name="Lightning Claw" hidden="false" collective="false" import="true" targetId="6923-4e42-5691-b13f" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="cfc4-03f3-89dd-24ef" name="Raven&apos;s Talons" hidden="false" collective="false" import="true" targetId="09d8-64f5-1936-e8ab" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="b00e-a624-b284-f482" name="Charnabal Weapon" hidden="false" collective="false" import="true" targetId="2376-af96-e101-e712" type="selectionEntry"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="18.0"/>
           </costs>
@@ -24984,7 +25200,7 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="2dde-c679-4d2d-e928" name="Legiones Unit Upgrades:" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="2dde-c679-4d2d-e928" name="0) Legiones Unit Upgrades:" hidden="false" collective="false" import="true">
           <entryLinks>
             <entryLink id="ad6b-cda8-6f05-594e" name="Preysight" hidden="false" collective="false" import="true" targetId="b905-4d78-c141-4e63" type="selectionEntry">
               <constraints>
@@ -25004,95 +25220,6 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="d5f6-9bc4-ce7f-170a" name="The Legion Veteran Sergeant may take (Wargear):" hidden="false" collective="false" import="true">
-          <selectionEntries>
-            <selectionEntry id="25c4-dbda-9880-348d" name="Master-craft one weapon" hidden="true" collective="false" import="true" type="upgrade">
-              <modifiers>
-                <modifier type="set" field="hidden" value="false">
-                  <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c805-ca3a-ff93-5e2f" type="equalTo"/>
-                  </conditions>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c823-a7aa-ecc0-f9ea" type="max"/>
-              </constraints>
-              <infoLinks>
-                <infoLink id="e284-cfdf-f472-ab68" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule"/>
-              </infoLinks>
-              <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <entryLinks>
-            <entryLink id="c280-5b98-cbda-9ec7" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d8d8-19c1-91d0-57c7" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="1242-5148-e7f5-470c" name="Cyber-Familiar" hidden="false" collective="false" import="true" targetId="6c85-4601-cf58-7b35" type="selectionEntry">
-              <modifiers>
-                <modifier type="set" field="hidden" value="true">
-                  <conditions>
-                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bfc9-c99c-bf8a-3917" type="equalTo"/>
-                  </conditions>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6df0-1264-857c-b03f" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="7b81-fd6c-d770-74dc" name="Toxin Bombs" hidden="false" collective="false" import="true" targetId="987b-9177-dde0-bf9b" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b341-8b53-b875-6abf" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="0e4a-9119-fa44-2a47" name="Infravisor" hidden="false" collective="false" import="true" targetId="bc5b-fcd7-aeed-e97c" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dca8-2e49-2bbc-ede7" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="2844-ef88-cad2-e6e0" name="Venom Spheres" hidden="false" collective="false" import="true" targetId="82f5-cca1-51a0-31dd" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="605a-4580-f106-e679" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="0cac-a5fc-be86-22bf" name="Power Dagger" hidden="false" collective="false" import="true" targetId="8157-b77c-0dd3-85b2" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ae20-a59b-0328-5030" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="1dd7-fbea-4810-0861" name="Trophies of Judgement" hidden="false" collective="false" import="true" targetId="bde7-7c77-5973-cd52" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e092-de76-c0a3-2772" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="4c8d-21a8-57fc-3907" name="Cult Arcana:" hidden="false" collective="false" import="true" targetId="e6a0-3ea2-f7ca-411f" type="selectionEntryGroup"/>
-            <entryLink id="a84d-8c3e-09c4-67ab" name="Surgical Augement" hidden="false" collective="false" import="true" targetId="aeb3-6a73-da1d-2b90" type="selectionEntryGroup"/>
-          </entryLinks>
-        </selectionEntryGroup>
         <selectionEntryGroup id="8fbf-dba5-5b44-1875" name="Dedicated Transport:" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a2a2-caa4-2d3a-8891" type="max"/>
@@ -25103,7 +25230,7 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
             <entryLink id="c09c-0bea-1d4c-e233" name="Termite Assault Drill" hidden="false" collective="false" import="true" targetId="cb30-307a-f0d7-3b13" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="1806-cfbe-ceeb-77ab" name="One Veteran may take:" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="1806-cfbe-ceeb-77ab" name="6) One Veteran may take:" hidden="false" collective="false" import="true">
           <entryLinks>
             <entryLink id="ae54-3958-6322-bb2d" name="Nuncio-Vox" hidden="false" collective="false" import="true" targetId="005e-aae6-ddac-bb45" type="selectionEntry">
               <constraints>
@@ -25131,25 +25258,38 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="7413-fd73-0aaf-283d" name="Any model in the unit may exchange it&apos;s bolter for:" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="7413-fd73-0aaf-283d" name="1) Any model may exchange its bolter for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="2be6-7ecf-28bb-36d4">
           <modifiers>
+            <modifier type="decrement" field="7f9d-ddef-7cc1-6bb5" value="5.0"/>
             <modifier type="increment" field="d10c-4533-f552-7de6" value="1.0">
               <repeats>
-                <repeat field="selections" scope="a423-7dd8-3f1b-3e28" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="a423-7dd8-3f1b-3e28" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+            <modifier type="increment" field="7f9d-ddef-7cc1-6bb5" value="1.0">
+              <repeats>
+                <repeat field="selections" scope="a423-7dd8-3f1b-3e28" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="d10c-4533-f552-7de6" value="1.0">
               <repeats>
-                <repeat field="selections" scope="a423-7dd8-3f1b-3e28" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6e0f-29bb-4be3-d6cb" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="a423-7dd8-3f1b-3e28" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="08e4-5e02-da82-f296" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="a423-7dd8-3f1b-3e28" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a6d2-b3a9-6d2c-1f6f" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+            <modifier type="decrement" field="7f9d-ddef-7cc1-6bb5" value="1.0">
+              <repeats>
+                <repeat field="selections" scope="a423-7dd8-3f1b-3e28" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a6d2-b3a9-6d2c-1f6f" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="a423-7dd8-3f1b-3e28" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="08e4-5e02-da82-f296" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
           </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d10c-4533-f552-7de6" type="max"/>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7f9d-ddef-7cc1-6bb5" type="min"/>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7f9d-ddef-7cc1-6bb5" type="min"/>
           </constraints>
           <selectionEntryGroups>
-            <selectionEntryGroup id="6537-3db5-2fb5-76db" name="For every five models in the unit, one Breacher may exchange his Bolter for:" hidden="false" collective="false" import="true">
+            <selectionEntryGroup id="6537-3db5-2fb5-76db" name="One in every five may exchange its bolter for:" hidden="false" collective="false" import="true">
               <modifiers>
                 <modifier type="increment" field="60d3-549f-72f1-f3e9" value="1.0">
                   <repeats>
@@ -25265,23 +25405,29 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
               </costs>
             </entryLink>
+            <entryLink id="2be6-7ecf-28bb-36d4" name="Bolter" hidden="false" collective="false" import="true" targetId="1ade-0c02-5612-252b" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="a423-7dd8-3f1b-3e28" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1941-21b5-932c-74d6" type="atLeast"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </entryLink>
+            <entryLink id="3fb4-2cf6-b648-0493" name="Shrapnel Bolter" hidden="false" collective="false" import="true" targetId="1941-21b5-932c-74d6" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
+              </costs>
+            </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="d6de-b894-9f87-81d5" name="Any model with a Bolter may take:" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="d6de-b894-9f87-81d5" name="2) Any model with a Bolter may take:" hidden="false" collective="false" import="true">
           <modifiers>
             <modifier type="increment" field="7492-d702-c339-0d05" value="1.0">
               <repeats>
-                <repeat field="selections" scope="a423-7dd8-3f1b-3e28" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
-              </repeats>
-            </modifier>
-            <modifier type="decrement" field="7492-d702-c339-0d05" value="1.0">
-              <repeats>
-                <repeat field="selections" scope="a423-7dd8-3f1b-3e28" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7413-fd73-0aaf-283d" repeats="1" roundUp="false"/>
-              </repeats>
-            </modifier>
-            <modifier type="decrement" field="7492-d702-c339-0d05" value="1.0">
-              <repeats>
-                <repeat field="selections" scope="a423-7dd8-3f1b-3e28" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6e0f-29bb-4be3-d6cb" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="a423-7dd8-3f1b-3e28" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3fb4-2cf6-b648-0493" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="a423-7dd8-3f1b-3e28" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d3d6-c20b-3b93-dd7b" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="a423-7dd8-3f1b-3e28" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1ade-0c02-5612-252b" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
           </modifiers>
@@ -25301,11 +25447,11 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="68b1-964e-2800-c723" name="Any model in the unit may take:" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="68b1-964e-2800-c723" name="5) Any Veteran in the unit may take:" hidden="false" collective="false" import="true">
           <modifiers>
             <modifier type="increment" field="a5eb-f17b-352b-1dd3" value="1.0">
               <repeats>
-                <repeat field="selections" scope="a423-7dd8-3f1b-3e28" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="a423-7dd8-3f1b-3e28" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2f9e-2fce-394f-f253" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
           </modifiers>
@@ -25319,21 +25465,6 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
               </costs>
             </entryLink>
             <entryLink id="5f1c-4cb4-16c9-65b7" name="Heavy Chainsword" hidden="false" collective="false" import="true" targetId="ba92-3eda-3a71-dabb" type="selectionEntry">
-              <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="84bd-72a8-7817-5422" name="Charnabal Glaive" hidden="false" collective="false" import="true" targetId="c07c-35e6-4616-ef25" type="selectionEntry">
-              <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="e9c8-722a-208b-32f7" name="Charnabal Sabre" hidden="false" collective="false" import="true" targetId="30c2-57eb-5bbe-be0b" type="selectionEntry">
-              <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="e7c2-1918-0566-e8f7" name="Charnabal Tabar" hidden="false" collective="false" import="true" targetId="4611-c33e-f360-7246" type="selectionEntry">
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
               </costs>
@@ -25363,31 +25494,43 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
               </costs>
             </entryLink>
+            <entryLink id="cc88-3083-abed-7912" name="Charnabal Weapon" hidden="false" collective="false" import="true" targetId="2376-af96-e101-e712" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="e537-9eb2-8677-b7b2" name="Any model may exchange it&apos;s bolt pistol for a:" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="e537-9eb2-8677-b7b2" name="3) Any Veteran may exchange its bolt pistol for a:" hidden="false" collective="false" import="true" defaultSelectionEntryId="539f-f5d3-e13b-9d5b">
           <modifiers>
+            <modifier type="decrement" field="40ae-94f3-959b-b897" value="4.0"/>
             <modifier type="increment" field="3508-5ef7-206f-785d" value="1.0">
               <repeats>
-                <repeat field="selections" scope="a423-7dd8-3f1b-3e28" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="a423-7dd8-3f1b-3e28" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2f9e-2fce-394f-f253" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+            <modifier type="increment" field="40ae-94f3-959b-b897" value="1.0">
+              <repeats>
+                <repeat field="selections" scope="a423-7dd8-3f1b-3e28" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2f9e-2fce-394f-f253" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+            <modifier type="decrement" field="40ae-94f3-959b-b897" value="1.0">
+              <repeats>
+                <repeat field="selections" scope="a423-7dd8-3f1b-3e28" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6e0f-29bb-4be3-d6cb" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="3508-5ef7-206f-785d" value="1.0">
               <repeats>
-                <repeat field="selections" scope="a423-7dd8-3f1b-3e28" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d202-6731-c54c-2cd9" repeats="1" roundUp="false"/>
-              </repeats>
-            </modifier>
-            <modifier type="decrement" field="3508-5ef7-206f-785d" value="1.0">
-              <repeats>
-                <repeat field="selections" scope="a423-7dd8-3f1b-3e28" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6e0f-29bb-4be3-d6cb" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="a423-7dd8-3f1b-3e28" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6e0f-29bb-4be3-d6cb" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
           </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3508-5ef7-206f-785d" type="max"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="40ae-94f3-959b-b897" type="min"/>
           </constraints>
           <entryLinks>
-            <entryLink id="5526-16c9-0c86-79be" name="Volkite Serpenta" hidden="false" collective="false" import="true" targetId="d535-1da8-290d-69a6" type="selectionEntry"/>
+            <entryLink id="5526-16c9-0c86-79be" name="Volkite Serpenta" hidden="false" collective="false" import="true" targetId="d535-1da8-290d-69a6" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+              </costs>
+            </entryLink>
             <entryLink id="d320-4f8d-c98a-fb3e" name="Hand Flamer" hidden="false" collective="false" import="true" targetId="e337-adf4-a11f-0280" type="selectionEntry">
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
@@ -25409,28 +25552,22 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
               </costs>
             </entryLink>
             <entryLink id="24f9-9430-205b-fcc8" name="Asphyx Bolt Pistol" hidden="false" collective="false" import="true" targetId="07f7-c486-f597-a1b9" type="selectionEntry"/>
+            <entryLink id="539f-f5d3-e13b-9d5b" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="a423-7dd8-3f1b-3e28" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7d72-7f6d-6330-6871" type="atLeast"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="6e0f-29bb-4be3-d6cb" name="Any model may exchange it&apos;s bolter and bolt pistol for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="a8bd-abd0-650d-1494">
+        <selectionEntryGroup id="6e0f-29bb-4be3-d6cb" name="4) Any Veteran may exchange its bolter and bolt pistol for:" hidden="false" collective="false" import="true">
           <modifiers>
             <modifier type="increment" field="0c7a-f96d-9dcc-f3c9" value="1.0">
               <repeats>
-                <repeat field="selections" scope="a423-7dd8-3f1b-3e28" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
-              </repeats>
-            </modifier>
-            <modifier type="decrement" field="0c7a-f96d-9dcc-f3c9" value="1.0">
-              <repeats>
-                <repeat field="selections" scope="a423-7dd8-3f1b-3e28" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d202-6731-c54c-2cd9" repeats="1" roundUp="false"/>
-              </repeats>
-            </modifier>
-            <modifier type="decrement" field="0c7a-f96d-9dcc-f3c9" value="1.0">
-              <repeats>
-                <repeat field="selections" scope="a423-7dd8-3f1b-3e28" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7413-fd73-0aaf-283d" repeats="1" roundUp="false"/>
-              </repeats>
-            </modifier>
-            <modifier type="decrement" field="0c7a-f96d-9dcc-f3c9" value="1.0">
-              <repeats>
-                <repeat field="selections" scope="a423-7dd8-3f1b-3e28" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e537-9eb2-8677-b7b2" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="a423-7dd8-3f1b-3e28" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2f9e-2fce-394f-f253" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
           </modifiers>
@@ -25440,55 +25577,6 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
           <entryLinks>
             <entryLink id="a8bd-abd0-650d-1494" name="Pair of Lightning Claws" hidden="false" collective="false" import="true" targetId="a6d2-b3a9-6d2c-1f6f" type="selectionEntry"/>
             <entryLink id="2f50-b156-24ac-ab48" name="Pair of Raven&apos;s Talons" hidden="false" collective="false" import="true" targetId="08e4-5e02-da82-f296" type="selectionEntry"/>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="32d5-6fda-b906-3b0e" name="The Legion Veteran Sergeant may take one of the following:" hidden="false" collective="false" import="true">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7aec-ad7c-5775-dbba" type="max"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="0de5-5658-999e-4c18" name="Thunder Hammer" hidden="false" collective="false" import="true" targetId="e6cc-bfce-a4d9-301c" type="selectionEntry">
-              <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="c54c-056f-6f7f-33bc" name="Power Fist" hidden="false" collective="false" import="true" targetId="a3e1-d633-dff9-028b" type="selectionEntry">
-              <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
-              </costs>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="d202-6731-c54c-2cd9" name="The Legion Veteran Sergeant may exchange his bolt pistol for:" hidden="false" collective="false" import="true">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c64a-e72f-108b-ab27" type="max"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="d8fb-9be2-6313-7622" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="717f-cf0a-1593-4bd8" type="selectionEntry">
-              <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="c51d-f93f-c880-361b" name="Inferno Pistol" hidden="false" collective="false" import="true" targetId="dcd1-8b2a-9d97-40ef" type="selectionEntry">
-              <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="eafa-baee-3cdc-9e13" name="Graviton Pistol" hidden="false" collective="false" import="true" targetId="0087-19d3-eca0-cc75" type="selectionEntry">
-              <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="c297-faf2-79a5-babd" name="Æther-Fire Pistol" hidden="false" collective="false" import="true" targetId="ae13-0ae8-a3ba-f6ff" type="selectionEntry">
-              <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="fece-b660-bb11-8a7c" name="Warpfire Pistol" hidden="false" collective="false" import="true" targetId="a94d-1f53-2902-0237" type="selectionEntry">
-              <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
-              </costs>
-            </entryLink>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
@@ -25509,12 +25597,6 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5e15-0994-0be2-80ae" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5ce6-a978-59f9-fdb9" type="min"/>
-          </constraints>
-        </entryLink>
-        <entryLink id="9cc0-d480-d920-dd52" name="Bolter" hidden="false" collective="false" import="true" targetId="1ade-0c02-5612-252b" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8681-13d5-d4de-fec6" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d708-70ad-fe5a-21a4" type="min"/>
           </constraints>
         </entryLink>
       </entryLinks>
@@ -25629,7 +25711,7 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="d88b-0216-2203-0ff7" name="5) Legiones Unit Upgrades:" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="d88b-0216-2203-0ff7" name="4) Legiones Unit Upgrades:" hidden="false" collective="false" import="true">
           <entryLinks>
             <entryLink id="fbda-03a7-cbb1-3caa" name="Preysight" hidden="false" collective="false" import="true" targetId="b905-4d78-c141-4e63" type="selectionEntry">
               <constraints>
@@ -25649,7 +25731,7 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="d5d2-debd-e503-b250" name="7) Sergeant may take (Wargear):" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="d5d2-debd-e503-b250" name="6) Sergeant may take (Wargear):" hidden="false" collective="false" import="true">
           <selectionEntries>
             <selectionEntry id="b6e1-009e-3aba-4f94" name="Master-craft one weapon" hidden="true" collective="false" import="true" type="upgrade">
               <modifiers>
@@ -25765,7 +25847,7 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="81ef-14f3-d6e5-445c" name="4) One Legion Destroyer may take:" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="81ef-14f3-d6e5-445c" name="3) One Destroyer may take:" hidden="false" collective="false" import="true">
           <entryLinks>
             <entryLink id="cd22-d221-08d6-d688" name="Nuncio-Vox" hidden="false" collective="false" import="true" targetId="005e-aae6-ddac-bb45" type="selectionEntry">
               <constraints>
@@ -25793,7 +25875,7 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="3c8c-1230-a356-8be7" name="8) The Entire unit may take:" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="3c8c-1230-a356-8be7" name="7) The Entire unit may take:" hidden="false" collective="false" import="true">
           <entryLinks>
             <entryLink id="fd7f-d067-b6aa-a292" name="Meltabombs" hidden="false" collective="false" import="true" targetId="b9dd-3b21-f3f8-78e3" type="selectionEntry">
               <constraints>
@@ -25805,72 +25887,7 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="24d4-183b-2808-6b72" name="1) Pair of Bolt Pistol Options:" hidden="false" collective="false" import="true" defaultSelectionEntryId="d8e8-617d-7715-c50a">
-          <modifiers>
-            <modifier type="increment" field="635f-f753-37c6-7b8c" value="1.0">
-              <repeats>
-                <repeat field="selections" scope="dbd4-930e-e003-9449" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
-              </repeats>
-            </modifier>
-            <modifier type="increment" field="02aa-44b3-570a-c121" value="1.0">
-              <repeats>
-                <repeat field="selections" scope="dbd4-930e-e003-9449" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
-              </repeats>
-            </modifier>
-            <modifier type="decrement" field="635f-f753-37c6-7b8c" value="5.0"/>
-            <modifier type="decrement" field="635f-f753-37c6-7b8c" value="1.0">
-              <repeats>
-                <repeat field="selections" scope="dbd4-930e-e003-9449" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6b0d-8620-e47d-82d0" repeats="1" roundUp="false"/>
-              </repeats>
-            </modifier>
-            <modifier type="decrement" field="02aa-44b3-570a-c121" value="1.0">
-              <repeats>
-                <repeat field="selections" scope="dbd4-930e-e003-9449" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6b0d-8620-e47d-82d0" repeats="1" roundUp="false"/>
-              </repeats>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="02aa-44b3-570a-c121" type="max"/>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="635f-f753-37c6-7b8c" type="min"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="8948-b7b0-92e6-dfa8" name="Alchem Pistol" hidden="false" collective="false" import="true" targetId="1899-9e9e-76dd-a7ba" type="selectionEntry">
-              <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="d8e8-617d-7715-c50a" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
-              <modifiers>
-                <modifier type="set" field="hidden" value="true">
-                  <conditions>
-                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7d72-7f6d-6330-6871" type="atLeast"/>
-                  </conditions>
-                </modifier>
-              </modifiers>
-            </entryLink>
-            <entryLink id="13fe-cb2a-3203-d301" name="Dragon&apos;s Breath Pistol" hidden="false" collective="false" import="true" targetId="c1cb-0fa7-0d39-73ae" type="selectionEntry">
-              <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="55da-97af-41cd-edd8" name="Volkite Serpenta" hidden="false" collective="false" import="true" targetId="d535-1da8-290d-69a6" type="selectionEntry">
-              <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="570a-6888-9d04-7de2" name="Hand Flamer" hidden="false" collective="false" import="true" targetId="e337-adf4-a11f-0280" type="selectionEntry">
-              <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="0e8c-10d4-6348-9a1b" name="Shrapnel Pistol" hidden="false" collective="false" import="true" targetId="7d72-7f6d-6330-6871" type="selectionEntry">
-              <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="4.0"/>
-              </costs>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="c335-8e0e-0970-8eac" name="6) Sergeant may exchange his Chainsword for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="b447-36c7-4465-8dce">
+        <selectionEntryGroup id="c335-8e0e-0970-8eac" name="5) Sergeant may exchange his Chainsword for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="b447-36c7-4465-8dce">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bcac-7164-eefb-ed3d" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1963-d084-ea1a-4ccb" type="max"/>
@@ -25931,7 +25948,7 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
             <entryLink id="8787-8389-2d63-6f6b" name="Chainaxe" hidden="false" collective="false" import="true" targetId="ed76-dace-31e4-b174" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="860c-0f1c-6c28-351a" name="3) Destroyer Melee Weapons" hidden="false" collective="false" import="true" defaultSelectionEntryId="874a-ba0e-3516-b4a4">
+        <selectionEntryGroup id="860c-0f1c-6c28-351a" name="2) Destroyer Melee Weapons" hidden="false" collective="false" import="true" defaultSelectionEntryId="874a-ba0e-3516-b4a4">
           <modifiers>
             <modifier type="increment" field="5f3f-8423-e3fd-d3e8" value="1.0">
               <repeats>
@@ -25943,7 +25960,7 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
                 <repeat field="selections" scope="dbd4-930e-e003-9449" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="af03-6de3-6d43-c03b" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
-            <modifier type="decrement" field="5f3f-8423-e3fd-d3e8" value="5.0"/>
+            <modifier type="decrement" field="5f3f-8423-e3fd-d3e8" value="4.0"/>
           </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0864-9791-cd98-8ab7" type="max"/>
@@ -25955,97 +25972,139 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
             <entryLink id="3c02-273c-e864-2e0d" name="Fenrisian Axe" hidden="false" collective="false" import="true" targetId="72ba-d2df-d98b-8b5d" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="6b0d-8620-e47d-82d0" name="2) One in five may instead take a bolt pistol and:" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="d53e-46b9-b817-9b35" name="1) Every Destroyer must choose one from:" hidden="false" collective="false" import="true" defaultSelectionEntryId="df6e-1b7f-7ae2-d55b">
           <modifiers>
-            <modifier type="increment" field="5ac0-b2ea-8081-2bff" value="2.0">
+            <modifier type="increment" field="d24c-04c8-3113-6809" value="1.0">
               <repeats>
-                <repeat field="selections" scope="dbd4-930e-e003-9449" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="dbd4-930e-e003-9449" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
-            <modifier type="increment" field="5ac0-b2ea-8081-2bff" value="1.0">
+            <modifier type="increment" field="9c9c-b558-7a91-1a5a" value="1.0">
               <repeats>
-                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="cdfc-3ebc-a5b1-f69d" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="dbd4-930e-e003-9449" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
+            <modifier type="decrement" field="d24c-04c8-3113-6809" value="5.0"/>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5ac0-b2ea-8081-2bff" type="min"/>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="06de-740e-4ea8-c1e4" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9c9c-b558-7a91-1a5a" type="max"/>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d24c-04c8-3113-6809" type="min"/>
           </constraints>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="cdfc-3ebc-a5b1-f69d" name="Bolt Pistol Options:" hidden="false" collective="false" import="true">
+          <selectionEntries>
+            <selectionEntry id="df6e-1b7f-7ae2-d55b" name="Two Bolt Pistols" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
-                <modifier type="increment" field="d77a-df4e-d973-0c7b" value="1.0">
-                  <repeats>
-                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0008-446d-7b5c-8607" repeats="1" roundUp="false"/>
-                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d240-3f84-9dcb-ec51" repeats="1" roundUp="false"/>
-                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8b62-fd1c-79e1-dc6f" repeats="1" roundUp="false"/>
-                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="60a6-bd17-5009-69b5" repeats="1" roundUp="false"/>
-                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f2d7-71fe-7628-726c" repeats="1" roundUp="false"/>
-                  </repeats>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="dbd4-930e-e003-9449" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ca85-a591-a2c1-0717" type="atLeast"/>
+                  </conditions>
                 </modifier>
-                <modifier type="increment" field="dbe0-d917-2620-8ad6" value="1.0">
+              </modifiers>
+              <infoLinks>
+                <infoLink id="3866-3c4d-d55b-f85a" name="Bolt Pistol" hidden="false" targetId="c0d3-c136-ef6e-3ff7" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="52c3-d3de-6718-4232" name="Two Volkite Serpenta" hidden="false" collective="false" import="true" type="upgrade">
+              <infoLinks>
+                <infoLink id="1146-c32a-a88e-aa9a" name="Volkite Serpenta" hidden="false" targetId="6150-1ce8-ef78-f686" type="profile"/>
+                <infoLink id="3a72-7168-d20d-57b9" name="Deflagrate" hidden="false" targetId="60bc-f79a-67ae-be4f" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="ef3c-4415-a787-57a0" name="Two Hand Flamers" hidden="false" collective="false" import="true" type="upgrade">
+              <infoLinks>
+                <infoLink id="cb8e-2deb-6d06-0693" name="Hand Flamer" hidden="false" targetId="eb62-ccfd-b605-ab5e" type="profile"/>
+                <infoLink id="f017-e780-5b0c-2f3a" name="Template Weapons" hidden="false" targetId="5e0e-88e6-db81-5a70" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="ddf4-fb00-ecd3-d6c7" name="Two Alchem Pistols" hidden="false" collective="false" import="true" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dd1f-1c51-706c-e5f7" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <infoLinks>
+                <infoLink id="e010-1146-7b84-b9f6" name="Alchem Pistol " hidden="false" targetId="c9bc-f720-f183-be0d" type="profile"/>
+                <infoLink id="f541-2e9b-2d84-f089" name="Template Weapons" hidden="false" targetId="5e0e-88e6-db81-5a70" type="rule"/>
+                <infoLink id="67f5-aa37-b7d1-ddd9" name="Fleshbane" hidden="false" targetId="40cd-9505-253c-e76f" type="rule"/>
+                <infoLink id="be74-5a06-75d3-5e72" name="Gets Hot" hidden="false" targetId="679f-9d97-5ace-a652" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="9813-75db-2189-0edf" name="Two Dragon&apos;s Breath Pistols" hidden="false" collective="false" import="true" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c805-ca3a-ff93-5e2f" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <infoLinks>
+                <infoLink id="a9f2-3731-efbb-16b7" name="Dragon&apos;s Breath Pistol" hidden="false" targetId="c4ff-6453-7bc3-1832" type="profile"/>
+                <infoLink id="0fab-e601-f937-4776" name="Template Weapons" hidden="false" targetId="5e0e-88e6-db81-5a70" type="rule"/>
+                <infoLink id="dbc7-5da1-e7f6-c022" name="Dragon&apos;s Breath" hidden="false" targetId="655c-988f-74b5-7e17" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="ca85-a591-a2c1-0717" name="Two Shrapnel Pistols" hidden="false" collective="false" import="true" type="upgrade">
+              <infoLinks>
+                <infoLink id="2062-00b6-d022-e5c8" name="Shrapnel Pistol" hidden="false" targetId="237f-c069-a680-dfae" type="profile"/>
+                <infoLink id="d892-77c6-4ab4-1a21" name="Pinning" hidden="false" targetId="1c96-205c-59a0-3cf2" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="4.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="275f-11e2-b2db-d976" name="One in five may instead take a bolt pistol and:" hidden="false" collective="false" import="true">
+              <modifiers>
+                <modifier type="increment" field="bba6-0b36-90a8-9d59" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0008-446d-7b5c-8607" repeats="1" roundUp="false"/>
-                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d240-3f84-9dcb-ec51" repeats="1" roundUp="false"/>
-                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8b62-fd1c-79e1-dc6f" repeats="1" roundUp="false"/>
-                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="60a6-bd17-5009-69b5" repeats="1" roundUp="false"/>
-                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f2d7-71fe-7628-726c" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="dbd4-930e-e003-9449" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
                   </repeats>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d77a-df4e-d973-0c7b" type="min"/>
-                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dbe0-d917-2620-8ad6" type="max"/>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bba6-0b36-90a8-9d59" type="max"/>
               </constraints>
               <entryLinks>
-                <entryLink id="0519-a2a4-4173-decf" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
-                  <modifiers>
-                    <modifier type="set" field="hidden" value="true">
-                      <conditions>
-                        <condition field="selections" scope="dbd4-930e-e003-9449" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7d72-7f6d-6330-6871" type="atLeast"/>
-                      </conditions>
-                    </modifier>
-                  </modifiers>
-                </entryLink>
-                <entryLink id="7c13-d815-0d83-2f44" name="Shrapnel Pistol" hidden="false" collective="false" import="true" targetId="7d72-7f6d-6330-6871" type="selectionEntry">
+                <entryLink id="037f-7b74-dd83-3d23" name="Toxiferran Flamer" hidden="false" collective="false" import="true" targetId="732a-29f9-edb7-5bc3" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="e2d2-9b13-db37-5d95" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="717f-cf0a-1593-4bd8" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="f64d-2d9c-6e15-0bcb" name="Missile Launcher (With suspensor web and rad missiles only)" hidden="false" collective="false" import="true" targetId="d000-9713-6bc2-e93b" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="bebf-cd67-adca-aeb8" name="Warpfire Pistol" hidden="false" collective="false" import="true" targetId="a94d-1f53-2902-0237" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
                   </costs>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
-          <entryLinks>
-            <entryLink id="8b62-fd1c-79e1-dc6f" name="Missile Launcher (With suspensor web and rad missiles only)" hidden="false" collective="false" import="true" targetId="d000-9713-6bc2-e93b" type="selectionEntry">
-              <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="d240-3f84-9dcb-ec51" name="Graviton Gun" hidden="false" collective="false" import="true" targetId="5303-5a3e-de51-1707" type="selectionEntry">
-              <modifiers>
-                <modifier type="append" field="name" value=" (with suspensor web)"/>
-              </modifiers>
-              <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="0008-446d-7b5c-8607" name="Disintegrator" hidden="false" collective="false" import="true" targetId="a567-9434-36f3-5fd4" type="selectionEntry">
-              <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="60a6-bd17-5009-69b5" name="Toxiferran Flamer" hidden="false" collective="false" import="true" targetId="732a-29f9-edb7-5bc3" type="selectionEntry">
-              <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="f2d7-71fe-7628-726c" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="717f-cf0a-1593-4bd8" type="selectionEntry">
-              <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
-              </costs>
-            </entryLink>
-          </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
@@ -26723,7 +26782,7 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="1.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="d39f-99d5-f7a4-7b86" name="Techmarine Covenent (Placeholder Points)" publicationId="a716-c1c4-7b26-8424" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="d39f-99d5-f7a4-7b86" name="Techmarine Covenant (Placeholder Points)" publicationId="a716-c1c4-7b26-8424" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
         <categoryLink id="bba9-768a-89c6-84ba" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
@@ -35730,6 +35789,9 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
       <infoLinks>
         <infoLink id="cf3d-6c58-b832-9d35" name="Master of the Legion" hidden="false" targetId="c772-87ea-d49c-c7ba" type="rule"/>
       </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
@@ -35831,7 +35893,7 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
         <entryLink id="78be-935f-1458-e8fd" name="Pavoni" hidden="false" collective="false" import="true" targetId="5532-04aa-8302-2038" type="selectionEntry"/>
       </entryLinks>
     </selectionEntryGroup>
-    <selectionEntryGroup id="aeb3-6a73-da1d-2b90" name="Surgical Augement" hidden="true" collective="false" import="true">
+    <selectionEntryGroup id="aeb3-6a73-da1d-2b90" name="Surgical Augment" hidden="true" collective="false" import="true">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
@@ -36438,7 +36500,7 @@ Special rules A Legion Warmonger Consul gains the Tip of the Spear special rule.
         <entryLink id="fbad-5b31-86ab-1246" name="Spear Of Perdition" hidden="false" collective="false" import="true" targetId="cb7e-e113-9008-6bdc" type="selectionEntry"/>
       </entryLinks>
     </selectionEntryGroup>
-    <selectionEntryGroup id="a176-0cea-601c-dea5" name="Tainted Weapon" hidden="false" collective="false" import="true">
+    <selectionEntryGroup id="a176-0cea-601c-dea5" name="Tainted Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="5795-6f95-49b9-481b">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d2e7-b818-34fd-d810" type="max"/>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="67f1-c2ec-b46b-91fe" type="min"/>
@@ -36472,7 +36534,7 @@ Special rules A Legion Warmonger Consul gains the Tip of the Spear special rule.
         <entryLink id="f06a-8dc1-9f46-e466" name="Minor Combi-Weapon - Alchem Flamer" hidden="false" collective="false" import="true" targetId="b941-687c-c95e-31a6" type="selectionEntry"/>
       </entryLinks>
     </selectionEntryGroup>
-    <selectionEntryGroup id="82b0-2459-4bbc-e15b" name="Charnabal Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="a904-5bf0-3545-575c">
+    <selectionEntryGroup id="82b0-2459-4bbc-e15b" name="Charnabal Weapon" hidden="false" collective="false" import="true">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3180-1876-0c05-1a10" type="max"/>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="122a-7f43-620c-2433" type="min"/>
@@ -36619,6 +36681,11 @@ Special rules A Legion Warmonger Consul gains the Tip of the Spear special rule.
           </modifiers>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+          </costs>
+        </entryLink>
+        <entryLink id="b3d9-5a37-e856-2f23" name="Graviton Crusher" hidden="false" collective="false" import="true" targetId="cc01-7fb0-8c1e-f968" type="selectionEntry">
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
           </costs>
         </entryLink>
       </entryLinks>
@@ -36811,7 +36878,7 @@ Special rules A Legion Warmonger Consul gains the Tip of the Spear special rule.
         <entryLink id="6e59-3be9-921b-b5c4" name="Barb-Hook Lash" hidden="false" collective="false" import="true" targetId="e711-ab63-4899-8b00" type="selectionEntry"/>
       </entryLinks>
     </selectionEntryGroup>
-    <selectionEntryGroup id="5123-62ae-8298-d982" name="Power Fist" hidden="false" collective="false" import="true">
+    <selectionEntryGroup id="5123-62ae-8298-d982" name="Power Fist" hidden="false" collective="false" import="true" defaultSelectionEntryId="6109-15a7-e083-4e48">
       <modifiers>
         <modifier type="set" field="name" value="0.0"/>
       </modifiers>
@@ -36868,7 +36935,7 @@ Special rules A Legion Warmonger Consul gains the Tip of the Spear special rule.
         </entryLink>
       </entryLinks>
     </selectionEntryGroup>
-    <selectionEntryGroup id="d52c-247f-4fe0-df6f" name="Thunder Hammer" hidden="false" collective="false" import="true">
+    <selectionEntryGroup id="d52c-247f-4fe0-df6f" name="Thunder Hammer" hidden="false" collective="false" import="true" defaultSelectionEntryId="c7f0-651b-e794-f198">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0e34-57c7-d7ee-a1a1" type="max"/>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2938-4b4e-4f78-4643" type="min"/>
@@ -36876,6 +36943,7 @@ Special rules A Legion Warmonger Consul gains the Tip of the Spear special rule.
       <entryLinks>
         <entryLink id="c7f0-651b-e794-f198" name="Thunder Hammer" hidden="false" collective="false" import="true" targetId="838c-4002-713d-d7c6" type="selectionEntry"/>
         <entryLink id="13b6-051f-97ae-cddf" name="Solarite Power Gauntlet" hidden="false" collective="false" import="true" targetId="b682-2c89-f979-aa74" type="selectionEntry"/>
+        <entryLink id="3759-b43f-6eef-75ef" name="Graviton Crusher" hidden="false" collective="false" import="true" targetId="cc01-7fb0-8c1e-f968" type="selectionEntry"/>
       </entryLinks>
     </selectionEntryGroup>
     <selectionEntryGroup id="3aae-b65d-3dbc-6f2e" name="Heavy Bolter" hidden="false" collective="false" import="true" defaultSelectionEntryId="d15a-4432-a97a-64df">
@@ -37087,53 +37155,6 @@ Special rules A Legion Warmonger Consul gains the Tip of the Spear special rule.
           </modifiers>
         </entryLink>
       </entryLinks>
-    </selectionEntryGroup>
-    <selectionEntryGroup id="b26e-c64c-f86f-8351" name="Shrapnel Weaponry Options" hidden="true" collective="false" import="true">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5f54-457a-fbb9-6730" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
-      <selectionEntries>
-        <selectionEntry id="7493-c54a-d99e-ba0b" name="Shrapnel Bolters" hidden="false" collective="false" import="true" type="upgrade">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditionGroups>
-                <conditionGroup type="or">
-                  <conditions>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4280-4963-02b5-e31d" type="instanceOf"/>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="23eb-0b9e-0857-e965" type="instanceOf"/>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e2b6-b770-784c-9e95" type="instanceOf"/>
-                  </conditions>
-                </conditionGroup>
-              </conditionGroups>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="408c-855b-0218-cad4" type="max"/>
-          </constraints>
-        </selectionEntry>
-        <selectionEntry id="eb09-b1ac-20f5-0013" name="Shrapnel Pistols" hidden="false" collective="false" import="true" type="upgrade">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditionGroups>
-                <conditionGroup type="or">
-                  <conditions>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4280-4963-02b5-e31d" type="instanceOf"/>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="23eb-0b9e-0857-e965" type="instanceOf"/>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e2b6-b770-784c-9e95" type="instanceOf"/>
-                  </conditions>
-                </conditionGroup>
-              </conditionGroups>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ecf0-48fb-6484-d063" type="max"/>
-          </constraints>
-        </selectionEntry>
-      </selectionEntries>
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <sharedRules>

--- a/2022 - Legiones Astartes.cat
+++ b/2022 - Legiones Astartes.cat
@@ -745,13 +745,13 @@
         <categoryLink id="8a64-b18f-25ad-5bcd" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="bcb7-198e-4c23-3e57" name="Apothecarion Detachment (Placeholder Points)" hidden="false" collective="false" import="true" targetId="81df-ffd4-a32b-b4a1" type="selectionEntry">
+    <entryLink id="bcb7-198e-4c23-3e57" name="*Apothecarion Detachment (Placeholder Points)" hidden="false" collective="false" import="true" targetId="81df-ffd4-a32b-b4a1" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="16eb-d597-678e-f643" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="73fc-3af7-851f-9f40" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="2899-286a-c961-ddeb" name="Techmarine Covenent (Placeholder Points)" hidden="false" collective="false" import="true" targetId="d39f-99d5-f7a4-7b86" type="selectionEntry">
+    <entryLink id="2899-286a-c961-ddeb" name="*Techmarine Covenant (Placeholder Points)" hidden="false" collective="false" import="true" targetId="d39f-99d5-f7a4-7b86" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="e4bc-5443-34b1-96ff" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="1a8a-33c9-645e-095e" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
@@ -847,7 +847,7 @@
         <categoryLink id="ba73-eec2-2811-1b8f" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="f717-0a10-cd1f-1351" name="Arquitor Squaron (Placeholder Points)" hidden="false" collective="false" import="true" targetId="9e46-a480-c382-c49c" type="selectionEntry">
+    <entryLink id="f717-0a10-cd1f-1351" name="**Arquitor Squadron " hidden="false" collective="false" import="true" targetId="9e46-a480-c382-c49c" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="8fb8-8f5f-cc51-7af0" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="3fa1-e04a-eb47-7e80" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
@@ -1214,10 +1214,52 @@
         <categoryLink id="27bc-1e1f-94be-65a8" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="3906-76aa-f024-5fea" name="*Tyrant Siege Terminator Squad" hidden="false" collective="false" import="true" targetId="07bc-13fe-b069-4afb" type="selectionEntry">
+    <entryLink id="3906-76aa-f024-5fea" name="Tyrant Siege Terminator Squad" hidden="false" collective="false" import="true" targetId="07bc-13fe-b069-4afb" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="9617-f6f8-557a-a2ba" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="8a05-0b67-8f3f-3642" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="1090-7262-1a7b-c8d7" name="New CategoryLink" hidden="false" targetId="9231-183c-b97b-63f9" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="d151-b439-f6f4-de6b" name="**Mortus Poisoner Squad" hidden="false" collective="false" import="true" targetId="3107-56ad-4cf6-0330" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="5ffa-4623-b982-b404" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="3504-d3f6-10d8-569f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="8089-206a-06ba-6b67" name="**Rapier Battery" hidden="false" collective="false" import="true" targetId="23e4-c64b-65b4-c8a5" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="69f8-0acb-82cc-5abf" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="d850-5248-836f-1737" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="b1ae-e09d-6962-0c3c" name="**Marshal Durak Rask" hidden="false" collective="false" import="true" targetId="4390-3aec-6ae6-5b81" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="b9ae-9507-41d3-2151" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="7744-596e-2a1e-0cf7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="677d-40c9-bd11-445a" name="*Castraferrum Dread Talon" hidden="false" collective="false" import="true" targetId="daf7-b23b-5474-5836" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="5597-bb2c-fd86-c7cf" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="3cf3-6ea6-f1e7-2170" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="3870-4373-1d58-f961" name="**Terminator Indomitus Squad" hidden="false" collective="false" import="true" targetId="aa7f-bd4c-5231-d459" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="6aa7-1cbd-8158-ec09" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="0a59-1af0-8703-cdc6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="ff7d-5072-81f6-2d65" name="**Nullificator Squad" hidden="false" collective="false" import="true" targetId="954d-cf8e-eefd-27a6" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="952e-ae58-0116-a5bb" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
+        <categoryLink id="c5af-e209-a36f-7653" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="ddd1-67e1-f8b6-5368" name="**Crysos Morturg" hidden="false" collective="false" import="true" targetId="bd58-7b96-a940-bd7f" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="9a81-8ca3-52ad-a91a" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
+        <categoryLink id="90c3-0113-59f7-898d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
   </entryLinks>
@@ -1710,7 +1752,7 @@
           </constraints>
           <infoLinks>
             <infoLink id="99df-d9d2-7e82-ba25" name="Thamaturge&apos;s Cleansing (P3P ZW) (Move to GST)" hidden="false" targetId="021c-8e6e-e2ff-3813" type="profile"/>
-            <infoLink id="e483-46b3-946f-f106" name="Thamaturgic Succour (P3P ZW) (Move to GST)" hidden="false" targetId="66c0-a79f-e220-cfb2" type="profile"/>
+            <infoLink id="e483-46b3-946f-f106" name="Thamaturgic Succour" hidden="false" targetId="66c0-a79f-e220-cfb2" type="profile"/>
             <infoLink id="e881-58ce-1713-65a4" name="Corvidae" hidden="false" targetId="6565-75e7-64c1-50a3" type="profile"/>
             <infoLink id="4f32-ad90-48ef-549d" name="Divinatory Aegis" hidden="false" targetId="a988-4aa9-a875-1fb0" type="profile"/>
             <infoLink id="fe85-83d2-9693-f1e7" name="Diviner&apos;s Dart" hidden="false" targetId="9616-6d6e-2516-9abd" type="profile"/>
@@ -1719,7 +1761,7 @@
             <infoLink id="51a9-34a6-daaf-72cd" name="Template Weapons" hidden="false" targetId="5e0e-88e6-db81-5a70" type="rule"/>
             <infoLink id="69da-69c6-1c89-130c" name="Sniper" hidden="false" targetId="9cd8-e726-5dbe-b106" type="rule"/>
             <infoLink id="01d9-2435-00c6-e058" name="Guided Fire" hidden="false" targetId="fa1e-0112-943e-b1f6" type="rule"/>
-            <infoLink id="ed13-086a-9510-68f5" name="Aetheric Lightning (P3P ZW)" hidden="false" targetId="3d0c-e779-247f-0332" type="profile"/>
+            <infoLink id="ed13-086a-9510-68f5" name="Aetheric Lightning" hidden="false" targetId="3d0c-e779-247f-0332" type="profile"/>
             <infoLink id="2b0e-7968-7d17-7cf4" name="Force" hidden="false" targetId="f39e-4c3b-38e0-0050" type="rule"/>
           </infoLinks>
           <costs>
@@ -7201,30 +7243,6 @@ The Instrument has two profiles. Pick which profile is used every time the weapo
         <infoLink id="f147-5409-db3d-abf0" name="Pinning" hidden="false" targetId="1c96-205c-59a0-3cf2" type="rule"/>
         <infoLink id="d3ce-61ac-54ed-94bc" name="Deathstorm" hidden="false" targetId="7208-c178-683e-3e39" type="rule"/>
         <infoLink id="c49a-7c1b-d98c-3c37" name="Limited Ammunition" hidden="false" targetId="9f09-5cb8-c3ea-c3f8" type="rule"/>
-      </infoLinks>
-      <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="ba21-c48f-3986-d1e2" name="Spicula Rocket System" hidden="false" collective="false" import="true" type="upgrade">
-      <profiles>
-        <profile id="68c0-f18c-645d-c555" name="Spicula Rocket System" publicationId="a716-c1c4-7b26-8424" page="133" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
-          <characteristics>
-            <characteristic name="Range" typeId="95ba-cda7-b831-6066">72&quot;</characteristic>
-            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">7</characteristic>
-            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">4</characteristic>
-            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Ordnance 1, Massive Blast (7&quot;), Rending (6+), Limited Ammunition</characteristic>
-          </characteristics>
-        </profile>
-      </profiles>
-      <infoLinks>
-        <infoLink id="58ef-a2f8-e852-c63c" name="Blast" hidden="false" targetId="1d9a-73ef-5f4f-8bd8" type="rule"/>
-        <infoLink id="6e0c-9351-81b2-8648" name="Rending (X)" hidden="false" targetId="0ac9-fab7-aef3-de1d" type="rule">
-          <modifiers>
-            <modifier type="set" field="name" value="Rending (6+)"/>
-          </modifiers>
-        </infoLink>
-        <infoLink id="b510-9a01-17f3-ae27" name="Limited Ammunition" hidden="false" targetId="9f09-5cb8-c3ea-c3f8" type="rule"/>
       </infoLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
@@ -15582,7 +15600,7 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
         <categoryLink id="e07d-b552-90ef-c096" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="baa7-a991-0755-959a" name="Legion Rhino Transport" hidden="false" collective="false" import="true" type="model">
+        <selectionEntry id="baa7-a991-0755-959a" name="Legion Rhino Transport" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e903-4c24-ad77-5be3" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7122-ce08-7f86-3c8c" type="min"/>
@@ -18716,7 +18734,7 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="150.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="83ac-f9cf-cc29-00a3" name="Drop Pod" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="83ac-f9cf-cc29-00a3" name="Drop Pod" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="febd-7328-3ea8-fc2f" name="Inertial Guidance System" hidden="false" targetId="d222-fde9-51b8-8739" type="rule"/>
         <infoLink id="7278-a30b-5237-7829" name="Impact-reactive Doors" hidden="false" targetId="6c21-dd77-4c93-eeed" type="rule"/>
@@ -18817,7 +18835,7 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="100.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="cb30-307a-f0d7-3b13" name="Termite Assault Drill" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="cb30-307a-f0d7-3b13" name="Termite Assault Drill" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="4c03-6cdb-b4f6-af7c" name="Infantry Transport" hidden="false" targetId="0c6b-9cc1-5801-3e83" type="rule"/>
       </infoLinks>
@@ -19001,6 +19019,39 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
           </constraints>
           <profiles>
             <profile id="aa3a-9a22-178b-6a2e" name="Contemptor Dreadnought" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
+              <modifiers>
+                <modifier type="set" field="f111-2ce5-dd12-d6b0" value="4">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="08be-6994-6a63-6279" type="equalTo"/>
+                        <condition field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b254-abfc-a57f-ab28" type="equalTo"/>
+                        <condition field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5ffe-2820-9b97-99db" type="equalTo"/>
+                      </conditions>
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b254-abfc-a57f-ab28" type="equalTo"/>
+                            <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="08be-6994-6a63-6279" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5ffe-2820-9b97-99db" type="equalTo"/>
+                            <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="08be-6994-6a63-6279" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b254-abfc-a57f-ab28" type="equalTo"/>
+                            <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5ffe-2820-9b97-99db" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Dreadnought</characteristic>
                 <characteristic name="Move" typeId="893e-2d76-8f04-44e5">8</characteristic>
@@ -19075,12 +19126,12 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
                 </entryLink>
                 <entryLink id="fea6-8369-146f-e9e6" name="Gravis Power Fist" hidden="false" collective="false" import="true" targetId="08be-6994-6a63-6279" type="selectionEntry">
                   <modifiers>
-                    <modifier type="append" field="name" value=" with in-built combi-bolter"/>
+                    <modifier type="append" field="name" value=" with in-built ranged weapon"/>
                   </modifiers>
                 </entryLink>
                 <entryLink id="f0ec-e84f-eb8b-d59e" name="Gravis Chainfist" hidden="false" collective="false" import="true" targetId="5ffe-2820-9b97-99db" type="selectionEntry">
                   <modifiers>
-                    <modifier type="append" field="name" value=" with in-built combi-bolter"/>
+                    <modifier type="append" field="name" value=" with in-built ranged weapon"/>
                   </modifiers>
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
@@ -19092,6 +19143,9 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
                   </costs>
                 </entryLink>
                 <entryLink id="f617-35bf-7879-5001" name="Graviton Maul" hidden="false" collective="false" import="true" targetId="b254-abfc-a57f-ab28" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="append" field="name" value=" with in-built ranged weapon"/>
+                  </modifiers>
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
                   </costs>
@@ -26131,24 +26185,194 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="45.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="81df-ffd4-a32b-b4a1" name="Apothecarion Detachment (Placeholder Points)" publicationId="a716-c1c4-7b26-8424" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="81df-ffd4-a32b-b4a1" name="Apothecarion Detachment" publicationId="a716-c1c4-7b26-8424" hidden="false" collective="false" import="true" type="unit">
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6f11-3eea-f7db-d017" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="5335-190f-28cf-f12b" name="Legiones Astartes (X)" hidden="false" targetId="61cf-75c2-56cd-2a31" type="rule"/>
+        <infoLink id="6764-07a2-98e6-b076" name="Apothecarion Detachment" hidden="false" targetId="edb9-295b-5d36-8fd7" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="bb97-be52-aa75-a4d0" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="415c-6834-f4d2-d967" name="Troops" publicationId="a716-c1c4-7b26-8424" hidden="false" collective="false" import="true" type="model">
+        <selectionEntry id="415c-6834-f4d2-d967" name="Apothecary" publicationId="a716-c1c4-7b26-8424" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="82ba-ef67-8481-b3f6" type="min"/>
-            <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aed5-305a-f104-74d5" type="max"/>
+            <constraint field="selections" scope="parent" value="7.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="aed5-305a-f104-74d5" type="max"/>
           </constraints>
+          <profiles>
+            <profile id="7567-d696-5087-265a" name="Apothecary" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
+              <modifiers>
+                <modifier type="set" field="e593-6b3c-f169-04f0" value="2+">
+                  <conditions>
+                    <condition field="selections" scope="415c-6834-f4d2-d967" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="583e-62cb-53f1-f952" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <characteristics>
+                <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character)</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
+                <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
+                <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
+                <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">4</characteristic>
+                <characteristic name="W" typeId="57ee-1126-32a9-5672">1</characteristic>
+                <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
+                <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">2</characteristic>
+                <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">8</characteristic>
+                <characteristic name="Save" typeId="e593-6b3c-f169-04f0">3+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="8eb3-6645-8321-61fb" name="5) Mobility:" hidden="false" collective="false" import="true">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0c0f-f751-cc4e-4951" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0753-2176-f6ed-94c8" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="f685-448d-b635-83c7" name="Warhawk Jump Pack" hidden="false" collective="false" import="true" targetId="a298-8584-70ed-18ce" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="eaa3-3358-4d3c-d682" name="Spatha Combat Bike" hidden="false" collective="false" import="true" targetId="e8a8-b526-beab-bb82" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="2c16-485f-9b87-2149" name="Scimitar Jetbike" hidden="false" collective="false" import="true" targetId="6fb4-adf6-dbe8-86af" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="efb3-a42b-62dd-5b7d" name="3) May take a ranged weapon:" hidden="false" collective="false" import="true">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="631d-a61a-482b-47ae" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="55b1-c3a7-785f-9413" name="Magna Combi-Weapon" hidden="false" collective="false" import="true" targetId="e5b1-83e5-7272-a59e" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="79e3-985b-4ce3-ac7b" name="Minor Combi-Weapon" hidden="false" collective="false" import="true" targetId="605e-1b86-ca08-9226" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="7042-c6f5-708b-91b0" name="Volkite Charger" hidden="false" collective="false" import="true" targetId="6f6e-ad55-e093-6503" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="0405-5044-57ac-bdd9" name="1) Bolt Pistol Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="b33e-8fbe-9704-aece">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="86c9-b70f-4477-48bb" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e08c-c419-5711-131e" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="ea05-7602-2846-1c7c" name="Asphyx Bolt Pistol" hidden="false" collective="false" import="true" targetId="07f7-c486-f597-a1b9" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="1.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="a3c3-15f5-aecb-487d" name="Shrapnel Pistol" hidden="false" collective="false" import="true" targetId="7d72-7f6d-6330-6871" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="b33e-8fbe-9704-aece" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry"/>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="61b5-27d3-22e0-d276" name="2) Melee Weapons" hidden="false" collective="false" import="true" defaultSelectionEntryId="bc74-6578-8ac5-7707">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="95b7-57dd-6e71-7727" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="81d8-2d9b-7702-b123" type="min"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="bc74-6578-8ac5-7707" name="Chainsword" hidden="false" collective="false" import="true" targetId="06e7-a6ae-ed1c-eb03" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d6d6-f454-6cd8-eed8" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="ecf6-019d-4459-c839" name="Charnabal Weapon" hidden="false" collective="false" import="true" targetId="2376-af96-e101-e712" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7ce0-9af4-5490-7862" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="a202-12bc-36bc-9cbf" name="Power Weapon" hidden="false" collective="false" import="true" targetId="8d9c-9f80-c0fd-adcf" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="420a-ce92-596f-f430" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="71f7-2bdd-8059-37b7" name="4) Armour:" hidden="false" collective="false" import="true" defaultSelectionEntryId="24d0-9bea-d4b5-71f6">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2059-10b1-cbdf-e4f4" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="46f7-cd75-1735-e905" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="b337-fda8-b2d3-25be" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c740-56d0-f913-6939" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="24d0-9bea-d4b5-71f6" name="Power Armour" hidden="false" collective="false" import="true" targetId="2d9d-480e-7c14-1a6f" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3dce-7b9d-3b98-ef62" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="6767-404e-f31a-44d9" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="43c0-4322-2608-2d55" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4112-bc96-ec2e-42e8" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="bd7d-5e03-165d-e3bf" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0a65-15b8-265e-3c29" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a1a2-770f-81bb-dd23" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="6da3-6ddb-578f-2c79" name="Narthecium" hidden="false" collective="false" import="true" targetId="dd7a-d404-a96c-1251" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c8f1-f137-72b8-497f" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="003b-a2d2-310f-696c" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="45.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
-      <entryLinks>
-        <entryLink id="8968-8b31-9653-905a" name="Upgrade Points (Placeholders)" hidden="false" collective="false" import="true" targetId="8b48-2da0-15da-2c1b" type="selectionEntry"/>
-      </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
       </costs>
@@ -26622,6 +26846,11 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
               </costs>
             </entryLink>
+            <entryLink id="62e5-26d3-cdb1-57b0" name="Magna Combi-Weapon - Disintegrator" hidden="false" collective="false" import="true" targetId="1d05-f467-b0aa-88b2" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+              </costs>
+            </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="3ca8-5ca2-3c96-b74a" name="The Legion Seeker Sergeant may take (Wargear):" hidden="false" collective="false" import="true">
@@ -26782,24 +27011,320 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="1.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="d39f-99d5-f7a4-7b86" name="Techmarine Covenant (Placeholder Points)" publicationId="a716-c1c4-7b26-8424" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="d39f-99d5-f7a4-7b86" name="Techmarine Covenant" publicationId="a716-c1c4-7b26-8424" hidden="false" collective="false" import="true" type="unit">
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ff7e-29e9-15ce-eb81" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="ad67-cade-eb63-f8c5" name="Techmarine Covenant" hidden="false" targetId="93e9-2806-e822-bfaf" type="rule"/>
+        <infoLink id="4850-bab0-b2cc-e3e7" name="Legiones Astartes (X)" hidden="false" targetId="61cf-75c2-56cd-2a31" type="rule"/>
+        <infoLink id="389a-dc31-670b-3f25" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
+        <infoLink id="c4b8-affe-6d31-e90b" name="Battlesmith (X)" hidden="false" targetId="5d57-4d02-1e36-4a82" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Battlesmith (5+)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="bba9-768a-89c6-84ba" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="fc32-089e-1c59-70bd" name="Troops" publicationId="a716-c1c4-7b26-8424" hidden="false" collective="false" import="true" type="model">
+        <selectionEntry id="fc32-089e-1c59-70bd" name="Techmarine" publicationId="a716-c1c4-7b26-8424" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cc3e-d2ef-58cf-da34" type="min"/>
             <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e93f-befc-bf06-3edd" type="max"/>
           </constraints>
+          <profiles>
+            <profile id="1d28-2760-4519-6fb6" name="Techmarine" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
+              <modifiers>
+                <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Infantry (Heavy, Character)">
+                  <conditions>
+                    <condition field="selections" scope="fc32-089e-1c59-70bd" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0c0f-f751-cc4e-4951" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <characteristics>
+                <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character)</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
+                <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
+                <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
+                <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">4</characteristic>
+                <characteristic name="W" typeId="57ee-1126-32a9-5672">1</characteristic>
+                <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
+                <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">2</characteristic>
+                <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">8</characteristic>
+                <characteristic name="Save" typeId="e593-6b3c-f169-04f0">2+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="b258-61fd-7012-66ac" name="3) May take a ranged weapon:" hidden="false" collective="false" import="true">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d73d-a1d4-c7db-c54d" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="165d-375f-17eb-c7ca" name="Master-crafted asphyx bolter" hidden="false" collective="false" import="true" type="upgrade">
+                  <infoLinks>
+                    <infoLink id="efe6-4ade-f684-9894" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule"/>
+                  </infoLinks>
+                  <entryLinks>
+                    <entryLink id="748e-c001-1a4a-24cf" name="Asphyx Bolter" hidden="false" collective="false" import="true" targetId="88c0-4623-9da3-f2b5" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4451-e9ab-035b-2ca4" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5216-a627-0479-418c" type="max"/>
+                      </constraints>
+                    </entryLink>
+                  </entryLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="6.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="fbf6-b464-6c49-85bf" name="Master-crafted bolter" hidden="false" collective="false" import="true" type="upgrade">
+                  <infoLinks>
+                    <infoLink id="28e4-6edb-9f14-b254" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule"/>
+                  </infoLinks>
+                  <entryLinks>
+                    <entryLink id="7e94-8c06-acf2-15ce" name="Bolter" hidden="false" collective="false" import="true" targetId="1ade-0c02-5612-252b" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0192-c743-6e4d-a7bc" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dea2-0cfc-0318-23cb" type="max"/>
+                      </constraints>
+                    </entryLink>
+                  </entryLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="8316-07f9-c2b1-8c09" name="Master-crafted shrapnel bolter" hidden="false" collective="false" import="true" type="upgrade">
+                  <infoLinks>
+                    <infoLink id="b246-add4-c516-eddf" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule"/>
+                  </infoLinks>
+                  <entryLinks>
+                    <entryLink id="8732-6d9d-6763-e0e3" name="Shrapnel Bolter" hidden="false" collective="false" import="true" targetId="1941-21b5-932c-74d6" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="10ce-689b-afa7-029e" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2668-04f0-a2fe-cdc5" type="min"/>
+                      </constraints>
+                    </entryLink>
+                  </entryLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="7.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <entryLinks>
+                <entryLink id="0468-8071-fb75-f6a8" name="Magna Combi-Weapon" hidden="false" collective="false" import="true" targetId="e5b1-83e5-7272-a59e" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="93ce-7763-6f61-2a97" name="Minor Combi-Weapon" hidden="false" collective="false" import="true" targetId="605e-1b86-ca08-9226" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="3706-60d9-e0fb-56a2" name="Volkite Charger" hidden="false" collective="false" import="true" targetId="6f6e-ad55-e093-6503" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="d9f3-bdc6-37e5-2342" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="717f-cf0a-1593-4bd8" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="a391-1d82-e8a6-68bd" name="Meltagun" hidden="false" collective="false" import="true" targetId="4ebd-57e0-3560-e568" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="6c9a-7bf9-e658-e754" name="Graviton Gun" hidden="false" collective="false" import="true" targetId="5303-5a3e-de51-1707" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="99ac-7c7f-dfdc-7581" name="Flamer" hidden="false" collective="false" import="true" targetId="9f41-82e2-90f6-973a" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="cc00-d00a-c4cb-bed5" name="Plasma Gun" hidden="false" collective="false" import="true" targetId="f0d1-332b-c719-ede7" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="25b9-4ba5-2979-dce6" name="Alchem Flamer" hidden="false" collective="false" import="true" targetId="0d08-eaaf-3793-0a70" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="4519-ccf5-af72-122e" name="Dragon&apos;s Breath Flamer" hidden="false" collective="false" import="true" targetId="d6c6-779a-0b83-fd15" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="42f8-0772-dc33-1bf7" name="2) Melee Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="d29d-8b18-ad8b-2d2d">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dab6-b9cd-10f8-ccca" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2439-bbfa-f7cf-821c" type="min"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="5c5d-64fe-0f41-8f15" name="Graviton Crusher" hidden="false" collective="false" import="true" targetId="cc01-7fb0-8c1e-f968" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="d29d-8b18-ad8b-2d2d" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry"/>
+                <entryLink id="0600-a4d1-f7d2-109c" name="Thunder Hammer" hidden="false" collective="false" import="true" targetId="838c-4002-713d-d7c6" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="ddba-9eed-06f6-49e8" name="Boarding Shield" hidden="false" collective="false" import="true" targetId="0c0f-f751-cc4e-4951" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="fc32-089e-1c59-70bd" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4e23-5d86-064d-7463" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="9192-581b-f084-c977" name="4) May take (Wargear):" hidden="false" collective="false" import="true">
+              <entryLinks>
+                <entryLink id="30f2-b22e-408c-92d8" name="Augury Scanner" hidden="false" collective="false" import="true" targetId="67ee-7338-3b74-04b4" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c97b-d26a-030b-4a8c" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="8a34-56a4-2187-b5a3" name="Cognis-Signum" hidden="false" collective="false" import="true" targetId="93b3-2d66-f7a3-be42" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="76ca-35f7-b122-171e" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="7ddb-f065-b8da-b914" name="Cyber-Familiar" hidden="false" collective="false" import="true" targetId="6c85-4601-cf58-7b35" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d946-bc0c-f9ae-08ae" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="d79a-230e-3394-7918" name="Meltabombs" hidden="false" collective="false" import="true" targetId="b9dd-3b21-f3f8-78e3" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e81b-57ba-add1-9f8a" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="a6db-d1d8-e7c3-30bd" name="Nuncio-Vox" hidden="false" collective="false" import="true" targetId="005e-aae6-ddac-bb45" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2b82-09ae-f576-3cbd" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="11e4-3852-444d-9dbf" name="5) Mobility:" hidden="false" collective="false" import="true">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0c0f-f751-cc4e-4951" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1b24-bc54-f61f-f44b" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="5b0d-d7fe-381a-4667" name="Warhawk Jump Pack" hidden="false" collective="false" import="true" targetId="a298-8584-70ed-18ce" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="8f37-5066-a403-58ff" name="Spatha Combat Bike" hidden="false" collective="false" import="true" targetId="e8a8-b526-beab-bb82" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="9c04-9880-bfde-113e" name="Scimitar Jetbike" hidden="false" collective="false" import="true" targetId="6fb4-adf6-dbe8-86af" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="68b8-f8af-7990-8186" name="1) Bolt Pistol Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="eaaf-d127-06f9-086f">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7519-519a-a86f-8736" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="95a4-3404-a318-ec26" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="acd8-5e3c-2e95-02bd" name="Asphyx Bolt Pistol" hidden="false" collective="false" import="true" targetId="07f7-c486-f597-a1b9" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="1.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="861b-0ff0-88dc-27f9" name="Shrapnel Pistol" hidden="false" collective="false" import="true" targetId="7d72-7f6d-6330-6871" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="cb04-85ae-cd17-bc82" name="Boarding Shield" hidden="false" collective="false" import="true" targetId="0c0f-f751-cc4e-4951" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="fc32-089e-1c59-70bd" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="57dd-7d75-4c6f-2557" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="eaaf-d127-06f9-086f" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="71c2-cc87-e1b0-2c32" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0474-c4ef-a510-53a7" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="acfc-bf19-2767-6f1a" type="min"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="16d0-a73e-9b4f-4798" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1403-4f1b-4515-9fe8" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4925-d83e-f83f-7292" type="min"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="107e-8c9c-a3aa-12f8" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c69e-2e59-f6bb-477f" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f9a-e119-17a3-c924" type="min"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="3278-b30b-2f17-def1" name="Servo-Arm" hidden="false" collective="false" import="true" targetId="4168-fc85-8912-7188" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ca8c-9ae9-04b8-e342" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="632f-5c00-7169-4911" type="min"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="55.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
-      <entryLinks>
-        <entryLink id="ef7b-07f6-5440-c797" name="Upgrade Points (Placeholders)" hidden="false" collective="false" import="true" targetId="8b48-2da0-15da-2c1b" type="selectionEntry"/>
-      </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
       </costs>
@@ -28234,27 +28759,321 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="9e46-a480-c382-c49c" name="Arquitor Squaron (Placeholder Points)" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="9e46-a480-c382-c49c" name="Arquitor Squadron " hidden="false" collective="false" import="true" type="unit">
+      <infoLinks>
+        <infoLink id="cf48-f754-db86-1035" name="Legiones Astartes (X)" hidden="false" targetId="61cf-75c2-56cd-2a31" type="rule"/>
+        <infoLink id="40d0-4a80-7e2c-62bc" name="Move Through Cover" hidden="false" targetId="2b6f-bfec-759e-1746" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="7c5e-2c98-9ff3-b2fa" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="51f1-7e20-8eac-f70c" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="29b7-c714-0a01-697b" name="Tank" hidden="false" collective="false" import="true" type="model">
+        <selectionEntry id="29b7-c714-0a01-697b" name="Arquitor" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5e63-fbf4-adc9-9bec" type="min"/>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="35b4-fbbc-8fb6-e176" type="max"/>
           </constraints>
+          <profiles>
+            <profile id="19aa-5883-3add-6fec" name="Arquitor" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName="Vehicle">
+              <characteristics>
+                <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Bombard)</characteristic>
+                <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">8&quot;</characteristic>
+                <characteristic name="BS" typeId="51fb-b7d9-aa59-863d">4</characteristic>
+                <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">12</characteristic>
+                <characteristic name="Side" typeId="f150-c0dc-c192-9cb3">12</characteristic>
+                <characteristic name="Rear" typeId="8d4e-2aea-fffc-d556">10</characteristic>
+                <characteristic name="HP" typeId="a76c-83b1-602f-9e62">5</characteristic>
+                <characteristic name="Transport Capacity" typeId="0c90-79e2-f768-e547">-</characteristic>
+                <characteristic name="Access Points" typeId="e217-1b1e-9494-3e3e">-</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
           <categoryLinks>
             <categoryLink id="c2f1-cd11-ca0c-0d3b" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
           </categoryLinks>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="ad38-0891-7db4-3528" name="1) Two Sponson Mounted Weapons:" hidden="false" collective="false" import="true" defaultSelectionEntryId="2994-0db0-8806-0201">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5028-04f9-e610-8555" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b005-55ce-dfaa-2896" type="min"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="2994-0db0-8806-0201" name="Heavy Bolters" hidden="false" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditions>
+                        <condition field="selections" scope="9e46-a480-c382-c49c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="975e-14eb-caed-4b5b" type="atLeast"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <entryLinks>
+                    <entryLink id="6489-f9f4-e312-eaf2" name="Heavy Bolter" hidden="false" collective="false" import="true" targetId="07fd-c24a-9235-4206" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed5b-071f-4d99-e7de" type="max"/>
+                        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2dcc-340c-7e4e-28d0" type="min"/>
+                      </constraints>
+                    </entryLink>
+                  </entryLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="26fc-3cda-e091-8bfc" name="Heavy Flamers" hidden="false" collective="false" import="true" type="upgrade">
+                  <entryLinks>
+                    <entryLink id="9297-e62e-890f-fd90" name="Heavy Flamer" hidden="false" collective="false" import="true" targetId="5507-b432-3b4c-df12" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0a1b-ac44-cad3-66b1" type="max"/>
+                        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c9a3-f9b5-db28-91ad" type="min"/>
+                      </constraints>
+                    </entryLink>
+                  </entryLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="0107-ac4d-106a-99a9" name="Shrapnel Cannons" hidden="true" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5f54-457a-fbb9-6730" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <entryLinks>
+                    <entryLink id="3905-e46c-3366-fc65" name="Shrapnel Cannon" hidden="false" collective="false" import="true" targetId="975e-14eb-caed-4b5b" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8cb9-0a6d-7104-fba5" type="max"/>
+                        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="afef-d691-9a41-a52d" type="min"/>
+                      </constraints>
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntry>
+                <selectionEntry id="6b87-884f-2fc1-02f0" name="Autocannons" hidden="false" collective="false" import="true" type="upgrade">
+                  <entryLinks>
+                    <entryLink id="4002-7ac6-dc7f-c49a" name="Autocannon" hidden="false" collective="false" import="true" targetId="56b3-de09-9fea-deb6" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bdd4-dafd-6c93-3edb" type="max"/>
+                        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="41af-7a45-6a0a-2fb1" type="min"/>
+                      </constraints>
+                    </entryLink>
+                  </entryLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="aa72-e968-8e98-0fc1" name="Lascannons" hidden="false" collective="false" import="true" type="upgrade">
+                  <entryLinks>
+                    <entryLink id="3d74-28f7-5d9d-4bb9" name="Lascannon" hidden="false" collective="true" import="true" targetId="b252-5a86-6e0f-218b" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d695-0da4-fb29-f467" type="max"/>
+                        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="29e4-d64b-b20d-e403" type="min"/>
+                      </constraints>
+                    </entryLink>
+                  </entryLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="df6f-893a-5986-12b8" name="Volkite Culverins" hidden="false" collective="false" import="true" type="upgrade">
+                  <entryLinks>
+                    <entryLink id="acd3-40dc-b247-9e50" name="Volkite Culverin" hidden="false" collective="false" import="true" targetId="170d-44e0-455c-8207" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e5de-325d-ef59-992e" type="max"/>
+                        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d417-9447-8156-f5c1" type="min"/>
+                      </constraints>
+                    </entryLink>
+                  </entryLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="26d6-9cec-367e-3574" name="2) Pintle mounted Weapon:" hidden="false" collective="false" import="true">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="08a2-29d1-2ff9-f776" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="8d51-a787-a8c6-23fc" name="Twin-linked Bolter" hidden="false" collective="false" import="true" targetId="e31a-fd70-35c7-8bed" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="d506-fda5-35a9-7749" name="Heavy Bolter" hidden="false" collective="false" import="true" targetId="07fd-c24a-9235-4206" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditions>
+                        <condition field="selections" scope="9e46-a480-c382-c49c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="975e-14eb-caed-4b5b" type="atLeast"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="2509-622b-e29e-4ba8" name="Heavy Flamer" hidden="false" collective="false" import="true" targetId="5507-b432-3b4c-df12" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="768b-6bdb-4b18-1651" name="Multi-Melta" hidden="false" collective="false" import="true" targetId="9332-3834-cf3a-56b4" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="573e-b90d-a9d6-6fc4" name="Havoc Launcher" hidden="false" collective="false" import="true" targetId="bde9-5abf-ec3d-2273" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="1674-5190-9479-4013" name="Dragon&apos;s Breath Heavy Flamer" hidden="false" collective="false" import="true" targetId="1a5c-0c5f-d798-a067" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="e539-2bbb-19f8-c1d6" name="Heavy Alchem Flamer" hidden="false" collective="false" import="true" targetId="2a3d-a4bb-5326-a16a" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="f722-1fad-c22d-368b" name="Minor Combi-Weapon - Alchem Flamer" hidden="false" collective="false" import="true" targetId="b941-687c-c95e-31a6" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="a678-1da5-33dc-041f" name="Magna Combi-Weapon - Plasma Gun" hidden="false" collective="false" import="true" targetId="cc98-8596-c713-516c" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="d71e-c63f-4e9e-6080" name="Magna Combi-Weapon - Meltagun" hidden="false" collective="false" import="true" targetId="0d1c-227e-a3f8-cd63" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="2a86-faa3-526d-fcc5" name="Minor Combi-Weapon - Flamer" hidden="false" collective="false" import="true" targetId="34c4-db99-db36-0f2a" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="4a4d-a075-485f-50bb" name="Minor Combi-Weapon - Grenade Launcher" hidden="false" collective="false" import="true" targetId="aa3c-f5a5-9ce9-1497" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="810b-7f1f-92d6-30fb" name="Minor Combi-Weapon - Volkite Charger" hidden="false" collective="false" import="true" targetId="7e5c-3d25-5c88-32e0" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="cfcf-b294-27db-6820" name="Shrapnel Cannon" hidden="false" collective="false" import="true" targetId="975e-14eb-caed-4b5b" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="12.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="948c-f0e5-1280-beac" name="3) May take any of the following:" hidden="false" collective="false" import="true">
+              <selectionEntries>
+                <selectionEntry id="f94b-9c8e-0836-87c1" name="Hull (Front) Mounted Hunter-Killer Missile" hidden="false" collective="false" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b6db-fad0-019e-b278" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="0ea3-9d0a-3b19-0363" name="Hunter-Killer Missile" hidden="false" collective="false" import="true" targetId="1bf8-72f8-c331-6900" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="384d-2ad1-ed30-6708" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3764-e1f7-979b-e817" type="max"/>
+                      </constraints>
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <entryLinks>
+                <entryLink id="8e86-cbe5-6bdf-2235" name="Searchlights" hidden="false" collective="false" import="true" targetId="4ae3-79b4-6051-505e" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8a3c-83a4-3628-de1a" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="185.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="bdc1-bd00-b445-f267" name="Centreline Mounted Weapon Options for Unit:" hidden="false" collective="false" import="true" defaultSelectionEntryId="17b7-6a9d-b164-39a3">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="27fe-3b5f-99fc-b58d" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d861-4c4a-6f2c-5dab" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="17b7-6a9d-b164-39a3" name="Morbus Bombard" hidden="false" collective="false" import="true" targetId="7102-6014-a965-bfd9" type="selectionEntry"/>
+            <entryLink id="6ac7-34a5-6eac-0840" name="Graviton-Charge Cannon" hidden="false" collective="false" import="true" targetId="3cd3-dd3f-6f7d-f833" type="selectionEntry">
+              <modifiers>
+                <modifier type="increment" field="d2ee-04cb-5f8a-2642" value="15.0">
+                  <repeats>
+                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+            </entryLink>
+            <entryLink id="099b-3397-63ba-ee6b" name="Spicula Rocket System" hidden="false" collective="false" import="true" targetId="4e4f-456f-8cee-10a4" type="selectionEntry">
+              <modifiers>
+                <modifier type="increment" field="d2ee-04cb-5f8a-2642" value="15.0">
+                  <repeats>
+                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="6800-8538-9535-dd08" name="Upgrade Points (Placeholders)" hidden="false" collective="false" import="true" targetId="8b48-2da0-15da-2c1b" type="selectionEntry"/>
+        <entryLink id="9780-3e98-88bb-a8d7" name="Smoke Launchers" hidden="false" collective="false" import="true" targetId="0873-34dd-e52d-d33c" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="16c2-afc2-48e3-d372" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d394-7518-d927-4650" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="884f-7f68-fc53-2d96" name="Phosphex Shell (Arquitor Morbus Bombard)" hidden="true" collective="false" import="true" targetId="6988-e6e1-7b49-7430" type="selectionEntry">
+          <modifiers>
+            <modifier type="increment" field="d2ee-04cb-5f8a-2642" value="20.0">
+              <repeats>
+                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+            <modifier type="set" field="hidden" value="false">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="9e46-a480-c382-c49c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7102-6014-a965-bfd9" type="equalTo"/>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4390-3aec-6ae6-5b81" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5b8e-53d9-cfe3-15f9" type="max"/>
+          </constraints>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
@@ -29788,7 +30607,7 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="3ef1-3886-773d-1742" name="Squad Weaponry:" hidden="false" collective="false" import="true" defaultSelectionEntryId="8d8d-dece-1b84-3813">
+        <selectionEntryGroup id="3ef1-3886-773d-1742" name="1) Squad Weaponry:" hidden="false" collective="false" import="true" defaultSelectionEntryId="8d8d-dece-1b84-3813">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8ea8-23b8-0667-7a4b" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b3da-e6f4-9fc5-24c0" type="min"/>
@@ -29901,7 +30720,7 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="c130-44c2-8689-5be5" name="One Legionary may take:" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="c130-44c2-8689-5be5" name="3) One Legionary may take:" hidden="false" collective="false" import="true">
           <entryLinks>
             <entryLink id="c68d-ea0f-bbe0-6903" name="Nuncio-Vox" hidden="false" collective="false" import="true" targetId="005e-aae6-ddac-bb45" type="selectionEntry">
               <constraints>
@@ -29929,7 +30748,7 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="5fba-d4ec-d178-0aec" name="The Legion Tactical Support Sergeant may take (Wargear):" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="5fba-d4ec-d178-0aec" name="4) The Legion Tactical Support Sergeant may take (Wargear):" hidden="false" collective="false" import="true">
           <selectionEntries>
             <selectionEntry id="e2ab-818c-7213-d7b9" name="Master-craft a one weapon" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
@@ -30026,7 +30845,7 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
             <entryLink id="9eec-7413-bebc-2a48" name="Rhino Transport" hidden="false" collective="false" import="true" targetId="03f1-8ed9-9867-8d18" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="f3c7-2852-0c6f-972e" name="Legiones Unit Upgrades:" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="f3c7-2852-0c6f-972e" name="0) Legiones Unit Upgrades:" hidden="false" collective="false" import="true">
           <entryLinks>
             <entryLink id="04ad-ee30-7b3b-d00e" name="Preysight" hidden="false" collective="false" import="true" targetId="b905-4d78-c141-4e63" type="selectionEntry">
               <constraints>
@@ -30046,28 +30865,43 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="f2a2-40d1-2d0c-967e" name="Bolt Pistol Options:" hidden="false" collective="false" import="true" defaultSelectionEntryId="8060-8cac-aca0-b558">
+        <selectionEntryGroup id="9f7f-7a1a-8e31-3d71" name="2) Bolt Pistol Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="b5cc-2767-440a-621a">
+          <modifiers>
+            <modifier type="decrement" field="c7fc-42b1-7fbd-d383" value="5.0"/>
+            <modifier type="increment" field="fb52-54f4-9427-56f2" value="1.0">
+              <repeats>
+                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+            <modifier type="increment" field="c7fc-42b1-7fbd-d383" value="1.0">
+              <repeats>
+                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d9d-6ee4-a170-29b3" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="71b4-f004-8acf-b0c4" type="max"/>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c7fc-42b1-7fbd-d383" type="min"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fb52-54f4-9427-56f2" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="8060-8cac-aca0-b558" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7f37-67cd-1344-e3d2" type="max"/>
-              </constraints>
-            </entryLink>
-            <entryLink id="71ce-25c5-b3f7-65ad" name="Shrapnel Pistol" hidden="false" collective="false" import="true" targetId="7d72-7f6d-6330-6871" type="selectionEntry">
+            <entryLink id="b5cc-2767-440a-621a" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
               <modifiers>
-                <modifier type="increment" field="d2ee-04cb-5f8a-2642" value="2.0">
-                  <repeats>
-                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
-                  </repeats>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7d72-7f6d-6330-6871" type="atLeast"/>
+                  </conditions>
                 </modifier>
               </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4670-d74f-fbd0-8e46" type="max"/>
-              </constraints>
+            </entryLink>
+            <entryLink id="ae19-df8d-d1c9-ebec" name="Shrapnel Pistol" hidden="false" collective="false" import="true" targetId="7d72-7f6d-6330-6871" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="015f-3d2a-52bf-8f77" name="Asphyx Bolt Pistol" hidden="false" collective="false" import="true" targetId="07f7-c486-f597-a1b9" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="1.0"/>
+              </costs>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
@@ -34391,6 +35225,14 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
             <entryLink id="2826-245c-b5ea-aa1b" name="Autocannon" hidden="false" collective="false" import="true" targetId="56b3-de09-9fea-deb6" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
+        <selectionEntryGroup id="4fe2-f620-7504-4a45" name="Dedicated Transport:" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="44d8-d9d9-0c9f-273c" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="7bcb-9519-27f0-6b23" name="Rhino Transport" hidden="false" collective="false" import="true" targetId="03f1-8ed9-9867-8d18" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
         <entryLink id="b16e-9b85-6aff-020b" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
@@ -35558,9 +36400,6 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f0d3-b9a1-a48e-4a85" type="max"/>
               </constraints>
-              <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="220.0"/>
-              </costs>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
@@ -35577,7 +36416,7 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="c123-bdc6-a6ba-79a2" name="Land Raider Proteus Carrier" hidden="false" collective="false" import="true" type="model">
+    <selectionEntry id="c123-bdc6-a6ba-79a2" name="Land Raider Proteus Carrier" hidden="false" collective="false" import="true" type="unit">
       <profiles>
         <profile id="2a46-a372-d986-d0eb" name="Land Raider Proteus Carrier" publicationId="a716-c1c4-7b26-8424" page="76" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName="Vehicle">
           <characteristics>
@@ -35772,7 +36611,7 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="220.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="0068-6b0a-0086-3d6b" name="Master of the Legion" hidden="false" collective="false" import="true" type="upgrade">
@@ -35792,6 +36631,1778 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
       </costs>
+    </selectionEntry>
+    <selectionEntry id="23e4-c64b-65b4-c8a5" name="Rapier Battery" hidden="false" collective="false" import="true" type="unit">
+      <selectionEntries>
+        <selectionEntry id="925b-d3f3-4d4c-fe67" name="Rapier Carrier (&amp; Gunners)" hidden="false" collective="true" import="true" type="unit">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="119c-570a-ee34-e901" type="min"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="990f-cc3a-0cb8-aa3d" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="75c0-8fc9-8dd1-0a34" name="Legiones Astartes (X)" hidden="false" targetId="61cf-75c2-56cd-2a31" type="rule"/>
+            <infoLink id="dcad-6d83-b92c-6fd3" name="Legion Artillerists" hidden="false" targetId="f268-05e5-8fc5-be12" type="rule"/>
+          </infoLinks>
+          <selectionEntries>
+            <selectionEntry id="25df-49f3-3b53-c4be" name="Rapier Carrier" hidden="false" collective="true" import="true" type="model">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="79e9-65ce-cb25-2cd4" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c81d-88f2-f586-f377" type="min"/>
+              </constraints>
+              <profiles>
+                <profile id="d616-76d1-776b-28a0" name="Rapier Carrier" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
+                  <characteristics>
+                    <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Artillery, Heavy)</characteristic>
+                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">4&quot;</characteristic>
+                    <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">1</characteristic>
+                    <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
+                    <characteristic name="S" typeId="e478-41d4-a092-48a8">1</characteristic>
+                    <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">5</characteristic>
+                    <characteristic name="W" typeId="57ee-1126-32a9-5672">2</characteristic>
+                    <characteristic name="I" typeId="62d3-22d7-2d49-52dc">1</characteristic>
+                    <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">1</characteristic>
+                    <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">-</characteristic>
+                    <characteristic name="Save" typeId="e593-6b3c-f169-04f0">3+</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink id="0eb4-7a54-ba0d-be3b" name="Bulky (X)" hidden="false" targetId="676c-7b75-4b6f-9405" type="rule">
+                  <modifiers>
+                    <modifier type="set" field="name" value="Bulky (4)"/>
+                  </modifiers>
+                </infoLink>
+                <infoLink id="9f10-0ad3-e8be-2c38" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
+              </infoLinks>
+            </selectionEntry>
+            <selectionEntry id="9cb7-f45a-8422-0f1b" name="Gunner" hidden="false" collective="true" import="true" type="model">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="62cc-fc11-6b46-304e" type="min"/>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fbae-d0d5-627f-5b44" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="7b9b-ead9-6979-4c37" name="Gunner" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
+                  <characteristics>
+                    <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy)</characteristic>
+                    <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                    <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
+                    <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
+                    <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
+                    <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">4</characteristic>
+                    <characteristic name="W" typeId="57ee-1126-32a9-5672">1</characteristic>
+                    <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
+                    <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">1</characteristic>
+                    <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">7</characteristic>
+                    <characteristic name="Save" typeId="e593-6b3c-f169-04f0">3+</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+          </selectionEntries>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="40.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="975a-c83c-1f06-b4c8" name="1) Battery Weapon Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="beaa-2d73-874a-0897">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d419-5ef9-cf5f-1fb5" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="caaf-b1b4-27bb-de70" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="9765-5254-38c2-206c" name="Laser Destroyer" hidden="false" collective="false" import="true" targetId="5534-6388-c8bb-945f" type="selectionEntry">
+              <modifiers>
+                <modifier type="increment" field="d2ee-04cb-5f8a-2642" value="25.0">
+                  <repeats>
+                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="925b-d3f3-4d4c-fe67" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+            </entryLink>
+            <entryLink id="6046-b6bd-7159-9a7d" name="Quad Launcher - Frag" hidden="false" collective="false" import="true" targetId="333a-6c28-1031-9134" type="selectionEntry">
+              <modifiers>
+                <modifier type="increment" field="d2ee-04cb-5f8a-2642" value="20.0">
+                  <repeats>
+                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="925b-d3f3-4d4c-fe67" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+            </entryLink>
+            <entryLink id="7d13-b518-6e4b-50fe" name="Graviton Cannon" hidden="false" collective="false" import="true" targetId="be9e-10d8-eab2-43b7" type="selectionEntry">
+              <modifiers>
+                <modifier type="increment" field="d2ee-04cb-5f8a-2642" value="20.0">
+                  <repeats>
+                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="925b-d3f3-4d4c-fe67" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+            </entryLink>
+            <entryLink id="beaa-2d73-874a-0897" name="Gravis Heavy Bolter Battery" hidden="false" collective="false" import="true" targetId="a160-9267-67ac-4546" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="1626-ca1e-12bf-300f" name="4) Quad Launcher Shell Options" hidden="true" collective="false" import="true">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6046-b6bd-7159-9a7d" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <entryLinks>
+            <entryLink id="a557-5cc8-c546-1fb5" name="Quad Launcher - Shatter" hidden="false" collective="false" import="true" targetId="adb6-7963-11bd-e72b" type="selectionEntry">
+              <modifiers>
+                <modifier type="increment" field="d2ee-04cb-5f8a-2642" value="20.0">
+                  <repeats>
+                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="925b-d3f3-4d4c-fe67" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="43a0-3233-f10b-3eb6" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="502a-d783-08e7-b9be" name="Quad Launcher - Incendiary" hidden="false" collective="false" import="true" targetId="8ff6-2222-75b5-ecf7" type="selectionEntry">
+              <modifiers>
+                <modifier type="increment" field="d2ee-04cb-5f8a-2642" value="5.0">
+                  <repeats>
+                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="925b-d3f3-4d4c-fe67" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="23ea-ce9c-b27f-9700" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="2f82-085a-8f4e-d1ec" name="Quad Launcher - Splinter" hidden="false" collective="false" import="true" targetId="f7cc-7f11-f82f-1fdf" type="selectionEntry">
+              <modifiers>
+                <modifier type="increment" field="d2ee-04cb-5f8a-2642" value="10.0">
+                  <repeats>
+                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="925b-d3f3-4d4c-fe67" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="817a-16e8-cef8-98f6" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="96d7-71a4-b02d-eeb4" name="Phosphex Canister Shot (Rapier)" hidden="true" collective="false" import="true" targetId="9bbe-701f-0a83-6ce8" type="selectionEntry">
+              <modifiers>
+                <modifier type="increment" field="d2ee-04cb-5f8a-2642" value="20.0">
+                  <repeats>
+                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="925b-d3f3-4d4c-fe67" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+                <modifier type="set" field="hidden" value="false">
+                  <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4390-3aec-6ae6-5b81" type="atLeast"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="084a-11e4-5f5f-d75e" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="36e2-d984-7862-cfe4" name="2) Bolt Pistol Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="608d-c66b-4571-502b">
+          <modifiers>
+            <modifier type="decrement" field="8d54-3ab9-e247-840e" value="2.0"/>
+            <modifier type="increment" field="32d4-deac-0cec-bc7d" value="2.0">
+              <repeats>
+                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="925b-d3f3-4d4c-fe67" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+            <modifier type="increment" field="8d54-3ab9-e247-840e" value="2.0">
+              <repeats>
+                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="925b-d3f3-4d4c-fe67" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8d54-3ab9-e247-840e" type="min"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="32d4-deac-0cec-bc7d" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="608d-c66b-4571-502b" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7d72-7f6d-6330-6871" type="atLeast"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </entryLink>
+            <entryLink id="99ce-9d02-20d2-5be8" name="Shrapnel Pistol" hidden="false" collective="false" import="true" targetId="7d72-7f6d-6330-6871" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="22ac-171f-b55f-9fbe" name="Asphyx Bolt Pistol" hidden="false" collective="false" import="true" targetId="07f7-c486-f597-a1b9" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="1.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="e5f8-9c5c-cb91-ecdf" name="3) Bolter Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="66c8-9231-9a93-f5a9">
+          <modifiers>
+            <modifier type="increment" field="5933-3d0d-3816-ab01" value="2.0">
+              <repeats>
+                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="925b-d3f3-4d4c-fe67" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+            <modifier type="increment" field="752f-2a2c-7d15-37bd" value="2.0">
+              <repeats>
+                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="925b-d3f3-4d4c-fe67" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+            <modifier type="decrement" field="752f-2a2c-7d15-37bd" value="2.0"/>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="752f-2a2c-7d15-37bd" type="min"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5933-3d0d-3816-ab01" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="66c8-9231-9a93-f5a9" name="Bolter" hidden="false" collective="false" import="true" targetId="1ade-0c02-5612-252b" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1941-21b5-932c-74d6" type="atLeast"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </entryLink>
+            <entryLink id="5327-b802-55ad-138f" name="Shrapnel Bolter" hidden="false" collective="false" import="true" targetId="1941-21b5-932c-74d6" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="6a64-ea68-edf7-757d" name="Asphyx Bolter" hidden="false" collective="false" import="true" targetId="88c0-4623-9da3-f2b5" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="1.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntry>
+    <selectionEntry id="954d-cf8e-eefd-27a6" name="Nullificator Squad" hidden="false" collective="false" import="true" type="unit">
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="06d8-ea57-0a19-b93a" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="2241-f384-19ca-2f6d" name="Legiones Astartes (X)" hidden="false" targetId="61cf-75c2-56cd-2a31" type="rule"/>
+        <infoLink id="af47-ac94-195e-cdd3" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
+        <infoLink id="4458-519c-39eb-8df6" name="Bulky (X)" hidden="false" targetId="676c-7b75-4b6f-9405" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Bulky (2)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="c4c0-ddb6-6c5a-f668" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
+        <infoLink id="4036-b363-6d45-9825" name="Hexagrammatic Wards" hidden="false" targetId="5529-bb7a-9448-b1f5" type="rule"/>
+      </infoLinks>
+      <selectionEntries>
+        <selectionEntry id="0740-a851-4e97-fced" name="Nullificator" hidden="false" collective="false" import="true" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="528b-e2e4-d199-ad7d" type="max"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7635-ba1e-3c10-070c" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="62e1-0acf-fd9b-3c69" name="Nullificator" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
+              <characteristics>
+                <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy)</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6&quot;</characteristic>
+                <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
+                <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
+                <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
+                <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">4</characteristic>
+                <characteristic name="W" typeId="57ee-1126-32a9-5672">2</characteristic>
+                <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
+                <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">2</characteristic>
+                <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">8</characteristic>
+                <characteristic name="Save" typeId="e593-6b3c-f169-04f0">2+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="698a-3dfd-294b-7129" name="Ranged Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="8ea5-8e1d-a31a-bfe5">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e429-6d08-1592-b5ae" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="66bf-143e-431c-20a8" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="8ea5-8e1d-a31a-bfe5" name="Combi-Bolter" hidden="false" collective="false" import="true" targetId="a498-c66f-9eb7-ca9a" type="selectionEntry"/>
+                <entryLink id="2de1-5d3f-a789-04cf" name="Toxiferran Flamer" hidden="false" collective="false" import="true" targetId="732a-29f9-edb7-5bc3" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="3930-5778-c30e-d79c" name="Disintegrator" hidden="false" collective="false" import="true" targetId="a567-9434-36f3-5fd4" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="e516-777d-cbc6-086e" name="Melee Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="a467-bac4-faef-ed63">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0802-6a0e-b19e-fe6b" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0512-1265-6051-ab66" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="b9e6-785a-eba5-43f0" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="a467-bac4-faef-ed63" name="Aether-shock Maul" hidden="false" collective="false" import="true" targetId="a696-4b44-8abe-771a" type="selectionEntry"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="1f5a-2a68-01b8-36ce" name="Grenade Harness" hidden="false" collective="false" import="true" targetId="251a-860d-2c4d-62cc" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b1ef-ceda-48ac-3c07" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="45.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="b511-e3bc-a12d-e0a6" name="Nullificator Sergeant" hidden="false" collective="false" import="true" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="66b5-ec93-c39d-4692" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9a50-cf10-e7ff-ca0a" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="76ba-0c88-e3b3-411e" name="Nullificator Sergeant" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
+              <characteristics>
+                <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy, Character)</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6&quot;</characteristic>
+                <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
+                <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
+                <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
+                <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">4</characteristic>
+                <characteristic name="W" typeId="57ee-1126-32a9-5672">2</characteristic>
+                <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
+                <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">3</characteristic>
+                <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">9</characteristic>
+                <characteristic name="Save" typeId="e593-6b3c-f169-04f0">2+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="1cf3-54c4-75e4-6cef" name="Melee Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="37e2-0f28-e250-b232">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="942f-4978-9857-fd10" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="76a6-e635-ca0b-588d" type="min"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="3e59-cdde-0a41-9568" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="37e2-0f28-e250-b232" name="Aether-shock Maul" hidden="false" collective="false" import="true" targetId="a696-4b44-8abe-771a" type="selectionEntry"/>
+                <entryLink id="3ff4-cf3d-f827-a7cb" name="Thunder Hammer" hidden="false" collective="false" import="true" targetId="838c-4002-713d-d7c6" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="9be5-996f-f5d2-ecbb" name="Power Weapon" hidden="false" collective="false" import="true" targetId="8d9c-9f80-c0fd-adcf" type="selectionEntry"/>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="f89d-d495-f16a-38eb" name="Ranged Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="548a-2e7a-82fa-6216">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3e72-abcf-67d3-0aef" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dd7d-4ea7-344e-f694" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="548a-2e7a-82fa-6216" name="Combi-Bolter" hidden="false" collective="false" import="true" targetId="a498-c66f-9eb7-ca9a" type="selectionEntry"/>
+                <entryLink id="c59a-d896-1258-58fd" name="Toxiferran Flamer" hidden="false" collective="false" import="true" targetId="732a-29f9-edb7-5bc3" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="6b00-b1a5-0e77-79fd" name="Disintegrator" hidden="false" collective="false" import="true" targetId="a567-9434-36f3-5fd4" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="e7e4-7b04-5116-b2ca" name="Grenade Harness" hidden="false" collective="false" import="true" targetId="251a-860d-2c4d-62cc" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2274-e121-f670-6ffc" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="45.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="16a0-0aeb-974a-33a9" name="Dedicated Transport" hidden="false" collective="false" import="true">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="954d-cf8e-eefd-27a6" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0740-a851-4e97-fced" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <entryLinks>
+            <entryLink id="1a69-d591-d70c-e359" name="Land Raider Proteus Carrier" hidden="false" collective="false" import="true" targetId="c123-bdc6-a6ba-79a2" type="selectionEntry"/>
+            <entryLink id="25c6-fe7a-6253-534a" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="true" targetId="bbe8-818d-3068-d79c" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="00fa-8a14-fa20-13b7" name="Cataphractii Terminator Armour" hidden="false" collective="false" import="true" targetId="7c9b-b9ab-9a40-8eb5" type="selectionEntry"/>
+      </entryLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="daf7-b23b-5474-5836" name="Castra Ferrum Dreadnought Talon" hidden="false" collective="false" import="true" type="unit">
+      <infoLinks>
+        <infoLink id="a87a-f9bb-ddda-a09b" name="Dreadnought Talon" hidden="false" targetId="a924-2634-73fd-aa96" type="rule"/>
+      </infoLinks>
+      <selectionEntries>
+        <selectionEntry id="5524-7631-a4d9-9cf9" name="Castra Ferrum Dreadnought" hidden="false" collective="false" import="true" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bad3-feb0-ed9a-e223" type="min"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="590a-4dd8-26a2-ba8b" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="7884-e18a-16ee-068c" name="Ferromantic Deflector" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
+              <characteristics>
+                <characteristic name="Description" typeId="347e-ee4a-764f-6be3">A model with an ferromantic deflector gains a 5+ Invulnerable Save and any model with a ferromantic deflector and a Wounds Characteristic that suffers an unsaved Wound with the Instant Death special rule is not immediately removed as a casualty, but instead loses three Wounds instead of one for each unsaved Wound with the Instant Death special rule inflicted on it. In addition, when a model with a ferromantic deflector loses its last Wound or Hull Point, but before it is removed as a casualty or replaced with a Wreck, all models both friendly and enemy within D6&quot; suffer an automatic Hit at Str 6, AP -.</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="4a23-7e8b-beec-8442" name="Castra Ferrum Dreadnought" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
+              <modifiers>
+                <modifier type="set" field="f111-2ce5-dd12-d6b0" value="4">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="5524-7631-a4d9-9cf9" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="08be-6994-6a63-6279" type="equalTo"/>
+                        <condition field="selections" scope="5524-7631-a4d9-9cf9" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b254-abfc-a57f-ab28" type="equalTo"/>
+                        <condition field="selections" scope="5524-7631-a4d9-9cf9" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5ffe-2820-9b97-99db" type="equalTo"/>
+                      </conditions>
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="5524-7631-a4d9-9cf9" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b254-abfc-a57f-ab28" type="equalTo"/>
+                            <condition field="selections" scope="5524-7631-a4d9-9cf9" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="08be-6994-6a63-6279" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="5524-7631-a4d9-9cf9" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5ffe-2820-9b97-99db" type="equalTo"/>
+                            <condition field="selections" scope="5524-7631-a4d9-9cf9" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="08be-6994-6a63-6279" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="5524-7631-a4d9-9cf9" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b254-abfc-a57f-ab28" type="equalTo"/>
+                            <condition field="selections" scope="5524-7631-a4d9-9cf9" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5ffe-2820-9b97-99db" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <characteristics>
+                <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Dreadnought (Heavy)</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6&quot;</characteristic>
+                <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
+                <characteristic name="BS" typeId="74ae-c840-0036-d244">5</characteristic>
+                <characteristic name="S" typeId="e478-41d4-a092-48a8">6</characteristic>
+                <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">6</characteristic>
+                <characteristic name="W" typeId="57ee-1126-32a9-5672">5</characteristic>
+                <characteristic name="I" typeId="62d3-22d7-2d49-52dc">2</characteristic>
+                <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">3</characteristic>
+                <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">9</characteristic>
+                <characteristic name="Save" typeId="e593-6b3c-f169-04f0">2+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="cdb1-bf93-df94-2bf9" name="4) May take:" hidden="false" collective="false" import="true">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8068-1183-4eee-345c" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="b54e-f412-f8e6-1a8d" name="Searchlights" hidden="false" collective="false" import="true" targetId="4ae3-79b4-6051-505e" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6b8a-56f3-bcb1-e76b" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="7ac3-d234-f96a-f924" name="Helical Targeting Array" hidden="false" collective="false" import="true" targetId="ff29-460e-a589-a376" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="53cb-3b4b-728f-db55" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="3eee-9556-18d9-c6f0" name="Havoc Launcher" hidden="false" collective="false" import="true" targetId="bde9-5abf-ec3d-2273" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4a6e-d575-1753-6492" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="0e90-9a68-73ba-f59c" name="3) May replace an in-built combi-bolter with one of the following:" hidden="false" collective="false" import="true" defaultSelectionEntryId="f6c5-cdb3-c7f0-3862">
+              <modifiers>
+                <modifier type="decrement" field="4dd3-5ebc-99b5-5c1c" value="1.0"/>
+                <modifier type="increment" field="b4d6-dd45-bc98-64c4" value="1.0">
+                  <repeats>
+                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5ffe-2820-9b97-99db" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="08be-6994-6a63-6279" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b254-abfc-a57f-ab28" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+                <modifier type="increment" field="4dd3-5ebc-99b5-5c1c" value="1.0">
+                  <repeats>
+                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5ffe-2820-9b97-99db" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="08be-6994-6a63-6279" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b254-abfc-a57f-ab28" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4dd3-5ebc-99b5-5c1c" type="min"/>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b4d6-dd45-bc98-64c4" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="f6c5-cdb3-c7f0-3862" name="Combi-Bolter" hidden="false" collective="false" import="true" targetId="a498-c66f-9eb7-ca9a" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="438f-0b19-ac18-5ae3" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="27bc-ddac-7b66-df56" name="Heavy Flamer" hidden="false" collective="false" import="true" targetId="5507-b432-3b4c-df12" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4480-0dd4-f58f-bdbe" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="c246-0b7b-876b-f6df" name="Meltagun" hidden="false" collective="false" import="true" targetId="4ebd-57e0-3560-e568" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9cb4-d34e-1460-fd96" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="cc48-1239-5e96-e812" name="Dragon&apos;s Breath Heavy Flamer" hidden="false" collective="false" import="true" targetId="1a5c-0c5f-d798-a067" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5719-aa3a-e15f-9fa1" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="29e4-44db-2769-40cc" name="Heavy Alchem Flamer" hidden="false" collective="false" import="true" targetId="2a3d-a4bb-5326-a16a" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed5c-85a6-dd3b-7a03" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="f41b-813d-f7c4-0bf8" name="Iliastus Asssult Cannon" hidden="false" collective="false" import="true" targetId="10aa-3c70-2bbe-9509" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ee8e-aebc-d30f-1f79" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="de4d-98e1-6b47-97ed" name="1) Weapon Option 1" hidden="false" collective="false" import="true" defaultSelectionEntryId="fe4c-83e2-90ab-32a6">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="308d-2e2c-c010-3e54" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d995-4ad7-27b3-d8bd" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="fe4c-83e2-90ab-32a6" name="Gravis Bolt Cannon" hidden="false" collective="false" import="true" targetId="3b5f-52ab-6534-94a3" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditions>
+                        <condition field="selections" scope="daf7-b23b-5474-5836" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ce7e-4548-10b5-8762" type="atLeast"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </entryLink>
+                <entryLink id="e844-44ed-af33-4c9f" name="Multi-Melta" hidden="false" collective="false" import="true" targetId="9332-3834-cf3a-56b4" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="d00e-7fbc-c412-122b" name="Gravis Autocannon" hidden="false" collective="false" import="true" targetId="8a23-e57d-b4a8-14a9" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="9c06-9104-9738-4b37" name="Gravis Plasma Cannon" hidden="false" collective="false" import="true" targetId="32ad-6250-29c7-5466" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="309e-5033-3899-93b6" name="Gravis Lascannon" hidden="false" collective="false" import="true" targetId="1fe0-7c96-5200-0e39" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="d164-4dca-9fb7-2cce" name="Gravis Power Fist" hidden="false" collective="false" import="true" targetId="08be-6994-6a63-6279" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="append" field="name" value="with in-built ranged weapon"/>
+                  </modifiers>
+                </entryLink>
+                <entryLink id="19cf-d40b-f2ec-c770" name="Gravis Chainfist" hidden="false" collective="false" import="true" targetId="5ffe-2820-9b97-99db" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="append" field="name" value="with in-built ranged weapon"/>
+                  </modifiers>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="6c77-2271-d8e3-e070" name="Gravis Shrapnel Cannon" hidden="false" collective="false" import="true" targetId="ce7e-4548-10b5-8762" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="dd08-5f73-b0b8-bc4b" name="Graviton Maul" hidden="false" collective="false" import="true" targetId="b254-abfc-a57f-ab28" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="b331-9e1a-0528-bfa9" name="Gravis Missile Launcher" hidden="false" collective="false" import="true" targetId="c2b4-503b-5732-a8a2" type="selectionEntry"/>
+                <entryLink id="3103-2bbd-6d54-7492" name="Flamestorm Cannon" hidden="false" collective="false" import="true" targetId="af97-b307-a484-4fbe" type="selectionEntry"/>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="d276-79d0-2989-80dd" name="2) Weapon Option 2" hidden="false" collective="false" import="true" defaultSelectionEntryId="0f35-46b7-e7fb-9d8d">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0dab-97af-482f-d53b" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8156-6630-772c-ea1b" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="2f7b-bc7c-73d1-baf1" name="Gravis Bolt Cannon" hidden="false" collective="false" import="true" targetId="3b5f-52ab-6534-94a3" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditions>
+                        <condition field="selections" scope="daf7-b23b-5474-5836" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ce7e-4548-10b5-8762" type="atLeast"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </entryLink>
+                <entryLink id="f5fb-ee23-cf29-4383" name="Multi-Melta" hidden="false" collective="false" import="true" targetId="9332-3834-cf3a-56b4" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="bb47-c453-cff3-e7ff" name="Gravis Autocannon" hidden="false" collective="false" import="true" targetId="8a23-e57d-b4a8-14a9" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="2559-2ca2-86b1-fda3" name="Gravis Plasma Cannon" hidden="false" collective="false" import="true" targetId="32ad-6250-29c7-5466" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="3b62-63e3-809a-358c" name="Gravis Lascannon" hidden="false" collective="false" import="true" targetId="1fe0-7c96-5200-0e39" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="0f35-46b7-e7fb-9d8d" name="Gravis Power Fist" hidden="false" collective="false" import="true" targetId="08be-6994-6a63-6279" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="append" field="name" value="with in-built ranged weapon"/>
+                  </modifiers>
+                </entryLink>
+                <entryLink id="4f73-5238-3264-a662" name="Gravis Chainfist" hidden="false" collective="false" import="true" targetId="5ffe-2820-9b97-99db" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="append" field="name" value="with in-built ranged weapon"/>
+                  </modifiers>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="0132-82cb-3b00-8b98" name="Gravis Shrapnel Cannon" hidden="false" collective="false" import="true" targetId="ce7e-4548-10b5-8762" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="0d3a-7ebc-d21b-3237" name="Graviton Maul" hidden="false" collective="false" import="true" targetId="b254-abfc-a57f-ab28" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="64c8-8348-260f-27ba" name="Gravis Missile Launcher" hidden="false" collective="false" import="true" targetId="c2b4-503b-5732-a8a2" type="selectionEntry"/>
+                <entryLink id="41b3-1e54-be42-9dd8" name="Flamestorm Cannon" hidden="false" collective="false" import="true" targetId="af97-b307-a484-4fbe" type="selectionEntry"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="125.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="5074-3ed9-844a-a330" name="Dreadnought Drop Pod" hidden="false" collective="false" import="true" targetId="1ffe-82e4-12db-538d" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="daf7-b23b-5474-5836" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5524-7631-a4d9-9cf9" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fb10-a568-6c81-d93b" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+    </selectionEntry>
+    <selectionEntry id="bd58-7b96-a940-bd7f" name="Crysos Morturg" hidden="true" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dd1f-1c51-706c-e5f7" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5196-9ec4-964f-c896" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="6bf8-917e-41f7-b787" name="Crysos Morturg" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
+          <characteristics>
+            <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character, Unique, Psyker, Heavy)</characteristic>
+            <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+            <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
+            <characteristic name="BS" typeId="74ae-c840-0036-d244">5</characteristic>
+            <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
+            <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">5</characteristic>
+            <characteristic name="W" typeId="57ee-1126-32a9-5672">3</characteristic>
+            <characteristic name="I" typeId="62d3-22d7-2d49-52dc">5</characteristic>
+            <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">3</characteristic>
+            <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">9</characteristic>
+            <characteristic name="Save" typeId="e593-6b3c-f169-04f0">2+</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="31a2-1caf-e943-595a" name="Shielded by Hate" hidden="false" typeId="5405-b3c6-e8d0-4e77" typeName="Psychic Power">
+          <characteristics>
+            <characteristic name="Description" typeId="4c0f-7e2f-586c-9305">Once per battle, when Crysos Morturg is reduced to 0 Wounds or otherwise removed from play as a casualty the controlling player may immediately make a Psychic check for Crysos Morturg. If the Psychic check is passed then Crysos Morturg is not removed as a casualty, but is instead placed in Reserves with 1 Wound remaining, and may re-enter play as normal. If the Psychic check is failed then Crysos Morturg is removed as a casualty as normal and if Crysos Morturg was part of a unit when the Psychic check is failed, then the unit suffers Perils of the Warp.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="ebcd-fcca-9204-8d74" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
+        <infoLink id="a3c5-f2dc-b9c6-3bc7" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
+        <infoLink id="f8a8-857e-c954-f4ee" name="Legiones Astartes (Death Guard) " hidden="false" targetId="48a9-493f-e255-5070" type="rule"/>
+        <infoLink id="f31f-691b-e079-4a7f" name="Counter-Attack (X)" hidden="false" targetId="fd6d-2a76-10e0-936a" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Counter-Attack (1)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="5a9f-6047-c561-8b7a" name="Bitter Duty" hidden="false" targetId="d1b8-31da-c53c-4fe2" type="rule"/>
+      </infoLinks>
+      <selectionEntries>
+        <selectionEntry id="63dd-eaaa-cebb-f3c8" name="Alchem combi-flamer" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f66f-c2f1-6b6d-46bd" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3b6e-d5dc-dcc3-76b8" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="c249-9165-df6e-fd08" name="Minor Combi-Weapon - Alchem Flamer" hidden="false" collective="false" import="true" targetId="b941-687c-c95e-31a6" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntry>
+        <selectionEntry id="4bf6-846d-c017-425a" name="The Revenant&apos;s Aegis" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="007e-17a1-677f-fca7" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="37d3-5a94-283e-ed31" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="6ca7-4b03-e496-4c6f" name="The Revenant&apos;s Aegis" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
+              <characteristics>
+                <characteristic name="Description" typeId="347e-ee4a-764f-6be3">The Revenant’s Aegis grants a 2+ Armour Save, a 4+ Invulnerable Save and a 6+ Shrouded Damage Mitigation roll.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+        </selectionEntry>
+        <selectionEntry id="ec7b-4e8a-5c2b-828b" name="Two Disintegrator pistols" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b1bf-968d-558d-81b2" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4a1d-e023-2c1d-b1ad" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="71f4-233b-d2dc-eeb5" name="Disintegrator Pistol" hidden="false" collective="false" import="true" targetId="980e-b1e7-a4a4-407f" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f7f1-7bb1-1e89-06ef" type="max"/>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="26ff-635e-567d-c832" type="min"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+        </selectionEntry>
+        <selectionEntry id="8a7a-52e1-787e-bd9f" name="Death&apos;s Tally" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9676-e250-0264-9c67" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="44cd-0231-9093-2293" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="0f19-03eb-2df0-81a5" name="Death&apos;s Tally" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
+                <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">+1</characteristic>
+                <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">2</characteristic>
+                <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Overcharged, Reaping Blow (2)</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="e64b-510c-b3ad-8faa" name="Overcharged" hidden="false">
+              <description>After a combat in which a model whose weapon has this special rule has made at least one Attack has been resolved, roll a dice. On the roll of a ‘1’ that model suffers a Wound against which only Invulnerable Saves may be taken.</description>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="8f70-8b3d-521e-98a7" name="Reaping Blow (X)" hidden="false" targetId="bd8c-4f52-d682-1b40" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Reaping Blow (2)"/>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="9d55-8de3-7185-154e" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7ebc-dd93-bbc2-3263" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8f3f-c88b-7671-ed79" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="4b4c-4845-e120-d4a7" name="Rad Grenades" hidden="false" collective="false" import="true" targetId="1b0b-3dfc-9521-b27e" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d587-3d6c-7df7-91d9" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c778-7bb9-a767-b202" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="b73b-4d08-b256-d2b8" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2742-742a-83e5-98de" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b7fe-d645-36b2-1bdd" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="ef21-f92f-ea2b-16e5" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b981-4c92-3b90-1229" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="2154-e9d1-55d1-1574" name="The Shadow of Death" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+              <characteristics>
+                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">During deployment, if any enemy unit is deployed within 18&quot; of Crysos Morturg, or any model in a unit he has joined, then once all Infiltrators and Scouts have been deployed (both friendly and enemy) Crysos Morturg and all models in any unit he has joined may be moved up to 7&quot; in any direction, but must end the move in Unit Coherency. In addition, Crysos Morturg and any unit he has joined may make a Reaction of any kind normally allowed to them at no cost to the controlling player’s Reaction Allotment, when Reacting to an enemy unit entering play from Reserves (including as part of a Deep Strike Assault).</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+        </entryLink>
+        <entryLink id="d096-f539-a01e-bf17" name="Aetheric Lightning" hidden="false" collective="false" import="true" targetId="b477-d985-8b95-69de" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="079b-81d4-0a66-7532" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9a5a-0eb7-2927-bf67" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="175.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3107-56ad-4cf6-0330" name="Mortus Poisoner Squad" hidden="true" collective="false" import="true" type="upgrade">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dd1f-1c51-706c-e5f7" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <infoLinks>
+        <infoLink id="aee6-abab-6c5a-5927" name="Bitter Duty" hidden="false" targetId="d1b8-31da-c53c-4fe2" type="rule"/>
+        <infoLink id="c7e7-bafb-61b6-c095" name="Counter-Attack (X)" hidden="false" targetId="fd6d-2a76-10e0-936a" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Counter-Attack (1)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="ab93-403d-2300-619e" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
+        <infoLink id="0e91-22ef-b5c1-db0a" name="Legiones Astartes (Death Guard) " hidden="false" targetId="48a9-493f-e255-5070" type="rule"/>
+      </infoLinks>
+      <selectionEntries>
+        <selectionEntry id="dc82-e9d1-0f3f-c29e" name="Mortus Poisoner" hidden="false" collective="false" import="true" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e7d0-6130-e624-7ff9" type="min"/>
+            <constraint field="selections" scope="parent" value="14.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bfc3-3fa4-484b-6b6a" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="0653-3567-877f-c852" name="Mortus Poisoner" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
+              <characteristics>
+                <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy)</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
+                <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
+                <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
+                <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">4</characteristic>
+                <characteristic name="W" typeId="57ee-1126-32a9-5672">1</characteristic>
+                <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
+                <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">1</characteristic>
+                <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">7</characteristic>
+                <characteristic name="Save" typeId="e593-6b3c-f169-04f0">3+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="5391-b952-937d-b861" name="Poison-master" hidden="false" collective="false" import="true" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="33ca-f6eb-bcb3-f2b1" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ee89-7b41-480b-0536" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="3a2d-8d24-7a9c-34f8" name="Poison-master" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
+              <modifiers>
+                <modifier type="set" field="e593-6b3c-f169-04f0" value="2+">
+                  <conditions>
+                    <condition field="selections" scope="3107-56ad-4cf6-0330" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ffa6-522c-4968-409b" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <characteristics>
+                <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character, Heavy)</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+                <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
+                <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
+                <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
+                <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">4</characteristic>
+                <characteristic name="W" typeId="57ee-1126-32a9-5672">2</characteristic>
+                <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
+                <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">1</characteristic>
+                <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">8</characteristic>
+                <characteristic name="Save" typeId="e593-6b3c-f169-04f0">3+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="9dcb-365a-56b9-74c3" name="2) Any model with a Bolter may take:" hidden="false" collective="false" import="true">
+          <modifiers>
+            <modifier type="increment" field="78d7-abd9-6c70-387f" value="1.0">
+              <repeats>
+                <repeat field="selections" scope="3107-56ad-4cf6-0330" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1ade-0c02-5612-252b" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="78d7-abd9-6c70-387f" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="5a9e-bacd-81bf-2117" name="Bayonet" hidden="false" collective="false" import="true" targetId="6904-6936-d6ca-a0eb" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="15.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="15ac-38cb-77a6-8d76" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="1.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="5422-9afe-7bee-3582" name="Chain Bayonet" hidden="false" collective="false" import="true" targetId="bd82-cef6-67f8-19b5" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="15.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="357e-83fb-f103-403d" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="e88a-4664-b921-ec65" name="1) Any model may exchange its bolter for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="f545-6391-459f-477b">
+          <modifiers>
+            <modifier type="increment" field="0bdd-914d-84a9-f36b" value="1.0">
+              <repeats>
+                <repeat field="selections" scope="3107-56ad-4cf6-0330" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+            <modifier type="increment" field="f64e-a2e1-c018-bbcf" value="1.0">
+              <repeats>
+                <repeat field="selections" scope="3107-56ad-4cf6-0330" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+            <modifier type="decrement" field="f64e-a2e1-c018-bbcf" value="5.0"/>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0bdd-914d-84a9-f36b" type="max"/>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f64e-a2e1-c018-bbcf" type="min"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="97cb-1422-1dbf-016e" name="One in every five may exchange its bolter for:" hidden="false" collective="false" import="true">
+              <modifiers>
+                <modifier type="increment" field="0b34-2194-b335-9ca2" value="1.0">
+                  <repeats>
+                    <repeat field="selections" scope="3107-56ad-4cf6-0330" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0b34-2194-b335-9ca2" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="191e-18d8-794c-9e1d" name="Heavy Alchem Flamer" hidden="false" collective="false" import="true" targetId="2a3d-a4bb-5326-a16a" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e978-bb78-00c1-2885" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="f545-6391-459f-477b" name="Bolter" hidden="false" collective="false" import="true" targetId="1ade-0c02-5612-252b" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="15.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="100f-3b2a-dc95-9ca0" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="bb16-2b90-9813-f421" name="Alchem Flamer" hidden="false" collective="false" import="true" targetId="0d08-eaaf-3793-0a70" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="15.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5e92-5d4a-ed4d-9085" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="aa39-6487-6a7b-bd44" name="3) Any model may take:" hidden="false" collective="false" import="true">
+          <modifiers>
+            <modifier type="increment" field="5849-f1b4-b82f-db0f" value="1.0">
+              <repeats>
+                <repeat field="selections" scope="3107-56ad-4cf6-0330" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="3107-56ad-4cf6-0330" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5849-f1b4-b82f-db0f" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="0d73-6b95-b4e2-66e6" name="Chainsword" hidden="false" collective="false" import="true" targetId="06e7-a6ae-ed1c-eb03" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="48b5-b5e8-d52b-e91a" name="4) One Mortus Poisoner may take:" hidden="false" collective="false" import="true">
+          <entryLinks>
+            <entryLink id="56b1-777a-e1e0-b894" name="Nuncio-Vox" hidden="false" collective="false" import="true" targetId="005e-aae6-ddac-bb45" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fe3a-5196-118a-238b" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="8df9-92b6-99ee-5f92" name="Augury Scanner" hidden="false" collective="false" import="true" targetId="67ee-7338-3b74-04b4" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="abb0-4b08-3394-7888" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="78e6-9ca7-6fc4-bbf3" name="Legion Vexilla" hidden="false" collective="false" import="true" targetId="21b1-2a90-9826-1782" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f4fb-52d8-f37f-0827" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="df83-c3d6-978a-bfc6" name="6) Poison-master Wargear" hidden="false" collective="false" import="true">
+          <entryLinks>
+            <entryLink id="ffa6-522c-4968-409b" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d31d-62ea-f012-9efa" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="0032-cc60-5ba0-4d8c" name="Phosphex Bomb" hidden="false" collective="false" import="true" targetId="4188-13ff-cb03-109e" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3f28-4f05-2529-e150" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="325d-2fdc-47f6-a4ad" name="Meltabombs" hidden="false" collective="false" import="true" targetId="b9dd-3b21-f3f8-78e3" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="81cb-649a-0bbc-80ba" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="f30f-eed7-18ff-ae70" name="5) Poison-master may take one:" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fc56-eee2-95ce-ae80" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="03e5-cfb3-63da-979c" name="Power Sword" hidden="false" collective="false" import="true" targetId="a3cd-aa97-a148-2309" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="cabd-c46d-a55a-c99c" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="b80c-23b9-4fc3-fd35" name="Power Maul" hidden="false" collective="false" import="true" targetId="0df4-c67e-cf64-82e0" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="a8af-853a-c202-7c61" name="Power Lance" hidden="false" collective="false" import="true" targetId="a4c8-c8ff-87f2-1ac9" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="9309-be95-6f25-95a5" name="Power Scythe" hidden="false" collective="false" import="true" targetId="2166-369e-0757-6f98" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="d7f3-65fe-cd49-ddb2" name="Dedicated Transport:" hidden="false" collective="false" import="true">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="3107-56ad-4cf6-0330" value="9.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dc82-e9d1-0f3f-c29e" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b226-8bb4-dcc0-75b2" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="7b24-6b77-960f-0085" name="Rhino Transport" hidden="false" collective="false" import="true" targetId="03f1-8ed9-9867-8d18" type="selectionEntry"/>
+            <entryLink id="fa36-8266-c374-0095" name="Land Raider Proteus Carrier" hidden="false" collective="false" import="true" targetId="c123-bdc6-a6ba-79a2" type="selectionEntry"/>
+            <entryLink id="ac1a-bf8c-ecfb-8b4a" name="Termite Assault Drill" hidden="false" collective="false" import="true" targetId="cb30-307a-f0d7-3b13" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="40.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4390-3aec-6ae6-5b81" name="Marshal Durak Rask" hidden="true" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f9c0-0c5a-3e24-58c7" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dd1f-1c51-706c-e5f7" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e188-d322-2b33-0da3" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="5b0f-47c3-0bab-2dae" name="Marshal Durak Rask" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
+          <characteristics>
+            <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character, Unique, Heavy)</characteristic>
+            <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7&quot;</characteristic>
+            <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
+            <characteristic name="BS" typeId="74ae-c840-0036-d244">5</characteristic>
+            <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
+            <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">4</characteristic>
+            <characteristic name="W" typeId="57ee-1126-32a9-5672">2</characteristic>
+            <characteristic name="I" typeId="62d3-22d7-2d49-52dc">5</characteristic>
+            <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">3</characteristic>
+            <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">9</characteristic>
+            <characteristic name="Save" typeId="e593-6b3c-f169-04f0">2+</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="7ee8-56b8-065f-54cc" name="Protocols of Destruction" hidden="false">
+          <description>The controlling player of a model with Protocols of Destruction may activate them at the start of any of their own turns, or, if the controlling player is not taking the first turn of the battle, at the start of the battle, before the beginning of the opposing player’s first turn. Once Protocols of Destruction are activated, any Penetrating Hits caused by a model with Protocols of Destruction and any unit that they have joined, gain +1 to any rolls on the Vehicle Damage chart until the beginning of the controlling player’s next turn. In addition, any Legion Rapier Carriers with quad launchers in the same Detachment as Marshal Durak Rask may be upgraded to have phosphex canister shot for +20 points per model, and any Legion Arquitor Squadrons with Morbus bombards in the same Detachment may be upgraded with phosphex shells for +20 points per model.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="3330-3835-586e-f9e1" name="Legiones Astartes (Death Guard) " hidden="false" targetId="48a9-493f-e255-5070" type="rule"/>
+      </infoLinks>
+      <selectionEntries>
+        <selectionEntry id="8991-b892-e8a3-c35e" name="Defiant" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d0f7-3a90-20b8-772e" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8651-80c1-be76-0e8c" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="96e6-90b9-21ff-84b1" name="Defiant" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
+                <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">8</characteristic>
+                <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">2</characteristic>
+                <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Unwieldy, Brutal (2), Specialist Weapon, Sunder</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="ff8e-e225-e53b-26d3" name="Unwieldy" hidden="false" targetId="1570-c21a-881f-8b8a" type="rule"/>
+            <infoLink id="7ed8-5548-349b-871f" name="Brutal (X)" hidden="false" targetId="5079-1fec-d32b-8b84" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Brutal (2)"/>
+              </modifiers>
+            </infoLink>
+            <infoLink id="e3dd-9cb1-e8cd-3331" name="Specialist Weapon" hidden="false" targetId="1a1f-3c9b-b097-5886" type="rule"/>
+            <infoLink id="7843-8908-8b98-82d2" name="Sunder" hidden="false" targetId="20e2-75cf-bc16-cd8f" type="rule"/>
+          </infoLinks>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="aa53-00a8-75ce-26f2" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="cd39-59f9-5d72-3526" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="25d3-97cb-e834-9dc9" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="d306-95fb-6323-31ac" name="Rad Grenades" hidden="false" collective="false" import="true" targetId="1b0b-3dfc-9521-b27e" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ef61-aeaa-048b-3b1d" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ebd2-e365-eddc-e76a" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="3df7-d1df-ba92-f813" name="Volkite Serpenta" hidden="false" collective="false" import="true" targetId="d535-1da8-290d-69a6" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6f3a-68a9-d8d3-c61b" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9013-e224-62c7-02dc" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="b357-1d03-0f48-38ea" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e73c-a477-a59c-c7a2" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="ce49-9aab-7eef-4cf0" name="Merciless Doctrine" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+              <characteristics>
+                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">Any Feel No Pain Damage Mitigation rolls taken against Wounds inflicted by Shooting Attacks made by Marshal Durak Rask and any unit that he has joined are reduced by -1, to a minimum of 6+ (for example, a model with a Feel No Pain (4+) requires a roll of 5+ against the attack). In addition, an army whose Warlord is Durak Rask may make an additional Reaction in the opposing player’s Shooting phase, as long as Marshal Durak Rask has not been removed as a casualty.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+        </entryLink>
+        <entryLink id="33fd-6701-16ef-47d9" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ff8b-c3d4-b1ae-7f74" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4ab2-883c-3425-e4dc" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="8f15-be9f-7f6e-8bff" name="Nuncio-Vox" hidden="false" collective="false" import="true" targetId="005e-aae6-ddac-bb45" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="68fc-ca73-21c9-7b1d" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d9c0-fdcb-b6f1-fc7e" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="38c6-c2ed-1ebe-e154" name="Refractor Field" hidden="false" collective="false" import="true" targetId="a06a-55a5-070b-1d0e" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9842-38ab-b08e-f42e" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a4a7-a67a-c17d-4ccf" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="5420-d212-0018-fddb" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f84b-d90c-9e11-a4be" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3651-a69e-cfc5-e9f7" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="c668-aa83-f906-d8b9" name="Phosphex Bomb" hidden="false" collective="false" import="true" targetId="4188-13ff-cb03-109e" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f7ef-0545-71c6-9618" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0e5c-5fff-fc88-b894" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="165.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="aa7f-bd4c-5231-d459" name="Terminator Indomitus Squad" hidden="false" collective="false" import="true" type="unit">
+      <infoLinks>
+        <infoLink id="9744-7613-6a6f-2621" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
+        <infoLink id="88b4-f414-3ff6-a7f2" name="Inexorable" hidden="false" targetId="d863-8a5e-ddb6-d5a4" type="rule"/>
+        <infoLink id="910d-b1cc-e104-a110" name="Bulky (X)" hidden="false" targetId="676c-7b75-4b6f-9405" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Bulky (2)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="000f-9e04-08d3-63aa" name="Support Squad" hidden="false" targetId="768e-56d6-ca52-24ae" type="rule"/>
+        <infoLink id="f2fa-16dd-9ff8-3933" name="Legiones Astartes (X)" hidden="false" targetId="61cf-75c2-56cd-2a31" type="rule"/>
+      </infoLinks>
+      <selectionEntries>
+        <selectionEntry id="82ac-f3c8-bfd7-e4a2" name="Legion Indomitus" hidden="false" collective="false" import="true" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2f9a-ed8e-4497-61ca" type="max"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8963-d63f-16be-4100" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="c4eb-e2bc-82fb-a941" name="Legion Indomitus" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
+              <characteristics>
+                <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy)</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6</characteristic>
+                <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
+                <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
+                <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
+                <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">4</characteristic>
+                <characteristic name="W" typeId="57ee-1126-32a9-5672">2</characteristic>
+                <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
+                <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">2</characteristic>
+                <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">7</characteristic>
+                <characteristic name="Save" typeId="e593-6b3c-f169-04f0">2+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="480c-ac07-cf8e-05a7" name="1) Ranged Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="a8c7-3b93-fa86-ce71">
+              <modifiers>
+                <modifier type="set" field="9eab-da42-7207-c13c" value="0.0">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b503-8902-fde3-7675" type="equalTo"/>
+                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f6d-a026-e6ca-1442" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+                <modifier type="set" field="c8a8-ee61-6620-f7c9" value="0.0">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b503-8902-fde3-7675" type="equalTo"/>
+                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f6d-a026-e6ca-1442" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9eab-da42-7207-c13c" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c8a8-ee61-6620-f7c9" type="min"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="c7f6-39c7-52f2-7cf7" name="Proteus pattern storm shield" hidden="false" collective="false" import="true" targetId="82b5-dbc8-0060-97a4" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5a9a-c49c-be86-1f19" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="4298-5313-5d43-1eab" name="Magna Combi-Weapon" hidden="false" collective="false" import="true" targetId="e5b1-83e5-7272-a59e" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="249a-7712-ecd0-b534" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="15c0-7388-6d56-eb1e" name="Minor Combi-Weapon" hidden="false" collective="false" import="true" targetId="605e-1b86-ca08-9226" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="12a2-c4db-c845-caf3" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="a8c7-3b93-fa86-ce71" name="Combi-Bolter" hidden="false" collective="false" import="true" targetId="a498-c66f-9eb7-ca9a" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c672-958f-311c-cc93" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="353d-34e0-bef1-bdec" name="2) Melee Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="76f7-cda1-7c70-0c7e">
+              <modifiers>
+                <modifier type="set" field="bba1-449b-d72b-f14c" value="0.0">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b503-8902-fde3-7675" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="ab65-49cc-02e6-55b2" value="0.0">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b503-8902-fde3-7675" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bba1-449b-d72b-f14c" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ab65-49cc-02e6-55b2" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="eca8-e38e-bedf-ab64" name="Chainfist" hidden="false" collective="false" import="true" targetId="7347-c5b1-5da3-a78f" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="2cd2-4403-3ca7-054b" name="Thunder Hammer" hidden="false" collective="false" import="true" targetId="e6cc-bfce-a4d9-301c" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="76f7-cda1-7c70-0c7e" name="Power Fist" hidden="false" collective="false" import="true" targetId="a3e1-d633-dff9-028b" type="selectionEntry"/>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="8f6d-a026-e6ca-1442" name="3) Heavy Weapon Options" hidden="false" collective="false" import="true">
+              <modifiers>
+                <modifier type="increment" field="7eab-854c-c708-7be9" value="1.0">
+                  <repeats>
+                    <repeat field="selections" scope="aa7f-bd4c-5231-d459" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="aa7f-bd4c-5231-d459" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7eab-854c-c708-7be9" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0f76-7aff-9914-8164" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="ac54-40d7-d0fe-4eba" name="Heavy Flamer" hidden="false" collective="false" import="true" targetId="efae-cd0d-a9f1-8be4" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="99cc-9f3e-32ec-1f44" name="Proteus assault cannon" hidden="false" collective="false" import="true" targetId="da1a-85ed-813f-829a" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="95ab-3b8b-d30a-dc70" name="Paired Melee Weapons:" hidden="false" collective="false" import="true" targetId="b503-8902-fde3-7675" type="selectionEntryGroup">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="be56-7014-0bad-887c" name="Legion Indomitus Sergeant" hidden="false" collective="false" import="true" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="89e6-538e-a03e-a8b5" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="597d-a532-cfc0-725b" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="e14d-1f3f-eb88-6d51" name="Legion Indomitus Sergeant" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
+              <characteristics>
+                <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy, Character)</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6</characteristic>
+                <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
+                <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
+                <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
+                <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">4</characteristic>
+                <characteristic name="W" typeId="57ee-1126-32a9-5672">2</characteristic>
+                <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
+                <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">3</characteristic>
+                <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">8</characteristic>
+                <characteristic name="Save" typeId="e593-6b3c-f169-04f0">2+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="abf3-d3fb-43e8-02c2" name="2) Melee Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="7ba2-da79-39e2-6cc3">
+              <modifiers>
+                <modifier type="set" field="b42c-4e7d-4fe0-3fd8" value="0.0">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b503-8902-fde3-7675" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="3ef0-f601-9486-a267" value="0.0">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b503-8902-fde3-7675" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ef0-f601-9486-a267" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b42c-4e7d-4fe0-3fd8" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="fdfe-9490-3a77-bf84" name="Chainfist" hidden="false" collective="false" import="true" targetId="7347-c5b1-5da3-a78f" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="294c-26b1-ed6c-80e3" name="Thunder Hammer" hidden="false" collective="false" import="true" targetId="e6cc-bfce-a4d9-301c" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="7ba2-da79-39e2-6cc3" name="Power Fist" hidden="false" collective="false" import="true" targetId="a3e1-d633-dff9-028b" type="selectionEntry"/>
+                <entryLink id="e14c-f736-0030-2dff" name="Power Weapon" hidden="false" collective="false" import="true" targetId="8d9c-9f80-c0fd-adcf" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="append" field="name" value="(master-crafted)"/>
+                  </modifiers>
+                  <infoLinks>
+                    <infoLink id="5752-bfc9-0dbc-bd8a" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="dc98-bb56-4f1a-afb9" name="1) Ranged Options" hidden="false" collective="false" import="true">
+              <modifiers>
+                <modifier type="set" field="1c52-f14e-94df-500b" value="0.0">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b503-8902-fde3-7675" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="4e86-e523-e47d-18ab" value="0.0">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b503-8902-fde3-7675" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4e86-e523-e47d-18ab" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1c52-f14e-94df-500b" type="min"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="16af-5d55-d4f6-e89b" name="Proteus pattern storm shield" hidden="false" collective="false" import="true" targetId="82b5-dbc8-0060-97a4" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d47e-9ea7-4390-e42d" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="a736-99aa-daae-bdb8" name="Magna Combi-Weapon" hidden="false" collective="false" import="true" targetId="e5b1-83e5-7272-a59e" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ed16-ad46-f1b4-e1a0" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="d177-4f28-a694-df05" name="Minor Combi-Weapon" hidden="false" collective="false" import="true" targetId="605e-1b86-ca08-9226" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e7e9-9c6c-db42-239d" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="4109-2f08-c8ba-91aa" name="Combi-Bolter" hidden="false" collective="false" import="true" targetId="a498-c66f-9eb7-ca9a" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5f00-7bb1-c20c-388a" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="3de3-3d0d-77e9-de34" name="Paired Melee Weapons:" hidden="false" collective="false" import="true" targetId="b503-8902-fde3-7675" type="selectionEntryGroup">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="2cdf-4b12-ec3b-6307" name="Grenade Harness" hidden="false" collective="false" import="true" targetId="251a-860d-2c4d-62cc" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1683-f563-bb96-b6ab" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="23e2-4e21-6229-2444" name="One Legion Indomitus may take:" hidden="false" collective="false" import="true">
+          <entryLinks>
+            <entryLink id="2c9a-fb0a-4631-c17d" name="Nuncio-Vox" hidden="false" collective="false" import="true" targetId="005e-aae6-ddac-bb45" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="43da-e814-ce88-4b01" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="f66c-37ea-c02e-abd2" name="Augury Scanner" hidden="false" collective="false" import="true" targetId="67ee-7338-3b74-04b4" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f865-6f41-8250-958f" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="1dff-e3da-0e2a-7f31" name="Legion Vexilla" hidden="false" collective="false" import="true" targetId="21b1-2a90-9826-1782" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1edd-f9d9-78f9-3e36" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="5372-67ef-f594-305b" name="Dedicated Transport:" hidden="false" collective="false" import="true">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="aa7f-bd4c-5231-d459" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="82ac-f3c8-bfd7-e4a2" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9761-d3bb-88c7-c35d" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="eae9-225f-a0ac-2e0d" name="Land Raider Proteus Carrier" hidden="false" collective="false" import="true" targetId="c123-bdc6-a6ba-79a2" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="015b-a670-8d49-c677" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="220.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="4d94-4719-9d1e-8f1c" name="Dreadclaw Drop Pod" hidden="false" collective="false" import="true" targetId="bbe8-818d-3068-d79c" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4a74-f0c5-1ee9-7130" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="7ccf-62af-7624-c903" name="Indomitus Terminator Armour" hidden="false" collective="false" import="true" targetId="5a55-baa5-1602-7223" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2428-2726-f389-1490" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0788-8354-4dd2-ef9b" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5a55-baa5-1602-7223" name="Indomitus Terminator Armour" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1387-080f-9c95-54bc" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9669-a63a-ab35-172f" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="0e40-edd6-eb42-8bc5" name="Indomitus Terminator Armour" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
+          <characteristics>
+            <characteristic name="Description" typeId="347e-ee4a-764f-6be3">Legion Indomitus Terminator armour confers a 2+ Armour Save and a 5+ Invulnerable Save.�</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+    </selectionEntry>
+    <selectionEntry id="da1a-85ed-813f-829a" name="Proteus assault cannon" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="8adb-b2d4-80f7-1942" name="Proteus assault cannon" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">24&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">6</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">4</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Assault, Rending (6+)</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="6354-ba35-47a0-a430" name="Rending (X)" hidden="false" targetId="0ac9-fab7-aef3-de1d" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Rending (6+)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+    </selectionEntry>
+    <selectionEntry id="82b5-dbc8-0060-97a4" name="Proteus pattern storm shield" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="03dd-18a0-b0bd-2649" name="Proteus pattern storm shield" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
+          <characteristics>
+            <characteristic name="Description" typeId="347e-ee4a-764f-6be3">A model with a Proteus storm shield gains a 4+ Invulnerable Save, Invulnerable Saves granted by a Proteus storm shield do not stack with other Invulnerable Saves, and cannot be modified by any other special rule. If a model has another Invulnerable Save then the controlling player must choose one to use. A model with a Proteus storm shield may never gain an additional Attack for being armed with two close combat weapons or make attacks using a weapon with the Two-handed special rule.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+    </selectionEntry>
+    <selectionEntry id="c2b4-503b-5732-a8a2" name="Gravis Missile Launcher" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="696b-2566-f913-550c" name="Gravis Missile Launcher - Frag" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">48&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">4</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">6</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 1, Large Blast (5&quot;), Pinning</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="b35f-574e-ac6d-03e3" name="Gravis Missile Launcher - Krak" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">48&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">8</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">3</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 2</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="1cdd-ef6d-d419-cda7" name="Blast" hidden="false" targetId="1d9a-73ef-5f4f-8bd8" type="rule"/>
+        <infoLink id="8beb-4fad-195b-1104" name="Pinning" hidden="false" targetId="1c96-205c-59a0-3cf2" type="rule"/>
+      </infoLinks>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
@@ -36517,7 +39128,15 @@ Special rules A Legion Warmonger Consul gains the Tip of the Spear special rule.
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fb92-9b56-ee75-7d43" type="min"/>
       </constraints>
       <entryLinks>
-        <entryLink id="e6df-8ece-3000-87a3" name="Magna Combi-Weapon - Disintegrator" hidden="false" collective="false" import="true" targetId="1d05-f467-b0aa-88b2" type="selectionEntry"/>
+        <entryLink id="e6df-8ece-3000-87a3" name="Magna Combi-Weapon - Disintegrator" hidden="true" collective="false" import="true" targetId="1d05-f467-b0aa-88b2" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="58e6-f9cc-4c46-e258" type="instanceOf"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
         <entryLink id="5150-6755-2b14-de31" name="Magna Combi-Weapon - Meltagun" hidden="false" collective="false" import="true" targetId="0d1c-227e-a3f8-cd63" type="selectionEntry"/>
         <entryLink id="3059-19ce-5ea6-872a" name="Magna Combi-Weapon - Plasma Gun" hidden="false" collective="false" import="true" targetId="cc98-8596-c713-516c" type="selectionEntry"/>
       </entryLinks>

--- a/2022 - Legiones Astartes.cat
+++ b/2022 - Legiones Astartes.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="6393-649c-7213-a327" name="(HH V2) Legions Astartes" revision="20" battleScribeVersion="2.03" authorName="Various" authorUrl="https://github.com/BSData/horus-heresy" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="8" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="6393-649c-7213-a327" name="(HH V2) Legions Astartes" revision="21" battleScribeVersion="2.03" authorName="Various" authorUrl="https://github.com/BSData/horus-heresy" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="7" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <categoryEntries>
     <categoryEntry id="11f2-472f-c1d1-9ae9" name="Legiones Astartes" hidden="false">
       <infoLinks>
@@ -1222,7 +1222,7 @@
     </entryLink>
   </entryLinks>
   <sharedSelectionEntries>
-    <selectionEntry id="51e5-c28f-d9dd-5e52" name="Fulgrim (*)" hidden="true" collective="false" import="true" type="unit">
+    <selectionEntry id="51e5-c28f-d9dd-5e52" name="Fulgrim" hidden="true" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditionGroups>
@@ -1248,12 +1248,12 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2217-dec0-9a6c-85e7" type="min"/>
           </constraints>
           <profiles>
-            <profile id="9e39-49d0-0ca2-1587" name="Firebrand (P3P ZW)" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+            <profile id="9e39-49d0-0ca2-1587" name="Firebrand" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
               <characteristics>
                 <characteristic name="Range" typeId="95ba-cda7-b831-6066">15&quot;</characteristic>
                 <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">6</characteristic>
                 <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">4</characteristic>
-                <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Pistol 2, Deflagerate, Shred, Master-crafted</characteristic>
+                <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Pistol 2, Deflagrate, Shred, Master-crafted</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -1272,7 +1272,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ac78-7506-bf5c-f70d" type="min"/>
           </constraints>
           <profiles>
-            <profile id="3fbc-09ab-5399-6db8" name="Fulgrim (P3P ZW)" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
+            <profile id="3fbc-09ab-5399-6db8" name="Fulgrim" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Primarch (Unique)
 </characteristic>
@@ -1290,14 +1290,8 @@
             </profile>
           </profiles>
           <rules>
-            <rule id="1502-2273-f6d9-0b17" name="Warlord: Sire of the Emperor&apos;s Children" hidden="false">
-              <description>If chosen as the army&apos;s Warlord, Fulgrim automatically has the Sire of the Emperor’s Children Warlord Trait and may not select any other Warlord Trait: 
-
-Sire of the Emperor’s Children - All friendly models with the Legiones Astartes (Emperor’s Children) that can draw a line of sight to Fulgrim may use Fulgrim’s Leadership Characteristic for all Morale and Pinning checks they are required to take and all friendly units with the Legiones Astartes (Emperor’s Children) special rule on the battlefield while Fulgrim is also on the battlefield gain +1 to the Wound value used to calculate if the unit has won a close combat. In addition, the first Reaction made in each Turn by Fulgrim and any unit he has joined does not use up a point of the controlling player’s Reaction Allotment.</description>
-            </rule>
             <rule id="1b6c-2f5b-5a96-fa48" name="The Gilded Panoply" hidden="false">
-              <description>The Gilded Panoply provides Fulgrim with a 2+ Armour Save, a 3+ Invulnerable Save against Melee
-Attacks and a 5+ Invulnerable Save against all other Wounds inflicted upon him</description>
+              <description>The Gilded Panoply provides Fulgrim with a 2+ Armour Save, a 3+ Invulnerable Save against Melee Attacks and a 5+ Invulnerable Save against all other Wounds inflicted upon him.</description>
             </rule>
             <rule id="6671-6d02-11ed-0c61" name="Sublime Swordsman" hidden="false">
               <description>When Fulgrim makes Melee Attacks as part of a Challenge, he gains a number of additional attacks equal to the amount which his Initiative Characteristic is greater than that of his opponent. For example, if Fulgrim attacks an enemy model with an Initiative Characteristic of 5 as part of a Challenge, Fulgrim’s Initiative of 8 grants him 3 extra Attacks</description>
@@ -1307,15 +1301,34 @@ Attacks and a 5+ Invulnerable Save against all other Wounds inflicted upon him</
             </rule>
           </rules>
           <infoLinks>
-            <infoLink id="b012-2dbb-2db0-99d7" name="Legiones Astartes (Emperor&apos;s Children) " hidden="false" targetId="4a36-8b9d-6b6c-51e1" type="rule"/>
+            <infoLink id="b012-2dbb-2db0-99d7" name="Bulky (X)" hidden="false" targetId="676c-7b75-4b6f-9405" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Bulky (6)"/>
+              </modifiers>
+            </infoLink>
+            <infoLink id="087d-f3e7-8a37-d12f" name="Sudden Strike (X)" hidden="false" targetId="58b3-7d84-b92d-1363" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Sudden Strike (1)"/>
+              </modifiers>
+            </infoLink>
+            <infoLink id="41e5-304e-b156-5789" name="Crusader" hidden="false" targetId="c705-0829-75f6-a785" type="rule"/>
+            <infoLink id="10f7-b0cb-c7ee-5f3d" name="Legiones Astartes (Emperor&apos;s Children) " hidden="false" targetId="4a36-8b9d-6b6c-51e1" type="rule"/>
           </infoLinks>
+          <entryLinks>
+            <entryLink id="64a1-5263-a5b1-2a9b" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8917-3800-68aa-9c07" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="95a6-641d-4f95-2173" type="min"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="e731-9fdc-c6a1-17c4" name="Weapon" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="e731-9fdc-c6a1-17c4" name="Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="a0e6-4565-3cd0-4ae7">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf07-7231-8147-a868" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fc05-2761-234b-037c" type="max"/>
@@ -1326,12 +1339,12 @@ Attacks and a 5+ Invulnerable Save against all other Wounds inflicted upon him</
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1f41-e9a5-a804-87a2" type="max"/>
               </constraints>
               <profiles>
-                <profile id="ea1b-b076-1279-d56a" name="The Blade of the Laer (P3P ZW)" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+                <profile id="ea1b-b076-1279-d56a" name="The Blade of the Laer" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
                   <characteristics>
                     <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
                     <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">User</characteristic>
                     <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">2</characteristic>
-                    <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Duellist’s Edge (1), Fleshbane, Specialist Weapon
+                    <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Duellist’s Edge (1), Fleshbane, Master-crafted, Specialist Weapon
 </characteristic>
                   </characteristics>
                 </profile>
@@ -1344,6 +1357,7 @@ Attacks and a 5+ Invulnerable Save against all other Wounds inflicted upon him</
                 </infoLink>
                 <infoLink id="adda-fee2-c667-1fee" name="Specialist Weapon" hidden="false" targetId="1a1f-3c9b-b097-5886" type="rule"/>
                 <infoLink id="440a-5212-8cb7-c4cb" name="Fleshbane" hidden="true" targetId="40cd-9505-253c-e76f" type="rule"/>
+                <infoLink id="4eb2-1e10-5e5d-1e0a" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
@@ -1354,7 +1368,7 @@ Attacks and a 5+ Invulnerable Save against all other Wounds inflicted upon him</
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ce75-bc71-e9b6-491f" type="max"/>
               </constraints>
               <profiles>
-                <profile id="56e0-acb7-2e37-df5e" name="Fireblade (P3P ZW)" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+                <profile id="56e0-acb7-2e37-df5e" name="Fireblade" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
                   <characteristics>
                     <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
                     <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">+1</characteristic>
@@ -1385,6 +1399,18 @@ Attacks and a 5+ Invulnerable Save against all other Wounds inflicted upon him</
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6348-0f99-a05c-320d" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c3c6-e782-1a6c-f31a" type="max"/>
           </constraints>
+        </entryLink>
+        <entryLink id="abd7-fc9b-94bf-9b2d" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5183-4afb-ba99-a704" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="b6d7-a53a-2236-42d7" name="Sire of the Emperor&apos;s Children" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+              <characteristics>
+                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">All friendly models with the Legiones Astartes (Emperor’s Children) that can draw a line of sight to Fulgrim may use Fulgrim’s Leadership Characteristic for all Morale and Pinning checks they are required to take and all friendly units with the Legiones Astartes (Emperor’s Children) special rule on the battlefield while Fulgrim is also on the battlefield gain +1 to the Wound value used to calculate if the unit has won a close combat. In addition, the first Reaction made in each Turn by Fulgrim and any unit he has joined does not use up a point of the controlling player’s Reaction Allotment.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
         </entryLink>
       </entryLinks>
       <costs>
@@ -1434,20 +1460,20 @@ Attacks and a 5+ Invulnerable Save against all other Wounds inflicted upon him</
               </characteristics>
             </profile>
           </profiles>
-          <rules>
-            <rule id="59c5-7a9e-7efd-18c3" name="Warlord: Prideful Onslaught" hidden="false">
-              <description>If chosen as the army&apos;s Warlord, Lord Commander Eidolon automatically has Prideful Onslaught as his Warlord Trait and may not select any other.
-
-Prideful Onslaught – If Lord Commander Eidolon is the Army&apos;s Warlord, then at the beginning of the battle, once all of the opposing player&apos;s models have been deployed, but before the first turn has begun, Lord Commander Eidolon&apos;s controlling player must select one enemy HQ or Primarch choice as Lord Commander Eidolon&apos;s &quot;Rival&quot;. Lord Commander Eidolon and any unit he has joined gain a bonus of +1 to all To Hit rolls made against the &quot;Rival&quot; unit - and if the &quot;Rival&quot; unit is part of any enemy Shooting Attack or Combat that results in a friendly unit being removed entirely as casualties or Falling Back, then Lord Commander Eidolon and any unit he has joined also gains a bonus of +1 to all To Wound rolls made against the &quot;Rival&quot; unit for the remainder of the battle after that Shooting Attack or Combat has been fully resolved. In addition Lord Commander Eidolon and any unit he has joined may only declare Reactions against the Rival unit, but the first such Reaction each turn is free and does not reduce the Player&apos;s Reaction Allotment for that Phase.</description>
-            </rule>
-          </rules>
           <infoLinks>
             <infoLink id="ed97-fc70-8fae-0274" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
             <infoLink id="129d-c508-d60a-ccd8" name="Independent Character" hidden="false" targetId="c57d-4820-458a-7ab5" type="rule"/>
-            <infoLink id="92ea-b42d-e0b0-6536" name="Master of the Legion" hidden="false" targetId="c772-87ea-d49c-c7ba" type="rule"/>
             <infoLink id="9061-b8a2-d961-d8a8" name="Traitor" hidden="false" targetId="eff2-8b0e-21da-2f0d" type="rule"/>
             <infoLink id="e36d-9086-0652-f442" name="Legiones Astartes (Emperor&apos;s Children) " hidden="false" targetId="4a36-8b9d-6b6c-51e1" type="rule"/>
           </infoLinks>
+          <entryLinks>
+            <entryLink id="38da-f86f-ea14-f6db" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="60fc-27ee-b0fb-5845" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fa17-944a-e074-61ae" type="min"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
           </costs>
@@ -1502,12 +1528,6 @@ Prideful Onslaught – If Lord Commander Eidolon is the Army&apos;s Warlord, the
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink id="4ff2-7484-8344-c7e7" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9cea-edb6-52f3-04a1" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0f50-482c-c153-520e" type="max"/>
-          </constraints>
-        </entryLink>
         <entryLink id="ca48-e753-625e-d090" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f071-0b94-265b-a892" type="min"/>
@@ -1550,6 +1570,16 @@ Prideful Onslaught – If Lord Commander Eidolon is the Army&apos;s Warlord, the
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="41c4-9ab9-46df-6679" type="min"/>
           </constraints>
         </entryLink>
+        <entryLink id="cad5-862f-1ce6-0dae" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fd63-1db3-8890-7a27" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="a923-6c52-5d0f-c287" name="Warlord: Prideful Onslaught" hidden="false">
+              <description>If Lord Commander Eidolon is the Army&apos;s Warlord, then at the beginning of the battle, once all of the opposing player&apos;s models have been deployed, but before the first turn has begun, Lord Commander Eidolon&apos;s controlling player must select one enemy HQ or Primarch choice as Lord Commander Eidolon&apos;s &quot;Rival&quot;. Lord Commander Eidolon and any unit he has joined gain a bonus of +1 to all To Hit rolls made against the &quot;Rival&quot; unit - and if the &quot;Rival&quot; unit is part of any enemy Shooting Attack or Combat that results in a friendly unit being removed entirely as casualties or Falling Back, then Lord Commander Eidolon and any unit he has joined also gains a bonus of +1 to all To Wound rolls made against the &quot;Rival&quot; unit for the remainder of the battle after that Shooting Attack or Combat has been fully resolved. In addition Lord Commander Eidolon and any unit he has joined may only declare Reactions against the Rival unit, but the first such Reaction each turn is free and does not reduce the Player&apos;s Reaction Allotment for that Phase.</description>
+            </rule>
+          </rules>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="215.0"/>
@@ -1576,13 +1606,13 @@ Prideful Onslaught – If Lord Commander Eidolon is the Army&apos;s Warlord, the
         <categoryLink id="ba62-71ba-ea83-829b" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="3604-b98f-1a09-5eab" name="Ahzek Ahriman (*)" hidden="false" collective="false" import="true" type="model">
+        <selectionEntry id="3604-b98f-1a09-5eab" name="Ahzek Ahriman" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f7bb-44c9-efd4-26a5" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bc18-cc04-dcd6-d0a0" type="min"/>
           </constraints>
           <profiles>
-            <profile id="2011-0ecb-3faa-7ff0" name="Ahzek Ahriman (P3P ZW)" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
+            <profile id="2011-0ecb-3faa-7ff0" name="Ahzek Ahriman" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character, Psyker, Unique)
 </characteristic>
@@ -1600,17 +1630,11 @@ Prideful Onslaught – If Lord Commander Eidolon is the Army&apos;s Warlord, the
             </profile>
           </profiles>
           <rules>
-            <rule id="c8cc-8ca0-dd64-a427" name="Warlord: The Patterns of Fates" hidden="false">
-              <description>If chosen as the army&apos;s Warlord, Azhek Ahriman automatically has The Pattern of Fates as his Warlord Trait and may not select any other.
-
-The Pattern of Fates –If an army’s Warlord has this Trait, then once all models have been deployed onto the battlefield (including any Infiltrating units and after any units have been redeployed using the Scout special rule), but before the first turn is begun, the controlling player may select up to three friendly units and either redeploy them to any other position within the controlling player’s Deployment Zone or remove them from the battlefield and place them in Reserves. In addition, an army that includes Ahriman may make an additional Reaction in any one phase once per turn, as long as Ahriman has not been removed as a casualty (the Phase in which the additional Reaction is made does not need to be declared in advance).</description>
-            </rule>
             <rule id="52d3-27bd-3db9-9aa8" name="Arch-magister of the Corvidae" hidden="false">
               <description>Ahriman gains the Minor Arcana Corvidae and the Divination and Thaumaturgy Disciplines from the Core Psychic Discipline list at no additional points cost.</description>
             </rule>
           </rules>
           <infoLinks>
-            <infoLink id="ae11-3a93-6c13-b594" name="Master of the Legion" hidden="false" targetId="c772-87ea-d49c-c7ba" type="rule"/>
             <infoLink id="322c-d601-5fe4-1289" name="Independent Character" hidden="false" targetId="c57d-4820-458a-7ab5" type="rule"/>
             <infoLink id="7130-1b26-ed3b-21ba" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
             <infoLink id="0232-9690-3c1d-c403" name="Adamantium Will (X+)" hidden="false" targetId="4380-44a5-f01a-d964" type="rule">
@@ -1625,6 +1649,14 @@ The Pattern of Fates –If an army’s Warlord has this Trait, then once all mod
             <categoryLink id="af14-1a0c-ce6c-3775" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="false"/>
             <categoryLink id="ea62-4186-8e7a-e7ec" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
           </categoryLinks>
+          <entryLinks>
+            <entryLink id="9c21-2727-49e6-4411" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f992-c802-5e74-a4da" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8e23-f3c4-9f48-790f" type="min"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
           </costs>
@@ -1720,6 +1752,18 @@ The Pattern of Fates –If an army’s Warlord has this Trait, then once all mod
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bb65-112d-9fab-828e" type="min"/>
           </constraints>
         </entryLink>
+        <entryLink id="801e-de07-63aa-7b66" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6cbd-1d8c-59c5-8660" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="bbaa-250b-c9c9-16e4" name="Warlord: The Pattern of Fates" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+              <characteristics>
+                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">If an army’s Warlord has this Trait, then once all models have been deployed onto the battlefield (including any Infiltrating units and after any units have been redeployed using the Scout special rule), but before the first turn is begun, the controlling player may select up to three friendly units and either redeploy them to any other position within the controlling player’s Deployment Zone or remove them from the battlefield and place them in Reserves. In addition, an army that includes Ahriman may make an additional Reaction in any one phase once per turn, as long as Ahriman has not been removed as a casualty (the Phase in which the additional Reaction is made does not need to be declared in advance).</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="185.0"/>
@@ -1751,7 +1795,7 @@ The Pattern of Fates –If an army’s Warlord has this Trait, then once all mod
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f890-77f2-bc62-4439" type="min"/>
           </constraints>
           <profiles>
-            <profile id="04b5-e6cc-854a-a8c1" name="Angron (P3P ZW)" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
+            <profile id="04b5-e6cc-854a-a8c1" name="Angron" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Primarch (Unique)
 </characteristic>
@@ -1770,18 +1814,10 @@ The Pattern of Fates –If an army’s Warlord has this Trait, then once all mod
           </profiles>
           <rules>
             <rule id="7da6-b1fe-3e3b-f348" name="Red Sands" hidden="false">
-              <description>In any given turn Angron may make as many Challenges as there are enemy models with the Character sub-type or Primarch Unit Type locked in combat with him, up to his current number
-of Attacks. Pull out all the challengers and fight them in an order decided by Angron’s controlling player during the Challenge part of the Fight sub-phase, save that any enemy model
-with the Primarch Unit Type must be fought first. Angron must divide his attacks between them and must devote at least one attack to each Challenge he fights in. All models challenged by Angron, and Angron himself, count as being in a Challenge and follow all the rules for Challenges and any models that are not removed as Casualties remain in a Challange with Angron until either all the Challengers are removed as Casualties, angron is removed as a Casualty or the challenge is ended by the effect of another rule.</description>
-            </rule>
-            <rule id="a1ca-99a6-d7f7-071b" name="Warlord: Sire of the World Eaters" hidden="false">
-              <description>If chosen as the army&apos;s Warlord, Angron automatically has the Sire of the World Eaters Warlord Trait and may not select any other Warlord Trait.
-
-Sire of the World Eaters - All models with the Legiones Astartes (World Eaters) special rule in the same army as Angron, including Angron himself, gain the Feel No Pain (6+) and Adamantium Will (3+) special rules. In addition, an army with Angron as its Warlord increases its Reaction Allotment to 3 in the Movement Phase (this does not allow more than three Reactions to be made in that phase, and may not be further modified by any other rule or effect), but may only make Advance Reactions.</description>
+              <description>In any given turn Angron may make as many Challenges as there are enemy models with the Character sub-type or Primarch Unit Type locked in combat with him, up to his current number of Attacks. Pull out all the challengers and fight them in an order decided by Angron’s controlling player during the Challenge part of the Fight sub-phase, save that any enemy model with the Primarch Unit Type must be fought first. Angron must divide his attacks between them and must devote at least one attack to each Challenge he fights in. All models challenged by Angron, and Angron himself, count as being in a Challenge and follow all the rules for Challenges and any models that are not removed as Casualties remain in a Challange with Angron until either all the Challengers are removed as Casualties, angron is removed as a Casualty or the challenge is ended by the effect of another rule.</description>
             </rule>
           </rules>
           <infoLinks>
-            <infoLink id="826b-53dc-26e5-3973" name="Master of the Legion" hidden="false" targetId="c772-87ea-d49c-c7ba" type="rule"/>
             <infoLink id="73a0-b0e4-7617-2e41" name="Hatred (X)" hidden="false" targetId="dc0b-fe69-6b71-e0a4" type="rule">
               <modifiers>
                 <modifier type="set" field="name" value="Hatred (Everything)"/>
@@ -1800,6 +1836,14 @@ Sire of the World Eaters - All models with the Legiones Astartes (World Eaters) 
             <infoLink id="87f1-55e9-fc85-4949" name="Traitor" hidden="false" targetId="eff2-8b0e-21da-2f0d" type="rule"/>
             <infoLink id="f1d2-c18b-df85-7fe8" name="Legiones Astartes (World Eaters) " hidden="false" targetId="405d-019f-9ef6-423c" type="rule"/>
           </infoLinks>
+          <entryLinks>
+            <entryLink id="1bbf-554b-0647-0daf" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f223-55d9-a533-419e" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="753f-87c4-3e81-ba2b" type="min"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
           </costs>
@@ -1902,6 +1946,16 @@ Sire of the World Eaters - All models with the Legiones Astartes (World Eaters) 
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="306f-bead-2d5d-2f30" type="max"/>
           </constraints>
         </entryLink>
+        <entryLink id="2f13-1d02-97a2-8c64" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aacb-a172-ee6e-6df5" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="2976-9b98-7d9e-e608" name="Warlord: Sire of the World Eaters" hidden="false">
+              <description>All models with the Legiones Astartes (World Eaters) special rule in the same army as Angron, including Angron himself, gain the Feel No Pain (6+) and Adamantium Will (3+) special rules. In addition, an army with Angron as its Warlord increases its Reaction Allotment to 3 in the Movement Phase (this does not allow more than three Reactions to be made in that phase, and may not be further modified by any other rule or effect), but may only make Advance Reactions.</description>
+            </rule>
+          </rules>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="450.0"/>
@@ -1934,7 +1988,7 @@ Sire of the World Eaters - All models with the Legiones Astartes (World Eaters) 
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4be0-f536-3d14-7cc6" type="min"/>
           </constraints>
           <profiles>
-            <profile id="e012-725a-c89d-fae6" name="Garviel Loken (P3P ZW)" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
+            <profile id="e012-725a-c89d-fae6" name="Garviel Loken" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">(Character, Unique)
 </characteristic>
@@ -1952,12 +2006,6 @@ Sire of the World Eaters - All models with the Legiones Astartes (World Eaters) 
             </profile>
           </profiles>
           <rules>
-            <rule id="71c9-4ec4-a077-5965" name="Warlord: Wolf of Luna" hidden="false">
-              <description>If chosen as the army&apos;s Warlord, Garviel Loken automatically has Wolf of Luna as his Warlord
-Trait and may not select any other.
-
-Wolf of Luna – A Warlord with this Trait may only join a unit composed entirely of models with both the Legiones Astartes (Sons of Horus) special rule and the Loyalist Allegiance. Both the Warlord and any unit it joins gain +1 Attack on any turn in which they successfully Charge, or are successfully charged by, an enemy unit with both the Legiones Astartes special rule and the Traitor Allegiance. These increases are in addition to any other bonuses granted by other special rules. In addition, an army whose Warlord has this Trait may make an additional Reaction during the Assault phase as long as the Warlord has not been removed as a casualty.</description>
-            </rule>
             <rule id="cafe-c87c-ad06-15f8" name="Born Survivor" hidden="false">
               <description>The first time in any game when a model with this special rule is reduced to 0 Wounds for any
 reason or otherwise removed from play as a casualty, the controlling player must immediately
@@ -1968,11 +2016,18 @@ remains in play and regains 1D3 Wounds.</description>
           </rules>
           <infoLinks>
             <infoLink id="10a6-d8ee-1655-1c08" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
-            <infoLink id="a2dc-bfd7-e311-4933" name="Master of the Legion" hidden="false" targetId="c772-87ea-d49c-c7ba" type="rule"/>
             <infoLink id="5978-b9ed-6b40-4e6f" name="Independent Character" hidden="false" targetId="c57d-4820-458a-7ab5" type="rule"/>
             <infoLink id="600b-0d8a-a659-5622" name="Loyalist" hidden="false" targetId="d1de-a45d-2b9b-c878" type="rule"/>
             <infoLink id="bf5a-ac03-6f00-7047" name="Legiones Astartes (Sons of Hours) " hidden="false" targetId="f4a2-e4ca-b8b2-35a1" type="rule"/>
           </infoLinks>
+          <entryLinks>
+            <entryLink id="c91f-5564-8123-5ca6" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e481-94ef-a19d-734d" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="02b4-6ab4-37de-a376" type="min"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
           </costs>
@@ -2014,6 +2069,16 @@ remains in play and regains 1D3 Wounds.</description>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8422-cfb5-b7f7-cfab" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e49c-9297-1eb5-cf79" type="min"/>
           </constraints>
+        </entryLink>
+        <entryLink id="8921-7820-77e0-7a63" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8950-5cd0-814b-d5c5" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="b593-3645-81e1-ceb2" name="Warlord: Wolf of Luna" hidden="false">
+              <description>A Warlord with this Trait may only join a unit composed entirely of models with both the Legiones Astartes (Sons of Horus) special rule and the Loyalist Allegiance. Both the Warlord and any unit it joins gain +1 Attack on any turn in which they successfully Charge, or are successfully charged by, an enemy unit with both the Legiones Astartes special rule and the Traitor Allegiance. These increases are in addition to any other bonuses granted by other special rules. In addition, an army whose Warlord has this Trait may make an additional Reaction during the Assault phase as long as the Warlord has not been removed as a casualty.</description>
+            </rule>
+          </rules>
         </entryLink>
       </entryLinks>
       <costs>
@@ -2071,14 +2136,8 @@ remains in play and regains 1D3 Wounds.</description>
             <rule id="64bb-7edd-8b5e-0570" name="Shrouded in Death" hidden="false">
               <description>When an enemy unit successfully Charges a unit that includes one or more models with this special rule, the Charge is always considered to be Disordered.</description>
             </rule>
-            <rule id="3ca1-42f2-6907-4a71" name="Warlord: Comes the Reaper" hidden="false">
-              <description>If chosen as the army&apos;s Warlord, Calas Typhon automatically has Comes the Reaper as his Warlord Trait and may not select any other.
-
-Comes the Reaper – When making attacks as part of a Shooting Attack or during an Assault with any weapon that has the Poison (X) special rule, Calas Typhon and any unit with the Legiones Astartes (Death Guard) and at least one model within 12” of Calas Typhon, increase the value of the Poison Special rule by 1 (I.e, from 3+ to 2+) and may reroll failed To Wound rolls for weapons with the Fleshbane special rule. In addition, an army whose Warlord has this Trait may make an additional Reaction in the Movement phase as long as Typhon has not been removed as a casualty.</description>
-            </rule>
           </rules>
           <infoLinks>
-            <infoLink id="5542-6b71-3c66-cb2d" name="Master of the Legion" hidden="false" targetId="c772-87ea-d49c-c7ba" type="rule"/>
             <infoLink id="d525-1a30-018a-4166" name="Independent Character" hidden="false" targetId="c57d-4820-458a-7ab5" type="rule"/>
             <infoLink id="251e-6de7-d0f5-d4e2" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
             <infoLink id="467a-71a2-e22b-d2f3" name="Inexorable" hidden="false" targetId="d863-8a5e-ddb6-d5a4" type="rule"/>
@@ -2101,6 +2160,14 @@ Comes the Reaper – When making attacks as part of a Shooting Attack or during 
               </modifiers>
             </infoLink>
           </infoLinks>
+          <entryLinks>
+            <entryLink id="416f-bff5-d5cd-f260" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2da6-a03e-e476-b1b7" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a1a7-c52a-bef1-beee" type="min"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
           </costs>
@@ -2186,6 +2253,16 @@ Comes the Reaper – When making attacks as part of a Shooting Attack or during 
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="48ca-53db-6a1b-8fb1" type="max"/>
           </constraints>
         </entryLink>
+        <entryLink id="8387-40fe-9dfe-1eb3" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="01d2-8cd1-d807-cc2b" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="fe93-3a7c-ac52-8edd" name="Warlord: Comes the Reaper" hidden="false">
+              <description>When making attacks as part of a Shooting Attack or during an Assault with any weapon that has the Poison (X) special rule, Calas Typhon and any unit with the Legiones Astartes (Death Guard) and at least one model within 12” of Calas Typhon, increase the value of the Poison Special rule by 1 (I.e, from 3+ to 2+) and may reroll failed To Wound rolls for weapons with the Fleshbane special rule. In addition, an army whose Warlord has this Trait may make an additional Reaction in the Movement phase as long as Typhon has not been removed as a casualty.</description>
+            </rule>
+          </rules>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="155.0"/>
@@ -2223,11 +2300,6 @@ Comes the Reaper – When making attacks as part of a Shooting Attack or during 
             </profile>
           </profiles>
           <rules>
-            <rule id="d8df-f21f-5ef9-9763" name="Warlord: Sire of the Dark Angels" hidden="false">
-              <description>If chosen as the army&apos;s Warlord, Lion El’Jonson automatically has the Sire of the Dark Angels Warlord Trait and may not select any other Warlord Trait.
-
-Sire of the Dark Angels – Any units with the Legiones Astartes (Dark Angels) special rule in the same army as Lion El&apos;Jonson gain the Crusader special rule, and any friendly models with the Legiones Astartes (Dark Angels) special rule that can draw line of sight to Lion El&apos;Jonson may add +1 to their Leadership (To a maximum of Ld 10). In addition, an army with Lion El&apos;Jonson as its Warlord may make an additional Reaction in the opposing player&apos;s Shooting phase as long as Lion El&apos;Jonson has not been removed as a casualty.</description>
-            </rule>
             <rule id="6e4a-99f9-cbcf-dc03" name="The Point of the Blade" hidden="false">
               <description>After declaring a Charge for Lion El’Jonson and any unit he has joined, the controlling player may choose not to make a Charge Distance roll and instead make a Charge move of 8&quot; for Lion El’Jonson and any unit he has joined, ignoring the effects of Difficult Terrain and Dangerous Terrain and adding no bonuses to the distance moved for the unit’s Movement Characteristic or Wargear.</description>
             </rule>
@@ -2240,13 +2312,20 @@ Sire of the Dark Angels – Any units with the Legiones Astartes (Dark Angels) s
           </rules>
           <infoLinks>
             <infoLink id="414c-411d-9350-9dc5" name="Loyalist" hidden="false" targetId="d1de-a45d-2b9b-c878" type="rule"/>
-            <infoLink id="5122-b6d1-17bd-a296" name="Master of the Legion" hidden="false" targetId="c772-87ea-d49c-c7ba" type="rule"/>
             <infoLink id="829e-8c38-6723-8ec8" name="Adamantium Will (X+)" hidden="false" targetId="4380-44a5-f01a-d964" type="rule">
               <modifiers>
                 <modifier type="set" field="name" value="Adamantium Will (3+)"/>
               </modifiers>
             </infoLink>
           </infoLinks>
+          <entryLinks>
+            <entryLink id="dd33-5a56-e746-f5a1" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aa8a-73e4-8ee5-a055" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8b0f-35b4-8038-a9a7" type="min"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
           </costs>
@@ -2387,6 +2466,16 @@ Sire of the Dark Angels – Any units with the Legiones Astartes (Dark Angels) s
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cd8f-36b3-c7fe-18c0" type="max"/>
           </constraints>
         </entryLink>
+        <entryLink id="d463-55c2-c11c-6249" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3cc3-8218-4c42-19e5" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="6932-fe22-67e7-3f3a" name="Warlord: Sire of the Dark Angels" hidden="false">
+              <description>Any units with the Legiones Astartes (Dark Angels) special rule in the same army as Lion El&apos;Jonson gain the Crusader special rule, and any friendly models with the Legiones Astartes (Dark Angels) special rule that can draw line of sight to Lion El&apos;Jonson may add +1 to their Leadership (To a maximum of Ld 10). In addition, an army with Lion El&apos;Jonson as its Warlord may make an additional Reaction in the opposing player&apos;s Shooting phase as long as Lion El&apos;Jonson has not been removed as a casualty.</description>
+            </rule>
+          </rules>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="460.0"/>
@@ -2422,19 +2511,6 @@ Sire of the Dark Angels – Any units with the Legiones Astartes (Dark Angels) s
               </characteristics>
             </profile>
           </profiles>
-          <rules>
-            <rule id="22be-a2e6-dbb2-ca53" name="Warlord: Marshal of the Crown (Deathwing)" hidden="false">
-              <description>If chosen as the army’s Warlord, Corswain automatically has the Marshal of the Crown (Deathwing) Warlord Trait and may not select any other Warlord Trait.
-
-A Warlord with this Trait must select one of the Hexagrammaton Unit Sub-types. All units that include at least one model with the corresponding Unit Sub-type and at least one model with line of sight to the Warlord gain +1 Leadership (to a maximum of 10). In addition an army whose Warlord has this Trait may make an additional Reaction in a Phase of the opponent’s turn dictated by the Hexagrammaton Unit sub-type possessed by the Warlord:
-
-• Deathwing, Dreadwing – Assault phase
-• Stormwing, Ironwing – Shooting phase
-• Ravenwing, Firewing – Movement phase
-
-This additional Reaction may only be made as long as the Warlord has not been removed as a casualty.</description>
-            </rule>
-          </rules>
           <infoLinks>
             <infoLink id="0033-5d1f-918f-b8ae" name="Deathwing" hidden="false" targetId="5e82-8a8f-d64f-0839" type="rule"/>
             <infoLink id="98e7-ce56-755d-df1d" name="Legiones Astartes (Dark Angels)" hidden="false" targetId="513e-0647-996a-6229" type="rule"/>
@@ -2446,8 +2522,15 @@ This additional Reaction may only be made as long as the Warlord has not been re
               </modifiers>
             </infoLink>
             <infoLink id="af0e-2351-162d-5596" name="Loyalist" hidden="false" targetId="d1de-a45d-2b9b-c878" type="rule"/>
-            <infoLink id="3b1b-fa9e-1c4a-137f" name="Master of the Legion" hidden="false" targetId="c772-87ea-d49c-c7ba" type="rule"/>
           </infoLinks>
+          <entryLinks>
+            <entryLink id="ac48-0418-6d2f-41e2" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bb2a-72dd-d8e3-318a" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2d40-a969-319d-d0d7" type="min"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
           </costs>
@@ -2532,6 +2615,22 @@ This additional Reaction may only be made as long as the Warlord has not been re
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="64ff-6c5b-973c-a92d" type="min"/>
           </constraints>
         </entryLink>
+        <entryLink id="4f7c-454d-3d5c-426e" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3731-a7c5-3867-b9b6" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="bfcf-64e8-42f0-3f44" name="Warlord: Marshal of the Crown (Deathwing)" hidden="false">
+              <description>A Warlord with this Trait must select one of the Hexagrammaton Unit Sub-types. All units that include at least one model with the corresponding Unit Sub-type and at least one model with line of sight to the Warlord gain +1 Leadership (to a maximum of 10). In addition an army whose Warlord has this Trait may make an additional Reaction in a Phase of the opponent’s turn dictated by the Hexagrammaton Unit sub-type possessed by the Warlord:
+
+• Deathwing, Dreadwing – Assault phase
+• Stormwing, Ironwing – Shooting phase
+• Ravenwing, Firewing – Movement phase
+
+This additional Reaction may only be made as long as the Warlord has not been removed as a casualty.</description>
+            </rule>
+          </rules>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="200.0"/>
@@ -2569,22 +2668,24 @@ This additional Reaction may only be made as long as the Warlord has not been re
             </profile>
           </profiles>
           <rules>
-            <rule id="a7e1-4d26-702b-c77b" name="Warlord: Preceptor of the Shattered Sceptre" hidden="false">
-              <description>If chosen as the army’s Warlord, Marduk Sedras automatically has the Preceptor of the Shattered Sceptre Warlord Trait and may not select any other Warlord Trait.
-
-Preceptor of the Shattered Sceptre – If Marduk Sedras is the army’s Warlord then a unit of Inner Circle Knights Cenobium may be selected as part of the same HQ choice. A unit selected in this manner is considered a ‘Retinue Squad’. The Retinue Squad does not use up a Force Organisation slot and is considered part of the same unit as Marduk Sedras. The Retinue Squad must be deployed with Marduk Sedras deployed as part of the unit and Marduk Sedras may not voluntarily leave the Retinue Squad during play. However, if this option is selected then no other unit may be selected for Marduk Sedras using the Retinue or Deathwing Retinue special rules. In addition, an army with Marduk Sedras as its Warlord may make an additional Reaction in the opposing player’s Assault phase as long as Marduk Sedras has not been removed as a casualty.</description>
-            </rule>
             <rule id="ba97-d963-19d7-8fef" name="Ancient of War" hidden="false">
               <description>At the start of the battle, after deployment but before the first turn has begun, the controlling player may select a single Faction from the Allies in the Age of Darkness table, including either the Agents of the Emperor/Warmaster, that is represented in the enemy army. Marduk Sedras, and any friendly units with the Legiones Astartes (Dark Angels) special rule that have at least one model within 6&quot; of Marduk Sedras or a model with the Transport Subtype on which he is Embarked when all models have been deployed, but before the first Game Turn, gain the Preferred Enemy (Chosen Faction) special rule for all models in that unit for the duration of the battle. If Marduk Sedras is in Reserves, this special rule has no effect.</description>
             </rule>
           </rules>
           <infoLinks>
             <infoLink id="896c-f7c3-15da-25b9" name="Legiones Astartes (Dark Angels)" hidden="false" targetId="513e-0647-996a-6229" type="rule"/>
-            <infoLink id="4bfc-370e-6b72-813b" name="Master of the Legion" hidden="false" targetId="c772-87ea-d49c-c7ba" type="rule"/>
             <infoLink id="a1c1-5773-2fe4-9be4" name="Independent Character" hidden="false" targetId="c57d-4820-458a-7ab5" type="rule"/>
             <infoLink id="c3c3-6fd7-6d08-5f5d" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
             <infoLink id="e1b0-20df-8a8b-7d6e" name="Loyalist" hidden="false" targetId="d1de-a45d-2b9b-c878" type="rule"/>
           </infoLinks>
+          <entryLinks>
+            <entryLink id="7032-efc7-875c-1a8a" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="25c1-11e2-fa43-51ad" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e3fa-20b9-324f-19f2" type="min"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
           </costs>
@@ -2647,6 +2748,16 @@ Preceptor of the Shattered Sceptre – If Marduk Sedras is the army’s Warlord 
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5d4d-fe60-df90-aeea" type="min"/>
           </constraints>
         </entryLink>
+        <entryLink id="68de-f3b7-0e0a-2c87" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8b25-d861-60d8-d205" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="aa90-73c1-3de2-15de" name="Warlord: Preceptor of the Shattered Sceptre" hidden="false">
+              <description>If Marduk Sedras is the army’s Warlord then a unit of Inner Circle Knights Cenobium may be selected as part of the same HQ choice. A unit selected in this manner is considered a ‘Retinue Squad’. The Retinue Squad does not use up a Force Organisation slot and is considered part of the same unit as Marduk Sedras. The Retinue Squad must be deployed with Marduk Sedras deployed as part of the unit and Marduk Sedras may not voluntarily leave the Retinue Squad during play. However, if this option is selected then no other unit may be selected for Marduk Sedras using the Retinue or Deathwing Retinue special rules. In addition, an army with Marduk Sedras as its Warlord may make an additional Reaction in the opposing player’s Assault phase as long as Marduk Sedras has not been removed as a casualty.</description>
+            </rule>
+          </rules>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="220.0"/>
@@ -2684,11 +2795,6 @@ Preceptor of the Shattered Sceptre – If Marduk Sedras is the army’s Warlord 
             </profile>
           </profiles>
           <rules>
-            <rule id="6a5c-1c95-39e6-ffa1" name="Warlord: Chosen of the Khagan" hidden="false">
-              <description>If chosen as the army&apos;s Warlord, Qin Xa automatically has the Chosen of the Khagan Warlord Trait and may not select any other Warlord Trait.
-
-Chosen of the Khagan – If Qin Xa is the army’s Warlord, once per battle the controlling player may choose to either bring a single eligible friendly unit or group of friendly units assigned to a Deep Strike Assault or Flanking Assault into play from Reserve automatically instead of rolling or have it remain in Reserve for that turn (this may not be used to bring a unit or units into play on a turn when a Reserves roll could not normally be made for them). In addition, an army whose Warlord has this trait may make an additional Reaction during the Assault phase as long as the Warlord has not been removed as a casualty.</description>
-            </rule>
             <rule id="8877-4018-bc9b-c98b" name="Master of the Keshig" hidden="false">
               <description>If Qin Xa is selected as the Leader of a Legion Tartaros Command Squad, any model in that Tartaros Command Squad may replace its power weapon with a power glaive for +5 points each.</description>
             </rule>
@@ -2699,7 +2805,6 @@ Chosen of the Khagan – If Qin Xa is the army’s Warlord, once per battle the 
           <infoLinks>
             <infoLink id="d5c7-7db3-8759-57e1" name="Legiones Astartes (White Scars) " hidden="false" targetId="4b54-8bd0-9fdd-cbc4" type="rule"/>
             <infoLink id="fc23-5e2e-1bf4-0b60" name="Independent Character" hidden="false" targetId="c57d-4820-458a-7ab5" type="rule"/>
-            <infoLink id="8283-1466-1537-2a84" name="Master of the Legion" hidden="false" targetId="c772-87ea-d49c-c7ba" type="rule"/>
             <infoLink id="4f8c-aa12-748d-6b7d" name="Counter-Attack (X)" hidden="false" targetId="fd6d-2a76-10e0-936a" type="rule">
               <modifiers>
                 <modifier type="set" field="name" value="Counter Attack (2)"/>
@@ -2719,6 +2824,14 @@ Chosen of the Khagan – If Qin Xa is the army’s Warlord, once per battle the 
             <infoLink id="a37e-c29a-84ac-aa56" name="Loyalist" hidden="false" targetId="d1de-a45d-2b9b-c878" type="rule"/>
             <infoLink id="8845-9cac-3f4f-3b5a" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
           </infoLinks>
+          <entryLinks>
+            <entryLink id="7916-96f2-2a90-d857" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d577-341d-82ba-d6da" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6e43-3b9a-d777-5c6d" type="min"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
           </costs>
@@ -2770,6 +2883,16 @@ Chosen of the Khagan – If Qin Xa is the army’s Warlord, once per battle the 
           </constraints>
         </entryLink>
         <entryLink id="3407-2264-2255-e7fb" name="Tartaros Terminator Armour" hidden="false" collective="false" import="true" targetId="f850-d0af-8663-ccac" type="selectionEntry"/>
+        <entryLink id="ce30-cc49-5e26-919d" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="84b5-752e-ee00-33e2" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="b747-3b76-56ba-9cd4" name="Warlord: Chosen of the Khagan" hidden="false">
+              <description>If Qin Xa is the army’s Warlord, once per battle the controlling player may choose to either bring a single eligible friendly unit or group of friendly units assigned to a Deep Strike Assault or Flanking Assault into play from Reserve automatically instead of rolling or have it remain in Reserve for that turn (this may not be used to bring a unit or units into play on a turn when a Reserves roll could not normally be made for them). In addition, an army whose Warlord has this trait may make an additional Reaction during the Assault phase as long as the Warlord has not been removed as a casualty.</description>
+            </rule>
+          </rules>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="220.0"/>
@@ -3005,13 +3128,6 @@ Chosen of the Khagan – If Qin Xa is the army’s Warlord, once per battle the 
               </characteristics>
             </profile>
           </profiles>
-          <rules>
-            <rule id="c550-585b-aea7-9ead" name="Warlord: Crown Breaker" hidden="false">
-              <description>If chosen as the army&apos;s Warlord, Geigor Fell-Hand automatically has Crown Breaker as his Warlord Trait and may not select any other.
-
-Crown Breaker - Geigor Fell-Hand and all models in any friendly unit he has joined gain the Preferred Enemy (Independent Characters) special rule. They also gain the Feel No Pain (4+) special rule when locked in combat with one or more enemy models with the Independent Character special rule. In addition, an army with Geigor Fell-Hand as its Warlord may make an additional Reaction during the opposing player’s Movement phase as long as Geigor Fell-Hand has not been removed as a casualty.</description>
-            </rule>
-          </rules>
           <infoLinks>
             <infoLink id="1392-e3a3-a490-3ddf" name="Legiones Astartes (Space Wolves) " hidden="false" targetId="f806-8d12-07ab-fdaf" type="rule"/>
             <infoLink id="3ca0-edfd-fdf7-f67e" name="Independent Character" hidden="false" targetId="c57d-4820-458a-7ab5" type="rule"/>
@@ -3021,8 +3137,15 @@ Crown Breaker - Geigor Fell-Hand and all models in any friendly unit he has join
                 <modifier type="set" field="name" value="Counter-attack (1)"/>
               </modifiers>
             </infoLink>
-            <infoLink id="30e1-81c0-afcd-f0b2" name="Master of the Legion" hidden="false" targetId="c772-87ea-d49c-c7ba" type="rule"/>
           </infoLinks>
+          <entryLinks>
+            <entryLink id="b6e6-af8a-18da-334b" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8c36-1cf8-d795-0746" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="295a-23e8-b077-1dc0" type="min"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
           </costs>
@@ -3090,6 +3213,16 @@ Crown Breaker - Geigor Fell-Hand and all models in any friendly unit he has join
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7b06-3567-e861-103b" type="min"/>
           </constraints>
         </entryLink>
+        <entryLink id="4217-939d-b5e9-5111" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="517f-6888-3013-2cc5" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="8b8e-7e8f-6c79-5973" name="Warlord: Crown Breaker" hidden="false">
+              <description>Geigor Fell-Hand and all models in any friendly unit he has joined gain the Preferred Enemy (Independent Characters) special rule. They also gain the Feel No Pain (4+) special rule when locked in combat with one or more enemy models with the Independent Character special rule. In addition, an army with Geigor Fell-Hand as its Warlord may make an additional Reaction during the opposing player’s Movement phase as long as Geigor Fell-Hand has not been removed as a casualty.</description>
+            </rule>
+          </rules>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="135.0"/>
@@ -3139,11 +3272,6 @@ Crown Breaker - Geigor Fell-Hand and all models in any friendly unit he has join
             </profile>
           </profiles>
           <rules>
-            <rule id="17ae-3b2e-9d75-30d5" name="Warlord: Head-taker" hidden="false">
-              <description>If chosen as the army’s Warlord, Hvarl Red-Blade automatically has Head-taker as his Warlord Trait and may not select any other
-
-Head-taker – Hvarl Red-Blade and all models in any friendly unit he joins gain the Preferred Enemy (Infantry) special rule. In addition, an army with Hvarl Red-Blade as its Warlord may make an additional Reaction during their opponent’s Assault phase as long as Hvarl has not been removed as a casualty.</description>
-            </rule>
             <rule id="40b1-bea5-f177-fd48" name="Battle Cunning" hidden="false">
               <description>Up to three units composed entirely of models with the Infantry Unit Type in the same Detachment as Hvarl Red-Blade may be given the Scout special rule.</description>
             </rule>
@@ -3151,7 +3279,6 @@ Head-taker – Hvarl Red-Blade and all models in any friendly unit he joins gain
           <infoLinks>
             <infoLink id="b31f-cae6-ced6-073d" name="Independent Character" hidden="false" targetId="c57d-4820-458a-7ab5" type="rule"/>
             <infoLink id="c779-18d5-2573-a97d" name="Legiones Astartes (Space Wolves) " hidden="false" targetId="f806-8d12-07ab-fdaf" type="rule"/>
-            <infoLink id="86c5-28db-6b9b-c040" name="Master of the Legion" hidden="false" targetId="c772-87ea-d49c-c7ba" type="rule"/>
             <infoLink id="85ba-c550-0ada-b8b1" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
             <infoLink id="8d43-e4f7-2565-f235" name="Inexorable" hidden="false" targetId="d863-8a5e-ddb6-d5a4" type="rule"/>
             <infoLink id="ae7f-1ffb-7e41-164a" name="Counter-Attack (X)" hidden="false" targetId="fd6d-2a76-10e0-936a" type="rule">
@@ -3170,6 +3297,14 @@ Head-taker – Hvarl Red-Blade and all models in any friendly unit he joins gain
               </modifiers>
             </infoLink>
           </infoLinks>
+          <entryLinks>
+            <entryLink id="1c28-e180-c51e-7304" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="27e8-24ae-513a-7c94" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9fa7-a871-01fd-c254" type="min"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
           </costs>
@@ -3213,6 +3348,16 @@ Head-taker – Hvarl Red-Blade and all models in any friendly unit he joins gain
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="15dc-4f1b-725d-7867" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b567-af04-a37d-16a7" type="max"/>
           </constraints>
+        </entryLink>
+        <entryLink id="4106-6565-9061-184e" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4aee-ac43-9b2c-6387" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="2af7-8a00-11c3-be97" name="Warlord: Head-taker" hidden="false">
+              <description>Hvarl Red-Blade and all models in any friendly unit he joins gain the Preferred Enemy (Infantry) special rule. In addition, an army with Hvarl Red-Blade as its Warlord may make an additional Reaction during their opponent’s Assault phase as long as Hvarl has not been removed as a casualty.</description>
+            </rule>
+          </rules>
         </entryLink>
       </entryLinks>
       <costs>
@@ -3269,16 +3414,10 @@ Head-taker – Hvarl Red-Blade and all models in any friendly unit he joins gain
             <rule id="a169-5fd6-a209-6fdb" name="Dolorous Fighter" hidden="false">
               <description>When a Challenge is issued in any combat that includes Sigismund, Sigismund’s controlling player must always accept that Challenge with Sigismund – if the opposing player does not issue a Challenge then Sigismund’s controlling player must do so and must nominate Sigismund to fight in that Challenge. Additionally, when fighting in a Challenge, successful Invulnerable Saves taken against Sigismund’s attacks must be re-rolled.</description>
             </rule>
-            <rule id="e10b-6f0c-a469-3710" name="Warlord: Slayer of Kings" hidden="false">
-              <description>If chosen as the army&apos;s Warlord, Sigismund automatically has Slayer of Kings as his Warlord Trait and may not select any other.
-
-Slayer of Kings - If Sigismund is the army’s Warlord and slays the enemy Warlord in a Challenge, Sigismund’s controlling player gains +1 Victory point and all models in the same army as Sigismund may add +1 to the total number of Wounds caused in each combat for the purposes of determining Assault results for the rest of the battle (this does not stack with any other rules that increase the Assault result). In addition, an army with Sigismund as its Warlord may make an additional Reaction during the opponent’s Movement phase as long as Sigismund has not been removed as a casualty.</description>
-            </rule>
           </rules>
           <infoLinks>
             <infoLink id="2bd3-daa8-f255-ff61" name="Legiones Astartes (Imperial Fists)" hidden="false" targetId="e876-4f8f-a30f-8b22" type="rule"/>
             <infoLink id="d7f1-e2e1-dd96-dfe2" name="Independent Character" hidden="false" targetId="c57d-4820-458a-7ab5" type="rule"/>
-            <infoLink id="17b6-3bcd-e551-1fdc" name="Master of the Legion" hidden="false" targetId="c772-87ea-d49c-c7ba" type="rule"/>
             <infoLink id="5dd1-13d0-c15a-cccd" name="Fearless" hidden="false" targetId="b48c-d7e1-2a83-2f5b" type="rule"/>
             <infoLink id="0859-2b0a-a6f2-ba83" name="Eternal Warrior" hidden="false" targetId="000b-fe96-31f8-c0ad" type="rule"/>
             <infoLink id="7955-2879-0557-f1f9" name="Adamantium Will (X+)" hidden="false" targetId="4380-44a5-f01a-d964" type="rule">
@@ -3293,6 +3432,14 @@ Slayer of Kings - If Sigismund is the army’s Warlord and slays the enemy Warlo
             </infoLink>
             <infoLink id="5f38-d039-4926-eed5" name="Loyalist" hidden="false" targetId="d1de-a45d-2b9b-c878" type="rule"/>
           </infoLinks>
+          <entryLinks>
+            <entryLink id="f567-0d86-e553-0a13" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2bfb-1517-0329-9e86" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9911-b296-c8b5-9f95" type="min"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
           </costs>
@@ -3369,6 +3516,16 @@ Slayer of Kings - If Sigismund is the army’s Warlord and slays the enemy Warlo
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f36f-2f67-bfe7-5107" type="min"/>
           </constraints>
         </entryLink>
+        <entryLink id="5bd8-3369-716b-f4ba" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ac66-acea-e1a0-0672" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="0bf8-fced-fb18-82d2" name="Warlord: Slayer of Kings" hidden="false">
+              <description>If Sigismund is the army’s Warlord and slays the enemy Warlord in a Challenge, Sigismund’s controlling player gains +1 Victory point and all models in the same army as Sigismund may add +1 to the total number of Wounds caused in each combat for the purposes of determining Assault results for the rest of the battle (this does not stack with any other rules that increase the Assault result). In addition, an army with Sigismund as its Warlord may make an additional Reaction during the opponent’s Movement phase as long as Sigismund has not been removed as a casualty.</description>
+            </rule>
+          </rules>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="230.0"/>
@@ -3425,19 +3582,21 @@ Slayer of Kings - If Sigismund is the army’s Warlord and slays the enemy Warlo
             <rule id="ad41-493c-c602-c58d" name="Hammer Blow" hidden="false">
               <description>During any Fight sub-phase, Alexis Polux’s controlling player may choose to have Alexis Polux make a single attack with the profile &quot;Hammer Blow&quot; (while using this option Alexis Polux may not gain bonus attacks for Charging, additional weapons or from any other special rule)</description>
             </rule>
-            <rule id="b368-c0a7-d0ea-f9c6" name="Warlord: Master Tactician" hidden="false">
-              <description>If chosen as the army&apos;s Warlord, Alexis Polux automatically has Master Tactician as his Warlord Trait and may not select any other.
-
-Master Tactician – After all models are deployed but before any rolls to Seize the Initiative are made, the controlling player of Alexis Polux may redeploy one friendly unit within the limitations of the mission being played. This may place a unit that had been deployed normally into Reserves, or bring a unit out of Reserves – but may not add or remove units that have been assigned to a Deep Strike Assault, Drop Pod Assault, Flanking Assault or Subterranean Assault. In addition, an army with Alexis Polux as its Warlord may make an additional Reaction during the opponent’s Assault phase as long as Alexis Polux has not been removed as a casualty.</description>
-            </rule>
           </rules>
           <infoLinks>
             <infoLink id="f8c9-a61a-f6a6-edf5" name="Legiones Astartes (Imperial Fists)" hidden="false" targetId="e876-4f8f-a30f-8b22" type="rule"/>
             <infoLink id="3e7d-cb5f-e2a2-6296" name="Independent Character" hidden="false" targetId="c57d-4820-458a-7ab5" type="rule"/>
-            <infoLink id="f16a-86d6-09dc-174f" name="Master of the Legion" hidden="false" targetId="c772-87ea-d49c-c7ba" type="rule"/>
             <infoLink id="2eb5-9af8-d7f7-d685" name="Deep Strike" hidden="false" targetId="f1e1-986f-c783-ca9e" type="rule"/>
             <infoLink id="b9d4-446e-cae3-6458" name="Loyalist" hidden="false" targetId="d1de-a45d-2b9b-c878" type="rule"/>
           </infoLinks>
+          <entryLinks>
+            <entryLink id="b946-2d48-3946-fdd0" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6d84-f368-230d-7498" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3d0f-374f-fec3-a513" type="min"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
           </costs>
@@ -3485,6 +3644,18 @@ Master Tactician – After all models are deployed but before any rolls to Seize
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9cce-4c35-1f48-932a" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="71ca-7450-03bc-6948" type="max"/>
           </constraints>
+        </entryLink>
+        <entryLink id="a2f6-f936-e39b-c45e" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3bbb-537e-9391-2729" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="eaa2-c0b9-5fc5-19d0" name="Warlord: Master Tactician" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+              <characteristics>
+                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">After all models are deployed but before any rolls to Seize the Initiative are made, the controlling player of Alexis Polux may redeploy one friendly unit within the limitations of the mission being played. This may place a unit that had been deployed normally into Reserves, or bring a unit out of Reserves – but may not add or remove units that have been assigned to a Deep Strike Assault, Drop Pod Assault, Flanking Assault or Subterranean Assault. In addition, an army with Alexis Polux as its Warlord may make an additional Reaction during the opponent’s Assault phase as long as Alexis Polux has not been removed as a casualty.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
         </entryLink>
       </entryLinks>
       <costs>
@@ -3541,16 +3712,10 @@ Master Tactician – After all models are deployed but before any rolls to Seize
             <rule id="7e89-1c74-753a-c440" name="Executioner&apos;s Tax" hidden="false">
               <description>When an enemy unit makes a successful Charge that places one or more enemy models in base contact with Fafnir Rann, or any model in a unit Fafnir Rann has joined, that enemy unit suffers D3+3 Str 5 AP- Hits. These attacks hit automatically and are resolved during the Fight sub-phase at Initiative Step 10, but grant no model a Pile-in move and do not benefit from any special rules that Fafnir Rann or any other model in the same unit may have. Hits inflicted by this special rule are allocated as normal for attacks made in an assault.</description>
             </rule>
-            <rule id="8ab4-601d-9b49-3b73" name="Warlord: The Unbroken Wall" hidden="false">
-              <description>If chosen as the army&apos;s Warlord, Fafnir Rann automatically has The Unbroken Wall Warlord Trait and may not select any other Warlord Trait.
-
-The Unbroken Wall – Fafnir Rann, and all models in any Legion Breacher Squads or Phalanx Warder Squads in the same Detachment, gain a bonus of +1 to their Weapon Skill for the duration of any Assault phase in which they successfully Charge an enemy unit. In addition, an army with Fafnir Rann as its Warlord may make an additional Reaction in the opposing player’s Assault phase as long as Fafnir Rann has not been removed as a casualty.</description>
-            </rule>
           </rules>
           <infoLinks>
             <infoLink id="2740-0b73-84f1-569b" name="Independent Character" hidden="false" targetId="c57d-4820-458a-7ab5" type="rule"/>
             <infoLink id="b4ac-2ecf-4650-adc2" name="Legiones Astartes (Imperial Fists)" hidden="false" targetId="e876-4f8f-a30f-8b22" type="rule"/>
-            <infoLink id="dc8c-9b88-47ff-80f9" name="Master of the Legion" hidden="false" targetId="c772-87ea-d49c-c7ba" type="rule"/>
             <infoLink id="556c-9191-0e0c-7cf8" name="Hammer of Wrath (X)" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
               <modifiers>
                 <modifier type="set" field="name" value="Hammer of Wrath (1)"/>
@@ -3558,6 +3723,14 @@ The Unbroken Wall – Fafnir Rann, and all models in any Legion Breacher Squads 
             </infoLink>
             <infoLink id="1bee-c772-693e-e94a" name="Loyalist" hidden="false" targetId="d1de-a45d-2b9b-c878" type="rule"/>
           </infoLinks>
+          <entryLinks>
+            <entryLink id="3850-9dbc-d0b5-1e6e" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d20b-812b-9695-d405" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="95a3-edd5-ee4e-ec90" type="min"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
           </costs>
@@ -3643,6 +3816,16 @@ Both weapons are counted as ‘Power’ weapons for those rules that affect such
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e534-5054-1f7c-d388" type="min"/>
           </constraints>
         </entryLink>
+        <entryLink id="7479-a56e-06b6-0e76" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a95d-1607-ff2c-5305" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="3e02-1be0-9658-5b59" name="Warlord: The Unbroken Wall" hidden="false">
+              <description>Fafnir Rann, and all models in any Legion Breacher Squads or Phalanx Warder Squads in the same Detachment, gain a bonus of +1 to their Weapon Skill for the duration of any Assault phase in which they successfully Charge an enemy unit. In addition, an army with Fafnir Rann as its Warlord may make an additional Reaction in the opposing player’s Assault phase as long as Fafnir Rann has not been removed as a casualty.</description>
+            </rule>
+          </rules>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="175.0"/>
@@ -3705,7 +3888,6 @@ Exarch of the High Host – If Dominion Zephon is the army’s Warlord then a Le
             <infoLink id="a69a-82c7-4dfb-f010" name="Legiones Astartes (Blood Angels) " hidden="false" targetId="b0d1-ccab-8708-500f" type="rule"/>
             <infoLink id="9e68-2964-7f9e-6829" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
             <infoLink id="d09a-9040-243e-c867" name="Independent Character" hidden="false" targetId="c57d-4820-458a-7ab5" type="rule"/>
-            <infoLink id="3a10-2e30-726c-c840" name="Master of the Legion" hidden="false" targetId="c772-87ea-d49c-c7ba" type="rule"/>
             <infoLink id="0e3d-b284-b9f3-8e43" name="Furious Charge (X)" hidden="false" targetId="2821-9269-862f-0554" type="rule">
               <modifiers>
                 <modifier type="set" field="name" value="Furious Charge (1)"/>
@@ -3720,6 +3902,14 @@ Exarch of the High Host – If Dominion Zephon is the army’s Warlord then a Le
               </modifiers>
             </infoLink>
           </infoLinks>
+          <entryLinks>
+            <entryLink id="2893-7375-079b-94f0" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cf63-26c2-4d79-dd0b" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="51df-4df3-75a8-ae62" type="min"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
           </costs>
@@ -3828,6 +4018,16 @@ Exarch of the High Host – If Dominion Zephon is the army’s Warlord then a Le
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="63b4-879a-0b45-bd69" type="min"/>
           </constraints>
         </entryLink>
+        <entryLink id="0b91-7fcf-540c-8947" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7930-97c5-18f9-12b8" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="15c2-c9a1-81e9-5cee" name="Warlord: Exarch of the High Host" hidden="false">
+              <description>If Dominion Zephon is the army’s Warlord then a Legion Destroyer Assault Squad may be selected as part of the same HQ choice, A unit selected in this manner is considered a ‘Retinue Squad’. The Retinue Squad does not use up a Force Organisation slot and is considered part of the same unit as Dominion Zephon. The Retinue Squad must be deployed with Dominion Zephon deployed as part of the unit and Dominion Zephon may not voluntarily leave the Retinue Squad during play. All models in a Legion Destroyer Assault Squad chosen using this Warlord Trait gain the Chosen Warriors special rule. If this option is selected then no other unit may be selected for Dominion Zephon using the Retinue special rule. In addition, an army with Dominion Zephon as its Warlord may make an additional Reaction in the opposing player’s Assault phase as long as Dominion Zephon has not been removed as a casualty.</description>
+            </rule>
+          </rules>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="185.0"/>
@@ -3876,11 +4076,6 @@ Exarch of the High Host – If Dominion Zephon is the army’s Warlord then a Le
               </characteristics>
             </profile>
           </profiles>
-          <rules>
-            <rule id="319b-821e-ccce-2495" name="Warlord: Archein of Wisdom" hidden="false">
-              <description>If Chapter Master Raldoron is selected as the army’s Warlord then his Warlord Trait may be selected from the Core Warlord Traits or from any Legion specific Warlord Trait from any of the following Legions (counting as though he possessed the appropriate variant of the Legiones Astartes special rule): White Scars, Imperial Fists, Space Wolves, Ultramarines, Iron Hands, Raven Guard and Salamanders. This does not include any Warlord Traits available only to specific named characters, or a Warlord Trait that requires the Traitor Allegiance may not be selected</description>
-            </rule>
-          </rules>
           <infoLinks>
             <infoLink id="0fec-2786-6813-4bf2" name="Legiones Astartes (Blood Angels) " hidden="false" targetId="b0d1-ccab-8708-500f" type="rule"/>
             <infoLink id="9a28-dfa2-e4bc-967f" name="Independent Character" hidden="false" targetId="c57d-4820-458a-7ab5" type="rule"/>
@@ -3890,9 +4085,16 @@ Exarch of the High Host – If Dominion Zephon is the army’s Warlord then a Le
                 <modifier type="set" field="name" value="Furious Charge (2)"/>
               </modifiers>
             </infoLink>
-            <infoLink id="e269-60df-8ca0-00ed" name="Master of the Legion" hidden="false" targetId="c772-87ea-d49c-c7ba" type="rule"/>
             <infoLink id="ccb8-97cb-5d36-18bd" name="Loyalist" hidden="false" targetId="d1de-a45d-2b9b-c878" type="rule"/>
           </infoLinks>
+          <entryLinks>
+            <entryLink id="bb68-6e67-d20e-9541" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="05ad-2c46-aa34-215b" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b167-9a2e-a5f6-5d16" type="min"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
           </costs>
@@ -3959,6 +4161,16 @@ Exarch of the High Host – If Dominion Zephon is the army’s Warlord then a Le
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eae4-4859-8c64-4b48" type="max"/>
           </constraints>
         </entryLink>
+        <entryLink id="e10d-1d1d-43da-57ee" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cd54-2ef9-2858-fde5" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="3db8-6905-e683-4e12" name="Archein of Wisdom" hidden="false">
+              <description>If Chapter Master Raldoron is selected as the army’s Warlord then his Warlord Trait may be selected from the Core Warlord Traits or from any Legion specific Warlord Trait from any of the following Legions (counting as though he possessed the appropriate variant of the Legiones Astartes special rule): White Scars, Imperial Fists, Space Wolves, Ultramarines, Iron Hands, Raven Guard and Salamanders. This does not include any Warlord Traits available only to specific named characters, or a Warlord Trait that requires the Traitor Allegiance may not be selected</description>
+            </rule>
+          </rules>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="180.0"/>
@@ -4007,24 +4219,24 @@ Exarch of the High Host – If Dominion Zephon is the army’s Warlord then a Le
               </characteristics>
             </profile>
           </profiles>
-          <rules>
-            <rule id="1fcf-2efa-cd0b-5e1c" name="Warlord: Resolute Planning" hidden="false">
-              <description>If chosen as the army&apos;s Warlord, Remus Ventanus automatically has the Resolute Planning Warlord Trait and may not select any other Warlord Trait.
-
-Resolute Planning – Both Remus Ventanus and any units composed entirely of models with the Legiones Astartes (Ultramarines) special rule in an army with Remus Ventanus as its Warlord automatically pass any Leadership tests or Morale checks made while they have at least one model within 3&quot; of an objective. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player’s Movement phase as long as Remus Ventanus has not been removed as a casualty.</description>
-            </rule>
-          </rules>
           <infoLinks>
             <infoLink id="8885-9f3c-5ecb-3dd5" name="Legiones Astartes (Ultramarines) (P3P ZW)" hidden="false" targetId="519d-a6ed-f57f-3642" type="rule"/>
-            <infoLink id="098c-8613-8131-b617" name="Master of the Legion (P3P LA)" hidden="false" targetId="c772-87ea-d49c-c7ba" type="rule"/>
             <infoLink id="5a18-8aa2-b29f-bd16" name="Independent Character (P3P)" hidden="false" targetId="c57d-4820-458a-7ab5" type="rule"/>
-            <infoLink id="b9b1-3fe5-28be-d6b9" name="Adamantium Will (X+) (P3P)" hidden="false" targetId="4380-44a5-f01a-d964" type="rule">
+            <infoLink id="b9b1-3fe5-28be-d6b9" name="Adamantium Will (X+)" hidden="false" targetId="4380-44a5-f01a-d964" type="rule">
               <modifiers>
                 <modifier type="set" field="name" value="Adamantium Will (3+)"/>
               </modifiers>
             </infoLink>
-            <infoLink id="d384-18f7-9a43-0a6c" name="Loyalist (P3P LA)" hidden="false" targetId="d1de-a45d-2b9b-c878" type="rule"/>
+            <infoLink id="d384-18f7-9a43-0a6c" name="Loyalist" hidden="false" targetId="d1de-a45d-2b9b-c878" type="rule"/>
           </infoLinks>
+          <entryLinks>
+            <entryLink id="f5d8-9b8d-2e72-e5ce" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="abf9-8bb7-8d75-a120" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="571c-9491-d756-9c4d" type="min"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
           </costs>
@@ -4106,6 +4318,16 @@ Resolute Planning – Both Remus Ventanus and any units composed entirely of mod
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af7c-ce33-9046-261f" type="max"/>
           </constraints>
         </entryLink>
+        <entryLink id="6a57-62b3-1036-0495" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ac1f-6b38-113f-db9b" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="dfdc-1d02-b27b-e583" name="Warlord: Resolute Planning" hidden="false">
+              <description>Both Remus Ventanus and any units composed entirely of models with the Legiones Astartes (Ultramarines) special rule in an army with Remus Ventanus as its Warlord automatically pass any Leadership tests or Morale checks made while they have at least one model within 3&quot; of an objective. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player’s Movement phase as long as Remus Ventanus has not been removed as a casualty.</description>
+            </rule>
+          </rules>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="175.0"/>
@@ -4156,28 +4378,12 @@ Resolute Planning – Both Remus Ventanus and any units composed entirely of mod
             </profile>
           </profiles>
           <rules>
-            <rule id="d4cc-56bd-c168-54d2" name="Warlord: Defiant unto Death" hidden="false">
-              <description>If chosen as the army&apos;s Warlord, Captain Saul Tarvitz automatically has Defiant unto Death as his
-Warlord Trait and may not select any other
-
-Defiant unto Death – If an army’s Warlord has this trait, then check at the start of each of the
-controlling player’s turns to see if any of the following is true:
-● The army that includes Captain Saul Tarvitz has accrued fewer Victory points than any
-enemy army.
-● The army including Captain Saul Tarvitz has less units on the battlefield than all enemy
-armies combined.
-● Captain Saul Tarvitz is within 6” of an objective
-● Captain Saul Tarvitz and any unit he has joined is locked in combat with more than one enemy unit, or a single enemy unit that outnumbers Captain Saul Tarvitz’s unit
-
-If any of these are true then Captain Saul Tarvitz and any friendly units with at least one model within 12” of Captain Saul Tarvitz gain the Fearless special rule. In addition, as long as Saul Tarvitz has not been removed as a casualty the army gains an additional Reaction in the Shooting Phase.</description>
-            </rule>
             <rule id="f725-c5d7-b27e-f0e5" name="A Brother Betrayed" hidden="false">
               <description>Captain Saul Tarvitz gains +1 Weapon Skill, +1 Strength and +1 Toughness while locked in combat with any enemy model that has both the Independent Character and Legiones Astartes (Emperor’s Children) special rules or any unit that such a model has joined. If an enemy model that has both the Independent Character and Legiones Astartes (Emperor’s Children) special rules is removed as a casualty whilst locked in combat with Captain Saul Tarvitz or any unit he has joined then Saul Tarvitz controlling player gains +1 bonus Victory point in addition to any others that might be gained from this, this bonus is increased to +2 bonus Victory points if Captain Lucius is removed as a casualty while engaged in a Challenge with Captain Saul Tarvitz.</description>
             </rule>
           </rules>
           <infoLinks>
             <infoLink id="1b99-efe3-ee8f-6615" name="Legiones Astartes (Emperor&apos;s Children) " hidden="false" targetId="4a36-8b9d-6b6c-51e1" type="rule"/>
-            <infoLink id="1704-0434-b3b7-0e34" name="Master of the Legion" hidden="false" targetId="c772-87ea-d49c-c7ba" type="rule"/>
             <infoLink id="19ad-8974-5026-cc11" name="Independent Character" hidden="false" targetId="c57d-4820-458a-7ab5" type="rule"/>
             <infoLink id="4ad2-c4c5-6115-1847" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
             <infoLink id="8a3b-f71f-f78a-33de" name="Loyalist" hidden="false" targetId="d1de-a45d-2b9b-c878" type="rule"/>
@@ -4187,6 +4393,14 @@ If any of these are true then Captain Saul Tarvitz and any friendly units with a
               </modifiers>
             </infoLink>
           </infoLinks>
+          <entryLinks>
+            <entryLink id="e040-2836-4f2c-c26d" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="df72-5ff3-d57a-0252" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="99b8-5100-ca15-1334" type="min"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
           </costs>
@@ -4270,6 +4484,22 @@ If any of these are true then Captain Saul Tarvitz and any friendly units with a
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="afb9-c867-9f4f-4bd0" type="max"/>
           </constraints>
         </entryLink>
+        <entryLink id="8022-31c1-f034-0888" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c310-980f-118c-5f02" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="393e-61c3-bd13-870a" name="Warlord: Defiant unto Death" hidden="false">
+              <description>If an army’s Warlord has this trait, then check at the start of each of the controlling player’s turns to see if any of the following is true:
+● The army that includes Captain Saul Tarvitz has accrued fewer Victory points than any enemy army.
+● The army including Captain Saul Tarvitz has less units on the battlefield than all enemy armies combined.
+● Captain Saul Tarvitz is within 6” of an objective
+● Captain Saul Tarvitz and any unit he has joined is locked in combat with more than one enemy unit, or a single enemy unit that outnumbers Captain Saul Tarvitz’s unit
+
+If any of these are true then Captain Saul Tarvitz and any friendly units with at least one model within 12” of Captain Saul Tarvitz gain the Fearless special rule. In addition, as long as Saul Tarvitz has not been removed as a casualty the army gains an additional Reaction in the Shooting Phase.</description>
+            </rule>
+          </rules>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="155.0"/>
@@ -4320,12 +4550,6 @@ If any of these are true then Captain Saul Tarvitz and any friendly units with a
             </profile>
           </profiles>
           <rules>
-            <rule id="3175-e517-c89b-ac94" name="Warlord: The Blade Alone" hidden="false">
-              <description>If chosen as the army&apos;s Warlord, Captain Lucius automatically has The Blade Alone as his Warlord Trait and may not select any other.
-
-The Blade Alone – If an army’s Warlord has this Trait, then no other models or units may use its Leadership regardless of any other rules or Wargear that a unit may have, however, whenever
-Captain Lucius is engaged in a Challenge all friendly models in the same combat gain the Fearless special rule. In addition, an army with Captain Lucius as its Warlord may make one additional Reaction each turn in any one Phase without using up a point of the army’s Reaction Allotment – but this additional Reaction must be made by Lucius and any unit he has joined.</description>
-            </rule>
             <rule id="e334-b6ba-6a64-c0db" name="Supreme Duellist" hidden="false">
               <description>While fighting in a challenge, if Captain Lucius’ Initiative Characteristic is higher than his opponents
 then he gains +1 to his Attacks Characteristic.</description>
@@ -4336,7 +4560,6 @@ then he gains +1 to his Attacks Characteristic.</description>
           </rules>
           <infoLinks>
             <infoLink id="c2d7-9936-dd9d-072d" name="Legiones Astartes (Emperor&apos;s Children) " hidden="false" targetId="4a36-8b9d-6b6c-51e1" type="rule"/>
-            <infoLink id="43d6-eab5-9bc9-88e2" name="Master of the Legion" hidden="false" targetId="c772-87ea-d49c-c7ba" type="rule"/>
             <infoLink id="b402-1c63-5015-3b70" name="Independent Character" hidden="false" targetId="c57d-4820-458a-7ab5" type="rule"/>
             <infoLink id="66cc-e92e-8881-5c02" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
             <infoLink id="c682-14a5-4ae2-6868" name="Preferred Enemy (X)" hidden="false" targetId="37ab-d4db-891a-de8c" type="rule">
@@ -4352,6 +4575,14 @@ then he gains +1 to his Attacks Characteristic.</description>
             <infoLink id="1a10-d1af-a9e4-c0b5" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
             <infoLink id="5f4b-559d-23b1-2405" name="Traitor" hidden="false" targetId="eff2-8b0e-21da-2f0d" type="rule"/>
           </infoLinks>
+          <entryLinks>
+            <entryLink id="5f4f-ed9d-f41e-006b" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="41b9-c9c6-f5d9-bd2d" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0fca-e961-3dfc-a95c" type="min"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
           </costs>
@@ -4466,6 +4697,17 @@ then he gains +1 to his Attacks Characteristic.</description>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
           </costs>
         </entryLink>
+        <entryLink id="8cb7-38b3-f47d-dc44" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b7d4-59a2-54cd-80ba" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="b5d1-1987-a7f5-9096" name="Warlord: The Blade Alone" hidden="false">
+              <description>If an army’s Warlord has this Trait, then no other models or units may use its Leadership regardless of any other rules or Wargear that a unit may have, however, whenever
+Captain Lucius is engaged in a Challenge all friendly models in the same combat gain the Fearless special rule. In addition, an army with Captain Lucius as its Warlord may make one additional Reaction each turn in any one Phase without using up a point of the army’s Reaction Allotment – but this additional Reaction must be made by Lucius and any unit he has joined.</description>
+            </rule>
+          </rules>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="175.0"/>
@@ -4515,12 +4757,6 @@ then he gains +1 to his Attacks Characteristic.</description>
             </profile>
           </profiles>
           <rules>
-            <rule id="5523-4187-e07c-defd" name="Warlord: Master of the Atramentar" hidden="false">
-              <description>If chosen as the army&apos;s Warlord, Sevatar automatically has the Master of the Atramentar as his
-Warlord Trait and may not select any other.
-
-Master of the Atramentar – Any units of Legion Cataphractii Terminators and Legion Tartaros Terminators included in the same Detachment as Sevatar gain the Deep Strike special rule (Sevatar himself does not). When any units of Legion Cataphractii Terminators, Legion Tartaros Terminators or Contekar Terminators that are part of the same Detachment as Sevatar are included as part of a Deep Strike Assault that does not include Sevatar they gain the Fearless and Preferred Enemy (Everything) special rules for the duration of the turn in which they are deployed. In addition, an army whose Warlord is Sevatar may make an additional Reaction in the Movement phase, as long as Sevatar has not been removed as a casualty.</description>
-            </rule>
             <rule id="6116-32ab-460c-bc21" name="Bloody Murder" hidden="false">
               <description>When a unit with this special rule declares a Charge targeting a unit that is Pinned or Falling Back, the Charge Roll gains an additional +1 modifier, and if the Charge is successful then all models in the Charging unit gain +1 Attack.</description>
             </rule>
@@ -4533,7 +4769,6 @@ Master of the Atramentar – Any units of Legion Cataphractii Terminators and Le
           </rules>
           <infoLinks>
             <infoLink id="e0d7-d140-8b1d-6078" name="Legiones Astartes (Night Lords) " hidden="false" targetId="8280-d4ea-b131-4970" type="rule"/>
-            <infoLink id="21ae-2600-7a33-f4c5" name="Master of the Legion" hidden="false" targetId="c772-87ea-d49c-c7ba" type="rule"/>
             <infoLink id="cb48-a86a-d9c9-8089" name="Independent Character" hidden="false" targetId="c57d-4820-458a-7ab5" type="rule"/>
             <infoLink id="0ee6-9cc6-6a04-bc51" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
             <infoLink id="5441-c663-e002-4b9c" name="Fear (X)" hidden="false" targetId="21f6-7842-df5c-d2e7" type="rule">
@@ -4548,6 +4783,14 @@ Master of the Atramentar – Any units of Legion Cataphractii Terminators and Le
             </infoLink>
             <infoLink id="2141-b059-54cc-9cbd" name="Traitor" hidden="false" targetId="eff2-8b0e-21da-2f0d" type="rule"/>
           </infoLinks>
+          <entryLinks>
+            <entryLink id="8312-55cc-361d-4505" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f54d-61b4-08e0-fb78" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="16cc-7e35-18e5-9656" type="min"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
           </costs>
@@ -4625,6 +4868,16 @@ Master of the Atramentar – Any units of Legion Cataphractii Terminators and Le
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4848-23f0-6370-db84" type="max"/>
           </constraints>
         </entryLink>
+        <entryLink id="01aa-3498-fb0d-e89a" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e4f8-8f3e-0171-1089" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="258d-9e24-9ce1-d06f" name="Warlord: Master of the Atramentar" hidden="false">
+              <description>Any units of Legion Cataphractii Terminators and Legion Tartaros Terminators included in the same Detachment as Sevatar gain the Deep Strike special rule (Sevatar himself does not). When any units of Legion Cataphractii Terminators, Legion Tartaros Terminators or Contekar Terminators that are part of the same Detachment as Sevatar are included as part of a Deep Strike Assault that does not include Sevatar they gain the Fearless and Preferred Enemy (Everything) special rules for the duration of the turn in which they are deployed. In addition, an army whose Warlord is Sevatar may make an additional Reaction in the Movement phase, as long as Sevatar has not been removed as a casualty.</description>
+            </rule>
+          </rules>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="220.0"/>
@@ -4674,11 +4927,6 @@ Master of the Atramentar – Any units of Legion Cataphractii Terminators and Le
             </profile>
           </profiles>
           <rules>
-            <rule id="5c02-bf6c-c58a-40c9" name="Warlord: Savage Assult" hidden="false">
-              <description>If chosen as the army&apos;s Warlord, Khârn the Bloody automatically has Savage Assault as his Warlord Trait and may not select any other.
-
-Savage Assault – No enemy unit may declare a Reaction against a Charge made by a unit that includes Khârn the Bloody, unless that unit includes a model with the Primarch Unit Type. In addition, an army with Khârn the Bloody as its Warlord may make an additional Advance Reaction during the Movement Phase as long as Khârn the Bloody has not been removed as a casualty.</description>
-            </rule>
             <rule id="6dd0-6d14-3395-47ab" name="Gorechild*" hidden="false">
               <description>If Gorechild is chosen, Kharn may not be taken in the same army as Angron.</description>
             </rule>
@@ -4687,7 +4935,6 @@ Savage Assault – No enemy unit may declare a Reaction against a Charge made by
             <infoLink id="72b1-b0c8-5de1-4591" name="Legiones Astartes (World Eaters) " hidden="false" targetId="405d-019f-9ef6-423c" type="rule"/>
             <infoLink id="6232-777e-d6b8-bb95" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
             <infoLink id="b484-d565-ccc5-d51d" name="Independent Character" hidden="false" targetId="c57d-4820-458a-7ab5" type="rule"/>
-            <infoLink id="0b03-2c87-a7ca-3edf" name="Master of the Legion" hidden="false" targetId="c772-87ea-d49c-c7ba" type="rule"/>
             <infoLink id="8b48-6ebd-84c5-c910" name="Rampage (X)" hidden="false" targetId="3efb-2a2c-2d0b-92fc" type="rule">
               <modifiers>
                 <modifier type="set" field="name" value="Rampage (3)"/>
@@ -4700,6 +4947,14 @@ Savage Assault – No enemy unit may declare a Reaction against a Charge made by
             </infoLink>
             <infoLink id="4b04-6264-fd79-c132" name="Traitor" hidden="false" targetId="eff2-8b0e-21da-2f0d" type="rule"/>
           </infoLinks>
+          <entryLinks>
+            <entryLink id="143b-b798-0f33-b9dc" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0997-3694-9d45-b280" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8d0e-34e9-8422-629e" type="min"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
           </costs>
@@ -4781,6 +5036,16 @@ Savage Assault – No enemy unit may declare a Reaction against a Charge made by
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dd25-bc57-2810-1426" type="min"/>
           </constraints>
         </entryLink>
+        <entryLink id="5bde-18d8-4639-7a3e" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6757-c045-0278-e08e" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="6fc6-6f98-5640-a090" name="Warlord: Savage Assult" hidden="false">
+              <description>No enemy unit may declare a Reaction against a Charge made by a unit that includes Khârn the Bloody, unless that unit includes a model with the Primarch Unit Type. In addition, an army with Khârn the Bloody as its Warlord may make an additional Advance Reaction during the Movement Phase as long as Khârn the Bloody has not been removed as a casualty.</description>
+            </rule>
+          </rules>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="175.0"/>
@@ -4840,21 +5105,22 @@ locked in combat with Magistus Amon using the following profile:</description>
               <description>Magistus Amon gains the Divination and Telepathy Disciplines from the Core Psychic Discipline
 list at no additional points cost.</description>
             </rule>
-            <rule id="4696-afaf-ecf4-9a3b" name="Warlord: Lord of Hidden Paths" hidden="false">
-              <description>If chosen as the army&apos;s Warlord, Magistus Amon automatically has The Lord of Hidden Paths as
-his Warlord Trait and may not select any other.
-
-Lord of Hidden Paths –If an army’s Warlord has this Trait, then all units with the Infiltrate and Scout special rules gain the Shrouded (5+) special rules from the start of the controlling player’s First turn until the beginning of the controlling player’s second turn. In addition, an army whose Warlord has this Trait may make an additional Reaction in the Movement phase</description>
-            </rule>
           </rules>
           <infoLinks>
             <infoLink id="db92-ff52-38c6-00c3" name="Legiones Astartes (Thousand Sons) " hidden="false" targetId="2377-1d73-44bc-fee2" type="rule"/>
-            <infoLink id="8cf3-ccd3-12e2-f2ae" name="Master of the Legion" hidden="false" targetId="c772-87ea-d49c-c7ba" type="rule"/>
             <infoLink id="e471-dc88-bca9-e648" name="Independent Character" hidden="false" targetId="c57d-4820-458a-7ab5" type="rule"/>
             <infoLink id="37a9-2d01-2b61-43e6" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
             <infoLink id="5d28-9507-cd4e-20c5" name="Infiltrate" hidden="false" targetId="0e32-5b92-a95a-8464" type="rule"/>
             <infoLink id="33b1-7298-c465-ef9a" name="Traitor" hidden="false" targetId="eff2-8b0e-21da-2f0d" type="rule"/>
           </infoLinks>
+          <entryLinks>
+            <entryLink id="3d33-8640-98c7-1904" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b51b-f281-4c65-2b56" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8754-f558-548b-a897" type="min"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
           </costs>
@@ -4970,6 +5236,16 @@ Lord of Hidden Paths –If an army’s Warlord has this Trait, then all units wi
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8e2f-03ff-b8ee-fedd" type="min"/>
           </constraints>
         </entryLink>
+        <entryLink id="3633-0ab6-0fd5-ae01" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ad37-33d3-8db2-adb6" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="fcb8-ce77-6d8f-c37e" name="Warlord: Lord of Hidden Paths" hidden="false">
+              <description>If an army’s Warlord has this Trait, then all units with the Infiltrate and Scout special rules gain the Shrouded (5+) special rules from the start of the controlling player’s First turn until the beginning of the controlling player’s second turn. In addition, an army whose Warlord has this Trait may make an additional Reaction in the Movement phase</description>
+            </rule>
+          </rules>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="185.0"/>
@@ -5018,16 +5294,8 @@ Lord of Hidden Paths –If an army’s Warlord has this Trait, then all units wi
               </characteristics>
             </profile>
           </profiles>
-          <rules>
-            <rule id="3bd2-2a43-8b7f-6c76" name="Warlord: The Vengeful Spirit" hidden="false">
-              <description>If chosen as the army&apos;s Warlord, Ezekyle Abaddon automatically has The Vengeful Spirit as his Warlord Trait and may not select any other.
-
-The Vengeful Spirit – Ezekyle Abbadon and any unit he joins gain the Feel No Pain (4+) special rule during the Movement and Shooting phases of any turn in which they are deployed as part of a Deep Strike Assault. In addition, an army with Ezekyle Abaddon as its Warlord may make an additional Reaction during the Movement phase as long as Ezekyle Abaddon has not been removed as a casualty.</description>
-            </rule>
-          </rules>
           <infoLinks>
             <infoLink id="62f4-c318-1874-e32e" name="Legiones Astartes (Sons of Hours) " hidden="false" targetId="f4a2-e4ca-b8b2-35a1" type="rule"/>
-            <infoLink id="3001-ec0f-f6da-d647" name="Master of the Legion" hidden="false" targetId="c772-87ea-d49c-c7ba" type="rule"/>
             <infoLink id="c175-5af6-399d-aef9" name="Independent Character" hidden="false" targetId="c57d-4820-458a-7ab5" type="rule"/>
             <infoLink id="612c-784e-4cc0-0937" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
             <infoLink id="d061-c7ea-38fc-98ff" name="Bulky (X)" hidden="false" targetId="676c-7b75-4b6f-9405" type="rule">
@@ -5049,6 +5317,14 @@ The Vengeful Spirit – Ezekyle Abbadon and any unit he joins gain the Feel No P
             </infoLink>
             <infoLink id="d86d-f8a3-afc7-94ab" name="Traitor" hidden="false" targetId="eff2-8b0e-21da-2f0d" type="rule"/>
           </infoLinks>
+          <entryLinks>
+            <entryLink id="164a-dd08-c25f-4074" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="45a0-a91d-32a4-79c4" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="69e8-57f7-f621-fd62" type="min"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
           </costs>
@@ -5093,6 +5369,16 @@ The Vengeful Spirit – Ezekyle Abbadon and any unit he joins gain the Feel No P
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e0aa-90d9-d813-7016" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c648-e25d-c4f5-4a72" type="min"/>
           </constraints>
+        </entryLink>
+        <entryLink id="c3e9-4567-f3f9-7dcd" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9c73-7003-6f58-cb91" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="b356-1824-85a3-cc6f" name="Warlord: The Vengeful Spirit" hidden="false">
+              <description>Ezekyle Abbadon and any unit he joins gain the Feel No Pain (4+) special rule during the Movement and Shooting phases of any turn in which they are deployed as part of a Deep Strike Assault. In addition, an army with Ezekyle Abaddon as its Warlord may make an additional Reaction during the Movement phase as long as Ezekyle Abaddon has not been removed as a casualty.</description>
+            </rule>
+          </rules>
         </entryLink>
       </entryLinks>
       <costs>
@@ -5146,11 +5432,6 @@ The Vengeful Spirit – Ezekyle Abbadon and any unit he joins gain the Feel No P
           <rules>
             <rule id="ef15-0eb6-8011-bf18" name="Broken in Body" hidden="false">
               <description>Maloghurst the Twisted and any unit he joins may not Run or make Sweeping Advances</description>
-            </rule>
-            <rule id="c9fa-2fe7-4f53-5e68" name="Warlord: Bearer of the Eye" hidden="false">
-              <description>If chosen as the army&apos;s Warlord, Maloghurst the Twistedautomatically has Bearer of the Eye as his Warlord Trait and may not select any other.
-
-Bearer of the Eye – Any unit joined by Maloghurst the Twisted gains the Line sub-type and counts as a Scoring unit, and when Maloghurst the Twistedor any unit he has joined controls an objective, that control may not be cancelled or contested by enemy Denial units - only an enemy Scoring unit can contest an objective held by Maloghurst the Twisted and any unit he has joined. In addition, an army with Maloghurst the Twisted as its Warlord may make an additional Reaction during the Shooting phase as long as Maloghurst the Twisted has not been removed as a casualty.</description>
             </rule>
           </rules>
           <infoLinks>
@@ -5224,6 +5505,16 @@ Bearer of the Eye – Any unit joined by Maloghurst the Twisted gains the Line s
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="37eb-c58b-b478-6f95" type="max"/>
           </constraints>
         </entryLink>
+        <entryLink id="5795-d4fc-23b2-dc0d" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="983f-ce8e-d90b-b18b" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="86c2-1efd-d257-ca26" name="Warlord: Bearer of the Eye" hidden="false">
+              <description>Any unit joined by Maloghurst the Twisted gains the Line sub-type and counts as a Scoring unit, and when Maloghurst the Twisted or any unit he has joined controls an objective, that control may not be cancelled or contested by enemy Denial units - only an enemy Scoring unit can contest an objective held by Maloghurst the Twisted and any unit he has joined. In addition, an army with Maloghurst the Twisted as its Warlord may make an additional Reaction during the Shooting phase as long as Maloghurst the Twisted has not been removed as a casualty.</description>
+            </rule>
+          </rules>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="140.0"/>
@@ -5282,12 +5573,6 @@ Bearer of the Eye – Any unit joined by Maloghurst the Twisted gains the Line s
                 <rule id="c8cc-6baa-1a2c-eb97" name="Binder of Souls" hidden="false">
                   <description>Zardu Layak gains the Psychic Discipline Soul Binding and may not select any other Psychic Discpline.</description>
                 </rule>
-                <rule id="b740-9800-10c4-3a0a" name="Warlord: Reign of Fire" hidden="false">
-                  <description>If chosen as the army&apos;s Warlord, Zardu Layak automatically has Reign of Fire as his Warlord Trait and may not select any other.
-
-
-Reign of Fire – If Zardu Layak is the army’s Warlord, then all models in an Ashen Circle Squad and all models with the Corrupted unit sub-type gain the Line unit sub-type. In addition, an army with Zardu Layak as its Warlord may make an additional Reaction during the Assault phase as long as Zardu Layak has not been removed as a casualty.</description>
-                </rule>
                 <rule id="3ab4-e3e7-c56c-a51a" name="Psychic Discipline: Soul Binding" hidden="false">
                   <description>A Psyker with this Discipline gains all the listed Powers, Weapon and other special rules, as well
 as the Aetheric Lightning Psychic Weapon</description>
@@ -5295,7 +5580,6 @@ as the Aetheric Lightning Psychic Weapon</description>
               </rules>
               <infoLinks>
                 <infoLink id="8ec0-f085-f675-f43c" name="Legiones Astartes (Word Bearers) " hidden="false" targetId="21ba-24fc-3fad-00fe" type="rule"/>
-                <infoLink id="5c66-597c-41f3-6d97" name="Master of the Legion" hidden="false" targetId="c772-87ea-d49c-c7ba" type="rule"/>
                 <infoLink id="8200-bd18-1c46-3fec" name="Independent Character" hidden="false" targetId="c57d-4820-458a-7ab5" type="rule"/>
                 <infoLink id="c81a-8c36-4da9-4412" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
                 <infoLink id="a132-a826-eeba-c182" name="Fearless" hidden="false" targetId="b48c-d7e1-2a83-2f5b" type="rule"/>
@@ -5306,6 +5590,14 @@ as the Aetheric Lightning Psychic Weapon</description>
                 </infoLink>
                 <infoLink id="ae32-89c3-b5e0-d259" name="Traitor" hidden="false" targetId="eff2-8b0e-21da-2f0d" type="rule"/>
               </infoLinks>
+              <entryLinks>
+                <entryLink id="842e-7c3d-5057-37d8" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4c21-b59c-4d44-eaca" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a8c5-ae15-171f-a653" type="min"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
               </costs>
@@ -5404,8 +5696,8 @@ as the Aetheric Lightning Psychic Weapon</description>
         </selectionEntry>
         <selectionEntry id="e07f-1e21-53e5-fb6e" name="Anaktis Kul Blade Slaves" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f07c-52d6-ad2a-7d42" type="min"/>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="012d-1da5-2f29-d665" type="max"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="aca5-3ec6-5095-6fa8" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="012d-1da5-2f29-d665" type="max"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="e2e6-0106-f215-45b7" name="Anaktis Kul Blade Slave" hidden="false" collective="false" import="true" type="model">
@@ -5524,6 +5816,18 @@ as the Aetheric Lightning Psychic Weapon</description>
           </costs>
         </selectionEntry>
       </selectionEntries>
+      <entryLinks>
+        <entryLink id="c7d8-990e-e450-973a" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d2fc-1ed1-6f89-1b4b" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="ad8e-6d79-d139-d279" name="Warlord: Reign of Fire" hidden="false">
+              <description>If Zardu Layak is the army’s Warlord, then all models in an Ashen Circle Squad and all models with the Corrupted unit sub-type gain the Line unit sub-type. In addition, an army with Zardu Layak as its Warlord may make an additional Reaction during the Assault phase as long as Zardu Layak has not been removed as a casualty.</description>
+            </rule>
+          </rules>
+        </entryLink>
+      </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
       </costs>
@@ -5870,16 +6174,8 @@ as the Aetheric Lightning Psychic Weapon</description>
               </characteristics>
             </profile>
           </profiles>
-          <rules>
-            <rule id="76de-f279-3e65-c253" name="Warlord: The Crimson Lord" hidden="false">
-              <description>If chosen as the army&apos;s Warlord, Argel Tal automatically has The Crimson Lord as his Warlord Trait and may not select any other.
-
-The Crimson Lord – If Argel Tal is the army’s Warlord, then all models with the Corrupted Unit sub-type gain the Line unit sub-type and both Argel Tal and any Gal Vorbak unit he joins gain a 5+ Invulnerable Save. In addition, an army with Argel Tal as its Warlord may make an additional Reaction during the Assault phase as long as Argel Tal has not been removed as a casualty.</description>
-            </rule>
-          </rules>
           <infoLinks>
             <infoLink id="b484-a773-273b-8da5" name="Legiones Astartes (Word Bearers) " hidden="false" targetId="21ba-24fc-3fad-00fe" type="rule"/>
-            <infoLink id="7921-64c1-cadc-cf85" name="Master of the Legion" hidden="false" targetId="c772-87ea-d49c-c7ba" type="rule"/>
             <infoLink id="d4cb-2655-f276-321b" name="Independent Character" hidden="false" targetId="c57d-4820-458a-7ab5" type="rule"/>
             <infoLink id="0c89-9075-7a17-7cdd" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
             <infoLink id="d024-0853-4c17-8e60" name="Bulky (X)" hidden="false" targetId="676c-7b75-4b6f-9405" type="rule">
@@ -5899,6 +6195,14 @@ The Crimson Lord – If Argel Tal is the army’s Warlord, then all models with 
             </infoLink>
             <infoLink id="c513-ed34-dd25-9b85" name="Traitor" hidden="false" targetId="eff2-8b0e-21da-2f0d" type="rule"/>
           </infoLinks>
+          <entryLinks>
+            <entryLink id="c7d9-e326-0988-d844" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ae1a-731b-4cb3-0fcb" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0f03-3931-bfed-9041" type="min"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
           </costs>
@@ -5960,6 +6264,16 @@ Argel Tal may not Run in any Turn in which the Umbral Pinions have been activate
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9b9b-b4ff-40fd-0c6f" type="max"/>
           </constraints>
         </entryLink>
+        <entryLink id="1fc7-b2d5-bc5c-49a0" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d645-3b21-73b0-440b" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="a454-a697-a811-09b5" name="Warlord: The Crimson Lord" hidden="false">
+              <description>If Argel Tal is the army’s Warlord, then all models with the Corrupted Unit sub-type gain the Line unit sub-type and both Argel Tal and any Gal Vorbak unit he joins gain a 5+ Invulnerable Save. In addition, an army with Argel Tal as its Warlord may make an additional Reaction during the Assault phase as long as Argel Tal has not been removed as a casualty.</description>
+            </rule>
+          </rules>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="225.0"/>
@@ -6009,11 +6323,6 @@ Argel Tal may not Run in any Turn in which the Umbral Pinions have been activate
             </profile>
           </profiles>
           <rules>
-            <rule id="deb3-2363-459e-00c7" name="Warlord: Shadow behind the Throne" hidden="false">
-              <description>If chosen as the army&apos;s Warlord, High Chaplain Erebus automatically has the Shadow behind the Throne as his Warlord Trait and may not select any other.
- 
-Shadow Behind the Throne – When High Chaplain Erebus is the army’s Warlord and is part of a unit composed entirely of models with any version of the Legiones Astartes special rule, no Wounds may be allocated to him, regardless of the attacking models rules or effects, as long as there is another model in the unit. If High Chaplain Erebus is engaged in a Challenge then this rule does not apply, however if High Chaplain Erebus’ controlling player chooses to refuse a Challenge for a unit that includes High Chaplain Erebus then the opposing player loses the option to stop one model from participating in the combat. In addition, an army whose Warlord is High Chaplain Erebus may make an additional Reaction in any one Phase, chosen by the controlling player at the start of the turn, as long as High Chaplain Erebus has not been removed as a casualty.</description>
-            </rule>
             <rule id="35c0-0f59-779f-8342" name="Harbinger of Chaos" hidden="false">
               <description>A Detachment that includes High Chaplain Erebus may select up to three non-compulsory Elites or HQ choices from the Ruinstorm Daemon army list - these choices are paid for in points and occupy slots on the Force Organisation chart as normal, but must begin the game in Reserve and may only enter play by means of the Breach the Veil Psychic power detailed below.</description>
             </rule>
@@ -6024,7 +6333,6 @@ Psychic Weapon</description>
           </rules>
           <infoLinks>
             <infoLink id="820d-c2fb-c3e1-15d6" name="Legiones Astartes (Word Bearers) " hidden="false" targetId="21ba-24fc-3fad-00fe" type="rule"/>
-            <infoLink id="9688-566f-7ba3-64d1" name="Master of the Legion" hidden="false" targetId="c772-87ea-d49c-c7ba" type="rule"/>
             <infoLink id="a3a3-e8e4-9a54-6f44" name="Independent Character" hidden="false" targetId="c57d-4820-458a-7ab5" type="rule"/>
             <infoLink id="eb18-a71a-74cd-49cd" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
             <infoLink id="9240-3045-429b-a1a0" name="Hatred (X)" hidden="false" targetId="dc0b-fe69-6b71-e0a4" type="rule">
@@ -6035,6 +6343,14 @@ Psychic Weapon</description>
             <infoLink id="cf37-af16-85dc-ac0c" name="Fearless" hidden="false" targetId="b48c-d7e1-2a83-2f5b" type="rule"/>
             <infoLink id="8215-78f6-6292-e18e" name="Traitor" hidden="false" targetId="eff2-8b0e-21da-2f0d" type="rule"/>
           </infoLinks>
+          <entryLinks>
+            <entryLink id="c29d-d17e-c85f-83e9" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3d7e-e25e-dd4a-f677" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6a6d-31eb-3085-62c6" type="min"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
           </costs>
@@ -6108,6 +6424,16 @@ Psychic Weapon</description>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="25e7-89b9-0548-1b3d" type="min"/>
           </constraints>
         </entryLink>
+        <entryLink id="2fef-c01e-16c3-f6ae" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7318-be4a-45c6-1082" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="383c-9b6a-a6ec-95c4" name="Warlord: Shadow behind the Throne" hidden="false">
+              <description>When High Chaplain Erebus is the army’s Warlord and is part of a unit composed entirely of models with any version of the Legiones Astartes special rule, no Wounds may be allocated to him, regardless of the attacking models rules or effects, as long as there is another model in the unit. If High Chaplain Erebus is engaged in a Challenge then this rule does not apply, however if High Chaplain Erebus’ controlling player chooses to refuse a Challenge for a unit that includes High Chaplain Erebus then the opposing player loses the option to stop one model from participating in the combat. In addition, an army whose Warlord is High Chaplain Erebus may make an additional Reaction in any one Phase, chosen by the controlling player at the start of the turn, as long as High Chaplain Erebus has not been removed as a casualty.</description>
+            </rule>
+          </rules>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="165.0"/>
@@ -6160,23 +6486,12 @@ Psychic Weapon</description>
             <rule id="2b11-bca0-ef39-7fb6" name="Jealous Command" hidden="false">
               <description>If Kor Phaeron or Lorgar is not chosen as the Warlord of an army that Kor Phaeron is part of, then his Leadership is reduced by -1 and he gains the Hatred (Everything) special rule. When Kor Phaeron is included as the same army as Lorgar, both models gain +1 WS and the Hatred (Everything) special rules while part of the same unit</description>
             </rule>
-            <rule id="b059-7876-ceab-d630" name="Warlord: Dark Oratory" hidden="false">
-              <description>If chosen as the army&apos;s Warlord, Kor Phaeron automatically has Dark Oratory as his Warlord Trait and may not select any other.
-
-Dark Oratory – When Kor Phaeron is the Warlord of the army then the controlling player can
-choose one of the following two options at the beginning of each of their own turns:
-
-Cruel Invective - All enemy units with at least one model within 12” of Kor Phaeron at the start of the controlling player’s turn (before any models are moved) must make an immediate Pinning check, and become Pinned if the Check is failed.
-
-Threatening Entreaties - Kor Phaeron and the unit he has joined gain the Fearless special rule until the start of the controlling player’s next turn, but all model’s other than Kor Phaeron in the unit reduce their WS and BS by -1 until the start of the controlling player’s next turn. In addition, an army with Kor Phaeron as its Warlord may make an additional Reaction during the Assault phase as long as Kor Phaeron has not been removed as a casualty.</description>
-            </rule>
             <rule id="c843-9eae-fdd2-f832" name="Patriarch&apos;s Claws" hidden="false">
               <description>The Patriarch’s Claws are a pair of two weapons and as such Kor Phaeron gains a bonus attack when using them.</description>
             </rule>
           </rules>
           <infoLinks>
             <infoLink id="742c-d8e8-f15b-f342" name="Legiones Astartes (Word Bearers) " hidden="false" targetId="21ba-24fc-3fad-00fe" type="rule"/>
-            <infoLink id="7488-7a8b-2d48-06d0" name="Master of the Legion" hidden="false" targetId="c772-87ea-d49c-c7ba" type="rule"/>
             <infoLink id="e56b-f65f-7447-243e" name="Independent Character" hidden="false" targetId="c57d-4820-458a-7ab5" type="rule"/>
             <infoLink id="b02f-6595-21ca-940c" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
             <infoLink id="347c-3293-3766-82bd" name="Bulky (X)" hidden="false" targetId="676c-7b75-4b6f-9405" type="rule">
@@ -6196,6 +6511,14 @@ Threatening Entreaties - Kor Phaeron and the unit he has joined gain the Fearles
             </infoLink>
             <infoLink id="0d06-d1ce-9b31-ca25" name="Traitor" hidden="false" targetId="eff2-8b0e-21da-2f0d" type="rule"/>
           </infoLinks>
+          <entryLinks>
+            <entryLink id="5b72-fd2a-56d4-1b24" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="243f-0d6c-c583-ddf9" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4f6b-2b16-1937-0b8a" type="min"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
           </costs>
@@ -6261,6 +6584,22 @@ Threatening Entreaties - Kor Phaeron and the unit he has joined gain the Fearles
           </costs>
         </selectionEntry>
       </selectionEntries>
+      <entryLinks>
+        <entryLink id="575e-60e2-bf76-83ec" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d44a-5342-5124-cc21" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="f4c8-a18f-0e65-723b" name="Warlord: Dark Oratory" hidden="false">
+              <description>When Kor Phaeron is the Warlord of the army then the controlling player can choose one of the following two options at the beginning of each of their own turns:
+
+Cruel Invective - All enemy units with at least one model within 12” of Kor Phaeron at the start of the controlling player’s turn (before any models are moved) must make an immediate Pinning check, and become Pinned if the Check is failed.
+
+Threatening Entreaties - Kor Phaeron and the unit he has joined gain the Fearless special rule until the start of the controlling player’s next turn, but all model’s other than Kor Phaeron in the unit reduce their WS and BS by -1 until the start of the controlling player’s next turn. In addition, an army with Kor Phaeron as its Warlord may make an additional Reaction during the Assault phase as long as Kor Phaeron has not been removed as a casualty.</description>
+            </rule>
+          </rules>
+        </entryLink>
+      </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="125.0"/>
       </costs>
@@ -6472,18 +6811,12 @@ The Instrument has two profiles. Pick which profile is used every time the weapo
             </profile>
           </profiles>
           <rules>
-            <rule id="664c-fe25-f824-06eb" name="Warlord: The Harrowing" publicationId="09c5-eeae-f398-b653" page="342" hidden="false">
-              <description>If chosen as the army&apos;s Warlord, Armillus Dynat automatically has The Harrowing as his Warlord Trait and may not select any other
-
-The Harrowing – At the start of the battle, before any models are deployed by either player, the controlling player of an army whose Warlord is Armillus Dynat may choose to select three friendly units composed entirely of models with the Legiones Astartes (Alpha Legion) special rule and the Infantry Unit Type and give all models in those units one of the following rules: Infiltrate, Scout, or Counter-attack (1). In addition, an army whose Warlord is Armillus Dynat may make an additional Reaction in the opposing player&apos;s Movement phase, as long as Armillus Dynat has not been removed as a casualty.</description>
-            </rule>
             <rule id="b9f5-8b4a-4e3c-ed68" name="Weapon Master" publicationId="09c5-eeae-f398-b653" page="343" hidden="false">
               <description>When attacking during the Assault phase, Armillus Dynat may choose to split his attacks between any of the weapons he has, declaring which Attacks will be used with which weapon profiles before any of his Attacks are rolled.</description>
             </rule>
           </rules>
           <infoLinks>
             <infoLink id="f8c5-aa30-2021-5ef8" name="Legiones Astartes (Alpha Legion) " hidden="false" targetId="2a9e-be1f-d6c1-0ec4" type="rule"/>
-            <infoLink id="a384-7604-1f31-e7cb" name="Master of the Legion" hidden="false" targetId="c772-87ea-d49c-c7ba" type="rule"/>
             <infoLink id="360d-b35b-6c6a-321c" name="Independent Character" hidden="false" targetId="c57d-4820-458a-7ab5" type="rule"/>
             <infoLink id="f121-7a49-4147-35d8" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
             <infoLink id="9bdb-7ad8-d93a-4da2" name="Precision Strikes (X)" hidden="false" targetId="2206-8497-8fe1-e973" type="rule">
@@ -6492,6 +6825,14 @@ The Harrowing – At the start of the battle, before any models are deployed by 
               </modifiers>
             </infoLink>
           </infoLinks>
+          <entryLinks>
+            <entryLink id="9e8e-0dee-e491-d5e7" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="78bc-a475-1c5d-2fd4" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9e1b-4fa3-5038-4a10" type="min"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
           </costs>
@@ -6578,6 +6919,16 @@ The Harrowing – At the start of the battle, before any models are deployed by 
           </constraints>
         </entryLink>
         <entryLink id="7bed-21e6-ad8e-80f1" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry"/>
+        <entryLink id="5d51-59a4-a43e-271a" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="35b8-84e8-c0d8-4a8a" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="35ba-7f53-a01f-a46f" name="Warlord: The Harrowing" publicationId="09c5-eeae-f398-b653" page="342" hidden="false">
+              <description>At the start of the battle, before any models are deployed by either player, the controlling player of an army whose Warlord is Armillus Dynat may choose to select three friendly units composed entirely of models with the Legiones Astartes (Alpha Legion) special rule and the Infantry Unit Type and give all models in those units one of the following rules: Infiltrate, Scout, or Counter-attack (1). In addition, an army whose Warlord is Armillus Dynat may make an additional Reaction in the opposing player&apos;s Movement phase, as long as Armillus Dynat has not been removed as a casualty.</description>
+            </rule>
+          </rules>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="185.0"/>
@@ -7547,7 +7898,7 @@ Sonic Lance</characteristic>
       <profiles>
         <profile id="2b38-2b2c-9b4a-4def" name="Teleport Strike" publicationId="817a-6288-e016-7469" page="228" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
           <characteristics>
-            <characteristic name="Description" typeId="347e-ee4a-764f-6be3">All models with the Legiones Astartes (Imperial Fists) special rule in a Legion Cataphractii Terminator Squad, Legion Tartaros Terminator Squad, Legion Cataphractii Command Squad or Legion Tartaros Command Squad may be giventhe Deep Strike special rule for +25 points per unit. Any model with both the Legiones Astartes (Imperial Fists) andIndependent Character special rules may be given the Deep Strike special rule for +20 points per model.</characteristic>
+            <characteristic name="Description" typeId="347e-ee4a-764f-6be3">All models with the Legiones Astartes (Imperial Fists) special rule in a Legion Cataphractii Terminator Squad, Legion Tartaros Terminator Squad, Legion Cataphractii Command Squad or Legion Tartaros Command Squad may be given the Deep Strike special rule for +25 points per unit. Any model with both the Legiones Astartes (Imperial Fists) and Independent Character special rules may be given the Deep Strike special rule for +20 points per model.</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -9811,15 +10162,9 @@ When a model has two Raven’s Talons, that model gains +2 Attacks instead of th
 
 In addition, once per battle, one friendly unit composed entirely of models with the Infantry or Cavalry Unit Type with at least one model within 18&quot; of Lorgar (But not a unit that includes lorgar himself) may be selected at the start of any Game Turn. The chosen units gain the Fearless and Feel No Pain (4+) special rules for the duration of that Game Turn.</description>
             </rule>
-            <rule id="260a-859b-a6c7-da53" name="Warlord: Sire of the Word Bearers" hidden="false">
-              <description>If chosen as the army&apos;s Warlord, Lorgar automatically has the Sire of the Word Bearers Warlord Trait and may not select any other Warlord Trait.
-
-Sire of the Word Bearers - All units composed entirely of models which have the Legiones Astartes (Word Bearers) special rule and which can draw line of sight to lorgar add +1 to the Result of Charge Distance rolls made for them, and may use Lorgar&apos;s Leadership in all Leadership tests, Morale checks and pinning tests made for them. In addition, an army with lorgar as its Warlord gains an extra Reaction in the Opposing player&apos;s Assult Phase, as long as Lorgar has not been removed as a casualty.</description>
-            </rule>
           </rules>
           <infoLinks>
             <infoLink id="b420-e000-db78-b36f" name="Legiones Astartes (Word Bearers) " hidden="false" targetId="21ba-24fc-3fad-00fe" type="rule"/>
-            <infoLink id="d060-3826-0144-e4e8" name="Master of the Legion" hidden="false" targetId="c772-87ea-d49c-c7ba" type="rule"/>
             <infoLink id="3101-dbda-771e-54b9" name="Crusader" hidden="false" targetId="c705-0829-75f6-a785" type="rule"/>
             <infoLink id="a878-9afb-4bfe-beac" name="Traitor" hidden="false" targetId="eff2-8b0e-21da-2f0d" type="rule"/>
             <infoLink id="d38e-6e31-b071-b636" name="It Will Not Die (X)" hidden="false" targetId="2784-d0be-a4e2-890f" type="rule">
@@ -9828,6 +10173,14 @@ Sire of the Word Bearers - All units composed entirely of models which have the 
               </modifiers>
             </infoLink>
           </infoLinks>
+          <entryLinks>
+            <entryLink id="be65-8c6d-f47a-e2ca" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="85ee-96d4-bfbc-7eff" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af11-c35a-34d3-da58" type="min"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
           </costs>
@@ -9986,6 +10339,18 @@ In additio, an army that includes Lorgar Transfigured may fill any non-compulsor
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="3a41-6520-ccce-e6ba" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="57c3-19ea-ce37-1fda" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="0f4a-bae0-544b-0e43" name="Warlord: Sire of the Word Bearers" hidden="false">
+              <description>All units composed entirely of models which have the Legiones Astartes (Word Bearers) special rule and which can draw line of sight to lorgar add +1 to the Result of Charge Distance rolls made for them, and may use Lorgar&apos;s Leadership in all Leadership tests, Morale checks and pinning tests made for them. In addition, an army with lorgar as its Warlord gains an extra Reaction in the Opposing player&apos;s Assult Phase, as long as Lorgar has not been removed as a casualty.</description>
+            </rule>
+          </rules>
+        </entryLink>
+      </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="415.0"/>
       </costs>
@@ -12851,11 +13216,6 @@ In additon, a Contekar Terminator Squad may be selected as a Retinue Squad in a 
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="72bc-3db3-e015-832b" type="max"/>
       </constraints>
       <rules>
-        <rule id="2aa1-c179-e2fd-ec49" name="Warlord: Sire of the Night Lords" hidden="false">
-          <description>If chosen as the army&apos;s Warlord, Konrad Curze automatically has the Sire of the Night Lords Warlord Trait and may not select any other Warlord Trait.
-
-Sire of the Night Lords - All models with the Infantry, Dreadnought or Cavalry Unit Type and Legiones Astartes (Night lords) special rule in the same army as Konrad Curze gain the Night Vision and Bloody Murder special rules and are immune to the effects of the Fear (X) special rule. In addition,  an army with Konrad Curze as it Warlord gain an additional Reaction in the Movement phase as long as Konrad Curze has not been removed as a casualty.</description>
-        </rule>
         <rule id="da01-cb0f-e7b4-a919" name="A Death Long Foreseen" hidden="false">
           <description>Konrad Curze gains access to the Glimpse of Death Psychic Power only and gains no other Disciplines.</description>
         </rule>
@@ -12865,7 +13225,6 @@ Sire of the Night Lords - All models with the Infantry, Dreadnought or Cavalry U
       </rules>
       <infoLinks>
         <infoLink id="6cab-bc69-76ee-1697" name="Legiones Astartes (Night Lords) " hidden="false" targetId="8280-d4ea-b131-4970" type="rule"/>
-        <infoLink id="6e20-19dd-0db2-dc00" name="Master of the Legion" hidden="false" targetId="c772-87ea-d49c-c7ba" type="rule"/>
         <infoLink id="feb2-8a96-8a6e-14fa" name="Hit &amp; Run" hidden="false" targetId="5986-e960-d432-affd" type="rule"/>
         <infoLink id="5056-0f2f-f8d4-4ad0" name="Fear (X)" hidden="false" targetId="21f6-7842-df5c-d2e7" type="rule">
           <modifiers>
@@ -12980,6 +13339,24 @@ Sire of the Night Lords - All models with the Infantry, Dreadnought or Cavalry U
           </costs>
         </selectionEntry>
       </selectionEntries>
+      <entryLinks>
+        <entryLink id="f0d5-7717-0fd1-582c" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bccb-1520-48ec-bfd9" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="5e55-4240-32ee-4865" name="Warlord: Sire of the Night Lords" hidden="false">
+              <description>All models with the Infantry, Dreadnought or Cavalry Unit Type and Legiones Astartes (Night lords) special rule in the same army as Konrad Curze gain the Night Vision and Bloody Murder special rules and are immune to the effects of the Fear (X) special rule. In addition,  an army with Konrad Curze as it Warlord gain an additional Reaction in the Movement phase as long as Konrad Curze has not been removed as a casualty.</description>
+            </rule>
+          </rules>
+        </entryLink>
+        <entryLink id="599f-b4a4-6810-2a9d" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="21c2-0167-f41e-198e" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="35ae-a5e8-c7d2-91d2" type="min"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="450.0"/>
       </costs>
@@ -13938,7 +14315,7 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="857c-de26-44e2-4872" name="All models must choose from:" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="857c-de26-44e2-4872" name="All models must choose from:" hidden="false" collective="false" import="true" defaultSelectionEntryId="a173-a560-75b2-2603">
           <modifiers>
             <modifier type="increment" field="2371-8baa-0a4c-828a" value="1.0">
               <repeats>
@@ -13950,10 +14327,11 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
                 <repeat field="selections" scope="fac4-294e-e670-59ff" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
+            <modifier type="decrement" field="2371-8baa-0a4c-828a" value="5.0"/>
           </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2174-93b9-5822-8338" type="max"/>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2371-8baa-0a4c-828a" type="min"/>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2371-8baa-0a4c-828a" type="min"/>
           </constraints>
           <entryLinks>
             <entryLink id="017d-af70-a48b-cc79" name="Charnabal Glaive" hidden="false" collective="false" import="true" targetId="c07c-35e6-4616-ef25" type="selectionEntry"/>
@@ -13990,7 +14368,7 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="276c-e1c2-48d0-0e1d" name="All models in the unit may take a Surgical Augment all models must choose the same Augment:" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="276c-e1c2-48d0-0e1d" name="All models in the unit may choose to take the same Surgical Augment:" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8ef8-ebf6-918d-de2e" type="max"/>
           </constraints>
@@ -14578,6 +14956,16 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
               </costs>
             </entryLink>
             <entryLink id="afed-7566-0c89-e748" name="Shrapnel Bolter" hidden="false" collective="false" import="true" targetId="1941-21b5-932c-74d6" type="selectionEntry">
+              <modifiers>
+                <modifier type="increment" field="4559-5233-c1d6-8a7c" value="1.0">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1941-21b5-932c-74d6" type="atLeast"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4559-5233-c1d6-8a7c" type="min"/>
+              </constraints>
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
               </costs>
@@ -14725,12 +15113,30 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
               </costs>
             </entryLink>
-            <entryLink id="c44a-4066-dfb3-e1be" name="Shrapnel Pistol" hidden="false" collective="false" import="true" targetId="7d72-7f6d-6330-6871" type="selectionEntry">
+            <entryLink id="1468-561b-1a7a-06d4" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7d72-7f6d-6330-6871" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </entryLink>
+            <entryLink id="dbb0-a521-dcec-e244" name="Shrapnel Pistol" hidden="false" collective="false" import="true" targetId="7d72-7f6d-6330-6871" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7d72-7f6d-6330-6871" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bf8e-7891-eff8-0691" type="min"/>
+              </constraints>
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
               </costs>
             </entryLink>
-            <entryLink id="1468-561b-1a7a-06d4" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="906c-fbcb-0f02-ffd9" name="The Legion Tactical Sergeant may take (Wargear):" hidden="false" collective="false" import="true">
@@ -14835,7 +15241,7 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="a61a-70e4-557e-eae2" name="Any Legionary may replace their Bolt Pistol with:" hidden="false" collective="false" import="true" defaultSelectionEntryId="4029-ea6c-2c4e-3579">
+        <selectionEntryGroup id="a61a-70e4-557e-eae2" name="Any Legionary may replace their Bolt Pistol with:" hidden="false" collective="false" import="true" defaultSelectionEntryId="21ca-c918-44fa-4776">
           <modifiers>
             <modifier type="increment" field="e6ba-373f-f3eb-d378" value="1.0">
               <repeats>
@@ -14860,11 +15266,29 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
               </costs>
             </entryLink>
             <entryLink id="bb75-9f24-460e-f1eb" name="Shrapnel Pistol" hidden="false" collective="false" import="true" targetId="7d72-7f6d-6330-6871" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7d72-7f6d-6330-6871" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e925-c83e-2711-131e" type="min"/>
+              </constraints>
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
               </costs>
             </entryLink>
-            <entryLink id="4029-ea6c-2c4e-3579" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry"/>
+            <entryLink id="21ca-c918-44fa-4776" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7d72-7f6d-6330-6871" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="0531-85dd-feb0-116d" name="Dedicated Transport:" hidden="false" collective="false" import="true">
@@ -14902,6 +15326,19 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
           </constraints>
           <entryLinks>
             <entryLink id="bf33-40bc-2a78-0c6b" name="Shrapnel Bolter" hidden="false" collective="false" import="true" targetId="1941-21b5-932c-74d6" type="selectionEntry">
+              <modifiers>
+                <modifier type="increment" field="baf3-8596-8ec0-19be" value="1.0">
+                  <repeats>
+                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                  </repeats>
+                  <conditions>
+                    <condition field="selections" scope="aa72-63e4-bc60-4611" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1941-21b5-932c-74d6" type="atLeast"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="baf3-8596-8ec0-19be" type="min"/>
+              </constraints>
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
               </costs>
@@ -14931,6 +15368,11 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
               </costs>
+            </entryLink>
+            <entryLink id="325c-7716-907c-bc13" name="Shrapnel Weaponry Options" hidden="false" collective="false" import="true" targetId="b26e-c64c-f86f-8351" type="selectionEntryGroup">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aaf1-7491-99ab-24de" type="max"/>
+              </constraints>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
@@ -17617,7 +18059,7 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
                 <repeat field="selections" scope="d30b-59bb-8ae0-36d1" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="532b-51a5-42d1-c133" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
-            <modifier type="set" field="6516-77d8-5967-ddb4" value="0.0"/>
+            <modifier type="decrement" field="6516-77d8-5967-ddb4" value="4.0"/>
           </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="44ad-2c17-c6e3-1198" type="max"/>
@@ -17625,6 +18067,13 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
           </constraints>
           <selectionEntries>
             <selectionEntry id="2363-7a9d-30e4-8242" name="Two Bolt Pistols" hidden="false" collective="false" import="true" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7d72-7f6d-6330-6871" type="atLeast"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <infoLinks>
                 <infoLink id="37aa-6f36-956a-e316" name="Bolt Pistol" hidden="false" targetId="c0d3-c136-ef6e-3ff7" type="profile"/>
               </infoLinks>
@@ -17684,6 +18133,16 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
               </costs>
+            </selectionEntry>
+            <selectionEntry id="829a-0315-ee4e-bf86" name="Two Shrapnel Pistols" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="0514-f470-b8fc-8996" name="Shrapnel Pistol" hidden="false" collective="false" import="true" targetId="7d72-7f6d-6330-6871" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4916-db1e-26c1-bcd9" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bff2-44dc-257f-6278" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
             </selectionEntry>
           </selectionEntries>
           <selectionEntryGroups>
@@ -17920,7 +18379,7 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
             <entryLink id="9118-e0b1-98b0-e40c" name="Fenrisian Axe" hidden="false" collective="false" import="true" targetId="72ba-d2df-d98b-8b5d" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="031e-adc8-ad3d-99c1" name="The Legion Destroyer Sergeant may exchange his Chainsword for:" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="031e-adc8-ad3d-99c1" name="The Legion Destroyer Sergeant may exchange his Chainsword for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="8632-e799-a6a6-abbe">
           <entryLinks>
             <entryLink id="d4cf-c5f4-98e1-acc6" name="Power Fist" hidden="false" collective="false" import="true" targetId="a3e1-d633-dff9-028b" type="selectionEntry">
               <costs>
@@ -17937,18 +18396,7 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
               </costs>
             </entryLink>
-            <entryLink id="8632-e799-a6a6-abbe" name="Chainsword" hidden="false" collective="false" import="true" targetId="06e7-a6ae-ed1c-eb03" type="selectionEntry">
-              <modifiers>
-                <modifier type="set" field="5756-0aee-3838-964a" value="0.0">
-                  <conditions>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="upgrade" type="greaterThan"/>
-                  </conditions>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5756-0aee-3838-964a" type="min"/>
-              </constraints>
-            </entryLink>
+            <entryLink id="8632-e799-a6a6-abbe" name="Chainsword" hidden="false" collective="false" import="true" targetId="06e7-a6ae-ed1c-eb03" type="selectionEntry"/>
             <entryLink id="6549-c014-b8fa-87be" name="Fenrisian Axe" hidden="false" collective="false" import="true" targetId="72ba-d2df-d98b-8b5d" type="selectionEntry">
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
@@ -18945,6 +19393,9 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
                       </costs>
                     </entryLink>
                   </entryLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                  </costs>
                 </selectionEntry>
               </selectionEntries>
               <entryLinks>
@@ -19086,7 +19537,6 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="91d7-85b2-0c16-6673" name="Master of the Legion" hidden="false" targetId="c772-87ea-d49c-c7ba" type="rule"/>
             <infoLink id="4e6f-3180-c5b0-671d" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
           </infoLinks>
           <selectionEntries>
@@ -19203,6 +19653,11 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
                 <entryLink id="b58b-7e7e-8977-08be" name="Raven&apos;s Talons" hidden="false" collective="false" import="true" targetId="09d8-64f5-1936-e8ab" type="selectionEntry">
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="22f1-1f9f-0146-3495" name="Shrapnel Pistol" hidden="false" collective="false" import="true" targetId="7d72-7f6d-6330-6871" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
                   </costs>
                 </entryLink>
               </entryLinks>
@@ -19487,6 +19942,17 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
                 <modifier type="set" field="name" value="May exchange both the Bolt Pistol &amp; Chainsword for:"/>
               </modifiers>
             </entryLink>
+            <entryLink id="d96a-89f7-c896-f924" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0466-f37c-7909-ca0b" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="59f0-e979-121e-fea1" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="19f8-617e-4309-8fe6" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6fb5-0534-e502-b144" type="min"/>
+              </constraints>
+            </entryLink>
           </entryLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="120.0"/>
@@ -19495,6 +19961,20 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
       </selectionEntries>
       <entryLinks>
         <entryLink id="e595-f320-64c8-1a39" name="Retinue" hidden="false" collective="false" import="true" targetId="2dd0-7045-8ae5-f394" type="selectionEntryGroup"/>
+        <entryLink id="7080-e03a-496d-df31" name="Warlord Traits" hidden="true" collective="false" import="true" targetId="dd08-dc56-c555-7e09" type="selectionEntryGroup">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b7f3-d303-9aec-977d" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
+        <entryLink id="6141-39e3-c23a-144c" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4f23-cc04-e13c-9d13" type="max"/>
+          </constraints>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
@@ -19525,7 +20005,6 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="e2ac-937c-dfeb-5915" name="Master of the Legion" hidden="false" targetId="c772-87ea-d49c-c7ba" type="rule"/>
             <infoLink id="dbf4-87b5-45e6-ca36" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
             <infoLink id="fe21-b1b2-b230-0d80" name="Inexorable" hidden="false" targetId="d863-8a5e-ddb6-d5a4" type="rule"/>
             <infoLink id="46a9-cb8e-0429-82f2" name="Bulky (X)" hidden="false" targetId="676c-7b75-4b6f-9405" type="rule">
@@ -19559,6 +20038,12 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
                 <modifier type="set" field="name" value="May exchange both his Combi-Bolter &amp; Power Weapon for:"/>
               </modifiers>
             </entryLink>
+            <entryLink id="a402-8989-2991-049e" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="34ac-8f7c-f63b-4970" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0de1-6602-ba9c-b949" type="min"/>
+              </constraints>
+            </entryLink>
           </entryLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="135.0"/>
@@ -19567,6 +20052,20 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
       </selectionEntries>
       <entryLinks>
         <entryLink id="228f-1cd8-98fe-c1d9" name="Retinue" hidden="false" collective="false" import="true" targetId="2dd0-7045-8ae5-f394" type="selectionEntryGroup"/>
+        <entryLink id="ba0d-0b4a-2122-951c" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e483-ee03-a9d4-7bb9" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="cb73-83f2-70dc-4763" name="Warlord Traits" hidden="true" collective="false" import="true" targetId="dd08-dc56-c555-7e09" type="selectionEntryGroup">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b7f3-d303-9aec-977d" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
@@ -19609,7 +20108,6 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
             </profile>
           </profiles>
           <infoLinks>
-            <infoLink id="18e0-3a31-5249-d36c" name="Master of the Legion" hidden="false" targetId="c772-87ea-d49c-c7ba" type="rule"/>
             <infoLink id="8968-f8a7-8dcd-0711" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
             <infoLink id="3943-f4be-34c3-e6d7" name="Inexorable" hidden="false" targetId="d863-8a5e-ddb6-d5a4" type="rule"/>
             <infoLink id="aae5-61fd-73c1-0724" name="Bulky (X)" hidden="false" targetId="676c-7b75-4b6f-9405" type="rule">
@@ -19643,6 +20141,12 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
                 <modifier type="set" field="name" value="May exchange both his Combi-Bolter &amp; Power Weapon for:"/>
               </modifiers>
             </entryLink>
+            <entryLink id="1097-01dd-ec7d-9762" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ccc1-ccc4-17c2-6d22" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1741-7427-20d9-3b4e" type="min"/>
+              </constraints>
+            </entryLink>
           </entryLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="110.0"/>
@@ -19651,6 +20155,20 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
       </selectionEntries>
       <entryLinks>
         <entryLink id="2fc5-66e7-8e85-1aae" name="Retinue" hidden="false" collective="false" import="true" targetId="2dd0-7045-8ae5-f394" type="selectionEntryGroup"/>
+        <entryLink id="467b-d1c9-09dc-f5d3" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4374-3eca-3ef0-107e" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="1e89-5fd2-5ca3-17b6" name="Warlord Traits" hidden="true" collective="false" import="true" targetId="dd08-dc56-c555-7e09" type="selectionEntryGroup">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b7f3-d303-9aec-977d" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
@@ -20074,6 +20592,7 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
                   </costs>
                 </entryLink>
+                <entryLink id="8eea-fe96-ed04-4a39" name="Shrapnel Pistol" hidden="false" collective="false" import="true" targetId="7d72-7f6d-6330-6871" type="selectionEntry"/>
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="525d-defc-1b29-0886" name="May take one of the following weapons:" hidden="false" collective="false" import="true">
@@ -20597,7 +21116,7 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
               </modifiers>
             </entryLink>
             <entryLink id="7e90-2605-6188-eb8f" name="Legiones Consularis (Work in Progress)" hidden="false" collective="false" import="true" targetId="3cbf-9466-2558-2c22" type="selectionEntryGroup"/>
-            <entryLink id="bdf6-df2b-567c-8c08" name="Warlord" hidden="false" collective="false" import="true" targetId="a4e9-50b6-e6d1-575f" type="selectionEntry">
+            <entryLink id="bdf6-df2b-567c-8c08" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
@@ -20608,6 +21127,15 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7e89-5a04-f6ed-d70b" type="max"/>
               </constraints>
+            </entryLink>
+            <entryLink id="5d31-f076-11c4-ea15" name="Warlord Traits" hidden="true" collective="false" import="true" targetId="dd08-dc56-c555-7e09" type="selectionEntryGroup">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b7f3-d303-9aec-977d" type="greaterThan"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
             </entryLink>
           </entryLinks>
           <costs>
@@ -21343,6 +21871,11 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
               </costs>
             </entryLink>
+            <entryLink id="c41d-ca51-50c1-e8c1" name="Shrapnel Weaponry Options" hidden="false" collective="false" import="true" targetId="b26e-c64c-f86f-8351" type="selectionEntryGroup">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="472c-2d0a-5ba5-809d" type="max"/>
+              </constraints>
+            </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="81cc-ac6d-99da-2a39" name="The Legion Assault Sergeant may exchange his Bolt Pistol and Chainsword for:" hidden="false" collective="false" import="true">
@@ -21742,13 +22275,13 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
         <categoryLink id="3a70-5ba0-7914-683a" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="11f2-e3be-0679-ecc7" name=" Despoilers" hidden="false" collective="false" import="true" type="model">
+        <selectionEntry id="11f2-e3be-0679-ecc7" name="Despoiler" hidden="false" collective="false" import="true" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e4f9-8398-70c9-bed1" type="max"/>
             <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="22a6-ea48-f399-aa2d" type="min"/>
           </constraints>
           <profiles>
-            <profile id="4ff5-c704-b85b-b7f7" name=" Despoilers" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
+            <profile id="4ff5-c704-b85b-b7f7" name="Despoiler" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
               <modifiers>
                 <modifier type="set" field="893e-2d76-8f04-44e5" value="8&quot;">
                   <conditions>
@@ -21902,6 +22435,11 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
               </costs>
             </entryLink>
+            <entryLink id="d80e-7874-dee8-554d" name="Shrapnel Weaponry Options" hidden="false" collective="false" import="true" targetId="b26e-c64c-f86f-8351" type="selectionEntryGroup">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a97c-4f42-b185-e8cd" type="max"/>
+              </constraints>
+            </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="ef54-aab4-53ae-d96c" name="Dedicated Transport:" hidden="false" collective="false" import="true">
@@ -22018,6 +22556,13 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
           </selectionEntryGroups>
           <entryLinks>
             <entryLink id="79ff-63b2-44f9-65f4" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="eb09-b1ac-20f5-0013" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="1.0"/>
               </costs>
@@ -22034,9 +22579,21 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
               </costs>
             </entryLink>
+            <entryLink id="dc9f-dcde-09d2-c87c" name="Shrapnel Pistol" hidden="false" collective="false" import="true" targetId="7d72-7f6d-6330-6871" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="eb09-b1ac-20f5-0013" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
+              </costs>
+            </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="689e-acc8-fe5a-2d23" name="The Legion  Despoiler Sergeant must pick two:" hidden="false" collective="false" import="true" defaultSelectionEntryId="c572-bd97-d901-a905">
+        <selectionEntryGroup id="689e-acc8-fe5a-2d23" name="The Legion Despoiler Sergeant must pick two:" hidden="false" collective="false" import="true" defaultSelectionEntryId="c572-bd97-d901-a905">
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="48bd-642c-9820-ed82" type="max"/>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="73b1-c46a-a870-fc0b" type="min"/>
@@ -22096,8 +22653,15 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
               </costs>
             </entryLink>
             <entryLink id="c572-bd97-d901-a905" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="eb09-b1ac-20f5-0013" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e732-fcde-19d9-e62b" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e732-fcde-19d9-e62b" type="max"/>
               </constraints>
             </entryLink>
             <entryLink id="ccaa-7a6e-39ef-ef74" name="Fenrisian Axe" hidden="false" collective="false" import="true" targetId="72ba-d2df-d98b-8b5d" type="selectionEntry">
@@ -22121,6 +22685,13 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
               </costs>
             </entryLink>
             <entryLink id="9c86-9643-673b-eca1" name="Shrapnel Pistol" hidden="false" collective="false" import="true" targetId="7d72-7f6d-6330-6871" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="eb09-b1ac-20f5-0013" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
               </costs>
@@ -22254,6 +22825,53 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
               </constraints>
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="fabb-c981-8a6c-e207" name="Bolt Pistol Options:" hidden="false" collective="false" import="true" defaultSelectionEntryId="86cb-96bb-eee5-e4da">
+          <modifiers>
+            <modifier type="increment" field="bbe7-da43-e36e-bd9d" value="1.0">
+              <repeats>
+                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="11f2-e3be-0679-ecc7" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+            <modifier type="increment" field="e4bd-34a2-5ec2-937b" value="1.0">
+              <repeats>
+                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="11f2-e3be-0679-ecc7" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+            <modifier type="decrement" field="e4bd-34a2-5ec2-937b" value="9.0"/>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bbe7-da43-e36e-bd9d" type="max"/>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e4bd-34a2-5ec2-937b" type="min"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="b7bd-73c6-8225-b316" name="Asphyx Bolt Pistol" hidden="false" collective="false" import="true" targetId="07f7-c486-f597-a1b9" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="1.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="86cb-96bb-eee5-e4da" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="eb09-b1ac-20f5-0013" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </entryLink>
+            <entryLink id="b6cf-0d72-97b1-f934" name="Shrapnel Pistol" hidden="false" collective="false" import="true" targetId="7d72-7f6d-6330-6871" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="eb09-b1ac-20f5-0013" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
               </costs>
             </entryLink>
           </entryLinks>
@@ -22817,14 +23435,9 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
         <selectionEntryGroup id="566e-c048-afb3-7d10" name="Any Breacher may replace their Bolt Pistol with:" hidden="true" collective="false" import="true">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
-              <conditionGroups>
-                <conditionGroup type="or">
-                  <conditions>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
-                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5f54-457a-fbb9-6730" type="equalTo"/>
-                  </conditions>
-                </conditionGroup>
-              </conditionGroups>
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="21c3-2f28-7820-e51a" type="equalTo"/>
+              </conditions>
             </modifier>
             <modifier type="increment" field="2661-0fce-ee4e-1bad" value="1.0">
               <repeats>
@@ -22839,11 +23452,6 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
             <entryLink id="fd93-e844-531e-ce45" name="Asphyx Bolt Pistol" hidden="false" collective="false" import="true" targetId="07f7-c486-f597-a1b9" type="selectionEntry">
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="1.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="92f6-4e80-e368-25c8" name="Shrapnel Pistol" hidden="false" collective="false" import="true" targetId="7d72-7f6d-6330-6871" type="selectionEntry">
-              <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
               </costs>
             </entryLink>
           </entryLinks>
@@ -24065,6 +24673,15 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="18.0"/>
           </costs>
         </selectionEntry>
+        <selectionEntry id="d05f-2585-8e8d-00d9" name="Until this unit is completed, Legion-specific options can go here" hidden="true" collective="false" import="true" type="upgrade">
+          <entryLinks>
+            <entryLink id="af99-bcb9-1fc5-aba4" name="Shrapnel Pistol" hidden="false" collective="false" import="true" targetId="7d72-7f6d-6330-6871" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="7b94-a9db-110b-0208" name="Upgrade Points (Placeholders)" hidden="false" collective="false" import="true" targetId="8b48-2da0-15da-2c1b" type="selectionEntry"/>
@@ -25012,7 +25629,7 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="d88b-0216-2203-0ff7" name="Legiones Unit Upgrades:" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="d88b-0216-2203-0ff7" name="5) Legiones Unit Upgrades:" hidden="false" collective="false" import="true">
           <entryLinks>
             <entryLink id="fbda-03a7-cbb1-3caa" name="Preysight" hidden="false" collective="false" import="true" targetId="b905-4d78-c141-4e63" type="selectionEntry">
               <constraints>
@@ -25032,7 +25649,7 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="d5d2-debd-e503-b250" name="The Legion Tactical Sergeant may take (Wargear):" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="d5d2-debd-e503-b250" name="7) Sergeant may take (Wargear):" hidden="false" collective="false" import="true">
           <selectionEntries>
             <selectionEntry id="b6e1-009e-3aba-4f94" name="Master-craft one weapon" hidden="true" collective="false" import="true" type="upgrade">
               <modifiers>
@@ -25148,7 +25765,7 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="81ef-14f3-d6e5-445c" name="One Legion Destroyer may take:" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="81ef-14f3-d6e5-445c" name="4) One Legion Destroyer may take:" hidden="false" collective="false" import="true">
           <entryLinks>
             <entryLink id="cd22-d221-08d6-d688" name="Nuncio-Vox" hidden="false" collective="false" import="true" targetId="005e-aae6-ddac-bb45" type="selectionEntry">
               <constraints>
@@ -25176,7 +25793,7 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="3c8c-1230-a356-8be7" name="The Entire unit may take:" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="3c8c-1230-a356-8be7" name="8) The Entire unit may take:" hidden="false" collective="false" import="true">
           <entryLinks>
             <entryLink id="fd7f-d067-b6aa-a292" name="Meltabombs" hidden="false" collective="false" import="true" targetId="b9dd-3b21-f3f8-78e3" type="selectionEntry">
               <constraints>
@@ -25188,7 +25805,7 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="24d4-183b-2808-6b72" name="Any model in the unit may replace both of its bolt pistols for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="7614-39e2-310a-7957">
+        <selectionEntryGroup id="24d4-183b-2808-6b72" name="1) Pair of Bolt Pistol Options:" hidden="false" collective="false" import="true" defaultSelectionEntryId="d8e8-617d-7715-c50a">
           <modifiers>
             <modifier type="increment" field="635f-f753-37c6-7b8c" value="1.0">
               <repeats>
@@ -25201,122 +25818,59 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
               </repeats>
             </modifier>
             <modifier type="decrement" field="635f-f753-37c6-7b8c" value="5.0"/>
+            <modifier type="decrement" field="635f-f753-37c6-7b8c" value="1.0">
+              <repeats>
+                <repeat field="selections" scope="dbd4-930e-e003-9449" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6b0d-8620-e47d-82d0" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+            <modifier type="decrement" field="02aa-44b3-570a-c121" value="1.0">
+              <repeats>
+                <repeat field="selections" scope="dbd4-930e-e003-9449" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6b0d-8620-e47d-82d0" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
           </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="02aa-44b3-570a-c121" type="max"/>
             <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="635f-f753-37c6-7b8c" type="min"/>
           </constraints>
-          <selectionEntries>
-            <selectionEntry id="7614-39e2-310a-7957" name="Pair of Bolt pistols" hidden="false" collective="false" import="true" type="upgrade">
-              <profiles>
-                <profile id="7691-ffbd-8a22-fcf2" name="Bolt Pistol" publicationId="a716-c1c4-7b26-8424" page="130" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
-                  <characteristics>
-                    <characteristic name="Range" typeId="95ba-cda7-b831-6066">12&quot;</characteristic>
-                    <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">4</characteristic>
-                    <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">5</characteristic>
-                    <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Pistol 1</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="a03e-a20a-a6e6-571b" name="Pair of Hand Flamers" hidden="false" collective="false" import="true" type="upgrade">
-              <profiles>
-                <profile id="0d95-88a3-8aa4-a573" name="Hand Flamer" publicationId="a716-c1c4-7b26-8424" page="132" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
-                  <characteristics>
-                    <characteristic name="Range" typeId="95ba-cda7-b831-6066">Template</characteristic>
-                    <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">3</characteristic>
-                    <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">-</characteristic>
-                    <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Pistol 1</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <infoLinks>
-                <infoLink id="5559-3351-ee26-c0b7" name="Template Weapons" hidden="false" targetId="5e0e-88e6-db81-5a70" type="rule"/>
-              </infoLinks>
+          <entryLinks>
+            <entryLink id="8948-b7b0-92e6-dfa8" name="Alchem Pistol" hidden="false" collective="false" import="true" targetId="1899-9e9e-76dd-a7ba" type="selectionEntry">
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
               </costs>
-            </selectionEntry>
-            <selectionEntry id="2ad1-f0d3-c860-d931" name="Pair of Vokite Serpenta" hidden="false" collective="false" import="true" type="upgrade">
-              <profiles>
-                <profile id="e78f-ebdd-1fa0-fdd4" name="Volkite Serpenta" publicationId="a716-c1c4-7b26-8424" page="134" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
-                  <characteristics>
-                    <characteristic name="Range" typeId="95ba-cda7-b831-6066">10&quot;</characteristic>
-                    <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">5</characteristic>
-                    <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">5</characteristic>
-                    <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Pistol 2, Deflagrate</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <infoLinks>
-                <infoLink id="59ba-5f23-1f19-eee9" name="Deflagrate" hidden="false" targetId="60bc-f79a-67ae-be4f" type="rule"/>
-              </infoLinks>
+            </entryLink>
+            <entryLink id="d8e8-617d-7715-c50a" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7d72-7f6d-6330-6871" type="atLeast"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </entryLink>
+            <entryLink id="13fe-cb2a-3203-d301" name="Dragon&apos;s Breath Pistol" hidden="false" collective="false" import="true" targetId="c1cb-0fa7-0d39-73ae" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="55da-97af-41cd-edd8" name="Volkite Serpenta" hidden="false" collective="false" import="true" targetId="d535-1da8-290d-69a6" type="selectionEntry">
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
               </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="61c6-19f0-306e-6b10" name="For every five models in the unit, one Legion Destroyer may exchange one of his bolt pistols for one of the following:" hidden="false" collective="false" import="true">
-              <modifiers>
-                <modifier type="increment" field="8b9f-a346-6a8f-4690" value="1.0">
-                  <repeats>
-                    <repeat field="selections" scope="dbd4-930e-e003-9449" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
-                  </repeats>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8b9f-a346-6a8f-4690" type="max"/>
-              </constraints>
-              <entryLinks>
-                <entryLink id="64a0-b74f-ab54-8c19" name="Missile Launcher (With suspensor web and rad missiles only)" hidden="false" collective="false" import="true" targetId="d000-9713-6bc2-e93b" type="selectionEntry">
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
-                  </costs>
-                </entryLink>
-                <entryLink id="3098-ef11-9eaa-b90e" name="Graviton Gun" hidden="false" collective="false" import="true" targetId="5303-5a3e-de51-1707" type="selectionEntry">
-                  <modifiers>
-                    <modifier type="append" field="name" value=" (with suspensor web)"/>
-                  </modifiers>
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
-                  </costs>
-                </entryLink>
-                <entryLink id="faeb-2c3f-6dd3-333d" name="Disintegrator" hidden="false" collective="false" import="true" targetId="a567-9434-36f3-5fd4" type="selectionEntry">
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
-                  </costs>
-                </entryLink>
-                <entryLink id="ba93-c169-1c43-8890" name="Toxiferran Flamer" hidden="false" collective="false" import="true" targetId="732a-29f9-edb7-5bc3" type="selectionEntry">
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
-                  </costs>
-                </entryLink>
-                <entryLink id="6d7b-a0ba-e609-0046" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="717f-cf0a-1593-4bd8" type="selectionEntry">
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
-                  </costs>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <entryLinks>
-            <entryLink id="c33a-9ad9-0733-0a97" name="Alchem Pistol" hidden="false" collective="false" import="true" targetId="1899-9e9e-76dd-a7ba" type="selectionEntry">
-              <modifiers>
-                <modifier type="set" field="name" value="Pair of Alchem pistols"/>
-              </modifiers>
             </entryLink>
-            <entryLink id="c7f0-3f3e-b1c2-f0a7" name="Dragon&apos;s Breath Pistol" hidden="false" collective="false" import="true" targetId="c1cb-0fa7-0d39-73ae" type="selectionEntry">
-              <modifiers>
-                <modifier type="set" field="name" value="Pair of Dragon&apos;s Breathe pistols"/>
-              </modifiers>
+            <entryLink id="570a-6888-9d04-7de2" name="Hand Flamer" hidden="false" collective="false" import="true" targetId="e337-adf4-a11f-0280" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="0e8c-10d4-6348-9a1b" name="Shrapnel Pistol" hidden="false" collective="false" import="true" targetId="7d72-7f6d-6330-6871" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="4.0"/>
+              </costs>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="c335-8e0e-0970-8eac" name="The Legion Destroyer Sergeant may exchange his Chainsword for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="b447-36c7-4465-8dce">
+        <selectionEntryGroup id="c335-8e0e-0970-8eac" name="6) Sergeant may exchange his Chainsword for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="b447-36c7-4465-8dce">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bcac-7164-eefb-ed3d" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1963-d084-ea1a-4ccb" type="max"/>
@@ -25377,7 +25931,7 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
             <entryLink id="8787-8389-2d63-6f6b" name="Chainaxe" hidden="false" collective="false" import="true" targetId="ed76-dace-31e4-b174" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="860c-0f1c-6c28-351a" name="Destroyer Melee Weapons" hidden="false" collective="false" import="true" defaultSelectionEntryId="874a-ba0e-3516-b4a4">
+        <selectionEntryGroup id="860c-0f1c-6c28-351a" name="3) Destroyer Melee Weapons" hidden="false" collective="false" import="true" defaultSelectionEntryId="874a-ba0e-3516-b4a4">
           <modifiers>
             <modifier type="increment" field="5f3f-8423-e3fd-d3e8" value="1.0">
               <repeats>
@@ -25399,6 +25953,98 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
             <entryLink id="3a65-e320-2cca-f042" name="Chainaxe" hidden="false" collective="false" import="true" targetId="ed76-dace-31e4-b174" type="selectionEntry"/>
             <entryLink id="874a-ba0e-3516-b4a4" name="Chainsword" hidden="false" collective="false" import="true" targetId="06e7-a6ae-ed1c-eb03" type="selectionEntry"/>
             <entryLink id="3c02-273c-e864-2e0d" name="Fenrisian Axe" hidden="false" collective="false" import="true" targetId="72ba-d2df-d98b-8b5d" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="6b0d-8620-e47d-82d0" name="2) One in five may instead take a bolt pistol and:" hidden="false" collective="false" import="true">
+          <modifiers>
+            <modifier type="increment" field="5ac0-b2ea-8081-2bff" value="2.0">
+              <repeats>
+                <repeat field="selections" scope="dbd4-930e-e003-9449" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+            <modifier type="increment" field="5ac0-b2ea-8081-2bff" value="1.0">
+              <repeats>
+                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="cdfc-3ebc-a5b1-f69d" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5ac0-b2ea-8081-2bff" type="min"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="06de-740e-4ea8-c1e4" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="cdfc-3ebc-a5b1-f69d" name="Bolt Pistol Options:" hidden="false" collective="false" import="true">
+              <modifiers>
+                <modifier type="increment" field="d77a-df4e-d973-0c7b" value="1.0">
+                  <repeats>
+                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0008-446d-7b5c-8607" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d240-3f84-9dcb-ec51" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8b62-fd1c-79e1-dc6f" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="60a6-bd17-5009-69b5" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f2d7-71fe-7628-726c" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+                <modifier type="increment" field="dbe0-d917-2620-8ad6" value="1.0">
+                  <repeats>
+                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0008-446d-7b5c-8607" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d240-3f84-9dcb-ec51" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8b62-fd1c-79e1-dc6f" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="60a6-bd17-5009-69b5" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f2d7-71fe-7628-726c" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d77a-df4e-d973-0c7b" type="min"/>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dbe0-d917-2620-8ad6" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="0519-a2a4-4173-decf" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditions>
+                        <condition field="selections" scope="dbd4-930e-e003-9449" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7d72-7f6d-6330-6871" type="atLeast"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </entryLink>
+                <entryLink id="7c13-d815-0d83-2f44" name="Shrapnel Pistol" hidden="false" collective="false" import="true" targetId="7d72-7f6d-6330-6871" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="8b62-fd1c-79e1-dc6f" name="Missile Launcher (With suspensor web and rad missiles only)" hidden="false" collective="false" import="true" targetId="d000-9713-6bc2-e93b" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="d240-3f84-9dcb-ec51" name="Graviton Gun" hidden="false" collective="false" import="true" targetId="5303-5a3e-de51-1707" type="selectionEntry">
+              <modifiers>
+                <modifier type="append" field="name" value=" (with suspensor web)"/>
+              </modifiers>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="0008-446d-7b5c-8607" name="Disintegrator" hidden="false" collective="false" import="true" targetId="a567-9434-36f3-5fd4" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="60a6-bd17-5009-69b5" name="Toxiferran Flamer" hidden="false" collective="false" import="true" targetId="732a-29f9-edb7-5bc3" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="f2d7-71fe-7628-726c" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="717f-cf0a-1593-4bd8" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+              </costs>
+            </entryLink>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
@@ -25605,16 +26251,6 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
             <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a8e6-e333-92f6-0dd5" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="c6b0-744d-2bd3-b006" name="Shrapnel Bolter" hidden="false" collective="false" import="true" targetId="1941-21b5-932c-74d6" type="selectionEntry">
-              <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="f150-d922-0c1e-9f03" name="Asphyx Bolter" hidden="false" collective="false" import="true" targetId="88c0-4623-9da3-f2b5" type="selectionEntry">
-              <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="1.0"/>
-              </costs>
-            </entryLink>
             <entryLink id="3996-48e1-6ef9-8b88" name="Nemesis Bolter" hidden="false" collective="false" import="true" targetId="c10a-61f8-9c33-fe8a" type="selectionEntry">
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
@@ -25828,7 +26464,15 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
               </costs>
             </entryLink>
-            <entryLink id="6186-d863-1434-a056" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry"/>
+            <entryLink id="6186-d863-1434-a056" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="58e6-f9cc-4c46-e258" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7d72-7f6d-6330-6871" type="atLeast"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="b068-0079-7bb4-5674" name="The Legion Seeker Sergeant may exchange his Kraken Bolter for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="6dae-f265-feeb-a334">
@@ -25870,11 +26514,6 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
             <entryLink id="1fec-ba7d-53d2-9c15" name="Asphyx Bolter" hidden="false" collective="false" import="true" targetId="88c0-4623-9da3-f2b5" type="selectionEntry">
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="1.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="69bd-bc4e-1172-e5a1" name="Shrapnel Bolter" hidden="false" collective="false" import="true" targetId="1941-21b5-932c-74d6" type="selectionEntry">
-              <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
               </costs>
             </entryLink>
             <entryLink id="940a-cffe-cb60-ea10" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry">
@@ -26032,6 +26671,45 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="220.0"/>
               </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="58c9-517b-c9e7-e0b8" name="Seeker Bolt Pistol Options:" hidden="false" collective="false" import="true" defaultSelectionEntryId="cd1e-48cb-e6ad-f879">
+          <modifiers>
+            <modifier type="increment" field="2fc1-4384-d538-4af9" value="1.0">
+              <repeats>
+                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="53c3-7eec-4676-996e" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+            <modifier type="increment" field="46d0-539d-94f1-dee8" value="1.0">
+              <repeats>
+                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="53c3-7eec-4676-996e" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+            <modifier type="decrement" field="2fc1-4384-d538-4af9" value="4.0"/>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2fc1-4384-d538-4af9" type="min"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="46d0-539d-94f1-dee8" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="cd1e-48cb-e6ad-f879" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="58e6-f9cc-4c46-e258" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7d72-7f6d-6330-6871" type="atLeast"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </entryLink>
+            <entryLink id="d582-f555-de5b-baee" name="Shrapnel Pistol" hidden="false" collective="false" import="true" targetId="7d72-7f6d-6330-6871" type="selectionEntry">
+              <modifiers>
+                <modifier type="increment" field="d2ee-04cb-5f8a-2642" value="2.0">
+                  <repeats>
+                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
@@ -27059,6 +27737,9 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
               </constraints>
             </entryLink>
           </entryLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -27202,6 +27883,9 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
                   </costs>
                 </entryLink>
               </entryLinks>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
             </selectionEntry>
           </selectionEntries>
           <entryLinks>
@@ -29045,87 +29729,11 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="3ef1-3886-773d-1742" name="Squad Weaponry:" hidden="false" collective="false" import="true" defaultSelectionEntryId="0606-f4f2-7a7b-c7e4">
+        <selectionEntryGroup id="3ef1-3886-773d-1742" name="Squad Weaponry:" hidden="false" collective="false" import="true" defaultSelectionEntryId="8d8d-dece-1b84-3813">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8ea8-23b8-0667-7a4b" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b3da-e6f4-9fc5-24c0" type="min"/>
           </constraints>
-          <selectionEntries>
-            <selectionEntry id="0606-f4f2-7a7b-c7e4" name="Heavy Bolter" hidden="false" collective="false" import="true" type="upgrade">
-              <selectionEntryGroups>
-                <selectionEntryGroup id="bfb9-35e7-f43a-a05d" name="Heavy Bolter" hidden="false" collective="false" import="true" defaultSelectionEntryId="f094-bbe0-550a-018d">
-                  <modifiers>
-                    <modifier type="set" field="name" value="0.0"/>
-                  </modifiers>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed4d-c5cb-c9be-ad70" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="222e-b138-6f5a-3121" type="min"/>
-                  </constraints>
-                  <entryLinks>
-                    <entryLink id="81bc-89f6-253c-431b" name="Shrapnel Cannon" hidden="false" collective="false" import="true" targetId="975e-14eb-caed-4b5b" type="selectionEntry">
-                      <modifiers>
-                        <modifier type="increment" field="d2ee-04cb-5f8a-2642" value="2.0">
-                          <repeats>
-                            <repeat field="selections" scope="bac9-5389-e2e7-0b1f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
-                          </repeats>
-                        </modifier>
-                      </modifiers>
-                      <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="7aaa-d18c-0207-3480" name="Asphyx Bolt Cannon" hidden="false" collective="false" import="true" targetId="ebce-ebc9-8ff7-d42d" type="selectionEntry">
-                      <modifiers>
-                        <modifier type="increment" field="d2ee-04cb-5f8a-2642" value="1.0">
-                          <repeats>
-                            <repeat field="selections" scope="bac9-5389-e2e7-0b1f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
-                          </repeats>
-                        </modifier>
-                      </modifiers>
-                      <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="1.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="59c9-cfac-b4de-9091" name="Dragon&apos;s Breath Heavy Flamer" hidden="false" collective="false" import="true" targetId="1a5c-0c5f-d798-a067" type="selectionEntry"/>
-                    <entryLink id="f094-bbe0-550a-018d" name="Heavy Bolter" hidden="false" collective="false" import="true" targetId="07fd-c24a-9235-4206" type="selectionEntry"/>
-                  </entryLinks>
-                </selectionEntryGroup>
-              </selectionEntryGroups>
-              <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="fda0-14c0-d10c-73d5" name="Heavy Flamer" hidden="false" collective="false" import="true" type="upgrade">
-              <selectionEntryGroups>
-                <selectionEntryGroup id="bc4f-5e10-d72d-f732" name="Heavy Flamer" hidden="false" collective="false" import="true" defaultSelectionEntryId="b47f-03bf-61a2-7651">
-                  <modifiers>
-                    <modifier type="set" field="name" value="0.0"/>
-                  </modifiers>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7f4d-086b-194a-f256" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d468-9b7c-67e8-4a7e" type="min"/>
-                  </constraints>
-                  <entryLinks>
-                    <entryLink id="b645-52f2-f320-687b" name="Heavy Alchem Flamer" hidden="false" collective="false" import="true" targetId="2a3d-a4bb-5326-a16a" type="selectionEntry"/>
-                    <entryLink id="5e17-5b2b-610c-7b18" name="Dragon&apos;s Breath Heavy Flamer" hidden="false" collective="false" import="true" targetId="1a5c-0c5f-d798-a067" type="selectionEntry"/>
-                    <entryLink id="f0d9-9d13-b7a6-e9f9" name="Iliastus Asssult Cannon" hidden="false" collective="false" import="true" targetId="10aa-3c70-2bbe-9509" type="selectionEntry">
-                      <modifiers>
-                        <modifier type="increment" field="d2ee-04cb-5f8a-2642" value="10.0">
-                          <repeats>
-                            <repeat field="selections" scope="bac9-5389-e2e7-0b1f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
-                          </repeats>
-                        </modifier>
-                      </modifiers>
-                    </entryLink>
-                    <entryLink id="b47f-03bf-61a2-7651" name="Heavy Flamer" hidden="false" collective="false" import="true" targetId="5507-b432-3b4c-df12" type="selectionEntry"/>
-                  </entryLinks>
-                </selectionEntryGroup>
-              </selectionEntryGroups>
-              <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
           <entryLinks>
             <entryLink id="b22f-1595-8eca-32c1" name="Autocannon" hidden="false" collective="false" import="true" targetId="56b3-de09-9fea-deb6" type="selectionEntry">
               <modifiers>
@@ -29191,6 +29799,39 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
               </entryLinks>
             </entryLink>
             <entryLink id="e604-a35e-2799-f0a9" name="Lascannon" hidden="false" collective="false" import="true" targetId="b252-5a86-6e0f-218b" type="selectionEntry">
+              <modifiers>
+                <modifier type="increment" field="d2ee-04cb-5f8a-2642" value="10.0">
+                  <repeats>
+                    <repeat field="selections" scope="bac9-5389-e2e7-0b1f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+            </entryLink>
+            <entryLink id="489b-38b0-8283-adc7" name="Shrapnel Cannon" hidden="false" collective="false" import="true" targetId="975e-14eb-caed-4b5b" type="selectionEntry">
+              <modifiers>
+                <modifier type="increment" field="d2ee-04cb-5f8a-2642" value="2.0">
+                  <repeats>
+                    <repeat field="selections" scope="bac9-5389-e2e7-0b1f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+            </entryLink>
+            <entryLink id="6bb6-85bf-1daa-fb37" name="Asphyx Bolt Cannon" hidden="false" collective="false" import="true" targetId="ebce-ebc9-8ff7-d42d" type="selectionEntry">
+              <modifiers>
+                <modifier type="increment" field="d2ee-04cb-5f8a-2642" value="1.0">
+                  <repeats>
+                    <repeat field="selections" scope="bac9-5389-e2e7-0b1f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="1.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="8d8d-dece-1b84-3813" name="Heavy Bolter" hidden="false" collective="false" import="true" targetId="07fd-c24a-9235-4206" type="selectionEntry"/>
+            <entryLink id="4986-232e-7ac5-32f9" name="Dragon&apos;s Breath Heavy Flamer" hidden="false" collective="false" import="true" targetId="1a5c-0c5f-d798-a067" type="selectionEntry"/>
+            <entryLink id="7292-41b9-8ebc-4d60" name="Heavy Alchem Flamer" hidden="false" collective="false" import="true" targetId="2a3d-a4bb-5326-a16a" type="selectionEntry"/>
+            <entryLink id="0836-25ca-9b0c-aa70" name="Iliastus Asssult Cannon" hidden="false" collective="false" import="true" targetId="10aa-3c70-2bbe-9509" type="selectionEntry">
               <modifiers>
                 <modifier type="increment" field="d2ee-04cb-5f8a-2642" value="10.0">
                   <repeats>
@@ -29346,14 +29987,33 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
+        <selectionEntryGroup id="f2a2-40d1-2d0c-967e" name="Bolt Pistol Options:" hidden="false" collective="false" import="true" defaultSelectionEntryId="8060-8cac-aca0-b558">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d9d-6ee4-a170-29b3" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="71b4-f004-8acf-b0c4" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="8060-8cac-aca0-b558" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7f37-67cd-1344-e3d2" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="71ce-25c5-b3f7-65ad" name="Shrapnel Pistol" hidden="false" collective="false" import="true" targetId="7d72-7f6d-6330-6871" type="selectionEntry">
+              <modifiers>
+                <modifier type="increment" field="d2ee-04cb-5f8a-2642" value="2.0">
+                  <repeats>
+                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4670-d74f-fbd0-8e46" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="7a49-c4ee-aa05-b779" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d94b-8870-b288-ea5f" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b222-9221-4c89-4638" type="min"/>
-          </constraints>
-        </entryLink>
         <entryLink id="0717-427a-3e3c-c2cc" name="Power Armour" hidden="false" collective="false" import="true" targetId="2d9d-480e-7c14-1a6f" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b478-0946-5e51-fcab" type="max"/>
@@ -29981,7 +30641,15 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e422-4687-47cd-0faa" type="min"/>
           </constraints>
           <entryLinks>
-            <entryLink id="b3a8-b252-98fd-b8a0" name="Heavy Bolter" hidden="false" collective="false" import="true" targetId="07fd-c24a-9235-4206" type="selectionEntry"/>
+            <entryLink id="b3a8-b252-98fd-b8a0" name="Heavy Bolter" hidden="false" collective="false" import="true" targetId="07fd-c24a-9235-4206" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="6263-c696-2f2e-c105" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="975e-14eb-caed-4b5b" type="atLeast"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </entryLink>
             <entryLink id="eff6-6cea-f753-fc4c" name="Volkite Culverin" hidden="false" collective="false" import="true" targetId="170d-44e0-455c-8207" type="selectionEntry">
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
@@ -29995,6 +30663,11 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
             <entryLink id="ec00-19f0-db4f-b97d" name="Multi-Melta" hidden="false" collective="false" import="true" targetId="9332-3834-cf3a-56b4" type="selectionEntry">
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="e4d3-1aaf-3584-f71e" name="Shrapnel Cannon" hidden="false" collective="false" import="true" targetId="975e-14eb-caed-4b5b" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
               </costs>
             </entryLink>
           </entryLinks>
@@ -30018,7 +30691,15 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="cb25-8dd9-f378-2958" type="min"/>
           </constraints>
           <entryLinks>
-            <entryLink id="a506-b9a6-cee5-337b" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry"/>
+            <entryLink id="a506-b9a6-cee5-337b" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="6263-c696-2f2e-c105" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7d72-7f6d-6330-6871" type="atLeast"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </entryLink>
             <entryLink id="fe88-b5cf-9950-94cf" name="Hand Flamer" hidden="false" collective="false" import="true" targetId="e337-adf4-a11f-0280" type="selectionEntry">
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
@@ -30027,6 +30708,11 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
             <entryLink id="5959-6d03-2e4c-ae23" name="Volkite Serpenta" hidden="false" collective="false" import="true" targetId="d535-1da8-290d-69a6" type="selectionEntry">
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="97d4-b6eb-8410-952c" name="Shrapnel Pistol" hidden="false" collective="false" import="true" targetId="7d72-7f6d-6330-6871" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
               </costs>
             </entryLink>
           </entryLinks>
@@ -30292,7 +30978,15 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
                   </costs>
                 </entryLink>
-                <entryLink id="e8ee-9957-bb72-3155" name="Heavy Bolter" hidden="false" collective="false" import="true" targetId="07fd-c24a-9235-4206" type="selectionEntry"/>
+                <entryLink id="e8ee-9957-bb72-3155" name="Heavy Bolter" hidden="false" collective="false" import="true" targetId="07fd-c24a-9235-4206" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditions>
+                        <condition field="selections" scope="a736-43ca-ed95-a08f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="975e-14eb-caed-4b5b" type="atLeast"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </entryLink>
                 <entryLink id="2f9c-cf41-5fd3-98b5" name="Volkite Culverin" hidden="false" collective="false" import="true" targetId="170d-44e0-455c-8207" type="selectionEntry">
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
@@ -30306,6 +31000,11 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
                 <entryLink id="bbc7-6aa1-0b17-32fb" name="Graviton Gun" hidden="false" collective="false" import="true" targetId="5303-5a3e-de51-1707" type="selectionEntry">
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="3bbe-ac9e-098d-aa8f" name="Shrapnel Cannon" hidden="false" collective="false" import="true" targetId="975e-14eb-caed-4b5b" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
                   </costs>
                 </entryLink>
               </entryLinks>
@@ -30342,6 +31041,13 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
                   </costs>
                 </entryLink>
                 <entryLink id="f0e4-22c6-a6a3-d5a8" name="Heavy Bolter" hidden="false" collective="false" import="true" targetId="07fd-c24a-9235-4206" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditions>
+                        <condition field="selections" scope="a736-43ca-ed95-a08f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="975e-14eb-caed-4b5b" type="atLeast"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
                   </costs>
@@ -30361,6 +31067,11 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
                   </costs>
                 </entryLink>
+                <entryLink id="f6d3-4990-f1fb-611c" name="Shrapnel Cannon" hidden="false" collective="false" import="true" targetId="975e-14eb-caed-4b5b" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="12.0"/>
+                  </costs>
+                </entryLink>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
@@ -30369,13 +31080,34 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
           </costs>
         </selectionEntry>
       </selectionEntries>
-      <entryLinks>
-        <entryLink id="bb56-45d8-22b6-eb81" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="6237-d3ea-960e-bd13" name="Bolt Pistol Options:" hidden="false" collective="false" import="true" defaultSelectionEntryId="8c4a-1ae1-08ca-7da6">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8478-a2f6-9190-08d8" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ea46-5be5-c5e6-e409" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ce3a-b4d9-4a75-63ae" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fe0e-be04-cf2b-776e" type="max"/>
           </constraints>
-        </entryLink>
+          <entryLinks>
+            <entryLink id="8c4a-1ae1-08ca-7da6" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cae3-af5d-0857-bc75" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="1c1f-c266-4cc0-6486" name="Shrapnel Pistol" hidden="false" collective="false" import="true" targetId="7d72-7f6d-6330-6871" type="selectionEntry">
+              <modifiers>
+                <modifier type="increment" field="d2ee-04cb-5f8a-2642" value="2.0">
+                  <repeats>
+                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a3ec-d5e4-5d8b-e8aa" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
         <entryLink id="ab17-b8dc-7301-a5ee" name="Chainsword" hidden="false" collective="false" import="true" targetId="06e7-a6ae-ed1c-eb03" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="84e0-19fe-3d7f-e8d7" type="min"/>
@@ -30472,6 +31204,11 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
                   </costs>
                 </entryLink>
+                <entryLink id="1dce-e017-c60f-0383" name="Shrapnel Cannon" hidden="false" collective="false" import="true" targetId="975e-14eb-caed-4b5b" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
+                  </costs>
+                </entryLink>
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="37b0-947a-1514-c1fb" name="3) Hunter-Killer Missiles" hidden="false" collective="false" import="true">
@@ -30490,17 +31227,38 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
           </costs>
         </selectionEntry>
       </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="60ee-a521-661d-0f74" name="Bolt Pistol Options:" hidden="false" collective="false" import="true" defaultSelectionEntryId="93fe-4640-1616-675c">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5fc7-c26f-73d5-4fd8" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ad00-1853-d334-055d" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="93fe-4640-1616-675c" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c26c-cdbb-9a32-9db6" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="36ef-4f60-f255-abfb" name="Shrapnel Pistol" hidden="false" collective="false" import="true" targetId="7d72-7f6d-6330-6871" type="selectionEntry">
+              <modifiers>
+                <modifier type="increment" field="d2ee-04cb-5f8a-2642" value="2.0">
+                  <repeats>
+                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="27d5-760f-368f-7b3c" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
       <entryLinks>
         <entryLink id="17ba-4233-f065-6a21" name="Power Armour" hidden="false" collective="false" import="true" targetId="2d9d-480e-7c14-1a6f" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0828-326e-e4fc-8d71" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bfa3-a9b4-df14-9f91" type="max"/>
-          </constraints>
-        </entryLink>
-        <entryLink id="0b37-1cf1-30ba-475d" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="27e0-b57d-9662-f39e" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1bec-254f-979c-6915" type="max"/>
           </constraints>
         </entryLink>
         <entryLink id="250b-1dfa-21bf-223d" name="Chainsword" hidden="false" collective="false" import="true" targetId="06e7-a6ae-ed1c-eb03" type="selectionEntry">
@@ -30808,6 +31566,22 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
           </costs>
         </selectionEntry>
       </selectionEntries>
+      <entryLinks>
+        <entryLink id="b3b7-317a-35e6-3d70" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3d5d-48a5-7be2-cc05" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="088f-0d71-c68e-14c4" name="Warlord: PLACEHOLDER" hidden="false"/>
+          </rules>
+        </entryLink>
+        <entryLink id="45fb-19c6-d7a8-46d9" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b5fb-057f-613f-b87f" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="16cd-8c1f-4af9-afe4" type="min"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="220.0"/>
       </costs>
@@ -30949,6 +31723,14 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0210-202b-6c4c-e530" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cc4c-7438-9a2e-9dd9" type="max"/>
           </constraints>
+          <entryLinks>
+            <entryLink id="e6f4-3555-8067-7045" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c4e7-f4b3-55d3-e21b" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d98b-b93e-b93e-3e49" type="min"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
           </costs>
@@ -30962,6 +31744,16 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
           </costs>
         </selectionEntry>
       </selectionEntries>
+      <entryLinks>
+        <entryLink id="4d38-101a-25e6-d452" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5522-32b1-cf31-abc0" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="e793-eddb-da43-5c7f" name="Warlord: PLACEHOLDER" hidden="false"/>
+          </rules>
+        </entryLink>
+      </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="440.0"/>
       </costs>
@@ -31018,6 +31810,14 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ce9a-37ab-99f8-c430" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e041-614e-d648-40bb" type="max"/>
           </constraints>
+          <entryLinks>
+            <entryLink id="6701-741f-57c6-25c0" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="89c4-aae9-a054-7883" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b1a3-dcd5-fc77-b45d" type="min"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
           </costs>
@@ -31031,6 +31831,14 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
           </costs>
+        </entryLink>
+        <entryLink id="a58a-ca94-ffc2-da16" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d06a-a893-e7dc-5296" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="454f-b7df-e693-e098" name="Warlord: PLACEHOLDER" hidden="false"/>
+          </rules>
         </entryLink>
       </entryLinks>
       <costs>
@@ -32868,14 +33676,8 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
 - The Preferred Enemy (Everything) special rule
 - The Sudden Strike (1) special rule</description>
             </rule>
-            <rule id="38ff-4959-187e-89a4" name="Warlord: Sire of the Alpha Legion" publicationId="09c5-eeae-f398-b653" page="336" hidden="false">
-              <description>If chosen as the army&apos;s Warlord, Alpharius automatically has the Sire of the Alpha Legion Warlord Trait and may not select any other Warlord Trait.
-
-Sire of the Alpha Legion - At the start of the battle, after all models from all armies have been deployed, including units deployed using the Infiltrator special rule and after any Scout moves have been made, Alpharius&apos; controlling player may select up to three friendly units composed entirely of models with the Legiones Astartes (Alpha Legion) special rule. The selected units may be redeployed to any position in the controlling player&apos;s Deploymen Zone or placed into Reserves. In addition, an army with Alpharius as its Warlord may declare a single Phase at the start of any turn in which Alpharius&apos; controlling player is the Reactive player, gaining an additional Reaction in the chosen Phase as long as Alpharius has not been removed as casualty.</description>
-            </rule>
           </rules>
           <infoLinks>
-            <infoLink id="a6d2-170c-a86c-3ee0" name="Master of the Legion" hidden="false" targetId="c772-87ea-d49c-c7ba" type="rule"/>
             <infoLink id="7eb4-649e-8966-f9bc" name="Adamantium Will (X+)" hidden="false" targetId="4380-44a5-f01a-d964" type="rule">
               <modifiers>
                 <modifier type="set" field="name" value="Adamantium Will (3+)"/>
@@ -32884,6 +33686,14 @@ Sire of the Alpha Legion - At the start of the battle, after all models from all
             <infoLink id="7d5b-270e-8abb-37ae" name="Crusader" hidden="false" targetId="c705-0829-75f6-a785" type="rule"/>
             <infoLink id="ba4d-2fb9-1096-e610" name="Legiones Astartes (Alpha Legion) " hidden="false" targetId="2a9e-be1f-d6c1-0ec4" type="rule"/>
           </infoLinks>
+          <entryLinks>
+            <entryLink id="5e31-a284-b02a-ba03" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1a7e-9d78-51f4-cc8f" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8051-0dbf-db58-0521" type="min"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
           </costs>
@@ -32968,6 +33778,16 @@ Sire of the Alpha Legion - At the start of the battle, after all models from all
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="20d0-a5e2-dc12-eb9d" type="min"/>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="44e6-8e36-27f4-8268" type="max"/>
           </constraints>
+        </entryLink>
+        <entryLink id="2f12-08c0-3463-7b8e" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7b8a-2f78-d580-b2e7" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="67ca-87e2-b3f9-557f" name="Warlord: Sire of the Alpha Legion" publicationId="09c5-eeae-f398-b653" page="336" hidden="false">
+              <description>At the start of the battle, after all models from all armies have been deployed, including units deployed using the Infiltrator special rule and after any Scout moves have been made, Alpharius&apos; controlling player may select up to three friendly units composed entirely of models with the Legiones Astartes (Alpha Legion) special rule. The selected units may be redeployed to any position in the controlling player&apos;s Deploymen Zone or placed into Reserves. In addition, an army with Alpharius as its Warlord may declare a single Phase at the start of any turn in which Alpharius&apos; controlling player is the Reactive player, gaining an additional Reaction in the chosen Phase as long as Alpharius has not been removed as casualty.</description>
+            </rule>
+          </rules>
         </entryLink>
       </entryLinks>
       <costs>
@@ -33661,17 +34481,18 @@ Sire of the Alpha Legion - At the start of the battle, after all models from all
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="567b-ee15-336f-5244" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="72da-8aa9-4068-3233" name="Warlord" hidden="false" collective="false" import="true" targetId="a4e9-50b6-e6d1-575f" type="selectionEntry">
+        <entryLink id="72da-8aa9-4068-3233" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9cf8-4dfa-4ad2-9a8e" type="max"/>
           </constraints>
-          <profiles>
-            <profile id="4346-e2cc-b67a-d55c" name="Warlord: Stoic Defender" hidden="false" typeId="7dee-5dcd-b6c5-0dd6" typeName="Warlord Trait">
-              <characteristics>
-                <characteristic name="Text" typeId="d76d-c91f-12f1-ce9a">PLACEHOLDER</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
+          <entryLinks>
+            <entryLink id="5852-c3df-bef4-f80b" name="Stoic Defender" hidden="false" collective="false" import="true" targetId="dcbb-3e5a-e54e-239c" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0820-d3b6-4e20-ce73" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="304e-f990-3927-6fcd" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
         </entryLink>
       </entryLinks>
       <costs>
@@ -33713,7 +34534,6 @@ Sire of the Alpha Legion - At the start of the battle, after all models from all
       </profiles>
       <infoLinks>
         <infoLink id="0583-841f-699f-02b7" name="Legiones Astartes (Iron Warriors) " hidden="false" targetId="c77b-f3fc-5dc8-1330" type="rule"/>
-        <infoLink id="e2fe-0963-a190-4dd8" name="Master of the Legion" hidden="false" targetId="c772-87ea-d49c-c7ba" type="rule"/>
         <infoLink id="528e-0c6c-f2fd-b622" name="Loyalist" hidden="false" targetId="d1de-a45d-2b9b-c878" type="rule"/>
         <infoLink id="da81-3030-1948-0f1a" name="Battle-Hardened (X)" hidden="false" targetId="5c3b-ed0b-4ad0-d547" type="rule">
           <modifiers>
@@ -33763,14 +34583,14 @@ Sire of the Alpha Legion - At the start of the battle, after all models from all
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink id="b7f3-d303-9aec-977d" name="Warlord" hidden="false" collective="false" import="true" targetId="a4e9-50b6-e6d1-575f" type="selectionEntry">
+        <entryLink id="b7f3-d303-9aec-977d" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9223-e429-151a-79f0" type="max"/>
           </constraints>
           <profiles>
-            <profile id="40f1-a5a9-0954-26cb" name="Warlord: Battle Logistician" hidden="false" typeId="7dee-5dcd-b6c5-0dd6" typeName="Warlord Trait">
+            <profile id="5ede-f15e-51d3-4db7" name="Battle Logistician" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
               <characteristics>
-                <characteristic name="Text" typeId="d76d-c91f-12f1-ce9a">PLACEHOLDER</characteristic>
+                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">When this Warlord Trait is selected, before deployment and before any models are placed on the board, the Controlling player may select a single unit of any type that begins the game deployed on the table. Whilst all models that are part of the selected unit are within the Controlling player’s deployment zone, this unit gains the Relentless special rule. In addition, an army whose Warlord has this Trait may make an additional Reaction during the opposing player’s Movement phase as long as the Warlord has not been removed as a casualty.</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -33824,6 +34644,12 @@ Sire of the Alpha Legion - At the start of the battle, after all models from all
           </constraints>
         </entryLink>
         <entryLink id="141d-fe78-39fe-59ac" name="Retinue" hidden="false" collective="false" import="true" targetId="2dd0-7045-8ae5-f394" type="selectionEntryGroup"/>
+        <entryLink id="668c-4c36-fef1-bca0" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="48b1-5c6a-9d07-701f" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="294c-9e91-6d5a-ccb6" type="min"/>
+          </constraints>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="195.0"/>
@@ -33858,7 +34684,6 @@ Sire of the Alpha Legion - At the start of the battle, after all models from all
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink id="fe1e-6211-8073-5c7c" name="Master of the Legion" hidden="false" targetId="c772-87ea-d49c-c7ba" type="rule"/>
         <infoLink id="fba8-e58f-a90f-2d9e" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
         <infoLink id="e68a-f39a-6db3-c7ba" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
         <infoLink id="df03-75a0-377e-98e2" name="Bulky (X)" hidden="false" targetId="676c-7b75-4b6f-9405" type="rule">
@@ -33928,19 +34753,26 @@ Sire of the Alpha Legion - At the start of the battle, after all models from all
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4fe5-03c0-3875-c711" type="min"/>
           </constraints>
         </entryLink>
-        <entryLink id="2ceb-4bde-18c5-ca59" name="Warlord" hidden="false" collective="false" import="true" targetId="a4e9-50b6-e6d1-575f" type="selectionEntry">
+        <entryLink id="2ceb-4bde-18c5-ca59" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cd11-c958-b9ca-6eed" type="max"/>
           </constraints>
-          <profiles>
-            <profile id="1ff4-7322-44ec-f511" name="Warlord: Bloody-handed" hidden="false" typeId="7dee-5dcd-b6c5-0dd6" typeName="Warlord Trait">
-              <characteristics>
-                <characteristic name="Text" typeId="d76d-c91f-12f1-ce9a">PLACEHOLDER</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
+          <entryLinks>
+            <entryLink id="b570-d888-eeb4-095a" name="Bloody-handed" hidden="false" collective="false" import="true" targetId="2b87-826d-22a1-682c" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0402-83c4-43b5-3725" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0cb8-b23c-11c2-da9a" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
         </entryLink>
         <entryLink id="fc1a-6954-e72a-6c4f" name="Retinue" hidden="false" collective="false" import="true" targetId="2dd0-7045-8ae5-f394" type="selectionEntryGroup"/>
+        <entryLink id="5895-0808-3195-fa0e" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8a49-ccc1-d252-0d42" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c875-283b-240b-fc5e" type="min"/>
+          </constraints>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="175.0"/>
@@ -34374,7 +35206,6 @@ Sire of the Alpha Legion - At the start of the battle, after all models from all
             <modifier type="set" field="name" value="Battlesmith (2+)"/>
           </modifiers>
         </infoLink>
-        <infoLink id="e76a-7056-aa9c-7688" name="Master of the Legion" hidden="false" targetId="c772-87ea-d49c-c7ba" type="rule"/>
         <infoLink id="28df-c4ee-e33d-c557" name="Firing Protocols (X)" hidden="false" targetId="32a3-f599-5c92-2945" type="rule">
           <modifiers>
             <modifier type="set" field="name" value="Firing Protocols (2)"/>
@@ -34418,6 +35249,9 @@ Sire of the Alpha Legion - At the start of the battle, after all models from all
             </infoLink>
             <infoLink id="4a1d-ed3f-7697-d804" name="Pinning" hidden="false" targetId="1c96-205c-59a0-3cf2" type="rule"/>
           </infoLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="7427-8249-6629-48a3" name="Forgebreaker Desecrated" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
@@ -34453,14 +35287,14 @@ Sire of the Alpha Legion - At the start of the battle, after all models from all
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink id="fcf1-1385-246d-9e9b" name="Warlord" hidden="false" collective="false" import="true" targetId="a4e9-50b6-e6d1-575f" type="selectionEntry">
+        <entryLink id="fcf1-1385-246d-9e9b" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7f06-5bf3-a13c-cc68" type="max"/>
           </constraints>
           <profiles>
-            <profile id="4156-b666-d6f2-0c2b" name="Warlord: Sire of the Iron Warriors" hidden="false" typeId="7dee-5dcd-b6c5-0dd6" typeName="Warlord Trait">
+            <profile id="4156-b666-d6f2-0c2b" name="Warlord: Sire of the Iron Warriors" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
               <characteristics>
-                <characteristic name="Text" typeId="d76d-c91f-12f1-ce9a">All models with the Legiones Astartes (Iron Warriors) special rule and the Infantry Unit Type in the same army as Perturabo roll an additional dice when making Morale checks or Pinning tests cause by Shooting Attacks and discard the dice with the highest result before determining the result of the Check. In addition, an army with Perturabo as its Warlord gains an additional Reaction during the Shooting phase only as long as Perturabo has not been removed as a casualty.</characteristic>
+                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">All models with the Legiones Astartes (Iron Warriors) special rule and the Infantry Unit Type in the same army as Perturabo roll an additional dice when making Morale checks or Pinning tests cause by Shooting Attacks and discard the dice with the highest result before determining the result of the Check. In addition, an army with Perturabo as its Warlord gains an additional Reaction during the Shooting phase only as long as Perturabo has not been removed as a casualty.</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -34478,6 +35312,12 @@ Sire of the Alpha Legion - At the start of the battle, after all models from all
           </constraints>
         </entryLink>
         <entryLink id="c9ee-e32c-6945-fd05" name="Retinue" hidden="false" collective="false" import="true" targetId="2dd0-7045-8ae5-f394" type="selectionEntryGroup"/>
+        <entryLink id="216a-beed-4d89-7b71" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a44d-4bc7-953e-ac16" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6a25-7a76-76b3-92ce" type="min"/>
+          </constraints>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="425.0"/>
@@ -34575,6 +35415,9 @@ Sire of the Alpha Legion - At the start of the battle, after all models from all
               </constraints>
             </entryLink>
           </entryLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="5b08-e977-66a1-4275" name="Tyrant" hidden="false" collective="false" import="true" type="model">
           <constraints>
@@ -34710,6 +35553,9 @@ Sire of the Alpha Legion - At the start of the battle, after all models from all
               </constraints>
             </entryLink>
           </entryLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -34866,6 +35712,24 @@ Sire of the Alpha Legion - At the start of the battle, after all models from all
           </constraints>
         </entryLink>
       </entryLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0068-6b0a-0086-3d6b" name="Master of the Legion" hidden="false" collective="false" import="true" type="upgrade">
+      <modifiers>
+        <modifier type="increment" field="1882-f7ef-7aa3-5304" value="1.0">
+          <repeats>
+            <repeat field="d2ee-04cb-5f8a-2642" scope="force" value="1000.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="any" repeats="1" roundUp="false"/>
+          </repeats>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1882-f7ef-7aa3-5304" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="cf3d-6c58-b832-9d35" name="Master of the Legion" hidden="false" targetId="c772-87ea-d49c-c7ba" type="rule"/>
+      </infoLinks>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
@@ -36223,6 +37087,53 @@ Special rules A Legion Warmonger Consul gains the Tip of the Spear special rule.
           </modifiers>
         </entryLink>
       </entryLinks>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="b26e-c64c-f86f-8351" name="Shrapnel Weaponry Options" hidden="true" collective="false" import="true">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5f54-457a-fbb9-6730" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <selectionEntries>
+        <selectionEntry id="7493-c54a-d99e-ba0b" name="Shrapnel Bolters" hidden="false" collective="false" import="true" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4280-4963-02b5-e31d" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="23eb-0b9e-0857-e965" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e2b6-b770-784c-9e95" type="instanceOf"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="408c-855b-0218-cad4" type="max"/>
+          </constraints>
+        </selectionEntry>
+        <selectionEntry id="eb09-b1ac-20f5-0013" name="Shrapnel Pistols" hidden="false" collective="false" import="true" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4280-4963-02b5-e31d" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="23eb-0b9e-0857-e965" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e2b6-b770-784c-9e95" type="instanceOf"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ecf0-48fb-6484-d063" type="max"/>
+          </constraints>
+        </selectionEntry>
+      </selectionEntries>
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <sharedRules>


### PR DESCRIPTION
**[Added]**
- Generic WLTs
- Legion-specific WLT placeholders
- WLT SEG added to generics (Praetors, Centurion)
- Graviton and Shrapnel weapons to all relevant models (I'm dead inside after needing to handle such needlessly picky formatting from GW)
- To facilitate Shrapnel Pistols, I added a Bolt Pistol Options SEG to several generic units

**[Changed]**
- Master of the Legion; now a separate SE that checks for 1 instance per 1k pts
- Added MotL to all relevant characters
- Mandatory generic WLTs handled as links to single WLT rather than SEG (Only done for IW characters, but can easily be duplicated for others)
- Mandatory non-generic WLTs only constrained by Min/Max 1 Warlord (didn't think it was relevant to make their specific WLTs also constrained as only one Warlord can be chosen at a time afaik)
- Reformatted Palatine Blades to fit Tactical template (Min X, decrement X, repeat X for models)
- Reformatted Centurion weapon options to cut down on clutter and bring in line with recent discussions/other entries
- Some fairly serious changes to Veterans to force checks on TLC and basic unit choice. I might honestly suggest formatting them more like Termies; as much I hate how clunky it is, there does not seem to be another way to force model integrity. The other option is completely ignoring the book's format and formatting it the way Recon Squads and several others currently are; please advise.

Pretty sure I missed some Shrapnel/Graviton options in some places, but I'm very tired and can deal with them when someone points them out.
