### PR TITLE
Maye   small updates and minor fixes

### DIFF
--- a/2022 - Horus Heresy.gst
+++ b/2022 - Horus Heresy.gst
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<gameSystem id="28d4-bd2e-4858-ece6" name="(HH V2) Horus Heresy (2022)" revision="9" battleScribeVersion="2.03" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
+<gameSystem id="28d4-bd2e-4858-ece6" name="(HH V2) Horus Heresy (2022)" revision="10" battleScribeVersion="2.03" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
   <publications>
     <publication id="e77a-823a-da94-16b9" name="Warhammer: The Horus Heresy - Age of Darkness Rulebook" shortName="Main Rules" publicationDate="June 18th, 2022"/>
     <publication id="817a-6288-e016-7469" name="Liber Astartes – Loyalist Legiones Astartes Army Book" publicationDate="June 18th, 2022"/>
@@ -389,10 +389,19 @@ Conversely, if an Independent Character joins a unit after that unit has been th
       </infoLinks>
     </categoryEntry>
     <categoryEntry id="fa00-64ef-f48c-11ee" name="Options:" hidden="false"/>
+    <categoryEntry id="f75a-d5c1-59ba-5c5a" name="Character" hidden="false"/>
+    <categoryEntry id="e8ed-ca49-ad6d-5688" name="Expanded Army Lists" hidden="false">
+      <rules>
+        <rule id="e6d4-65d6-66af-32da" name="Expanded Army Lists" hidden="false">
+          <description>Some events/group choose not to allow official rules in &quot;Legacies of The Age of Darkness&quot; download pdf (which are not playtest). This option is included to make it easier for users for those events/groups.</description>
+        </rule>
+      </rules>
+    </categoryEntry>
   </categoryEntries>
   <forceEntries>
     <forceEntry id="d926-652f-8436-30ce" name="Crusade Force Organisation Chart" hidden="false">
       <categoryLinks>
+        <categoryLink id="d65e-4a0a-fa1a-7ec6" name="Explanded Army Lists" hidden="false" targetId="e8ed-ca49-ad6d-5688" primary="false"/>
         <categoryLink id="17a5-4c80-0c5d-df4d" name="Allegiance:" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="false">
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7ab6-7d01-ec54-52df" type="min"/>
@@ -405,6 +414,7 @@ Conversely, if an Independent Character joins a unit after that unit has been th
             <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="84d6-d8d5-49ec-27fb" type="min"/>
           </constraints>
         </categoryLink>
+        <categoryLink id="609a-e750-e92c-da9f" name="Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="false"/>
         <categoryLink id="1375-8457-86ca-67dd" name="Elites:" hidden="false" targetId="7aee-565f-b0ae-294e" primary="false">
           <constraints>
             <constraint field="selections" scope="force" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="4fb9-8be5-6fb5-0869" type="max"/>
@@ -441,7 +451,6 @@ Conversely, if an Independent Character joins a unit after that unit has been th
             <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1c0d-0ff5-e468-703c" type="max"/>
           </constraints>
         </categoryLink>
-        <categoryLink id="609a-e750-e92c-da9f" name="Retinue:" hidden="false" targetId="bbe5-14a5-68a1-544f" primary="false"/>
       </categoryLinks>
     </forceEntry>
     <forceEntry id="d4f2-6da5-b6de-06ec" name="Allied Detachment" hidden="false">
@@ -509,6 +518,13 @@ Conversely, if an Independent Character joins a unit after that unit has been th
       </costs>
     </selectionEntry>
     <selectionEntry id="15dd-ba85-599e-d215" name="Expanded Army List Profiles:" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9b27-8da6-1ace-a81d" type="min"/>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e555-35cf-f840-e444" type="max"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="ec0a-62f9-971f-1f1e" name="New CategoryLink" hidden="false" targetId="e8ed-ca49-ad6d-5688" primary="true"/>
+      </categoryLinks>
       <entryLinks>
         <entryLink id="3790-e8af-d3e2-0dec" name="Exemplary Option" hidden="false" collective="false" import="true" targetId="a149-55c5-23a1-9236" type="selectionEntryGroup"/>
         <entryLink id="e0e7-c67d-a672-77e3" name="Legacy Option" hidden="false" collective="false" import="true" targetId="58be-66fe-3385-cf9c" type="selectionEntryGroup"/>
@@ -3679,14 +3695,14 @@ During Reactions made in any Phase, a unit equipped with Jump Packs may not acti
             <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
             <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">+1</characteristic>
             <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">2</characteristic>
-            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Murderous Strike (5+), Specialist Weapon</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Murderous Strike (6+), Specialist Weapon</characteristic>
           </characteristics>
         </profile>
       </profiles>
       <infoLinks>
         <infoLink id="8a45-89c7-57d1-2e8d" name="Murderous Strike (X)" hidden="false" targetId="93b9-1454-0e7c-42ae" type="rule">
           <modifiers>
-            <modifier type="set" field="name" value="Murderous Strike (5+)"/>
+            <modifier type="set" field="name" value="Murderous Strike (6+)"/>
           </modifiers>
         </infoLink>
         <infoLink id="5a15-43f8-d36a-d8db" name="Specialist Weapon" hidden="false" targetId="1a1f-3c9b-b097-5886" type="rule"/>
@@ -6406,7 +6422,7 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
     </selectionEntryGroup>
     <selectionEntryGroup id="58be-66fe-3385-cf9c" name="Legacy Option" hidden="false" collective="false" import="true">
       <selectionEntryGroups>
-        <selectionEntryGroup id="e196-9f62-2db3-4814" name="Legacy Units" publicationId="d0df-7166-5cd3-89fd" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="e196-9f62-2db3-4814" name="Legacy Units" publicationId="d0df-7166-5cd3-89fd" hidden="false" collective="false" import="true" defaultSelectionEntryId="d344-d97b-4687-8a62">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a153-731e-d815-ff40" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="83e1-20de-6cb4-1e59" type="min"/>
@@ -6428,7 +6444,7 @@ Hawks – Any models with this special rule gain the Shrouded (6+) special rule 
     </selectionEntryGroup>
     <selectionEntryGroup id="a149-55c5-23a1-9236" name="Exemplary Option" hidden="false" collective="false" import="true">
       <selectionEntryGroups>
-        <selectionEntryGroup id="9149-0b99-5a42-de1d" name="Exemplary Battles" publicationId="09b3-d525-cdea-260c" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="9149-0b99-5a42-de1d" name="Exemplary Battles" publicationId="09b3-d525-cdea-260c" hidden="false" collective="false" import="true" defaultSelectionEntryId="8d56-d960-0687-7fee">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="85ed-bdad-e61d-dcdb" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cea4-7f7f-3de0-f765" type="min"/>

--- a/2022 - LA - Iron Warriors.cat
+++ b/2022 - LA - Iron Warriors.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="2ee4-57ed-db44-8a63" name="LA - IV: Iron Warriors" revision="1" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="7" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="2ee4-57ed-db44-8a63" name="LA - IV: Iron Warriors" revision="2" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="10" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="fe10-3104-0252-96de" name="Nârik Dreygur" hidden="false" collective="false" import="true" targetId="ac97-c8ce-16ba-9c49" type="selectionEntry">
       <categoryLinks>
@@ -29,7 +29,7 @@
     <entryLink id="6d85-0a41-fc02-2844" name="Tyrant Siege Terminator Squad" hidden="false" collective="false" import="true" targetId="795a-5698-a1bc-6ec6" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="002f-dc9a-b983-d44c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="08e3-28b0-0801-51ec" name="New CategoryLink" hidden="false" targetId="9231-183c-b97b-63f9" primary="true"/>
+        <categoryLink id="7da6-dade-1275-d75a" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="ef25-725f-b90b-46fa" name="The Tormentor" hidden="false" collective="false" import="true" targetId="ec77-b9e7-904a-f49b" type="selectionEntry">

--- a/2022 - Legiones Astartes.cat
+++ b/2022 - Legiones Astartes.cat
@@ -1022,7 +1022,7 @@
     <entryLink id="3906-76aa-f024-5fea" name="Tyrant Siege Terminator Squad" hidden="false" collective="false" import="true" targetId="07bc-13fe-b069-4afb" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="8a05-0b67-8f3f-3642" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
-        <categoryLink id="1090-7262-1a7b-c8d7" name="New CategoryLink" hidden="false" targetId="9231-183c-b97b-63f9" primary="true"/>
+        <categoryLink id="af27-5b36-cad4-c34b" name="New CategoryLink" hidden="false" targetId="7031-469a-1aeb-eab0" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="d151-b439-f6f4-de6b" name="**Mortus Poisoner Squad" hidden="false" collective="false" import="true" targetId="3107-56ad-4cf6-0330" type="selectionEntry">
@@ -32513,14 +32513,9 @@ In additon, a Contekar Terminator Squad may be selected as a Retinue Squad in a 
     <selectionEntry id="d5f8-3620-24ed-044b" name="Deathwing Companion Detachment" publicationId="817a-6288-e016-7469" page="164" hidden="true" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="equalTo"/>
+          </conditions>
         </modifier>
       </modifiers>
       <rules>
@@ -32870,14 +32865,9 @@ In additon, a Contekar Terminator Squad may be selected as a Retinue Squad in a 
     <selectionEntry id="3fc7-588f-6f75-d227" name="Deathwing Terminator Cataphractii Companions" publicationId="d0df-7166-5cd3-89fd" page="48" hidden="true" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="equalTo"/>
+          </conditions>
         </modifier>
       </modifiers>
       <rules>
@@ -33168,14 +33158,9 @@ In additon, a Contekar Terminator Squad may be selected as a Retinue Squad in a 
     <selectionEntry id="180e-a80f-663f-2f5b" name="Deathwing Terminator Tartaros Companions" publicationId="d0df-7166-5cd3-89fd" page="50" hidden="true" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="equalTo"/>
+          </conditions>
         </modifier>
       </modifiers>
       <rules>
@@ -37511,7 +37496,7 @@ Legion and Legiones Astartes (Dark Angels) special rules is referred to as the r
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="425.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="07bc-13fe-b069-4afb" name="Tyrant Siege Terminator Squad" hidden="true" collective="false" import="true" type="unit">
+    <selectionEntry id="07bc-13fe-b069-4afb" name="Tyrant Siege Terminator Squad" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
           <conditions>
@@ -39874,14 +39859,9 @@ Legion and Legiones Astartes (Dark Angels) special rules is referred to as the r
     <selectionEntry id="c537-636f-7a55-51c5" name="Inner Circle Knights Cenobium" publicationId="09b3-d525-cdea-260c" page="7" hidden="true" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="equalTo"/>
+          </conditions>
         </modifier>
       </modifiers>
       <infoLinks>
@@ -40121,14 +40101,9 @@ Legion and Legiones Astartes (Dark Angels) special rules is referred to as the r
     <selectionEntry id="68d3-14e8-a6ee-229c" name="Inner Circle Knights Cenobium - Order of the Broken Claws" publicationId="09b3-d525-cdea-260c" page="7" hidden="true" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="equalTo"/>
+          </conditions>
         </modifier>
       </modifiers>
       <rules>
@@ -40340,14 +40315,9 @@ part of a close combat attack.</description>
     <selectionEntry id="ed1f-3909-bf79-2780" name="Dreadwing Interemptor Squad" publicationId="817a-6288-e016-7469" page="162" hidden="true" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="equalTo"/>
+          </conditions>
         </modifier>
       </modifiers>
       <infoLinks>
@@ -43270,14 +43240,9 @@ part of a close combat attack.</description>
     <selectionEntry id="76b5-1013-5e69-65a1" name="Gorgon Terminator Squad" publicationId="817a-6288-e016-7469" page="282" hidden="true" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bfc9-c99c-bf8a-3917" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bfc9-c99c-bf8a-3917" type="equalTo"/>
+          </conditions>
         </modifier>
       </modifiers>
       <infoLinks>
@@ -43536,14 +43501,9 @@ part of a close combat attack.</description>
     <selectionEntry id="cca9-59af-3e26-ab98" name="Medusan Immortal Squad" publicationId="817a-6288-e016-7469" page="283" hidden="true" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bfc9-c99c-bf8a-3917" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bfc9-c99c-bf8a-3917" type="equalTo"/>
+          </conditions>
         </modifier>
       </modifiers>
       <infoLinks>

--- a/2022 - Legiones Astartes.cat
+++ b/2022 - Legiones Astartes.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="6393-649c-7213-a327" name="(HH V2) Legions Astartes" revision="24" battleScribeVersion="2.03" authorName="Various" authorUrl="https://github.com/BSData/horus-heresy" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="8" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="6393-649c-7213-a327" name="(HH V2) Legions Astartes" revision="25" battleScribeVersion="2.03" authorName="Various" authorUrl="https://github.com/BSData/horus-heresy" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="10" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profileTypes>
     <profileType id="7002-2f9a-59c4-2742" name="Cult Arcana">
       <characteristicTypes>
@@ -31022,6 +31022,7 @@ In additon, a Contekar Terminator Squad may be selected as a Retinue Squad in a 
                 </modifier>
               </modifiers>
             </entryLink>
+            <entryLink id="4b0c-c736-9dae-bdde" name="Heavy Flamer" hidden="false" collective="false" import="true" targetId="efae-cd0d-a9f1-8be4" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="c130-44c2-8689-5be5" name="3) One Legionary may take:" hidden="false" collective="false" import="true">
@@ -32473,14 +32474,9 @@ In additon, a Contekar Terminator Squad may be selected as a Retinue Squad in a 
     <selectionEntry id="5bed-1c5c-a11e-05a1" name="Dark Sons of Death (Placeholders 2)" publicationId="09b3-d525-cdea-260c" page="11" hidden="true" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="set" field="hidden" value="false">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b2b4-2198-0b90-dd9f" type="equalTo"/>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d0b6-712f-0b12-a308" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e01e-5cdd-e512-8353" type="equalTo"/>
+          </conditions>
         </modifier>
       </modifiers>
       <categoryLinks>
@@ -43509,9 +43505,6 @@ part of a close combat attack.</description>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="cedf-90e0-2a0a-ebfb" type="max"/>
               </constraints>
-              <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="350.0"/>
-              </costs>
             </entryLink>
             <entryLink id="d40a-997b-036a-ff80" name="Land Raider Proteus Carrier" hidden="false" collective="false" import="true" targetId="c123-bdc6-a6ba-79a2" type="selectionEntry">
               <modifiers>
@@ -43524,9 +43517,6 @@ part of a close combat attack.</description>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0a45-d93c-0f80-8913" type="max"/>
               </constraints>
-              <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="220.0"/>
-              </costs>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>


### PR DESCRIPTION
GST v10
LA v25
IW v2

## Added Stuff
Expanded Army List - Small QoL fix
Character - Catagory Added. Will need adding to all characters.
Expanded Army Lists Catagory added.
Retinue - Moved under HQ for ease of Roster building as they are attached to HQ, so less likely to be missed this way.

## Fixed Units
Heavy Support Squad - added Heavy Flamer #2187
Dark Sons of Death - Fixed to Whitescars (not Dark Angels)
Gorgon Termy - Landraider and Sparten pts fixed.
Gorgon Termy - Fixed that they were mislabled as Loyal only
Medusan Immortal - Fixed that they were mislabled as Loyal only
Tyrant Seige Terminators - Fixed catagory as it was marked as "Heavy" not "Heavy Support" in both LA and IW cats.
Dark Angels unique units - Fixed that they were mislabled as Loyal only

## Fixed Item
Paragon blade - Murderous Strike to 6+ #2188

* closes # [insert issue name here](insert link here)
#2188
#2187
#2196