### PR TITLE
8-8 Fixes

### DIFF
--- a/2022 - Horus Heresy.gst
+++ b/2022 - Horus Heresy.gst
@@ -1222,280 +1222,137 @@ Conversely, if an Independent Character joins a unit after that unit has been th
       </costs>
     </selectionEntry>
     <selectionEntry id="0d1c-227e-a3f8-cd63" name="Magna Combi-Weapon - Meltagun" hidden="false" collective="true" import="true" type="upgrade">
-      <selectionEntries>
-        <selectionEntry id="5802-2997-7df7-c667" name="Bolter (Primary)" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6a42-845e-25e9-5661" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e6d7-c319-b5c6-cc22" type="min"/>
-          </constraints>
-          <infoLinks>
-            <infoLink id="4a1f-485a-efeb-b1ac" name="Bolter (Primary)" hidden="false" targetId="ace5-c6fe-e205-07d1" type="profile"/>
-          </infoLinks>
-          <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="f47b-bf0d-0541-c338" name="Meltagun (Secondary)" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6b4a-3449-7a89-867b" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="321d-a019-b4c3-21f5" type="min"/>
-          </constraints>
-          <profiles>
-            <profile id="fec9-6a14-0a52-621e" name="Meltagun (Secondary)" publicationId="a716-c1c4-7b26-8424" page="130" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
-              <characteristics>
-                <characteristic name="Range" typeId="95ba-cda7-b831-6066">12&quot;</characteristic>
-                <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">8</characteristic>
-                <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">1</characteristic>
-                <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Assault 1, Armourbane (Melta), One Shot</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <infoLinks>
-            <infoLink id="18e0-4575-c5cd-6324" name="Armourbane (X)" hidden="false" targetId="cb59-f920-f071-7cd4" type="rule">
-              <modifiers>
-                <modifier type="set" field="name" value="Armourbane (Melta)"/>
-              </modifiers>
-            </infoLink>
-            <infoLink id="68a2-2ef6-6583-efb1" name="One Use/One Shot" hidden="false" targetId="df0c-5423-b892-491e" type="rule"/>
-          </infoLinks>
-          <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
+      <profiles>
+        <profile id="b1d7-11cb-4c84-e5fd" name="Meltagun (Secondary)" publicationId="a716-c1c4-7b26-8424" page="130" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">12&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">8</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">1</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Assault 1, Armourbane (Melta), One Shot</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="de57-acd3-fb12-e8e9" name="Bolter (Primary)" hidden="false" targetId="ace5-c6fe-e205-07d1" type="profile"/>
+        <infoLink id="831b-9477-56b1-ff35" name="Armourbane (X)" hidden="false" targetId="cb59-f920-f071-7cd4" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Armourbane (Melta)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="4044-e337-f6d9-6af6" name="One Use/One Shot" hidden="false" targetId="df0c-5423-b892-491e" type="rule"/>
+      </infoLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="cc98-8596-c713-516c" name="Magna Combi-Weapon - Plasma Gun" hidden="false" collective="true" import="true" type="upgrade">
-      <selectionEntries>
-        <selectionEntry id="fce5-ae2c-346c-8d27" name="Bolter (Primary)" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0659-90fd-1b44-364d" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="65c6-e26c-7e79-0286" type="min"/>
-          </constraints>
-          <infoLinks>
-            <infoLink id="d282-9fcb-9fa4-5d56" name="Bolter (Primary)" hidden="false" targetId="ace5-c6fe-e205-07d1" type="profile"/>
-          </infoLinks>
-          <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="8ee3-1dbf-b5a8-74a3" name="Plasma Gun (Secondary)" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ae8-6d6e-461d-bfaf" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8197-8587-0e12-6cee" type="min"/>
-          </constraints>
-          <profiles>
-            <profile id="48ce-1fac-f9c0-6110" name="Plasma Gun (Secondary)" publicationId="a716-c1c4-7b26-8424" page="130" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
-              <characteristics>
-                <characteristic name="Range" typeId="95ba-cda7-b831-6066">24&quot;</characteristic>
-                <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">7</characteristic>
-                <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">4</characteristic>
-                <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Rapid Fire, Breaching (4+), Gets Hot, One Shot</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <infoLinks>
-            <infoLink id="8dec-0a4c-aad6-9eef" name="Breaching (X)" hidden="false" targetId="a760-f736-1bf3-fa3c" type="rule">
-              <modifiers>
-                <modifier type="set" field="name" value="Breaching (4+)"/>
-              </modifiers>
-            </infoLink>
-            <infoLink id="be39-a96c-606d-c370" name="Gets Hot" hidden="false" targetId="679f-9d97-5ace-a652" type="rule"/>
-            <infoLink id="d781-8d8b-9d49-4534" name="One Use/One Shot" hidden="false" targetId="df0c-5423-b892-491e" type="rule"/>
-          </infoLinks>
-          <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
+      <profiles>
+        <profile id="7c1f-9fd7-99c5-b3ac" name="Plasma Gun (Secondary)" publicationId="a716-c1c4-7b26-8424" page="130" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">24&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">7</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">4</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Rapid Fire, Breaching (4+), Gets Hot, One Shot</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="325e-3b2d-2e6d-350e" name="Bolter (Primary)" hidden="false" targetId="ace5-c6fe-e205-07d1" type="profile"/>
+        <infoLink id="db2d-8a33-5c54-80f6" name="Breaching (X)" hidden="false" targetId="a760-f736-1bf3-fa3c" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Breaching (4+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="e0f6-8719-f2da-e916" name="Gets Hot" hidden="false" targetId="679f-9d97-5ace-a652" type="rule"/>
+        <infoLink id="b916-01ec-36f7-4c1f" name="One Use/One Shot" hidden="false" targetId="df0c-5423-b892-491e" type="rule"/>
+      </infoLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="1d05-f467-b0aa-88b2" name="Magna Combi-Weapon - Disintegrator" hidden="false" collective="true" import="true" type="upgrade">
-      <selectionEntries>
-        <selectionEntry id="329f-976a-de55-f41b" name="Bolter (Primary)" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d45e-c49a-70a5-ec94" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f691-c29a-f763-8e25" type="min"/>
-          </constraints>
-          <infoLinks>
-            <infoLink id="1868-d556-c708-d363" name="Bolter (Primary)" hidden="false" targetId="ace5-c6fe-e205-07d1" type="profile"/>
-          </infoLinks>
-          <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="4ad2-e057-486a-ada6" name="Disintegrator (Secondary)" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a27d-32f6-7f9b-0a30" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="16fb-541f-2ece-8e9d" type="min"/>
-          </constraints>
-          <profiles>
-            <profile id="6c9b-2254-dd99-85f7" name="Disintegrator (Secondary)" publicationId="a716-c1c4-7b26-8424" page="130" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
-              <characteristics>
-                <characteristic name="Range" typeId="95ba-cda7-b831-6066">24&quot;</characteristic>
-                <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">5</characteristic>
-                <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">2</characteristic>
-                <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Rapid Fire, Instant Death, Gets Hot, One Shot</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <infoLinks>
-            <infoLink id="2380-420c-f07f-828d" name="Instant Death" hidden="false" targetId="9e96-fff1-b916-d9a3" type="rule"/>
-            <infoLink id="1742-4fbf-7c68-dde3" name="Gets Hot" hidden="false" targetId="679f-9d97-5ace-a652" type="rule"/>
-            <infoLink id="6b4e-ec44-8a04-1d77" name="One Use/One Shot" hidden="false" targetId="df0c-5423-b892-491e" type="rule"/>
-          </infoLinks>
-          <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
+      <profiles>
+        <profile id="ebb6-18b7-561a-a720" name="Disintegrator (Secondary)" publicationId="a716-c1c4-7b26-8424" page="130" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">24&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">5</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">2</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Rapid Fire, Instant Death, Gets Hot, One Shot</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="1ba4-225d-3684-1654" name="Bolter (Primary)" hidden="false" targetId="ace5-c6fe-e205-07d1" type="profile"/>
+        <infoLink id="c9a8-e582-be23-4976" name="Gets Hot" hidden="false" targetId="679f-9d97-5ace-a652" type="rule"/>
+        <infoLink id="c38e-4540-8a5b-9e74" name="Instant Death" hidden="false" targetId="9e96-fff1-b916-d9a3" type="rule"/>
+        <infoLink id="8733-eec9-75d8-e139" name="One Use/One Shot" hidden="false" targetId="df0c-5423-b892-491e" type="rule"/>
+      </infoLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="34c4-db99-db36-0f2a" name="Minor Combi-Weapon - Flamer" hidden="false" collective="true" import="true" type="upgrade">
-      <selectionEntries>
-        <selectionEntry id="af40-7cac-918b-0ee7" name="Bolter (Primary)" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="94ce-1755-26e4-acca" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f5b7-c800-403c-8e7e" type="min"/>
-          </constraints>
-          <infoLinks>
-            <infoLink id="bf59-ccf1-a388-48b0" name="Bolter (Primary)" hidden="false" targetId="ace5-c6fe-e205-07d1" type="profile"/>
-          </infoLinks>
-          <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="9a23-f724-ce24-967f" name="Flamer (Secondary)" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d080-03ee-c240-7beb" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="61e4-3247-c1ca-4739" type="min"/>
-          </constraints>
-          <profiles>
-            <profile id="9976-abe4-ab53-acdf" name="Flamer (Secondary)" publicationId="a716-c1c4-7b26-8424" page="130" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
-              <characteristics>
-                <characteristic name="Range" typeId="95ba-cda7-b831-6066">Template</characteristic>
-                <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">4</characteristic>
-                <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">5</characteristic>
-                <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Assault 1</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <infoLinks>
-            <infoLink id="697d-eea2-e7fd-8cb6" name="Template Weapons" hidden="false" targetId="5e0e-88e6-db81-5a70" type="rule"/>
-          </infoLinks>
-          <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
+      <profiles>
+        <profile id="ebe4-5e5f-0c3d-08ea" name="Flamer (Secondary)" publicationId="a716-c1c4-7b26-8424" page="130" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">Template</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">4</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">5</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Assault 1</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="c640-b368-64ef-46eb" name="Bolter (Primary)" hidden="false" targetId="ace5-c6fe-e205-07d1" type="profile"/>
+        <infoLink id="f1ea-aaa1-f7b1-96bb" name="Template Weapons" hidden="false" targetId="5e0e-88e6-db81-5a70" type="rule"/>
+      </infoLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="7e5c-3d25-5c88-32e0" name="Minor Combi-Weapon - Volkite Charger" hidden="false" collective="true" import="true" type="upgrade">
-      <selectionEntries>
-        <selectionEntry id="64a2-ce6d-6fc9-104e" name="Bolter (Primary)" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aeb8-1b41-ce76-26ca" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="97e9-8636-71e2-92da" type="min"/>
-          </constraints>
-          <infoLinks>
-            <infoLink id="667e-cf23-f650-a3e5" name="Bolter (Primary)" hidden="false" targetId="ace5-c6fe-e205-07d1" type="profile"/>
-          </infoLinks>
-          <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="9197-d25e-cc9f-d492" name="Volkite Charger (Secondary)" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8806-60b5-670c-ebcf" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e9d7-24a1-bc01-adab" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="8b69-5a39-5f38-61c7" name="Volkite Charger (Secondary)" publicationId="a716-c1c4-7b26-8424" page="130" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
-              <characteristics>
-                <characteristic name="Range" typeId="95ba-cda7-b831-6066">15&quot;</characteristic>
-                <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">5</characteristic>
-                <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">5</characteristic>
-                <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Assault 2, Deflagrate</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <infoLinks>
-            <infoLink id="67fa-0efa-ae43-93c3" name="Deflagrate" hidden="false" targetId="60bc-f79a-67ae-be4f" type="rule"/>
-          </infoLinks>
-          <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
+      <profiles>
+        <profile id="ef29-8682-0c6f-43ea" name="Volkite Charger (Secondary)" publicationId="a716-c1c4-7b26-8424" page="130" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">15&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">5</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">5</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Assault 2, Deflagrate</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="c005-d40f-1886-0e90" name="Bolter (Primary)" hidden="false" targetId="ace5-c6fe-e205-07d1" type="profile"/>
+        <infoLink id="2f6b-db86-19b5-c7f6" name="Deflagrate" hidden="false" targetId="60bc-f79a-67ae-be4f" type="rule"/>
+      </infoLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="aa3c-f5a5-9ce9-1497" name="Minor Combi-Weapon - Grenade Launcher" hidden="false" collective="true" import="true" type="upgrade">
-      <selectionEntries>
-        <selectionEntry id="5754-890b-f99c-2584" name="Bolter (Primary)" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7a09-fb7e-5724-57d4" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b4cd-17c5-3963-2e79" type="min"/>
-          </constraints>
-          <infoLinks>
-            <infoLink id="c74d-65af-928d-ac42" name="Bolter (Primary)" hidden="false" targetId="ace5-c6fe-e205-07d1" type="profile"/>
-          </infoLinks>
-          <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="df94-9fc8-70a6-24ea" name="Grenade Launcher - Frag (Secondary)" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1f2d-ac23-feca-8ae7" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="30d8-ab2e-8dea-b576" type="min"/>
-          </constraints>
-          <profiles>
-            <profile id="25f0-61fd-a8da-64e0" name="Grenade launcher - Frag (Secondary)" publicationId="a716-c1c4-7b26-8424" page="130" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
-              <characteristics>
-                <characteristic name="Range" typeId="95ba-cda7-b831-6066">24&quot;</characteristic>
-                <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">3</characteristic>
-                <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">6</characteristic>
-                <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Assault 1, Blast (3&quot;), Pinning</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <infoLinks>
-            <infoLink id="ae3e-608e-7cad-8c9a" name="Pinning" hidden="false" targetId="1c96-205c-59a0-3cf2" type="rule"/>
-            <infoLink id="94ed-534e-c204-ceb5" name="Blast" hidden="false" targetId="1d9a-73ef-5f4f-8bd8" type="rule"/>
-          </infoLinks>
-          <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="6896-8cca-bc55-cadd" name="Grenade Launcher - Krak (Secondary)" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fa2e-296f-ca66-85cb" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f6b8-7824-7919-daab" type="min"/>
-          </constraints>
-          <profiles>
-            <profile id="d225-edb4-8ffc-636d" name="Grenade launcher - Krak (Secondary)" publicationId="a716-c1c4-7b26-8424" page="130" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
-              <characteristics>
-                <characteristic name="Range" typeId="95ba-cda7-b831-6066">24&quot;</characteristic>
-                <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">5</characteristic>
-                <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">4</characteristic>
-                <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Assault 1</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
+      <profiles>
+        <profile id="71e6-ddb0-279a-7101" name="Grenade launcher - Krak (Secondary)" publicationId="a716-c1c4-7b26-8424" page="130" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">24&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">5</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">4</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Assault 1</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="5bff-6214-348d-0536" name="Grenade launcher - Frag (Secondary)" publicationId="a716-c1c4-7b26-8424" page="130" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">24&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">3</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">6</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Assault 1, Blast (3&quot;), Pinning</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="e6d4-7d81-b610-6358" name="Bolter (Primary)" hidden="false" targetId="ace5-c6fe-e205-07d1" type="profile"/>
+        <infoLink id="ed62-62b5-171c-155a" name="Blast" hidden="false" targetId="1d9a-73ef-5f4f-8bd8" type="rule"/>
+        <infoLink id="c8b8-9218-cf90-6751" name="Pinning" hidden="false" targetId="1c96-205c-59a0-3cf2" type="rule"/>
+      </infoLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
       </costs>

--- a/2022 - Horus Heresy.gst
+++ b/2022 - Horus Heresy.gst
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<gameSystem id="28d4-bd2e-4858-ece6" name="(HH V2) Horus Heresy (2022)" revision="7" battleScribeVersion="2.03" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
+<gameSystem id="28d4-bd2e-4858-ece6" name="(HH V2) Horus Heresy (2022)" revision="8" battleScribeVersion="2.03" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
   <publications>
     <publication id="e77a-823a-da94-16b9" name="Warhammer: The Horus Heresy - Age of Darkness Rulebook" shortName="Main Rules" publicationDate="June 18th, 2022"/>
     <publication id="817a-6288-e016-7469" name="Liber Astartes – Loyalist Legiones Astartes Army Book" publicationDate="June 18th, 2022"/>

--- a/2022 - Horus Heresy.gst
+++ b/2022 - Horus Heresy.gst
@@ -4937,19 +4937,8 @@ All models in a unit under the effect of this Hexagrammaton Unit Sub-type, other
         </selectionEntry>
         <selectionEntry id="5f54-457a-fbb9-6730" name="   IV: Iron Warriors" hidden="false" collective="false" import="true" type="upgrade">
           <rules>
-            <rule id="50d0-9314-636f-0b0b" name="The Armoury of the Iron Warriors" hidden="false">
-              <description>• A single Legion Praetor, Legion Cataphractii Praetor or Legion Tartaros Praetor with the Legiones Astates (Iron Warriors) special rule in any given Detachment may be upgraded toa Warsmith for +20 points. A Warsmith gains a conrtex controller and Servo-arm as well as the Master of Automata and Battlesmith (3+) special rules. A model upgraded to a Warsmith may not be given a Legions Spatha combat bike, Legion Scimitar jetbke or Legion Warhawk jump pack.
-
-• Any model with the Legiones Astartes (Iron Warriors) special rule and the Character Sub-type may exchange a power weapon for a Graviton Mace or exchange a thunder hammer for a Graviton crusher for no additional points cost. Additionally, any model with the Legiones Astartes (Iron Warriors) special rule and the Dreadnought Unit Type may exchange a Gravis power fist for a Graviton Maul for +15 points per weapon (This does not replace or remove the built in weapon included with the Gravis Power Fist)
-
-• Any model with the Legiones Astartes (Iron Warriors) and Independent Character special rules may exchange a bolt pistol for a shrapnel pistol or a bolter for a shrapnel bolter for no additional points cost.
-
-• Any unit composed entirely of models with the Legiones Astartes (Iron Warriors) special rule may upgrade all bolt pistols in the unit to shrapnel pistols, and/or all bolters for shrapnel bolters and/or all heavy bolters for shrapnel cannons for a cost of +2 points per weapon.
-
-•Any unit composed entirely of models with the Vehicle Unit Type and the Legiones Astartes (Iron Warriors) special rule may exchange all heavy bolters in the unit for shrapnel cannons for +2 points per weapon and any unit composed entirely of models with the Dreadnought Unit Type and the Legiones Astartes (Iron Warriors) special rule may exchange all Gravis bolt cannons for Gravis shrapnel cannons for +5 points per weapon.</description>
-            </rule>
-            <rule id="fc44-1c30-d724-14cf" name="Legiones Astartes (Iron Warriors) " hidden="false">
-              <description>Wrack &amp; Ruin: When a model with this special rule makes a Shooting Attack or Melee attack targeting a model with the Dreadnought, Automata, Vehicle or Building Unit Type it gains +1 to the Strength of that attack.</description>
+            <rule id="fc44-1c30-d724-14cf" name="Wrack &amp; Ruin" hidden="false">
+              <description>When a model with this special rule makes a Shooting Attack or Melee attack targeting a model with the Dreadnought, Automata, Vehicle or Building Unit Type it gains +1 to the Strength of that attack.</description>
             </rule>
           </rules>
           <costs>

--- a/2022 - Legiones Astartes.cat
+++ b/2022 - Legiones Astartes.cat
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="6393-649c-7213-a327" name="(HH V2) Legions Astartes" revision="22" battleScribeVersion="2.03" authorName="Various" authorUrl="https://github.com/BSData/horus-heresy" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="7" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="6393-649c-7213-a327" name="(HH V2) Legions Astartes" revision="23" battleScribeVersion="2.03" authorName="Various" authorUrl="https://github.com/BSData/horus-heresy" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="8" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profileTypes>
-    <profileType id="7002-2f9a-59c4-2742" name="Cult Acana">
+    <profileType id="7002-2f9a-59c4-2742" name="Cult Arcana">
       <characteristicTypes>
         <characteristicType id="931f-3b2d-da54-8d8d" name="Description"/>
       </characteristicTypes>
@@ -213,36 +213,12 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="5d35-5265-17fb-46b8" name="Lion El&apos;Jonson " hidden="true" collective="false" import="true" targetId="c159-feb0-607f-bb5b" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="2cba-f3cb-e339-5171" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="ddfd-8ea5-a35d-2c9d" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="7961-69a3-d0fe-5c22" name="Corswain" hidden="true" collective="false" import="true" targetId="e589-a616-3a22-5b3e" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="a2b9-686c-63eb-2017" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="752a-e1bb-ffe2-634f" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
@@ -267,18 +243,6 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="c5ee-ab63-c6aa-1ea0" name="Qin Xa" hidden="true" collective="false" import="true" targetId="ec0c-1416-50af-5f2d" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="ff93-d19b-19b2-1b55" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="bb72-96a6-318e-2498" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
@@ -764,12 +728,6 @@
         <categoryLink id="1a8a-33c9-645e-095e" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="27b8-5842-1c02-b882" name="Rapier Battery (Placeholder Points)" hidden="false" collective="false" import="true" targetId="92a9-8ee8-51ed-bef0" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="d84a-2ee9-3fea-080d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="4cd7-3b68-37c4-9d48" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-      </categoryLinks>
-    </entryLink>
     <entryLink id="a9b2-1d6e-2232-d6f2" name="Seeker Squad" hidden="false" collective="false" import="true" targetId="58e6-f9cc-4c46-e258" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="c3ef-f746-669e-8a48" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -903,189 +861,66 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="2389-a97b-7449-15c2" name="Dark Sons of Death (Placeholders 2)" hidden="true" collective="false" import="true" targetId="5bed-1c5c-a11e-05a1" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="666c-3292-bfdb-c10c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="0ca9-3c3f-239f-c2a2" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="4a8e-14eb-2956-efcc" name="Deathwing Companion Detachment (Placeholders 2)" hidden="true" collective="false" import="true" targetId="d5f8-3620-24ed-044b" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="c658-38c7-2bfa-10e7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="dd4a-2fa2-4db4-9439" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="c50d-6834-37a3-f712" name="Deathwing Terminator Cataphractii Companions (Placeholders 2)" hidden="true" collective="false" import="true" targetId="3fc7-588f-6f75-d227" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="2cb5-d43d-97f1-4ff7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="bf3e-f878-a165-d8e8" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="a3ed-f918-a415-0c50" name="Deathwing Terminator Tartaros Companions (Placeholders 2)" hidden="true" collective="false" import="true" targetId="180e-a80f-663f-2f5b" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="0bce-0dc3-6705-7274" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="c6bb-12de-9103-8e0f" name="New CategoryLink" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="dd02-2df2-8e6d-3adb" name="Ebon Keshig (Placeholders 2)" hidden="true" collective="false" import="true" targetId="3ca6-0bb4-d735-aff8" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="4a99-bcc7-e5cd-897c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="ec98-4c07-3927-bf6d" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-      </categoryLinks>
-    </entryLink>
     <entryLink id="33b0-90cf-ba87-f1c1" name="Excindio Battle-automata (Placeholders 2)" hidden="true" collective="false" import="true" targetId="986e-2e9e-259e-f67f" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="906a-e90f-f1b7-9378" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="34f3-fe60-4689-5d35" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="41f5-fab9-49af-5d0a" name="Falcon&apos;s Claws (Placeholders 2)" hidden="true" collective="false" import="true" targetId="c325-a413-2ffb-3f9e" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="330b-1d1f-3dae-3651" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="7437-a6c9-013f-239d" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="86a7-8a80-533c-44a1" name="Farith Redloss (Placeholders 2)" hidden="true" collective="false" import="true" targetId="1681-2c32-a677-574e" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="37d0-729e-090e-ec86" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="5086-5cbd-eb73-090c" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="a6f5-fdcf-b0e5-dbbe" name="Firewing Enigmatus Cabal (Placeholders 2)" hidden="true" collective="false" import="true" targetId="57b8-7273-0b2d-70c8" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="2aba-1aad-d3d2-c072" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="5ec4-3da2-9ede-c32d" name="New CategoryLink" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="80b6-8e94-c7e6-dfd0" name="Golden Keshig (Placeholders 2)" hidden="true" collective="false" import="true" targetId="0ddf-406c-8cdf-ab21" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="d873-d3ee-9192-fe62" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="c1c1-b9bb-8ba4-28fd" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
-      </categoryLinks>
-    </entryLink>
     <entryLink id="612c-7d5b-1fad-6d97" name="Holguin (Placeholders 2)" hidden="true" collective="false" import="true" targetId="b151-c07e-6730-534b" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="741e-13a0-d94e-5890" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="a014-9788-398a-f93a" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="88fb-a7b9-9e0d-8ccc" name="Tsolmon Khan (Placeholders 2)" hidden="true" collective="false" import="true" targetId="4586-b65a-7632-d5c8" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="7e42-9a1f-63ce-afb7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="72c5-837c-7cf1-ac16" name="New CategoryLink" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="7c4b-5d84-0f4b-ef07" name="Jaghatai Khan (Placeholders 2)" hidden="true" collective="false" import="true" targetId="a08a-c092-aaca-424e" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="34f3-eed5-19cc-4c1c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="9e4f-aa9d-95e7-4bcd" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
@@ -1168,7 +1003,13 @@
         <categoryLink id="7778-8a19-51ff-a658" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="977a-bd55-18d0-4049" name="Alpharius" hidden="false" collective="false" import="true" targetId="0f5b-57a5-1b1f-7312" type="selectionEntry"/>
+    <entryLink id="977a-bd55-18d0-4049" name="Alpharius" hidden="false" collective="false" import="true" targetId="0f5b-57a5-1b1f-7312" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="347f-4311-700c-0f3d" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
+        <categoryLink id="adbb-725d-3d93-4b51" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="false"/>
+        <categoryLink id="3a95-a0a3-cc70-6d55" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
     <entryLink id="5218-e5c6-67f5-9785" name="Phoenix Terminator Squad" hidden="false" collective="false" import="true" targetId="bea3-69db-c555-e384" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="f156-3988-a1d6-2bd7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -1239,72 +1080,25 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="308a-94de-2ced-9a11" name="Vulkan" hidden="true" collective="false" import="true" targetId="fe24-20af-f493-649b" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c805-ca3a-ff93-5e2f" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="6acc-bbe9-50c8-92cd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
         <categoryLink id="475e-8785-f99e-3311" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="true"/>
+        <categoryLink id="8503-11bf-6706-a665" name="HQ:" hidden="false" targetId="4f85-eb33-30c9-8f51" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="97df-0db0-7692-837c" name="Dreadwing Interemptor Squad" hidden="false" collective="false" import="true" targetId="ed1f-3909-bf79-2780" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="1904-e6e7-c7a7-ee4b" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="d009-034f-9246-0702" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="6a42-4fe1-2140-d91e" name="Inner Circle Knights Cenobium" hidden="false" collective="false" import="true" targetId="c537-636f-7a55-51c5" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="7963-7eb8-4304-ff70" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="dbe3-b6e6-e89d-03d3" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="5618-179a-c311-5733" name="Inner Circle Knights Cenobium - Order of the Broken Claws" hidden="false" collective="false" import="true" targetId="68d3-14e8-a6ee-229c" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="881b-1600-d901-6071" name="New CategoryLink" hidden="false" targetId="7aee-565f-b0ae-294e" primary="true"/>
         <categoryLink id="0802-10fc-03e1-0c88" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
@@ -2368,6 +2162,13 @@ remains in play and regains 1D3 Wounds.</description>
           </costs>
         </selectionEntry>
         <selectionEntry id="9919-b6d9-4095-7026" name="Psychic Powers" hidden="false" collective="false" import="true" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6846-3315-ebf9-310d" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0487-df43-b7cb-5691" type="max"/>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ba52-eb88-90e5-9851" type="min"/>
@@ -2428,15 +2229,17 @@ remains in play and regains 1D3 Wounds.</description>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="01d2-8cd1-d807-cc2b" type="max"/>
           </constraints>
-          <rules>
-            <rule id="fe93-3a7c-ac52-8edd" name="Warlord: Comes the Reaper" hidden="false">
-              <description>When making attacks as part of a Shooting Attack or during an Assault with any weapon that has the Poison (X) special rule, Calas Typhon and any unit with the Legiones Astartes (Death Guard) and at least one model within 12” of Calas Typhon, increase the value of the Poison Special rule by 1 (I.e, from 3+ to 2+) and may reroll failed To Wound rolls for weapons with the Fleshbane special rule. In addition, an army whose Warlord has this Trait may make an additional Reaction in the Movement phase as long as Typhon has not been removed as a casualty.</description>
-            </rule>
-          </rules>
+          <profiles>
+            <profile id="cffc-0a3b-12da-1024" name="Comes the Reaper" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+              <characteristics>
+                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">When making attacks as part of a Shooting Attack or during an Assault with any weapon that has the Poison (X) special rule, Calas Typhon and any unit with the Legiones Astartes (Death Guard) and at least one model within 12” of Calas Typhon, increase the value of the Poison Special rule by 1 (I.e, from 3+ to 2+) and may reroll failed To Wound rolls for weapons with the Fleshbane special rule. In addition, an army whose Warlord has this Trait may make an additional Reaction in the Movement phase as long as Typhon has not been removed as a casualty.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="155.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="200.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="c159-feb0-607f-bb5b" name="Lion El&apos;Jonson " hidden="false" collective="false" import="true" type="unit">
@@ -2652,7 +2455,19 @@ remains in play and regains 1D3 Wounds.</description>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="460.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="e589-a616-3a22-5b3e" name="Corswain" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="e589-a616-3a22-5b3e" name="Corswain" hidden="true" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="08d9-c28b-9c86-11d0" type="max"/>
       </constraints>
@@ -2935,6 +2750,18 @@ This additional Reaction may only be made as long as the Warlord has not been re
       </costs>
     </selectionEntry>
     <selectionEntry id="ec0c-1416-50af-5f2d" name="Qin Xa" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="380a-cadc-b450-0b5a" type="max"/>
       </constraints>
@@ -2969,13 +2796,12 @@ This additional Reaction may only be made as long as the Warlord has not been re
             <rule id="8877-4018-bc9b-c98b" name="Master of the Keshig" hidden="false">
               <description>If Qin Xa is selected as the Leader of a Legion Tartaros Command Squad, any model in that Tartaros Command Squad may replace its power weapon with a power glaive for +5 points each.</description>
             </rule>
-            <rule id="da6e-5846-ad97-6090" name="The Tails of the Dragon*" hidden="false">
+            <rule id="da6e-5846-ad97-6090" name="The Tails of the Dragon" hidden="false">
               <description>The Tails of the Dragon are two separate but identical weapons, and the bonus for wielding two melee weapons has already been included in Qin Xa’s profile. When attacking with the Tails of the Dragon in close combat, select one of the profiles to use from those shown below for both weapons at the start of each of the controlling player’s Assault phases, before any attacks are made.</description>
             </rule>
           </rules>
           <infoLinks>
             <infoLink id="d5c7-7db3-8759-57e1" name="Legiones Astartes (White Scars) " hidden="false" targetId="4b54-8bd0-9fdd-cbc4" type="rule"/>
-            <infoLink id="fc23-5e2e-1bf4-0b60" name="Independent Character" hidden="false" targetId="c57d-4820-458a-7ab5" type="rule"/>
             <infoLink id="4f8c-aa12-748d-6b7d" name="Counter-Attack (X)" hidden="false" targetId="fd6d-2a76-10e0-936a" type="rule">
               <modifiers>
                 <modifier type="set" field="name" value="Counter Attack (2)"/>
@@ -2992,7 +2818,6 @@ This additional Reaction may only be made as long as the Warlord has not been re
               </modifiers>
             </infoLink>
             <infoLink id="034d-f9a7-8961-a5ad" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
-            <infoLink id="a37e-c29a-84ac-aa56" name="Loyalist" hidden="false" targetId="d1de-a45d-2b9b-c878" type="rule"/>
             <infoLink id="8845-9cac-3f4f-3b5a" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
           </infoLinks>
           <entryLinks>
@@ -3007,13 +2832,13 @@ This additional Reaction may only be made as long as the Warlord has not been re
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="b7be-1380-479b-11b2" name="The Tails of the Dragon*" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="b7be-1380-479b-11b2" name="The Tails of the Dragon" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="859d-1a0a-0722-a88e" type="min"/>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7086-81b1-8cfa-85eb" type="max"/>
           </constraints>
           <profiles>
-            <profile id="891a-8a5d-00d4-8d2b" name="Tails of the Dragon* - Split the Mountain (P3P ZW)" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+            <profile id="891a-8a5d-00d4-8d2b" name="Split the Mountain" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
               <characteristics>
                 <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
                 <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">+3</characteristic>
@@ -3021,7 +2846,7 @@ This additional Reaction may only be made as long as the Warlord has not been re
                 <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Unwieldy, Master-crafted</characteristic>
               </characteristics>
             </profile>
-            <profile id="885c-7d8f-c994-1d2b" name="Tails of the Dragon* - Part the Horse&apos;s Mane (P3P ZW)" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+            <profile id="885c-7d8f-c994-1d2b" name="Part the Horse&apos;s Mane" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
               <characteristics>
                 <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
                 <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">+1</characteristic>
@@ -3053,16 +2878,23 @@ This additional Reaction may only be made as long as the Warlord has not been re
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2579-0b5d-5a42-e911" type="min"/>
           </constraints>
         </entryLink>
-        <entryLink id="3407-2264-2255-e7fb" name="Tartaros Terminator Armour" hidden="false" collective="false" import="true" targetId="f850-d0af-8663-ccac" type="selectionEntry"/>
+        <entryLink id="3407-2264-2255-e7fb" name="Tartaros Terminator Armour" hidden="false" collective="false" import="true" targetId="f850-d0af-8663-ccac" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c83c-33d3-942e-5101" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="baa9-8f63-0eb3-2f2a" type="max"/>
+          </constraints>
+        </entryLink>
         <entryLink id="ce30-cc49-5e26-919d" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="84b5-752e-ee00-33e2" type="max"/>
           </constraints>
-          <rules>
-            <rule id="b747-3b76-56ba-9cd4" name="Warlord: Chosen of the Khagan" hidden="false">
-              <description>If Qin Xa is the army’s Warlord, once per battle the controlling player may choose to either bring a single eligible friendly unit or group of friendly units assigned to a Deep Strike Assault or Flanking Assault into play from Reserve automatically instead of rolling or have it remain in Reserve for that turn (this may not be used to bring a unit or units into play on a turn when a Reserves roll could not normally be made for them). In addition, an army whose Warlord has this trait may make an additional Reaction during the Assault phase as long as the Warlord has not been removed as a casualty.</description>
-            </rule>
-          </rules>
+          <profiles>
+            <profile id="db2b-1637-e42d-70a9" name="Chosen of the Khagan" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+              <characteristics>
+                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">If Qin Xa is the army’s Warlord, once per battle the controlling player may choose to either bring a single eligible friendly unit or group of friendly units assigned to a Deep Strike Assault or Flanking Assault into play from Reserve automatically instead of rolling or have it remain in Reserve for that turn (this may not be used to bring a unit or units into play on a turn when a Reserves roll could not normally be made for them). In addition, an army whose Warlord has this trait may make an additional Reaction during the Assault phase as long as the Warlord has not been removed as a casualty.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
         </entryLink>
       </entryLinks>
       <costs>
@@ -6479,7 +6311,7 @@ Argel Tal may not Run in any Turn in which the Umbral Pinions have been activate
         </entryLink>
         <entryLink id="ba11-ec40-c21e-0763" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="afa2-a5d4-ec49-e9a4" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="afa2-a5d4-ec49-e9a4" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9b9b-b4ff-40fd-0c6f" type="max"/>
           </constraints>
         </entryLink>
@@ -6495,7 +6327,7 @@ Argel Tal may not Run in any Turn in which the Umbral Pinions have been activate
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="225.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="240.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="0c89-7883-2e1c-0838" name="High Chaplain Erebus" hidden="true" collective="false" import="true" type="unit">
@@ -9136,15 +8968,18 @@ During a Reaction made in any Phase, a player may not choose to activate a model
             <modifier type="set" field="name" value="Brutal (3)"/>
           </modifiers>
         </infoLink>
+        <infoLink id="7210-a0cc-4990-19b2" name="Armourbane (X)" hidden="false" targetId="cb59-f920-f071-7cd4" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Armourbane (Melta)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="8da9-f501-0de6-0aaf" name="Meltagun" hidden="false" targetId="f683-e63a-b2a3-b9d2" type="profile"/>
+        <infoLink id="656a-5246-3048-07b0" name="Armourbane (X)" hidden="false" targetId="cb59-f920-f071-7cd4" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Armourbane (Melta)"/>
+          </modifiers>
+        </infoLink>
       </infoLinks>
-      <entryLinks>
-        <entryLink id="23c9-54cb-1634-8182" name="Meltagun" hidden="false" collective="false" import="true" targetId="4ebd-57e0-3560-e568" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e28b-4a8d-2f81-3d43" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c3d1-830a-81e6-b4e0" type="max"/>
-          </constraints>
-        </entryLink>
-      </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
       </costs>
@@ -9166,15 +9001,13 @@ During a Reaction made in any Phase, a player may not choose to activate a model
             <modifier type="set" field="name" value="Armourbane (Melee)"/>
           </modifiers>
         </infoLink>
+        <infoLink id="0aec-b9a1-889b-b155" name="Armourbane (X)" hidden="false" targetId="cb59-f920-f071-7cd4" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Armourbane (Melta)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="896e-9b95-550b-ff26" name="Meltagun" hidden="false" targetId="f683-e63a-b2a3-b9d2" type="profile"/>
       </infoLinks>
-      <entryLinks>
-        <entryLink id="06e8-b2ca-ab18-cfbd" name="Meltagun" hidden="false" collective="false" import="true" targetId="4ebd-57e0-3560-e568" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c9a2-393e-2065-dc05" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="16ad-8779-6613-9b7f" type="max"/>
-          </constraints>
-        </entryLink>
-      </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
       </costs>
@@ -12063,11 +11896,11 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="bb03-34bd-7919-7ba7" name="Ebon Keshig Cohort" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="bb03-34bd-7919-7ba7" name="Ebon Keshig Cohort" hidden="true" collective="false" import="true" type="unit">
       <modifiers>
-        <modifier type="set" field="hidden" value="true">
+        <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
           </conditions>
         </modifier>
       </modifiers>
@@ -12290,11 +12123,11 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="102a-93e1-7fb3-85b1" name="Golden Keshig Squadron" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="102a-93e1-7fb3-85b1" name="Golden Keshig Squadron" hidden="true" collective="false" import="true" type="unit">
       <modifiers>
-        <modifier type="set" field="hidden" value="true">
+        <modifier type="set" field="hidden" value="false">
           <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
           </conditions>
         </modifier>
       </modifiers>
@@ -15599,7 +15432,7 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
     </selectionEntry>
     <selectionEntry id="1aa4-4557-f274-2ba1" name="Raptora" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
-        <profile id="b8a1-9e1b-5bb6-9267" name="Raptora" publicationId="09c5-eeae-f398-b653" page="255" hidden="false" typeId="7002-2f9a-59c4-2742" typeName="Cult Acana">
+        <profile id="b8a1-9e1b-5bb6-9267" name="Raptora" publicationId="09c5-eeae-f398-b653" page="255" hidden="false" typeId="7002-2f9a-59c4-2742" typeName="Cult Arcana">
           <characteristics>
             <characteristic name="Description" typeId="931f-3b2d-da54-8d8d">When a unit that includes a Psyker with this power is selected to make a Move or a Run move during the controlling player&apos;s Movement phase that ends within 12&quot; of an enemy unit, the controlling player may make a Psychic check for the Psyker with this power before any models in the unit are moved. If the Psychic check is successful then all models in the unit with the Psyker Sub-type and Legiones Astartes (Thousand Sons) special rule gain a 6+ Invulnerable Save, or if the unit already has an Invulnerable Save, that save is increased by one step (for example, from 6+ to 5+) up to a maximum of a 4+ Invulnerable Save, until the start of the controlling player&apos;s next turn. If the Psychic check is failed then the Psyker suffers Perils of the Warp.</characteristic>
           </characteristics>
@@ -15611,7 +15444,7 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
     </selectionEntry>
     <selectionEntry id="78eb-adbb-1cc2-b002" name="Pyrae" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
-        <profile id="317c-9940-79a1-e015" name="Pyrae" publicationId="09c5-eeae-f398-b653" page="255" hidden="false" typeId="7002-2f9a-59c4-2742" typeName="Cult Acana">
+        <profile id="317c-9940-79a1-e015" name="Pyrae" publicationId="09c5-eeae-f398-b653" page="255" hidden="false" typeId="7002-2f9a-59c4-2742" typeName="Cult Arcana">
           <characteristics>
             <characteristic name="Description" typeId="931f-3b2d-da54-8d8d">When a Charge is declared for a unit that includes a Psyker with this power, the controlling player may make a Psychic check for the Psyker with this power before any dice are rolled to determine if the Charge is successful. If the Psychic check is passed then all models in the Charging unit with the Psyker Sub-type and Legiones Astartes (Thousand Sons) special rule gain the Hamer of Wrath (2) special rules - with all hits infliicted by this Hammer of Wrath special rule counted as &apos;Flame&apos; attacks. IF the Check is failed then the Psyker suffers Perils of the Warp.</characteristic>
           </characteristics>
@@ -15623,7 +15456,7 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
     </selectionEntry>
     <selectionEntry id="5532-04aa-8302-2038" name="Pavoni" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
-        <profile id="cf42-9ef7-801e-0e7d" name="Pavoni" publicationId="09c5-eeae-f398-b653" page="255" hidden="false" typeId="7002-2f9a-59c4-2742" typeName="Cult Acana">
+        <profile id="cf42-9ef7-801e-0e7d" name="Pavoni" publicationId="09c5-eeae-f398-b653" page="255" hidden="false" typeId="7002-2f9a-59c4-2742" typeName="Cult Arcana">
           <characteristics>
             <characteristic name="Description" typeId="931f-3b2d-da54-8d8d">When a unit that includes a Psyker with this power is selected to make a Move or a Run move during the controlling player&apos;s Movement Phase, the controlling player may make a Psychic check for the Psyker with this power before any models in the unit are moved. If the Check is successful then all models in the moving unit with the Psyker Sub-type and the Legiones Astartes (Thousand Sons) special rule add a bonus of +3 to the distance moved and may ignore any penalties to their movement for moving through Difficult Terrain during the Movement phase only. If the Psychic check is failed then the unit suffers Perils of the Warp.</characteristic>
           </characteristics>
@@ -15635,7 +15468,7 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
     </selectionEntry>
     <selectionEntry id="f040-f723-e145-9e1f" name="Corvidae" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
-        <profile id="6565-75e7-64c1-50a3" name="Corvidae" publicationId="09c5-eeae-f398-b653" page="255" hidden="false" typeId="7002-2f9a-59c4-2742" typeName="Cult Acana">
+        <profile id="6565-75e7-64c1-50a3" name="Corvidae" publicationId="09c5-eeae-f398-b653" page="255" hidden="false" typeId="7002-2f9a-59c4-2742" typeName="Cult Arcana">
           <characteristics>
             <characteristic name="Description" typeId="931f-3b2d-da54-8d8d">When a unit that includes a Psyker with this power makes a Shooting Attack, the controlling player may make a Psychic check for the Psyker with this power before any rolls To Hit are made. If the Check is successful then the first Wound scored on the target unit by the Shooting Attack is allocated by the Psyker&apos;s controlling player (but once this model has been removed as a casualty, any further Wounds are allocated as per the normal rules). If the Psychic check is failed then the Psyker suffers Perils of the Warp.</characteristic>
           </characteristics>
@@ -15647,7 +15480,7 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
     </selectionEntry>
     <selectionEntry id="a06f-f3f7-ba92-365d" name="Athanaen" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
-        <profile id="ac61-8beb-2cb9-7588" name="Athanaen" publicationId="09c5-eeae-f398-b653" page="255" hidden="false" typeId="7002-2f9a-59c4-2742" typeName="Cult Acana">
+        <profile id="ac61-8beb-2cb9-7588" name="Athanaen" publicationId="09c5-eeae-f398-b653" page="255" hidden="false" typeId="7002-2f9a-59c4-2742" typeName="Cult Arcana">
           <characteristics>
             <characteristic name="Description" typeId="931f-3b2d-da54-8d8d">When a unit that includes a Psyker with this power makes a Shooting Attack, the controlling player may make a Psychic check for the Psyker with this power before any rolls To Hit are made. or Reactions declared. If the Psychic check is successful, then the enemy unit targeted by the Shooting Attack must reduce the Leadership Characteristic of all models in the unit by 1 for any Pinning or Morale check caused by the Shooting Attack. If the Psychic check is failed then the Psyker suffers Perils of the Warp.</characteristic>
           </characteristics>
@@ -19739,6 +19572,13 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
       </costs>
     </selectionEntry>
     <selectionEntry id="03be-5d55-d05a-771d" name="Praetor" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="set" field="name" value="Warsmith">
+          <conditions>
+            <condition field="selections" scope="03be-5d55-d05a-771d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5c94-f7b4-19f7-c12b" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <selectionEntries>
         <selectionEntry id="d862-5767-da41-cff0" name="Legion Praetor" hidden="false" collective="false" import="true" type="model">
           <constraints>
@@ -20081,16 +19921,6 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
                   </costs>
                 </entryLink>
-                <entryLink id="86ed-068a-b7fc-2aa9" name="Magna Combi-Weapon - Disintegrator" hidden="false" collective="false" import="true" targetId="1d05-f467-b0aa-88b2" type="selectionEntry">
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
-                  </costs>
-                </entryLink>
-                <entryLink id="6f8f-01d1-f965-8747" name="Minor Combi-Weapon - Alchem Flamer" hidden="false" collective="false" import="true" targetId="b941-687c-c95e-31a6" type="selectionEntry">
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
-                  </costs>
-                </entryLink>
                 <entryLink id="e413-366e-15c4-a093" name="Volkite Charger" hidden="false" collective="false" import="true" targetId="6f6e-ad55-e093-6503" type="selectionEntry">
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
@@ -20106,33 +19936,59 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
                   </costs>
                 </entryLink>
-                <entryLink id="953d-3362-075f-a91d" name="Magna Combi-Weapon - Meltagun" hidden="false" collective="false" import="true" targetId="0d1c-227e-a3f8-cd63" type="selectionEntry">
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
-                  </costs>
-                </entryLink>
-                <entryLink id="9bea-7468-b71e-4edc" name="Magna Combi-Weapon - Plasma Gun" hidden="false" collective="false" import="true" targetId="cc98-8596-c713-516c" type="selectionEntry">
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
-                  </costs>
-                </entryLink>
-                <entryLink id="9784-9abd-c5ff-0cf8" name="Minor Combi-Weapon - Flamer" hidden="false" collective="false" import="true" targetId="34c4-db99-db36-0f2a" type="selectionEntry">
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
-                  </costs>
-                </entryLink>
-                <entryLink id="91ae-8ef6-bde1-42b6" name="Minor Combi-Weapon - Grenade Launcher" hidden="false" collective="false" import="true" targetId="aa3c-f5a5-9ce9-1497" type="selectionEntry">
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
-                  </costs>
-                </entryLink>
-                <entryLink id="a561-c15a-8c76-947f" name="Minor Combi-Weapon - Volkite Charger" hidden="false" collective="false" import="true" targetId="7e5c-3d25-5c88-32e0" type="selectionEntry">
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
-                  </costs>
-                </entryLink>
                 <entryLink id="b130-67c9-087f-7947" name="Shrapnel Bolter" hidden="false" collective="false" import="true" targetId="1941-21b5-932c-74d6" type="selectionEntry"/>
+                <entryLink id="99a8-753d-f02f-c959" name="Magna Combi-Weapon" hidden="false" collective="false" import="true" targetId="e5b1-83e5-7272-a59e" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="99e6-2a2d-9ec4-4a3f" name="Minor Combi-Weapon" hidden="false" collective="false" import="true" targetId="605e-1b86-ca08-9226" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
               </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="f662-22a4-b0b4-3f15" name="0) Legion-upgrades" hidden="false" collective="false" import="true">
+              <selectionEntries>
+                <selectionEntry id="5c94-f7b4-19f7-c12b" name="Warsmith" hidden="true" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditions>
+                        <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5f54-457a-fbb9-6730" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e750-9ce9-acc5-a141" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="baf9-4a25-9efd-d0e3" name="Battlesmith (X)" hidden="false" targetId="5d57-4d02-1e36-4a82" type="rule">
+                      <modifiers>
+                        <modifier type="set" field="name" value="Battlesmith (3+)"/>
+                      </modifiers>
+                    </infoLink>
+                    <infoLink id="09cb-8a79-58e6-1c5a" name="Master of Automata" hidden="false" targetId="8eef-f84b-37cb-554b" type="rule"/>
+                  </infoLinks>
+                  <entryLinks>
+                    <entryLink id="8712-b2df-d027-f0de" name="Servo-Arm" hidden="false" collective="false" import="true" targetId="4168-fc85-8912-7188" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f115-1c33-9ca2-9bc3" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="576b-033d-2823-3073" type="min"/>
+                      </constraints>
+                    </entryLink>
+                    <entryLink id="0ad1-6904-f4d1-acf2" name="Cortex Controller" hidden="false" collective="false" import="true" targetId="2fda-455f-d34d-97e0" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cbbb-42db-9c08-4294" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bbc0-4601-c8ed-a5ae" type="min"/>
+                      </constraints>
+                    </entryLink>
+                  </entryLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks>
@@ -20427,11 +20283,6 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
             <modifier type="set" field="name" value="Librarian">
               <conditions>
                 <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8846-2f93-a2be-18dc" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" field="name" value="Warsmith">
-              <conditions>
-                <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b210-3082-c0d3-d8ef" type="equalTo"/>
               </conditions>
             </modifier>
             <modifier type="set" field="name" value="Master of Signals">
@@ -20757,38 +20608,6 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
                   </costs>
                 </entryLink>
-                <entryLink id="d63b-e0d3-a555-60fa" name="Magna Combi-Weapon - Disintegrator" hidden="false" collective="false" import="true" targetId="1d05-f467-b0aa-88b2" type="selectionEntry">
-                  <modifiers>
-                    <modifier type="set" field="hidden" value="true">
-                      <conditionGroups>
-                        <conditionGroup type="or">
-                          <conditions>
-                            <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="35ac-992e-97a7-1612" type="equalTo"/>
-                          </conditions>
-                        </conditionGroup>
-                      </conditionGroups>
-                    </modifier>
-                  </modifiers>
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
-                  </costs>
-                </entryLink>
-                <entryLink id="1f1f-c5e5-e02c-54fa" name="Minor Combi-Weapon - Alchem Flamer" hidden="false" collective="false" import="true" targetId="b941-687c-c95e-31a6" type="selectionEntry">
-                  <modifiers>
-                    <modifier type="set" field="hidden" value="true">
-                      <conditionGroups>
-                        <conditionGroup type="or">
-                          <conditions>
-                            <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="35ac-992e-97a7-1612" type="equalTo"/>
-                          </conditions>
-                        </conditionGroup>
-                      </conditionGroups>
-                    </modifier>
-                  </modifiers>
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
-                  </costs>
-                </entryLink>
                 <entryLink id="b16b-82f4-c5a0-52d4" name="Volkite Charger" hidden="false" collective="false" import="true" targetId="6f6e-ad55-e093-6503" type="selectionEntry">
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
@@ -20804,7 +20623,7 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
                   </costs>
                 </entryLink>
-                <entryLink id="3313-fc44-eee9-206f" name="Magna Combi-Weapon - Meltagun" hidden="false" collective="false" import="true" targetId="0d1c-227e-a3f8-cd63" type="selectionEntry">
+                <entryLink id="e8a2-6dde-daf2-8928" name="Magna Combi-Weapon" hidden="false" collective="false" import="true" targetId="e5b1-83e5-7272-a59e" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="hidden" value="true">
                       <conditionGroups>
@@ -20820,55 +20639,7 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
                   </costs>
                 </entryLink>
-                <entryLink id="b595-7aed-9805-e9e9" name="Magna Combi-Weapon - Plasma Gun" hidden="false" collective="false" import="true" targetId="cc98-8596-c713-516c" type="selectionEntry">
-                  <modifiers>
-                    <modifier type="set" field="hidden" value="true">
-                      <conditionGroups>
-                        <conditionGroup type="or">
-                          <conditions>
-                            <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="35ac-992e-97a7-1612" type="equalTo"/>
-                          </conditions>
-                        </conditionGroup>
-                      </conditionGroups>
-                    </modifier>
-                  </modifiers>
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
-                  </costs>
-                </entryLink>
-                <entryLink id="854c-6a50-c6b3-2ccd" name="Minor Combi-Weapon - Flamer" hidden="false" collective="false" import="true" targetId="34c4-db99-db36-0f2a" type="selectionEntry">
-                  <modifiers>
-                    <modifier type="set" field="hidden" value="true">
-                      <conditionGroups>
-                        <conditionGroup type="or">
-                          <conditions>
-                            <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="35ac-992e-97a7-1612" type="equalTo"/>
-                          </conditions>
-                        </conditionGroup>
-                      </conditionGroups>
-                    </modifier>
-                  </modifiers>
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
-                  </costs>
-                </entryLink>
-                <entryLink id="40b4-401b-6f86-5548" name="Minor Combi-Weapon - Grenade Launcher" hidden="false" collective="false" import="true" targetId="aa3c-f5a5-9ce9-1497" type="selectionEntry">
-                  <modifiers>
-                    <modifier type="set" field="hidden" value="true">
-                      <conditionGroups>
-                        <conditionGroup type="or">
-                          <conditions>
-                            <condition field="selections" scope="25a2-7a52-632a-6b2c" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="35ac-992e-97a7-1612" type="equalTo"/>
-                          </conditions>
-                        </conditionGroup>
-                      </conditionGroups>
-                    </modifier>
-                  </modifiers>
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
-                  </costs>
-                </entryLink>
-                <entryLink id="211c-e425-cfb6-106e" name="Minor Combi-Weapon - Volkite Charger" hidden="false" collective="false" import="true" targetId="7e5c-3d25-5c88-32e0" type="selectionEntry">
+                <entryLink id="9a52-5163-3aa3-7665" name="Minor Combi-Weapon" hidden="false" collective="false" import="true" targetId="605e-1b86-ca08-9226" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="hidden" value="true">
                       <conditionGroups>
@@ -20910,7 +20681,6 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
                         <condition field="selections" scope="c681-938e-6d11-cd43" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="31f5-cbc4-58e0-ed6e" type="atLeast"/>
                         <condition field="selections" scope="c681-938e-6d11-cd43" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="27e9-630d-4cf4-6d68" type="atLeast"/>
                         <condition field="selections" scope="c681-938e-6d11-cd43" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a28d-408e-c833-9055" type="atLeast"/>
-                        <condition field="selections" scope="c681-938e-6d11-cd43" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b210-3082-c0d3-d8ef" type="atLeast"/>
                         <condition field="selections" scope="c681-938e-6d11-cd43" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3c8b-1020-32f3-3b2a" type="atLeast"/>
                       </conditions>
                     </conditionGroup>
@@ -26479,32 +26249,6 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="92a9-8ee8-51ed-bef0" name="Rapier Battery (Placeholder Points)" publicationId="a716-c1c4-7b26-8424" hidden="false" collective="false" import="true" type="unit">
-      <categoryLinks>
-        <categoryLink id="4c86-4762-543a-1834" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="98b4-81e5-19ad-553e" name="Artillery Sub-type:" hidden="false" targetId="6f99-c178-6f9d-fb63" primary="false"/>
-        <categoryLink id="c2e2-66f9-2ec1-fcb8" name="Artillery Sub-type:" hidden="false" targetId="6f99-c178-6f9d-fb63" primary="false"/>
-        <categoryLink id="71bf-8eda-9250-4e9a" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-        <categoryLink id="9acd-2b27-1ce1-2410" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
-      </categoryLinks>
-      <selectionEntries>
-        <selectionEntry id="beb0-78e1-dc70-11e6" name="Troops" publicationId="a716-c1c4-7b26-8424" hidden="false" collective="false" import="true" type="model">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2c22-a959-d9e4-ed0f" type="min"/>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f4ec-ee78-45d2-948a" type="max"/>
-          </constraints>
-          <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="40.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <entryLinks>
-        <entryLink id="71bd-5652-63ae-ea33" name="Upgrade Points (Placeholders)" hidden="false" collective="false" import="true" targetId="8b48-2da0-15da-2c1b" type="selectionEntry"/>
-      </entryLinks>
-      <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
-      </costs>
-    </selectionEntry>
     <selectionEntry id="58e6-f9cc-4c46-e258" name="Seeker Squad" publicationId="a716-c1c4-7b26-8424" hidden="false" collective="false" import="true" type="unit">
       <infoLinks>
         <infoLink id="df2d-b66a-8e2d-98b5" name="Infiltrate" hidden="false" targetId="0e32-5b92-a95a-8464" type="rule"/>
@@ -26587,7 +26331,7 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
                 </modifier>
                 <modifier type="set" field="e593-6b3c-f169-04f0" value="2+">
                   <conditions>
-                    <condition field="selections" scope="58e6-f9cc-4c46-e258" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="edb3-ec25-6559-2bcb" type="equalTo"/>
+                    <condition field="selections" scope="58e6-f9cc-4c46-e258" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="583e-62cb-53f1-f952" type="equalTo"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -27474,22 +27218,11 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
                 <modifier type="decrement" field="f111-2ce5-dd12-d6b0" value="1">
                   <conditionGroups>
                     <conditionGroup type="or">
-                      <conditionGroups>
-                        <conditionGroup type="and">
-                          <comment>Weapon Option 1</comment>
-                          <conditions>
-                            <condition field="selections" scope="ac2d-77a1-ecd7-a555" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" childId="9387-8dfb-2134-9387" type="notEqualTo"/>
-                            <condition field="selections" scope="ac2d-77a1-ecd7-a555" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" childId="9b8b-a8c9-481f-fafe" type="notEqualTo"/>
-                          </conditions>
-                        </conditionGroup>
-                        <conditionGroup type="and">
-                          <comment>Weapon Option 2</comment>
-                          <conditions>
-                            <condition field="selections" scope="ac2d-77a1-ecd7-a555" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" childId="a5fa-d13e-ae6d-19a9" type="notEqualTo"/>
-                            <condition field="selections" scope="ac2d-77a1-ecd7-a555" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" childId="48c0-5a26-c6e5-eccb" type="notEqualTo"/>
-                          </conditions>
-                        </conditionGroup>
-                      </conditionGroups>
+                      <conditions>
+                        <condition field="selections" scope="ac2d-77a1-ecd7-a555" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="454f-a4bc-46cc-6f1b" type="atLeast"/>
+                        <condition field="selections" scope="ac2d-77a1-ecd7-a555" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4ab1-ee7c-0ab2-8372" type="atLeast"/>
+                        <condition field="selections" scope="ac2d-77a1-ecd7-a555" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7b60-94de-1d33-8317" type="atLeast"/>
+                      </conditions>
                     </conditionGroup>
                   </conditionGroups>
                 </modifier>
@@ -27521,7 +27254,6 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
           <selectionEntryGroups>
             <selectionEntryGroup id="5f5a-bc15-c9d5-e890" name="May take one of the following:" hidden="false" collective="false" import="true">
               <constraints>
-                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5584-5c85-0695-6f61" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="79ac-e95d-f127-67e6" type="max"/>
               </constraints>
               <entryLinks>
@@ -27535,10 +27267,26 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
               </constraints>
               <entryLinks>
                 <entryLink id="9387-8dfb-2134-9387" name="Leviathan Siege Claw" hidden="false" collective="false" import="true" targetId="4838-a0ca-93d8-f6b2" type="selectionEntry"/>
-                <entryLink id="9b8b-a8c9-481f-fafe" name="Leviathan Siege Drill" hidden="false" collective="false" import="true" targetId="d266-0d1e-b8e5-1e90" type="selectionEntry"/>
-                <entryLink id="0260-3edc-aa2a-48ea" name="Grav-Flux Bombard" hidden="false" collective="false" import="true" targetId="4ab1-ee7c-0ab2-8372" type="selectionEntry"/>
-                <entryLink id="6522-1c85-a947-a6cf" name="Cyclonic Melta Lance" hidden="false" collective="false" import="true" targetId="454f-a4bc-46cc-6f1b" type="selectionEntry"/>
-                <entryLink id="0919-e4c0-5990-bbaf" name="Leviathan Storm Cannon" hidden="false" collective="false" import="true" targetId="7b60-94de-1d33-8317" type="selectionEntry"/>
+                <entryLink id="9b8b-a8c9-481f-fafe" name="Leviathan Siege Drill" hidden="false" collective="false" import="true" targetId="d266-0d1e-b8e5-1e90" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="0260-3edc-aa2a-48ea" name="Grav-Flux Bombard" hidden="false" collective="false" import="true" targetId="4ab1-ee7c-0ab2-8372" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="6522-1c85-a947-a6cf" name="Cyclonic Melta Lance" hidden="false" collective="false" import="true" targetId="454f-a4bc-46cc-6f1b" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="0919-e4c0-5990-bbaf" name="Leviathan Storm Cannon" hidden="false" collective="false" import="true" targetId="7b60-94de-1d33-8317" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="1e4a-80d4-7ad9-78c4" name="Weapon Option 2" hidden="false" collective="false" import="true" defaultSelectionEntryId="48c0-5a26-c6e5-eccb">
@@ -27547,11 +27295,27 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8275-a4a3-080d-5fb4" type="max"/>
               </constraints>
               <entryLinks>
-                <entryLink id="f0c9-e2b9-f66b-e76a" name="Cyclonic Melta Lance" hidden="false" collective="false" import="true" targetId="454f-a4bc-46cc-6f1b" type="selectionEntry"/>
-                <entryLink id="1b96-dafe-f744-2186" name="Grav-Flux Bombard" hidden="false" collective="false" import="true" targetId="4ab1-ee7c-0ab2-8372" type="selectionEntry"/>
+                <entryLink id="f0c9-e2b9-f66b-e76a" name="Cyclonic Melta Lance" hidden="false" collective="false" import="true" targetId="454f-a4bc-46cc-6f1b" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="1b96-dafe-f744-2186" name="Grav-Flux Bombard" hidden="false" collective="false" import="true" targetId="4ab1-ee7c-0ab2-8372" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
                 <entryLink id="48c0-5a26-c6e5-eccb" name="Leviathan Siege Claw" hidden="false" collective="false" import="true" targetId="4838-a0ca-93d8-f6b2" type="selectionEntry"/>
-                <entryLink id="a5fa-d13e-ae6d-19a9" name="Leviathan Siege Drill" hidden="false" collective="false" import="true" targetId="d266-0d1e-b8e5-1e90" type="selectionEntry"/>
-                <entryLink id="03c6-ed15-62df-d13f" name="Leviathan Storm Cannon" hidden="false" collective="false" import="true" targetId="7b60-94de-1d33-8317" type="selectionEntry"/>
+                <entryLink id="a5fa-d13e-ae6d-19a9" name="Leviathan Siege Drill" hidden="false" collective="false" import="true" targetId="d266-0d1e-b8e5-1e90" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="03c6-ed15-62df-d13f" name="Leviathan Storm Cannon" hidden="false" collective="false" import="true" targetId="7b60-94de-1d33-8317" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="f42d-6f3b-4898-27dc" name="2x Hull Weapons" hidden="false" collective="false" import="true" defaultSelectionEntryId="02a9-990a-cf07-a47e">
@@ -27572,6 +27336,9 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
                   <infoLinks>
                     <infoLink id="ff3d-ace8-e4fc-3b8e" name="Twin-linked" hidden="false" targetId="8542-ee9d-e2fa-52fe" type="rule"/>
                   </infoLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                  </costs>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
@@ -32487,7 +32254,19 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="5bed-1c5c-a11e-05a1" name="Dark Sons of Death (Placeholders 2)" publicationId="09b3-d525-cdea-260c" page="11" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="5bed-1c5c-a11e-05a1" name="Dark Sons of Death (Placeholders 2)" publicationId="09b3-d525-cdea-260c" page="11" hidden="true" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="b0e0-4e64-c3d1-a29a" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="9824-992b-d742-ecff" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
@@ -32519,7 +32298,19 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="75.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="d5f8-3620-24ed-044b" name="Deathwing Companion Detachment (Placeholders 2)" publicationId="817a-6288-e016-7469" page="164" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="d5f8-3620-24ed-044b" name="Deathwing Companion Detachment (Placeholders 2)" publicationId="817a-6288-e016-7469" page="164" hidden="true" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="57b8-5c22-c421-5350" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="6265-3377-83ce-43d4" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
@@ -32551,7 +32342,19 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="3fc7-588f-6f75-d227" name="Deathwing Terminator Cataphractii Companions (Placeholders 2)" publicationId="d0df-7166-5cd3-89fd" page="48" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="3fc7-588f-6f75-d227" name="Deathwing Terminator Cataphractii Companions (Placeholders 2)" publicationId="d0df-7166-5cd3-89fd" page="48" hidden="true" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="2dec-da68-6c81-2270" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="7472-1378-cbc4-3d6f" name="Terminators:" hidden="false" targetId="bab3-f50d-3e5f-2f78" primary="false"/>
@@ -32585,7 +32388,19 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="240.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="180e-a80f-663f-2f5b" name="Deathwing Terminator Tartaros Companions (Placeholders 2)" publicationId="d0df-7166-5cd3-89fd" page="50" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="180e-a80f-663f-2f5b" name="Deathwing Terminator Tartaros Companions (Placeholders 2)" publicationId="d0df-7166-5cd3-89fd" page="50" hidden="true" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="85f2-bcd0-471d-a6fd" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="ff52-a568-eff0-24c8" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
@@ -32617,29 +32432,19 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="225.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="3ca6-0bb4-d735-aff8" name="Ebon Keshig (Placeholders 2)" publicationId="817a-6288-e016-7469" page="185" hidden="false" collective="false" import="true" type="unit">
-      <categoryLinks>
-        <categoryLink id="976f-e923-7359-8ed5" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-      </categoryLinks>
-      <selectionEntries>
-        <selectionEntry id="7926-9455-b561-f28a" name="Troops" publicationId="817a-6288-e016-7469" page="185" hidden="false" collective="false" import="true" type="model">
-          <constraints>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f091-cbe6-e59d-68de" type="min"/>
-            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="421c-f1f8-b728-87c7" type="max"/>
-          </constraints>
-          <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="40.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <entryLinks>
-        <entryLink id="c3a0-bc94-6368-0ee9" name="Upgrade Points (Placeholders)" hidden="false" collective="false" import="true" targetId="8b48-2da0-15da-2c1b" type="selectionEntry"/>
-      </entryLinks>
-      <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="986e-2e9e-259e-f67f" name="Excindio Battle-automata (Placeholders 2)" publicationId="d0df-7166-5cd3-89fd" page="54" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="986e-2e9e-259e-f67f" name="Excindio Battle-automata (Placeholders 2)" publicationId="d0df-7166-5cd3-89fd" page="54" hidden="true" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="4d06-330c-5159-0aae" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="a78c-9f8b-f94c-b416" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
@@ -32662,7 +32467,14 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="350.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="c325-a413-2ffb-3f9e" name="Falcon&apos;s Claws (Placeholders 2)" publicationId="d0df-7166-5cd3-89fd" page="57" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="c325-a413-2ffb-3f9e" name="Falcon&apos;s Claws (Placeholders 2)" publicationId="d0df-7166-5cd3-89fd" page="57" hidden="true" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="2771-0452-ee18-42a5" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="dbe0-4bcb-3864-90b4" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
@@ -32696,7 +32508,19 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="31.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="1681-2c32-a677-574e" name="Farith Redloss (Placeholders 2)" publicationId="d0df-7166-5cd3-89fd" page="45" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="1681-2c32-a677-574e" name="Farith Redloss (Placeholders 2)" publicationId="d0df-7166-5cd3-89fd" page="45" hidden="true" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ff4e-64e9-0694-cff2" type="max"/>
       </constraints>
@@ -32736,7 +32560,19 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="220.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="57b8-7273-0b2d-70c8" name="Firewing Enigmatus Cabal (Placeholders 2)" publicationId="d0df-7166-5cd3-89fd" page="52" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="57b8-7273-0b2d-70c8" name="Firewing Enigmatus Cabal (Placeholders 2)" publicationId="d0df-7166-5cd3-89fd" page="52" hidden="true" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="e8d5-a7b5-2d70-7953" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
         <categoryLink id="e77c-aef9-c951-cd26" name="Jump Infantry:" hidden="false" targetId="eee8-3c7c-2762-e33e" primary="false"/>
@@ -32759,40 +32595,19 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="150.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="0ddf-406c-8cdf-ab21" name="Golden Keshig (Placeholders 2)" publicationId="817a-6288-e016-7469" page="184" hidden="false" collective="false" import="true" type="unit">
-      <categoryLinks>
-        <categoryLink id="3858-b9ca-e4ef-fef7" name="Legiones Astartes" hidden="false" targetId="11f2-472f-c1d1-9ae9" primary="false"/>
-        <categoryLink id="f44d-3076-cfd9-a403" name="Cavalry Sub-type:" hidden="false" targetId="6d79-a3e4-381f-7b0f" primary="false"/>
-        <categoryLink id="ae02-aee3-45f1-8325" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-      </categoryLinks>
-      <selectionEntries>
-        <selectionEntry id="550c-6568-5881-45d0" name="Sergeant" publicationId="817a-6288-e016-7469" page="184" hidden="false" collective="false" import="true" type="model">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2466-d38a-d46d-b2f1" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c37b-c717-8e7d-7207" type="max"/>
-          </constraints>
-          <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="f298-60f7-169d-821f" name="Troops" publicationId="817a-6288-e016-7469" page="184" hidden="false" collective="false" import="true" type="model">
-          <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fae4-5e84-6967-75e5" type="min"/>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6877-2723-368d-86d0" type="max"/>
-          </constraints>
-          <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="40.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <entryLinks>
-        <entryLink id="ba7d-4ceb-75ee-4d73" name="Upgrade Points (Placeholders)" hidden="false" collective="false" import="true" targetId="8b48-2da0-15da-2c1b" type="selectionEntry"/>
-      </entryLinks>
-      <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="60.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="b151-c07e-6730-534b" name="Holguin (Placeholders 2)" publicationId="d0df-7166-5cd3-89fd" page="47" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="b151-c07e-6730-534b" name="Holguin (Placeholders 2)" publicationId="d0df-7166-5cd3-89fd" page="47" hidden="true" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0493-1df0-1f91-f0b8" type="max"/>
       </constraints>
@@ -32817,7 +32632,7 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="150.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="a08a-c092-aaca-424e" name="Jaghatai Khan (Placeholders 2)" publicationId="817a-6288-e016-7469" page="182" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="a08a-c092-aaca-424e" name="Jaghatai Khan (Placeholders 2)" publicationId="817a-6288-e016-7469" page="182" hidden="true" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="add" field="category" value="6d79-a3e4-381f-7b0f">
           <conditions>
@@ -32828,6 +32643,16 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
           <conditions>
             <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fd19-4031-d763-437c" type="equalTo"/>
           </conditions>
+        </modifier>
+        <modifier type="set" field="hidden" value="false">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
         </modifier>
       </modifiers>
       <categoryLinks>
@@ -32906,12 +32731,22 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="4586-b65a-7632-d5c8" name="Tsolmon Khan (Placeholders 2)" publicationId="d0df-7166-5cd3-89fd" page="58" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="4586-b65a-7632-d5c8" name="Tsolmon Khan (Placeholders 2)" publicationId="d0df-7166-5cd3-89fd" page="58" hidden="true" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="add" field="category" value="8b4f-bfe2-ce7b-f1b1">
           <conditions>
             <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6fb4-adf6-dbe8-86af" type="equalTo"/>
           </conditions>
+        </modifier>
+        <modifier type="set" field="hidden" value="false">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
         </modifier>
       </modifiers>
       <constraints>
@@ -32959,7 +32794,7 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="180.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="137a-e079-34cd-8161" name="Cerberus Squadron" hidden="false" collective="false" import="true" type="unit">
@@ -38194,7 +38029,11 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
             <constraint field="selections" scope="3107-56ad-4cf6-0330" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5849-f1b4-b82f-db0f" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="0d73-6b95-b4e2-66e6" name="Chainsword" hidden="false" collective="false" import="true" targetId="06e7-a6ae-ed1c-eb03" type="selectionEntry"/>
+            <entryLink id="0d73-6b95-b4e2-66e6" name="Chainsword" hidden="false" collective="false" import="true" targetId="06e7-a6ae-ed1c-eb03" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+              </costs>
+            </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="48b5-b5e8-d52b-e91a" name="4) One Mortus Poisoner may take:" hidden="false" collective="false" import="true">
@@ -39027,6 +38866,18 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
       </costs>
     </selectionEntry>
     <selectionEntry id="c537-636f-7a55-51c5" name="Inner Circle Knights Cenobium" publicationId="09b3-d525-cdea-260c" page="7" hidden="true" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <infoLinks>
         <infoLink id="694f-869f-a2ad-974d" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
         <infoLink id="6153-7439-b2e1-9be0" name="Bulky (X)" hidden="false" targetId="676c-7b75-4b6f-9405" type="rule">
@@ -39245,8 +39096,23 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
         <entryLink id="2eaf-6b42-103c-9035" name="Cataphractii Terminator Armour" hidden="false" collective="false" import="true" targetId="7c9b-b9ab-9a40-8eb5" type="selectionEntry"/>
         <entryLink id="d46d-d3e8-0bd2-6776" name="Hexagrammaton Choice:" hidden="false" collective="false" import="true" targetId="61a2-7005-1e6c-c08e" type="selectionEntryGroup"/>
       </entryLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="68d3-14e8-a6ee-229c" name="Inner Circle Knights Cenobium - Order of the Broken Claws" publicationId="09b3-d525-cdea-260c" page="7" hidden="true" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <rules>
         <rule id="a927-0fda-e71a-6293" name="Order of the Broken Claws" publicationId="09b3-d525-cdea-260c" page="7" hidden="false">
           <description>Models in a unit representing this Order require one lower result To Wound than they would
@@ -39412,6 +39278,9 @@ part of a close combat attack.</description>
         <entryLink id="0504-171a-8b2d-fa8b" name="Cataphractii Terminator Armour" hidden="false" collective="false" import="true" targetId="7c9b-b9ab-9a40-8eb5" type="selectionEntry"/>
         <entryLink id="7a4c-dae0-226e-264b" name="Hexagrammaton Choice:" hidden="false" collective="false" import="true" targetId="61a2-7005-1e6c-c08e" type="selectionEntryGroup"/>
       </entryLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="12b8-ffd2-d5d6-28c5" name="Advex-mors Greatsword" publicationId="09b3-d525-cdea-260c" page="7" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
@@ -42188,6 +42057,29 @@ part of a close combat attack.</description>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
       </costs>
     </selectionEntry>
+    <selectionEntry id="6846-3315-ebf9-310d" name="Mortarion (Placeholder)" hidden="true" collective="false" import="true" type="unit">
+      <profiles>
+        <profile id="124a-e10d-8fdd-af2e" name="Mortarion" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
+          <characteristics>
+            <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Primarch (Unique)
+</characteristic>
+            <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6&quot;</characteristic>
+            <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">7</characteristic>
+            <characteristic name="BS" typeId="74ae-c840-0036-d244">6</characteristic>
+            <characteristic name="S" typeId="e478-41d4-a092-48a8">7</characteristic>
+            <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">7</characteristic>
+            <characteristic name="W" typeId="57ee-1126-32a9-5672">7</characteristic>
+            <characteristic name="I" typeId="62d3-22d7-2d49-52dc">5</characteristic>
+            <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">6</characteristic>
+            <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">10</characteristic>
+            <characteristic name="Save" typeId="e593-6b3c-f169-04f0">2+</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="425.0"/>
+      </costs>
+    </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup id="61a2-7005-1e6c-c08e" name="Hexagrammaton Choice:" hidden="true" collective="false" import="true">
@@ -42847,43 +42739,6 @@ Special rules A Legion Warmonger Consul gains the Tip of the Spear special rule.
         <selectionEntry id="d3d6-dfc2-4da2-54cc" name="Centurion" hidden="false" collective="false" import="true" type="upgrade">
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="b210-3082-c0d3-d8ef" name="Warsmith" hidden="true" collective="false" import="true" type="upgrade">
-          <modifiers>
-            <modifier type="set" field="hidden" value="false">
-              <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5f54-457a-fbb9-6730" type="equalTo"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7116-b602-d199-629f" type="max"/>
-          </constraints>
-          <infoLinks>
-            <infoLink id="9d6c-b224-009f-39e0" name="Battlesmith (X)" hidden="false" targetId="5d57-4d02-1e36-4a82" type="rule">
-              <modifiers>
-                <modifier type="set" field="name" value="Battlesmith (3+)"/>
-              </modifiers>
-            </infoLink>
-            <infoLink id="f31a-954c-a086-f658" name="Master of Automata" hidden="false" targetId="8eef-f84b-37cb-554b" type="rule"/>
-          </infoLinks>
-          <entryLinks>
-            <entryLink id="6f04-41a3-6aa5-322a" name="Servo-Arm" hidden="false" collective="false" import="true" targetId="4168-fc85-8912-7188" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1c4b-3541-8a44-1668" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="169a-8f86-ffc6-00a7" type="min"/>
-              </constraints>
-            </entryLink>
-            <entryLink id="4387-e19a-25a0-1891" name="Cortex Controller" hidden="false" collective="false" import="true" targetId="2fda-455f-d34d-97e0" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7645-265e-5c1b-55ba" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b39f-fc8d-f882-65e8" type="min"/>
-              </constraints>
-            </entryLink>
-          </entryLinks>
-          <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -43991,22 +43846,6 @@ A Legion Centurion, Legion Cataphractii Centurion or Legion Tartaros Centurion t
         <characteristic name="Save" typeId="e593-6b3c-f169-04f0">2+</characteristic>
       </characteristics>
     </profile>
-    <profile id="e065-2215-10e1-17de" name="Mortarion (P3P ZW)" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
-      <characteristics>
-        <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Primarch (Unique)
-</characteristic>
-        <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6&quot;</characteristic>
-        <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">7</characteristic>
-        <characteristic name="BS" typeId="74ae-c840-0036-d244">6</characteristic>
-        <characteristic name="S" typeId="e478-41d4-a092-48a8">7</characteristic>
-        <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">7</characteristic>
-        <characteristic name="W" typeId="57ee-1126-32a9-5672">7</characteristic>
-        <characteristic name="I" typeId="62d3-22d7-2d49-52dc">5</characteristic>
-        <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">6</characteristic>
-        <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">10</characteristic>
-        <characteristic name="Save" typeId="e593-6b3c-f169-04f0">2+</characteristic>
-      </characteristics>
-    </profile>
     <profile id="d91d-6828-deb0-f6b1" name="Night Raptor (P3P ZW)" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
       <characteristics>
         <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Skirmisher)
@@ -44178,6 +44017,14 @@ A Legion Centurion, Legion Cataphractii Centurion or Legion Tartaros Centurion t
         <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">2</characteristic>
         <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">8</characteristic>
         <characteristic name="Save" typeId="e593-6b3c-f169-04f0">2+</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="f683-e63a-b2a3-b9d2" name="Meltagun" publicationId="a716-c1c4-7b26-8424" page="133" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="95ba-cda7-b831-6066">12&quot;</characteristic>
+        <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">8</characteristic>
+        <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">1</characteristic>
+        <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Assault 1, Armourbane (Melta)</characteristic>
       </characteristics>
     </profile>
   </sharedProfiles>

--- a/2022 - Legiones Astartes.cat
+++ b/2022 - Legiones Astartes.cat
@@ -1194,20 +1194,6 @@
         <categoryLink id="280e-ad37-d236-f49b" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="4a30-d1a8-5b8c-2982" name="Ferrus Manus" publicationId="817a-6288-e016-7469" page="280" hidden="false" collective="false" import="true" targetId="832f-5715-b804-6d2a" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bfc9-c99c-bf8a-3917" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
-    </entryLink>
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="51e5-c28f-d9dd-5e52" name="Fulgrim" hidden="true" collective="false" import="true" type="unit">
@@ -2215,7 +2201,7 @@ remains in play and regains 1D3 Wounds.</description>
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6846-3315-ebf9-310d" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3e9b-f9e5-b5e0-73d9" type="equalTo"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -39146,6 +39132,9 @@ A Perfect Fury: If a model or models with the Skill Unmatched special rule selec
         <entryLink id="2eaf-6b42-103c-9035" name="Cataphractii Terminator Armour" hidden="false" collective="false" import="true" targetId="7c9b-b9ab-9a40-8eb5" type="selectionEntry"/>
         <entryLink id="d46d-d3e8-0bd2-6776" name="Hexagrammaton Choice:" hidden="false" collective="false" import="true" targetId="61a2-7005-1e6c-c08e" type="selectionEntryGroup"/>
       </entryLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="68d3-14e8-a6ee-229c" name="Inner Circle Knights Cenobium - Order of the Broken Claws" publicationId="09b3-d525-cdea-260c" page="7" hidden="true" collective="false" import="true" type="unit">
       <modifiers>
@@ -39325,6 +39314,9 @@ part of a close combat attack.</description>
         <entryLink id="0504-171a-8b2d-fa8b" name="Cataphractii Terminator Armour" hidden="false" collective="false" import="true" targetId="7c9b-b9ab-9a40-8eb5" type="selectionEntry"/>
         <entryLink id="7a4c-dae0-226e-264b" name="Hexagrammaton Choice:" hidden="false" collective="false" import="true" targetId="61a2-7005-1e6c-c08e" type="selectionEntryGroup"/>
       </entryLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="12b8-ffd2-d5d6-28c5" name="Advex-mors Greatsword" publicationId="09b3-d525-cdea-260c" page="7" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
@@ -42101,6 +42093,714 @@ part of a close combat attack.</description>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
       </costs>
     </selectionEntry>
+    <selectionEntry id="2c27-5478-1a5b-f5e1" name="Ferrus Manus" publicationId="817a-6288-e016-7469" page="280" hidden="true" collective="false" import="true" type="model">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0899-8b4b-2591-afac" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b561-aabd-b334-c0ef" type="max"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="3ccc-f053-6e88-f15d" name="New CategoryLink" hidden="false" targetId="ad5f-31db-8bc7-5c46" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="5328-8096-cd39-7b25" name="Ferrus Manus" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ecf-0300-2787-f7d7" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bd29-c640-3162-02aa" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="041b-88d2-920b-78cb" name="Ferrus Manus" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
+              <characteristics>
+                <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e"/>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5"/>
+                <characteristic name="WS" typeId="cc42-7ed5-7092-5c84"/>
+                <characteristic name="BS" typeId="74ae-c840-0036-d244"/>
+                <characteristic name="S" typeId="e478-41d4-a092-48a8"/>
+                <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f"/>
+                <characteristic name="W" typeId="57ee-1126-32a9-5672"/>
+                <characteristic name="I" typeId="62d3-22d7-2d49-52dc"/>
+                <characteristic name="A" typeId="f111-2ce5-dd12-d6b0"/>
+                <characteristic name="Ld" typeId="e8a6-1da9-d384-8727"/>
+                <characteristic name="Save" typeId="e593-6b3c-f169-04f0"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="8889-3157-b65b-1112" name="Battlesmith (X)" hidden="false" targetId="5d57-4d02-1e36-4a82" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Battlesmith (2+)"/>
+              </modifiers>
+            </infoLink>
+            <infoLink id="3738-3ac4-7e91-d7a8" name="Firing Protocols (X)" hidden="false" targetId="32a3-f599-5c92-2945" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Firing Protocols (3)"/>
+              </modifiers>
+            </infoLink>
+            <infoLink id="08df-c4d4-72f9-cdc9" name="Legiones Astartes (Iron Hands) " hidden="false" targetId="2e45-4b61-44fb-260b" type="rule"/>
+            <infoLink id="1d43-c744-5836-2b52" name="Master of the Legion" hidden="false" targetId="c772-87ea-d49c-c7ba" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="8b51-b53b-710d-5a84" name="The Medusan Carapace" publicationId="817a-6288-e016-7469" page="281" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a1a0-b294-9555-6713" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="867f-4057-2c4a-6542" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="2e43-59cc-cdfa-56b5" name="The Medusan Carapace" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
+              <characteristics>
+                <characteristic name="Description" typeId="347e-ee4a-764f-6be3">The Medusan Carapace grants a 2+ armor save and a 3+ invulnerable save</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="7233-aa5f-f079-a5be" name="Forgebreaker" publicationId="817a-6288-e016-7469" page="281" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cad0-e4fe-d5c2-1b34" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f35e-2136-1eed-411b" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="d4f7-964f-eceb-f557" name="Forgebreaker" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
+                <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">12</characteristic>
+                <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">1</characteristic>
+                <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Master-crafted, Exoshock (3+), Brutal (3)</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="3327-ca0b-4675-b601" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule"/>
+            <infoLink id="0585-d528-d2be-1492" name="Exoshock (X)" hidden="false" targetId="69ca-318a-b47a-7a3c" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Exoshock (3+)"/>
+              </modifiers>
+            </infoLink>
+            <infoLink id="66eb-5411-98a2-18a2" name="Brutal (X)" hidden="false" targetId="5079-1fec-d32b-8b84" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Brutal (3)"/>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="e65c-e3ec-df53-fe35" name="Warlord" hidden="false" collective="false" import="true" targetId="0176-56a3-d590-b103" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8d9b-2c91-0f6e-294a" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="7fa5-c40a-56d5-d83b" name="Warlord: Sire of the Iron Hands" hidden="false">
+              <description>All models with the infantry unit type and the Legiones Astartes  (Iron Hands) special rule in the same army as Ferrus Manus gain the Feel No Pain (+6). )This does not stack with other versions of the same special rule and models that already have a better version of the special rule may use either at the choice of the controlling player.) and all models with both the Vehicle unit type and the Legiones Astartes (Iron Hands) special rule gain the It Will Not Die (5+) special rule. In addition, an army with Ferrys Manus gains an additional Reaction in the opposing Player&apos;s Assult phase as long as Ferrus Manus has not been removed as a casualty. </description>
+            </rule>
+          </rules>
+        </entryLink>
+        <entryLink id="ecd8-198a-2697-bb6d" name="Servo-Arm" hidden="false" collective="false" import="true" targetId="4168-fc85-8912-7188" type="selectionEntry"/>
+        <entryLink id="ace8-c940-7cb5-423d" name="Plasma Blaster" hidden="false" collective="false" import="true" targetId="cd52-e9e8-3ab1-995c" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="name" value="Master-crafted plasma blaster"/>
+          </modifiers>
+          <infoLinks>
+            <infoLink id="e69d-9197-6448-f64d" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule"/>
+          </infoLinks>
+        </entryLink>
+        <entryLink id="3cf2-c26f-8994-6e4c" name="Graviton Shredder" hidden="false" collective="false" import="true" targetId="0849-b63b-0b1b-fd4f" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="name" value="Master-crafted gravitron shredder"/>
+          </modifiers>
+          <infoLinks>
+            <infoLink id="567d-a0de-0cce-33b7" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule"/>
+          </infoLinks>
+        </entryLink>
+        <entryLink id="b994-6b58-8abd-dad0" name="Heavy Flamer" hidden="false" collective="false" import="true" targetId="5507-b432-3b4c-df12" type="selectionEntry"/>
+        <entryLink id="c3a8-8c33-4586-a46a" name="Grenade Harness" hidden="false" collective="false" import="true" targetId="251a-860d-2c4d-62cc" type="selectionEntry"/>
+        <entryLink id="9c91-c424-1c1e-4568" name="Master of the Legion" hidden="false" collective="false" import="true" targetId="0068-6b0a-0086-3d6b" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="46cf-834a-16a5-9009" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="eef3-bb98-9827-8cbf" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="465.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="76b5-1013-5e69-65a1" name="Gorgon Terminator Squad" publicationId="817a-6288-e016-7469" page="282" hidden="true" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0899-8b4b-2591-afac" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <infoLinks>
+        <infoLink id="5b4f-acc4-9b40-6d29" name="Feel No Pain (X)" hidden="false" targetId="ec46-ff29-32e0-c2aa" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Feel No Pain (5+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="524e-e832-744b-6ff0" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
+        <infoLink id="d514-2fdc-58b0-a28e" name="Legiones Astartes (Iron Hands) " hidden="false" targetId="2e45-4b61-44fb-260b" type="rule"/>
+        <infoLink id="6134-b4c9-b600-71c5" name="Bulky (X)" hidden="false" targetId="676c-7b75-4b6f-9405" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Bulky (2)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="198e-7fae-59c8-6518" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="9ece-99d7-ff6d-ab22" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="false"/>
+        <categoryLink id="c130-1b2c-10fc-6210" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+        <categoryLink id="9822-00c7-db28-980b" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="4802-8c54-43d4-293b" name="Gorgon Terminator" hidden="false" collective="false" import="true" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f4d1-8f09-cb6d-6c0a" type="min"/>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="20fa-fd80-9c48-1a7c" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="b2e9-e0f4-4445-20e7" name="Gorgon Terminator" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
+              <characteristics>
+                <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy)</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6&quot;</characteristic>
+                <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
+                <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
+                <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
+                <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">4</characteristic>
+                <characteristic name="W" typeId="57ee-1126-32a9-5672">2</characteristic>
+                <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
+                <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">2</characteristic>
+                <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">8</characteristic>
+                <characteristic name="Save" typeId="e593-6b3c-f169-04f0">2+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="a9f1-a79b-8cd6-29d0" name="1) Melee Options" hidden="false" collective="false" import="true">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e4b3-c67b-9fdb-93b6" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5f7e-f45b-2d44-5b54" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="c1d6-3456-c231-c26d" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="962a-b8c7-a67a-a437" name="Lightning Claw" hidden="false" collective="false" import="true" targetId="6923-4e42-5691-b13f" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="e773-f9b0-d59a-7b9d" name="Chainfist" hidden="false" collective="false" import="true" targetId="7347-c5b1-5da3-a78f" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="6cd5-5db1-7bf3-d0c7" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry"/>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="b52b-8f8c-85ba-b910" name="2) Ranged Options" hidden="false" collective="false" import="true">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a238-2507-81a3-2b03" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="cf15-0457-62f7-6d56" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="75d1-fbf4-9561-e05a" name="Magna Combi-Weapon" hidden="false" collective="false" import="true" targetId="e5b1-83e5-7272-a59e" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="ef1e-1b65-a48e-c390" name="Minor Combi-Weapon" hidden="false" collective="false" import="true" targetId="605e-1b86-ca08-9226" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="c2be-7356-4325-907f" name="Lightning Claw" hidden="false" collective="false" import="true" targetId="6923-4e42-5691-b13f" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="5a6d-3551-53be-affd" name="Combi-Bolter" hidden="false" collective="false" import="true" targetId="a498-c66f-9eb7-ca9a" type="selectionEntry"/>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="1141-8900-53a9-0285" name="3) Heavy Weapons" hidden="false" collective="false" import="true">
+              <modifiers>
+                <modifier type="increment" field="81a9-7b81-06ba-3719" value="1.0">
+                  <repeats>
+                    <repeat field="selections" scope="76b5-1013-5e69-65a1" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="76b5-1013-5e69-65a1" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="81a9-7b81-06ba-3719" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="71f1-e5af-e54c-b8a1" name="Heavy Flamer" hidden="false" collective="false" import="true" targetId="5507-b432-3b4c-df12" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="8d4b-163a-b657-0051" name="Plasma Blaster" hidden="false" collective="false" import="true" targetId="cd52-e9e8-3ab1-995c" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="93e1-14d7-1736-fe45" name="Reaper Autocannon" hidden="false" collective="false" import="true" targetId="b87f-48de-6ced-043b" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="d954-ea0d-e5a5-a09e" name="Graviton Gun" hidden="false" collective="false" import="true" targetId="5303-5a3e-de51-1707" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="ad36-048c-7f21-1778" name="Gorgon Hammerbearer" hidden="false" collective="false" import="true" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ae10-7690-46e6-8887" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7bf0-cd33-9a4c-6b9d" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="d5ce-f593-4594-a860" name="Gorgon Hammerbearer" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
+              <characteristics>
+                <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character, Heavy)</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6&quot;</characteristic>
+                <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
+                <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
+                <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
+                <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">4</characteristic>
+                <characteristic name="W" typeId="57ee-1126-32a9-5672">2</characteristic>
+                <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
+                <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">3</characteristic>
+                <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">9</characteristic>
+                <characteristic name="Save" typeId="e593-6b3c-f169-04f0">2+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="daec-59cb-2a73-e109" name="The Gorgon Hammerbearer may exchange their combi-bolter for:" hidden="false" collective="false" import="true">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="099c-c769-616c-acc8" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="255f-0aec-f7d7-2217" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="917c-8dd7-12ab-2cae" name="Magna Combi-Weapon" hidden="false" collective="false" import="true" targetId="e5b1-83e5-7272-a59e" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="e94c-d7d6-c1aa-2fa6" name="Minor Combi-Weapon" hidden="false" collective="false" import="true" targetId="605e-1b86-ca08-9226" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="dead-14c2-03f2-416f" name="Combi-Bolter" hidden="false" collective="false" import="true" targetId="a498-c66f-9eb7-ca9a" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="37b1-c22b-3e78-782a" name="Grenade Harness" hidden="false" collective="false" import="true" targetId="251a-860d-2c4d-62cc" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="58e1-4ccf-ca7e-c8d5" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="377c-aa28-ee53-a5b4" type="min"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="1198-295c-e9b1-fff4" name="Thunder Hammer" hidden="false" collective="false" import="true" targetId="838c-4002-713d-d7c6" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7e77-b27e-28dd-78a2" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="92ea-28ae-db15-3d49" type="min"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="19bc-6c23-417d-4fe3" name="One Gorgon Terminator may take:" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="896f-aa2e-0847-4f8a" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="1d70-f3b3-d457-72ee" name="Legion Vexilla" hidden="false" collective="false" import="true" targetId="21b1-2a90-9826-1782" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9b28-fc01-2088-6e00" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="09ba-033c-4ed0-cce2" name="Dedicated Transport:" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5781-3671-f7e2-b675" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="5152-bc92-8eb8-8b70" name="Land Raider Spartan" hidden="false" collective="false" import="true" targetId="bac1-f30e-2c04-d27d" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="cedf-90e0-2a0a-ebfb" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="350.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="d40a-997b-036a-ff80" name="Land Raider Proteus Carrier" hidden="false" collective="false" import="true" targetId="c123-bdc6-a6ba-79a2" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4802-8c54-43d4-293b" type="greaterThan"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0a45-d93c-0f80-8913" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="220.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="2e33-8060-1472-30b6" name="Gorgon Terminator Armour" hidden="false" collective="false" import="true" targetId="6ee0-262f-191a-1c6b" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4e09-1c36-2f8d-3f0e" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="53c4-7548-b188-d043" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="cca9-59af-3e26-ab98" name="Medusan Immortal Squad" publicationId="817a-6288-e016-7469" page="283" hidden="true" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
+                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0899-8b4b-2591-afac" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <infoLinks>
+        <infoLink id="0c98-c042-d7fe-9aac" name="Legiones Astartes (Iron Hands) " hidden="false" targetId="2e45-4b61-44fb-260b" type="rule"/>
+        <infoLink id="312f-5617-e0d5-64d4" name="Feel No Pain (X)" hidden="false" targetId="ec46-ff29-32e0-c2aa" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Feel No Pain (5+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="8d41-ab9a-89e4-c374" name="Bitter Duty" hidden="false" targetId="d1b8-31da-c53c-4fe2" type="rule"/>
+        <infoLink id="32be-36bb-ea21-7b7c" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="9625-2d6a-2b82-b8c5" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="352e-9c33-7725-39d9" name="Immortal" hidden="false" collective="false" import="true" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3901-e96c-7be8-689d" type="max"/>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d4d4-5b78-5f4a-35a2" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="a2f5-f91b-65c0-340d" name="Immortal" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
+              <characteristics>
+                <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e"/>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7</characteristic>
+                <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
+                <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
+                <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
+                <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">4</characteristic>
+                <characteristic name="W" typeId="57ee-1126-32a9-5672">1</characteristic>
+                <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
+                <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">2</characteristic>
+                <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">10</characteristic>
+                <characteristic name="Save" typeId="e593-6b3c-f169-04f0">3+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <categoryLinks>
+            <categoryLink id="1de0-cb51-b259-c1fb" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+            <categoryLink id="0fb5-d18c-b596-e881" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+          </categoryLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="18.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="19ed-d912-954b-6e31" name="Immortal Sergeant" hidden="false" collective="false" import="true" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5892-6f85-5b44-6a3f" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="50a5-bcec-aa98-84f6" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="6865-abc2-3c3d-367d" name="Immortal Sergeant" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
+              <modifiers>
+                <modifier type="set" field="e593-6b3c-f169-04f0" value="2+">
+                  <conditions>
+                    <condition field="selections" scope="cca9-59af-3e26-ab98" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="583e-62cb-53f1-f952" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <characteristics>
+                <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e"/>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7</characteristic>
+                <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
+                <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
+                <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
+                <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">4</characteristic>
+                <characteristic name="W" typeId="57ee-1126-32a9-5672">1</characteristic>
+                <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
+                <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">3</characteristic>
+                <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">10</characteristic>
+                <characteristic name="Save" typeId="e593-6b3c-f169-04f0">3+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <categoryLinks>
+            <categoryLink id="d29e-3347-56ed-6f1d" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+            <categoryLink id="3b95-3a70-c4db-86bf" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+          </categoryLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="18.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="67d1-95d9-9f7e-7431" name="The Immortal Sergeant may take (Wargear):" hidden="false" collective="false" import="true">
+          <entryLinks>
+            <entryLink id="f9c7-6243-56f1-aa66" name="Artificer Armour" hidden="false" collective="false" import="true" targetId="583e-62cb-53f1-f952" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="854c-0c7e-1368-9269" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="24e9-e8bc-6c49-1e94" name="Meltabombs" hidden="false" collective="false" import="true" targetId="b9dd-3b21-f3f8-78e3" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c002-5305-2dcf-0eb7" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="cfae-0a7c-c3c4-07da" name="Any model with a Bolter may take:" hidden="false" collective="false" import="true">
+          <modifiers>
+            <modifier type="increment" field="8cd7-3e6b-e2b4-ed1c" value="1.0">
+              <repeats>
+                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" childId="1ade-0c02-5612-252b" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8cd7-3e6b-e2b4-ed1c" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="4bad-97b9-3849-f44f" name="Bayonet" hidden="false" collective="false" import="true" targetId="6904-6936-d6ca-a0eb" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="1.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="4055-4146-94a9-b861" name="Chain Bayonet" hidden="false" collective="false" import="true" targetId="bd82-cef6-67f8-19b5" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="c5a6-7634-f0c4-3801" name="Any Immortal may replace their Bolter with:" hidden="false" collective="false" import="true" defaultSelectionEntryId="542a-692f-7061-10b3">
+          <modifiers>
+            <modifier type="increment" field="6a9d-ac4c-85e3-dfe9" value="1.0">
+              <repeats>
+                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+            <modifier type="decrement" field="6a9d-ac4c-85e3-dfe9" value="9.0"/>
+            <modifier type="increment" field="d4c1-db4b-70cb-c8e8" value="1.0">
+              <repeats>
+                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6a9d-ac4c-85e3-dfe9" type="min"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d4c1-db4b-70cb-c8e8" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="de82-4d43-f345-793e" name="Volkite Charger" hidden="false" collective="false" import="true" targetId="6f6e-ad55-e093-6503" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="17ac-89f9-b1bf-3ac4" name="Chainsword" hidden="false" collective="false" import="true" targetId="06e7-a6ae-ed1c-eb03" type="selectionEntry"/>
+            <entryLink id="542a-692f-7061-10b3" name="Bolter" hidden="false" collective="false" import="true" targetId="1ade-0c02-5612-252b" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="eceb-5bbd-6c7b-628b" name="For every 5 models in the unit one may exchange their Bolter for" hidden="false" collective="false" import="true">
+          <modifiers>
+            <modifier type="increment" field="98f5-41eb-d477-5e92" value="1.0">
+              <repeats>
+                <repeat field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="98f5-41eb-d477-5e92" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="9fdb-586e-a82c-9a25" name="Graviton Gun" hidden="false" collective="false" import="true" targetId="5303-5a3e-de51-1707" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="da11-55ef-2bc8-147c" name="Meltagun" hidden="false" collective="false" import="true" targetId="4ebd-57e0-3560-e568" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="0acc-a113-07d7-1ed4" name="Flamer" hidden="false" collective="false" import="true" targetId="9f41-82e2-90f6-973a" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="12d9-1176-587a-127d" name="Lascutter" hidden="false" collective="false" import="true" targetId="6331-c1b9-bf0e-d0e5" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="182e-0010-3afd-d382" name="The Immortal Sergeant may exchange his Bolt Pistol and/or Chainsword for:" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="697d-2de2-ef84-bd0c" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="963f-6c5d-f589-b075" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="717f-cf0a-1593-4bd8" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a532-19d3-ab91-b291" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="a78d-8369-79b3-0352" name="Volkite Serpenta" hidden="false" collective="false" import="true" targetId="d535-1da8-290d-69a6" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2418-3dbc-7b35-5579" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="25d0-03eb-c9c3-9e72" name="Power Weapon" hidden="false" collective="false" import="true" targetId="8d9c-9f80-c0fd-adcf" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ab19-ba69-d555-741e" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="f7f9-b5eb-b26e-9f58" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fcd4-5743-9d91-28ee" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="d695-b96d-82c1-e351" name="Thunder Hammer" hidden="false" collective="false" import="true" targetId="838c-4002-713d-d7c6" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="02b4-7770-8ad7-3075" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="7bf1-2a80-32bf-5882" name="Dedicated Transport:" hidden="false" collective="false" import="true">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="11.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" type="atLeast"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b9df-f632-7255-3e39" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="c790-66aa-ee39-18f9" name="Land Raider Proteus Carrier" hidden="false" collective="false" import="true" targetId="c123-bdc6-a6ba-79a2" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="220.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="0399-bc0e-1174-4c89" name="Power Armour" hidden="false" collective="false" import="true" targetId="2d9d-480e-7c14-1a6f" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eee6-04ea-757b-a481" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ef37-b7a4-f19f-7eba" type="min"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="11d6-a64c-c8f1-f06d" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry"/>
+        <entryLink id="1890-1e31-a811-229e" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry"/>
+        <entryLink id="0660-c1d2-4b12-b7c7" name="Krak Grenades" hidden="false" collective="false" import="true" targetId="99df-2421-acf7-a5ad" type="selectionEntry"/>
+        <entryLink id="2dc2-c120-a794-445a" name="Boarding Shield" hidden="false" collective="false" import="true" targetId="0c0f-f751-cc4e-4951" type="selectionEntry"/>
+      </entryLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3e9b-f9e5-b5e0-73d9" name="Mortarion (Placeholder)" hidden="false" collective="false" import="true" type="upgrade"/>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup id="61a2-7005-1e6c-c08e" name="Hexagrammaton Choice:" hidden="true" collective="false" import="true">


### PR DESCRIPTION
Closes #2174 , #2173 , #2168 , #2160 , #2152

**Legiones Astartes:**
- Made Mortarion placeholder to reference in order to hide Typhus's psychic powers if present
- Updated Praetor/Centurion to SEG links for Combi

**GST:**
- Broke out all Combi-weapons into base profiles to avoid button syndrome
- Changed some IW wording; meant to add constraint, but can't do that til LA - IW is merged.