### PR TITLE
Updated Dreadwing Interemptors and Inner Circle Knights Cenobium

### DIFF
--- a/2022 - Legiones Astartes.cat
+++ b/2022 - Legiones Astartes.cat
@@ -38642,7 +38642,7 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
             </profile>
           </profiles>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="75.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="a9c1-2633-b1f0-6e34" name="Order Cenobites" publicationId="09b3-d525-cdea-260c" page="7" hidden="false" collective="false" import="true" type="model">
@@ -38817,9 +38817,6 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
         <entryLink id="2eaf-6b42-103c-9035" name="Cataphractii Terminator Armour" hidden="false" collective="false" import="true" targetId="7c9b-b9ab-9a40-8eb5" type="selectionEntry"/>
         <entryLink id="d46d-d3e8-0bd2-6776" name="Hexagrammaton Choice:" hidden="false" collective="false" import="true" targetId="61a2-7005-1e6c-c08e" type="selectionEntryGroup"/>
       </entryLinks>
-      <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="75.0"/>
-      </costs>
     </selectionEntry>
     <selectionEntry id="68d3-14e8-a6ee-229c" name="Inner Circle Knights Cenobium - Order of the Broken Claws" publicationId="09b3-d525-cdea-260c" page="7" hidden="true" collective="false" import="true" type="unit">
       <rules>
@@ -38873,7 +38870,7 @@ part of a close combat attack.</description>
             </profile>
           </profiles>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="75.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="9366-d32d-cb61-cc24" name="Order Cenobites" publicationId="09b3-d525-cdea-260c" page="7" hidden="false" collective="false" import="true" type="model">
@@ -38987,9 +38984,6 @@ part of a close combat attack.</description>
         <entryLink id="0504-171a-8b2d-fa8b" name="Cataphractii Terminator Armour" hidden="false" collective="false" import="true" targetId="7c9b-b9ab-9a40-8eb5" type="selectionEntry"/>
         <entryLink id="7a4c-dae0-226e-264b" name="Hexagrammaton Choice:" hidden="false" collective="false" import="true" targetId="61a2-7005-1e6c-c08e" type="selectionEntryGroup"/>
       </entryLinks>
-      <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="75.0"/>
-      </costs>
     </selectionEntry>
     <selectionEntry id="12b8-ffd2-d5d6-28c5" name="Advex-mors Greatsword" publicationId="09b3-d525-cdea-260c" page="7" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>

--- a/2022 - Legiones Astartes.cat
+++ b/2022 - Legiones Astartes.cat
@@ -38566,6 +38566,9 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
             </infoLink>
             <infoLink id="904f-de7a-bcb1-df8a" name="Instant Death" hidden="false" targetId="9e96-fff1-b916-d9a3" type="rule"/>
           </infoLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="8289-597c-36f7-669c" name="The Furnace&apos;s Heart" hidden="false" collective="false" import="true" type="upgrade">
           <profiles>
@@ -38582,6 +38585,9 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
             <infoLink id="3dc9-cfa7-8d5a-d3b5" name="Lance" hidden="false" targetId="3d6b-9e0b-56f0-8a1e" type="rule"/>
             <infoLink id="46c5-5d68-1ec2-1703" name="Achean Force" hidden="false" targetId="c56f-80ff-5d8e-1af4" type="rule"/>
           </infoLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
@@ -38698,7 +38704,6 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
             <entryLink id="2f43-6d3c-fca6-c406" name="Thunder Hammer" hidden="false" collective="false" import="true" targetId="838c-4002-713d-d7c6" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a2b4-c3cc-9b0d-1649" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5a66-fc48-e5ea-09db" type="max"/>
               </constraints>
             </entryLink>
           </entryLinks>
@@ -39053,7 +39058,7 @@ part of a close combat attack.</description>
             </profile>
           </profiles>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="f81e-4ad7-2cbd-ab3c" name="Interemptors" publicationId="817a-6288-e016-7469" page="162" hidden="false" collective="false" import="true" type="model">
@@ -39154,8 +39159,16 @@ part of a close combat attack.</description>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d450-d7fd-6f87-879b" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="fc23-57bf-fc95-d515" name="Plasma Incinerator" hidden="false" collective="false" import="true" targetId="e0ff-7d2c-a195-6a45" type="selectionEntry"/>
-            <entryLink id="c983-5ac2-4ff7-2628" name="Missile launcher with suspensor web, rad missiles and statis missiles" hidden="false" collective="false" import="true" targetId="ba02-3861-5d52-de30" type="selectionEntry"/>
+            <entryLink id="fc23-57bf-fc95-d515" name="Plasma Incinerator" hidden="false" collective="false" import="true" targetId="e0ff-7d2c-a195-6a45" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="c983-5ac2-4ff7-2628" name="Missile launcher with suspensor web, rad missiles and statis missiles" hidden="false" collective="false" import="true" targetId="ba02-3861-5d52-de30" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+              </costs>
+            </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="7eec-ab16-b63c-fb29" name="The Interemptor Praefectus may take up to:" hidden="false" collective="false" import="true">
@@ -39174,6 +39187,9 @@ part of a close combat attack.</description>
                 <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7742-ba12-2b5e-fa67" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bab8-002f-1a75-9eb2" type="max"/>
               </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+              </costs>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
@@ -39183,6 +39199,9 @@ part of a close combat attack.</description>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6856-0b59-82e9-578e" type="max"/>
               </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+              </costs>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
@@ -39226,7 +39245,7 @@ part of a close combat attack.</description>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="45.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="ba02-3861-5d52-de30" name="Missile launcher with suspensor web, rad missiles and statis missiles" hidden="false" collective="false" import="true" type="upgrade">


### PR DESCRIPTION
Please set a title for the PR describing your changes,
fill out the information below, and delete this heading.

## Added Units

## Fixed Units
Dreadwing Interemptors
Added points to Misslie Launchers, Plasma Incinerators, Melta Bombs, and Artificer Armour upgrades.
Added points to Praefectus and adjusted hidden cost

Inner Circle Knights
Updated to allow users to select as many Thunder Hammers as they want.
Updated Point values of Inner Circle Knights Preceptor 

### Related Issues

* closes #2161 [Interemptor Squad](https://github.com/BSData/horus-heresy/issues/2161)
* closes #2162 [Inner Circle Knights Cenobium](https://github.com/BSData/horus-heresy/issues/2162)

## Not done yet

_Any issues related to your new changes, or known missing options_

## Test Case

Please upload a roster do demonstrate your changes. 
