### PR TITLE
Whole lot of Mechy stuff and a couple of fixes

### DIFF
--- a/2022 - Horus Heresy.gst
+++ b/2022 - Horus Heresy.gst
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<gameSystem id="28d4-bd2e-4858-ece6" name="(HH V2) Horus Heresy (2022)" revision="11" battleScribeVersion="2.03" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
+<gameSystem id="28d4-bd2e-4858-ece6" name="(HH V2) Horus Heresy (2022)" revision="12" battleScribeVersion="2.03" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
   <publications>
     <publication id="e77a-823a-da94-16b9" name="Warhammer: The Horus Heresy - Age of Darkness Rulebook" shortName="Main Rules" publicationDate="June 18th, 2022"/>
     <publication id="817a-6288-e016-7469" name="Liber Astartes – Loyalist Legiones Astartes Army Book" shortName="LA - Loyalist" publicationDate="June 18th, 2022"/>
@@ -83,6 +83,21 @@
     <profileType id="a0e6-a7b4-d55d-85b8" name="Warlord Trait">
       <characteristicTypes>
         <characteristicType id="c68e-2cda-b67b-baca" name="Text"/>
+      </characteristicTypes>
+    </profileType>
+    <profileType id="75b5-9f7a-156e-6889" name="Knights and Titans">
+      <characteristicTypes>
+        <characteristicType id="3c44-1e2a-23fe-c9e0" name="Unit Type"/>
+        <characteristicType id="7f12-0cc3-9dcd-25bc" name="Move"/>
+        <characteristicType id="4227-8eed-0c5c-a2d9" name="WS"/>
+        <characteristicType id="6c5a-df71-fefa-2ee3" name="BS"/>
+        <characteristicType id="02ba-082e-e385-1ede" name="S"/>
+        <characteristicType id="0d00-68d8-0535-e898" name="Front"/>
+        <characteristicType id="cb92-5809-d327-6981" name="Side"/>
+        <characteristicType id="8fa4-6e34-29c4-d8c6" name="Rear"/>
+        <characteristicType id="91b3-4335-71bf-3fa9" name="I"/>
+        <characteristicType id="d54a-56a6-68c5-ae72" name="A"/>
+        <characteristicType id="2490-aa2f-f5db-6070" name="HP"/>
       </characteristicTypes>
     </profileType>
   </profileTypes>
@@ -399,6 +414,28 @@ Conversely, if an Independent Character joins a unit after that unit has been th
       </rules>
     </categoryEntry>
     <categoryEntry id="8247-54dc-9194-948f" name="Siege Breaker:" hidden="false"/>
+    <categoryEntry id="2440-b64e-cb24-87f0" name="Cybernetica Sub-type:" publicationId="bde1-6db1-163b-3b76" page="90" hidden="false">
+      <rules>
+        <rule id="ad70-0b7c-539c-3e16" name="Cybernetica Sub-type:" publicationId="bde1-6db1-163b-3b76" page="90" hidden="false">
+          <description>The following rules apply to all models with the Cybernetica Unit Sub-type:
+• Models with the Cybernetica Unit Sub-type are subject to the Programmed Behaviour provision. During both the controlling player’s Shooting phase and the Charge sub-phase, an Automata unit must attempt a Shooting Attack and/or Charge if there is an enemy unit within range, and must target the closest enemy unit possible that is within its line of sight and is a valid target for a Shooting Attack or Charge. If two or more targets are equally close then the controlling player chooses which will be the target of a Shooting Attack or Charge.
+• A model with the Cybernetica Unit Sub-type may fire all weapons they are equipped with in each Shooting Attack they make, including as part of a Reaction where eligible (this rule on its own does not allow units to make Reactions if they would otherwise be prevented from doing so).
+• Models with the Cybernetica Unit Sub-type may fire Heavy and Ordnance weapons and count as Stationary even if they moved in the preceding Movement phase, and may declare Charges as normal regardless of any Shooting Attacks made in the same turn.
+• Models with the Cybernetica Unit Sub-type ignore any penalties to their Initiative Characteristic when Charging into or through Difficult Terrain or Dangerous Terrain.</description>
+        </rule>
+      </rules>
+    </categoryEntry>
+    <categoryEntry id="0ea2-efb5-b7af-226e" name="Fast Vehicles" hidden="false">
+      <rules>
+        <rule id="2cbf-c1a1-844a-6456" name="Fast Vehicles" hidden="false">
+          <description>When a Fast Vehicle moves, other than to pivot in place, it is always considered to have moved at Combat Speed regardless of how many inches it moves, unless it chooses to move Flat-out.
+In addition, when a Fast Vehicle moves, it may choose to move at Flat-out:</description>
+        </rule>
+        <rule id="4a20-b387-1253-5966" name="Flat Out" publicationId="e77a-823a-da94-16b9" page="214" hidden="false">
+          <description>Flat-out - A Vehicle choosing to move Flat-out may move up to twice its Movement Characteristic, but at the end of its move must roll a single D6. If the result of this roll is a ‘1’ then the Vehicle suffers a Glancing Hit and all the effects of the Crew Stunned result on the Vehicle Damage table. Vehicles moving at Flat-out speed may only fire Snap Shots.</description>
+        </rule>
+      </rules>
+    </categoryEntry>
   </categoryEntries>
   <forceEntries>
     <forceEntry id="d926-652f-8436-30ce" name="Crusade Force Organisation Chart" hidden="false">
@@ -1848,9 +1885,9 @@ Conversely, if an Independent Character joins a unit after that unit has been th
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="5ac0-ef19-fed7-ea88" name="Turbo-Laser Destructor" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="5ac0-ef19-fed7-ea88" name="Turbo-Laser Destructor**" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
-        <profile id="34f1-b3c4-112d-5f6e" name="Turbo-Laser Destructor" publicationId="a716-c1c4-7b26-8424" page="132" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+        <profile id="34f1-b3c4-112d-5f6e" name="Turbo-Laser Destructor**" publicationId="a716-c1c4-7b26-8424" page="132" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
           <characteristics>
             <characteristic name="Range" typeId="95ba-cda7-b831-6066">96&quot;</characteristic>
             <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">12</characteristic>
@@ -1863,6 +1900,7 @@ Conversely, if an Independent Character joins a unit after that unit has been th
         <infoLink id="825e-27b1-ee08-4bc8" name="Destroyer" hidden="false" targetId="44d6-09b2-3bd3-b2d6" type="rule"/>
         <infoLink id="ad67-b373-e6f4-47db" name="Blast" hidden="false" targetId="1d9a-73ef-5f4f-8bd8" type="rule"/>
         <infoLink id="7532-b85b-3c29-20bf" name="Ignores Cover" hidden="false" targetId="fdb5-59e2-c446-1cbc" type="rule"/>
+        <infoLink id="6283-8eda-b550-c151" name="**Turbo-Laser issue" hidden="false" targetId="2ac7-9784-9b0f-182b" type="rule"/>
       </infoLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
@@ -4940,6 +4978,1374 @@ Thaumaturge’s Cleansing (Psychic Weapon)</description>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
       </costs>
     </selectionEntry>
+    <selectionEntry id="e127-4c28-1a5b-e372" name="Apocalypse Missile Launcher" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="eaff-a79a-d9f4-21bf" name="Apocalypse Missile Launcher" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">24&quot;- 360&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">7</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">3</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Destroyer 2, Apocalyptic Barrage</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="f126-df8f-4427-9ef4" name="Destroyer" hidden="false" targetId="44d6-09b2-3bd3-b2d6" type="rule"/>
+        <infoLink id="9e5f-8ab3-6455-b9e2" name="Barrage" hidden="false" targetId="7255-b5ee-c3f4-3037" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="c1d2-77e3-5d1c-5297" name="Arioch Power Claw" publicationId="bde1-6db1-163b-3b76" page="122" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="86f8-ab1b-6868-15bc" name="Arioch Power Claw" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">15</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">1</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Shred, Destructor, Instant Death, Armourbane (Melee)</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="9639-9f60-1ec1-2fdf" name="Shred" hidden="false" targetId="5e7e-1628-8174-6f2c" type="rule"/>
+        <infoLink id="e471-c4b0-fb6e-7637" name="Destructor" hidden="false" targetId="1f93-c765-f7b2-a025" type="rule"/>
+        <infoLink id="6c62-c1df-00e5-10cf" name="Instant Death" hidden="false" targetId="9e96-fff1-b916-d9a3" type="rule"/>
+        <infoLink id="71c8-9f03-b6e1-3c46" name="Armourbane (X)" hidden="false" targetId="cb59-f920-f071-7cd4" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Armourbane (Melee)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="454e-eb44-05fc-0471" name="Belicosa Volcano Cannon" publicationId="bde1-6db1-163b-3b76" page="117" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="ff92-564d-36b8-a808" name="Belicosa Volcano Cannon" publicationId="bde1-6db1-163b-3b76" page="117" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">120&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">14</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">1</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Destroyer 1, Apocalyptic Blast (9&quot;), Sunder</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="91b8-90d5-181e-2d3c" name="Blast" hidden="false" targetId="1d9a-73ef-5f4f-8bd8" type="rule"/>
+        <infoLink id="d9b8-712e-2590-361f" name="Sunder" hidden="false" targetId="20e2-75cf-bc16-cd8f" type="rule"/>
+        <infoLink id="927a-e169-b324-3e09" name="Destroyer" hidden="false" targetId="44d6-09b2-3bd3-b2d6" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="537f-846d-90e3-2526" name="Castellax Battle-Automata Maniple " publicationId="bde1-6db1-163b-3b76" page="37" hidden="false" collective="false" import="true" type="unit">
+      <categoryLinks>
+        <categoryLink id="c983-0d60-1e45-d450" name="Automata Unit-type:" hidden="false" targetId="d8ab-8e21-e193-63ba" primary="false"/>
+        <categoryLink id="efaf-7a32-0d19-5370" name="Cybernetica Sub-type:" hidden="false" targetId="2440-b64e-cb24-87f0" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="ab78-91e2-bb5c-9da3" name="Castellax" publicationId="bde1-6db1-163b-3b76" page="37" hidden="false" collective="false" import="true" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e15e-beff-e63f-0b56" type="min"/>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1c4c-58d1-59b2-df0a" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="2b2b-6a5d-8e25-8dfa" name="Castellax" publicationId="bde1-6db1-163b-3b76" page="37" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
+              <modifiers>
+                <modifier type="increment" field="f111-2ce5-dd12-d6b0" value="1">
+                  <conditions>
+                    <condition field="selections" scope="ab78-91e2-bb5c-9da3" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2121-ee7c-8ac9-5133" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <characteristics>
+                <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Automata (Cybernetica)</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7</characteristic>
+                <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">3</characteristic>
+                <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
+                <characteristic name="S" typeId="e478-41d4-a092-48a8">7</characteristic>
+                <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">6</characteristic>
+                <characteristic name="W" typeId="57ee-1126-32a9-5672">4</characteristic>
+                <characteristic name="I" typeId="62d3-22d7-2d49-52dc">3</characteristic>
+                <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">2</characteristic>
+                <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">7</characteristic>
+                <characteristic name="Save" typeId="e593-6b3c-f169-04f0">3+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="c3fb-9ffb-5a52-e31d" name="Hammer of Wrath (X)" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Hammer of Wrath (1)"/>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="e983-48d4-cde7-040e" name="A) May Exchange Main Weapon for:" hidden="false" collective="false" import="true">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5a40-0fc1-b193-81ac" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4709-d97c-fb4d-6a82" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="b927-430f-d60e-e4c7" name="Mauler Bolt Cannon" hidden="false" collective="false" import="true" targetId="7478-2c29-dfc4-f4cf" type="selectionEntry"/>
+                <entryLink id="b87c-b6d7-106d-b5e4" name="Multi-Melta" hidden="false" collective="false" import="true" targetId="9332-3834-cf3a-56b4" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="75ef-82ba-98ba-4821" name="Darkfire Cannon" hidden="false" collective="false" import="true" targetId="6f3d-9a42-da1d-2c2e" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="11c0-d3c0-d632-ba9c" name="B) May Exchange both Melee Weapons for:" hidden="false" collective="false" import="true">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b1d6-8a8c-191d-fe8c" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7eee-d4d6-6660-04c2" type="min"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="59ea-b328-a16f-3a4b" name="Shock Charger" hidden="false" collective="false" import="true" targetId="3234-492f-9ebf-f23c" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="name" value="Two Shock Charger"/>
+                  </modifiers>
+                </entryLink>
+                <entryLink id="11be-ab2c-90d2-a096" name="Siege Wrecker" hidden="false" collective="false" import="true" targetId="178d-8a3a-bfda-7443" type="selectionEntry"/>
+                <entryLink id="0fc0-fe96-a918-6761" name="Power Blade Array" hidden="false" collective="false" import="true" targetId="2121-ee7c-8ac9-5133" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="name" value="Two Power Blade Array"/>
+                  </modifiers>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="a0b3-b91e-9efd-32da" name="C) Shock Charger / Power Blades may Exchange In-Built Bolter for:" hidden="false" collective="false" import="true">
+              <modifiers>
+                <modifier type="increment" field="2acc-367e-880f-a688" value="2.0">
+                  <repeats>
+                    <repeat field="selections" scope="ab78-91e2-bb5c-9da3" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2121-ee7c-8ac9-5133" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="ab78-91e2-bb5c-9da3" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3234-492f-9ebf-f23c" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+                <modifier type="increment" field="9629-ad8d-df33-e930" value="2.0">
+                  <repeats>
+                    <repeat field="selections" scope="ab78-91e2-bb5c-9da3" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3234-492f-9ebf-f23c" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="ab78-91e2-bb5c-9da3" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2121-ee7c-8ac9-5133" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9629-ad8d-df33-e930" type="min"/>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2acc-367e-880f-a688" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="263e-f3ca-ea00-171e" name="Bolter" hidden="false" collective="false" import="true" targetId="1ade-0c02-5612-252b" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="name" value="In-Built Bolter"/>
+                  </modifiers>
+                </entryLink>
+                <entryLink id="cfb0-3d95-e727-23b1" name="Maxima Bolter" hidden="false" collective="false" import="true" targetId="1d3e-1b60-d133-ea0d" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="name" value="In-Built Maxima Bolter"/>
+                  </modifiers>
+                </entryLink>
+                <entryLink id="8256-19fd-7b72-660e" name="Flamer" hidden="false" collective="false" import="true" targetId="9f41-82e2-90f6-973a" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="name" value="In-Built Flamer"/>
+                  </modifiers>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="b191-e6a3-ec6b-f986" name="Paragon of Metal" hidden="false" collective="false" import="true" targetId="cc2a-46fe-bbf3-6ba2" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="537f-846d-90e3-2526" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab78-91e2-bb5c-9da3" type="greaterThan"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="85.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="f5d5-dc3a-7642-c6e0" name="Searchlights" hidden="false" collective="false" import="true" targetId="4ae3-79b4-6051-505e" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="d2ee-04cb-5f8a-2642" value="1.0">
+              <repeats>
+                <repeat field="selections" scope="537f-846d-90e3-2526" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ab78-91e2-bb5c-9da3" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c33d-1bca-1121-a3bf" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6f3d-9a42-da1d-2c2e" name="Darkfire Cannon" publicationId="bde1-6db1-163b-3b76" page="117" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="f9b1-869e-9b30-6413" name="Darkfire Cannon" publicationId="bde1-6db1-163b-3b76" page="117" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">36&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">7</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">2</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 2, Blind, Lance, Gets Hot</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="2016-0c2e-d948-14d5" name="Blind" hidden="false" targetId="d836-747d-07d6-2b63" type="rule"/>
+        <infoLink id="d91d-7508-71f5-25be" name="Lance" hidden="false" targetId="3d6b-9e0b-56f0-8a1e" type="rule"/>
+        <infoLink id="d6bb-d9c3-2b9a-076c" name="Gets Hot" hidden="false" targetId="679f-9d97-5ace-a652" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="55e4-0853-3720-c068" name="Defensor Autocannon Battery" publicationId="bde1-6db1-163b-3b76" page="114" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="4ddd-1d39-8f02-1e99" name="Defensor Autocannon Battery" publicationId="bde1-6db1-163b-3b76" page="114" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">72&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">7</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">4</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 4, Rending (6+), Twin-linked, Sunder, Skyfire</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="2d12-cf79-2991-a694" name="Rending (X)" hidden="false" targetId="0ac9-fab7-aef3-de1d" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Rending (6+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="707d-4700-a7b0-1da0" name="Twin-linked" hidden="false" targetId="8542-ee9d-e2fa-52fe" type="rule"/>
+        <infoLink id="faf9-82b1-cc68-83b8" name="Sunder" hidden="false" targetId="20e2-75cf-bc16-cd8f" type="rule"/>
+        <infoLink id="998e-cd8d-7e3e-93cb" name="Skyfire" hidden="false" targetId="f2bf-5daa-9f93-0b01" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="fee2-949c-6d55-2a2f" name="Defensor Bolt Cannon" publicationId="bde1-6db1-163b-3b76" page="114" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="6590-8653-7d8f-78c6" name="Defensor Bolt Cannon" publicationId="bde1-6db1-163b-3b76" page="114" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">24&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">6</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">4</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 6, Ardex-defensor</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="dac5-8a5f-a367-1d93" name="Ardex-Defensor" hidden="false" targetId="d242-cb71-bc7f-eadd" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2a03-11f0-739e-01a7" name="Defensor Lascannon" publicationId="bde1-6db1-163b-3b76" page="114" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="6151-332a-2039-4716" name="Defensor Lascannon" publicationId="bde1-6db1-163b-3b76" page="114" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">48&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">9</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">2</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 1, Ardex-defensor, Sunder, Twin-linked</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="d6b0-83a6-a9a9-d4ee" name="Ardex-Defensor" hidden="false" targetId="d242-cb71-bc7f-eadd" type="rule"/>
+        <infoLink id="560a-b8d1-c9f3-4abd" name="Sunder" hidden="false" targetId="20e2-75cf-bc16-cd8f" type="rule"/>
+        <infoLink id="a3be-17ad-5153-5017" name="Twin-linked" hidden="false" targetId="8542-ee9d-e2fa-52fe" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1a1b-fa35-a6a2-ca78" name="Domitar Battle-Automata Maniple" publicationId="bde1-6db1-163b-3b76" page="31" hidden="false" collective="false" import="true" type="unit">
+      <categoryLinks>
+        <categoryLink id="f34b-917f-4dc5-41a0" name="Automata Unit-type:" hidden="false" targetId="d8ab-8e21-e193-63ba" primary="false"/>
+        <categoryLink id="ba42-793b-aee7-2b65" name="Cybernetica Sub-type:" hidden="false" targetId="2440-b64e-cb24-87f0" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="200f-3379-95a3-c3a4" name="Domitar" hidden="false" collective="false" import="true" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7684-c5d0-888e-0668" type="min"/>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6560-36ea-b5d0-b855" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="27b6-ab96-5544-b612" name="Domitar" publicationId="bde1-6db1-163b-3b76" page="31" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
+              <characteristics>
+                <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Automata (Cybernetica)</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">8</characteristic>
+                <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
+                <characteristic name="BS" typeId="74ae-c840-0036-d244">3</characteristic>
+                <characteristic name="S" typeId="e478-41d4-a092-48a8">7</characteristic>
+                <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">7</characteristic>
+                <characteristic name="W" typeId="57ee-1126-32a9-5672">5</characteristic>
+                <characteristic name="I" typeId="62d3-22d7-2d49-52dc">3</characteristic>
+                <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">3</characteristic>
+                <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">7</characteristic>
+                <characteristic name="Save" typeId="e593-6b3c-f169-04f0">3+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="573c-7dd2-5f44-2aae" name="Hammer of Wrath (X)" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Hammer of Wrath (1)"/>
+              </modifiers>
+            </infoLink>
+            <infoLink id="930b-7c31-044a-40f8" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
+          </infoLinks>
+          <selectionEntries>
+            <selectionEntry id="b871-734b-b876-f794" name="Missile Launcher with Frag, Krak and Ignis Missiles" publicationId="bde1-6db1-163b-3b76" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b107-efec-e9cb-b6fb" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5fc6-1f16-aa7c-977e" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="fa47-f0be-b1c4-5a4d" name="Missile Launcher - Frag" publicationId="a716-c1c4-7b26-8424" page="133" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="95ba-cda7-b831-6066">48&quot;</characteristic>
+                    <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">4</characteristic>
+                    <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">6</characteristic>
+                    <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 1, Blast (3&quot;), Pinning</characteristic>
+                  </characteristics>
+                </profile>
+                <profile id="ee3b-1cc3-4a97-6fdd" name="Missile Launcher - Ignis" publicationId="bde1-6db1-163b-3b76" page="118" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="95ba-cda7-b831-6066">48&quot;</characteristic>
+                    <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">5</characteristic>
+                    <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">6</characteristic>
+                    <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 1, Blast (3&quot;), Ignores Cover</characteristic>
+                  </characteristics>
+                </profile>
+                <profile id="2783-8001-8e0d-0f7f" name="Missile Launcher - Krak" publicationId="a716-c1c4-7b26-8424" page="133" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="95ba-cda7-b831-6066">48&quot;</characteristic>
+                    <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">8</characteristic>
+                    <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">3</characteristic>
+                    <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 1</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink id="19b7-4553-d94e-4746" name="Pinning" hidden="false" targetId="1c96-205c-59a0-3cf2" type="rule"/>
+                <infoLink id="a034-61f7-5d44-6466" name="Blast" hidden="false" targetId="1d9a-73ef-5f4f-8bd8" type="rule"/>
+                <infoLink id="ec38-2e57-c47c-94a2" name="Ignores Cover" hidden="false" targetId="fdb5-59e2-c446-1cbc" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <entryLinks>
+            <entryLink id="7549-b055-00a9-7fbe" name="Graviton Hammer" hidden="false" collective="false" import="true" targetId="ceaa-178d-3995-c2c8" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f4e-6276-589c-4e89" type="min"/>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3817-88a0-382c-01f0" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="9d03-1f50-3111-a224" name="Atomantic Deflector" hidden="false" collective="false" import="true" targetId="38fb-9a0b-edef-a497" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="be33-1192-2508-125a" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b895-152b-024d-c335" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="8045-8709-9262-02f8" name="Searchlights" hidden="false" collective="false" import="true" targetId="4ae3-79b4-6051-505e" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6282-1ce5-0c03-d93a" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="46f5-b818-cac3-aa5d" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="d4dc-190d-5cc9-e7b1" name="Paragon of Metal" hidden="false" collective="false" import="true" targetId="cc2a-46fe-bbf3-6ba2" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="1a1b-fa35-a6a2-ca78" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="200f-3379-95a3-c3a4" type="greaterThan"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="130.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="12c4-10db-40e2-04c4" name="Gatling Blaster" publicationId="bde1-6db1-163b-3b76" page="114" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="49a1-1118-ae6e-e535" name="Gatling Blaster" publicationId="bde1-6db1-163b-3b76" page="114" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">60&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">8</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">3</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Destroyer 2, Apocalyptic Blast (9&quot;), Pinning, Shell Shock (1)</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="9e9b-4926-c603-df3e" name="Pinning" hidden="false" targetId="1c96-205c-59a0-3cf2" type="rule"/>
+        <infoLink id="d888-d68e-f8ee-8558" name="Destroyer" hidden="false" targetId="44d6-09b2-3bd3-b2d6" type="rule"/>
+        <infoLink id="71ce-f18e-f378-2443" name="Shell Shock (X)" hidden="false" targetId="46b7-63a1-941c-96a5" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Shell Shock (1)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="12a9-123a-1516-c633" name="Blast" hidden="false" targetId="1d9a-73ef-5f4f-8bd8" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ceaa-178d-3995-c2c8" name="Graviton Hammer" publicationId="bde1-6db1-163b-3b76" page="116" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="3135-eb29-2a63-329d" name="Graviton Hammer (Melee)" publicationId="bde1-6db1-163b-3b76" page="116" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">10</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">2</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Armourbane (Melee), Concussive (2)</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="d867-d7b0-ce2b-dc88" name="Graviton Hammer (Ranged)" publicationId="bde1-6db1-163b-3b76" page="116" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">Template</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">*</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">6</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 1, Concussive (1), Graviton Pulse*, Grav Wave, Haywire</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="88f3-0cb5-d310-74fc" name="Armourbane (X)" hidden="false" targetId="cb59-f920-f071-7cd4" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Armourbane (Melee)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="0d30-dbad-b929-3bd5" name="Concussive (X)" hidden="false" targetId="7ce5-1bfb-64e6-f826" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Concussive (2)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="3a2b-4675-ded5-a6f0" name="Concussive (X)" hidden="false" targetId="7ce5-1bfb-64e6-f826" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Concussive (1)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="1d35-d0fa-0e25-3fff" name="Grav Wave" hidden="false" targetId="1cc2-eaee-8bcf-96d3" type="rule"/>
+        <infoLink id="9561-cc6f-740e-7fe9" name="Graviton Pulse" hidden="false" targetId="5b9c-2738-616c-abdf" type="rule"/>
+        <infoLink id="72a9-4787-6458-78e4" name="Haywire" hidden="false" targetId="1dd4-7a75-5c59-8425" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f610-008f-5046-ea99" name="Graviton Ram" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="3e1c-ee75-1b61-ee8c" name="Graviton Ram (Melee)" publicationId="bde1-6db1-163b-3b76" page="116" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">10</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">1</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Armourbane (Melee), Concussive (2)</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="1b9d-98a0-4f71-a759" name="Graviton Ram (Ranged)" publicationId="bde1-6db1-163b-3b76" page="116" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">Template</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">*</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">4</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 1, Concussive (1), Graviton Pulse*,Grav Wave, Haywire</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="e8af-0d94-e6ca-0d94" name="Armourbane (X)" hidden="false" targetId="cb59-f920-f071-7cd4" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Armourbane (Melee)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="539a-b835-dcc9-f587" name="Concussive (X)" hidden="false" targetId="7ce5-1bfb-64e6-f826" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Concussive (2)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="eded-97c0-8a97-bc09" name="Concussive (X)" hidden="false" targetId="7ce5-1bfb-64e6-f826" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Concussive (1)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="978d-b745-6af5-6a62" name="Grav Wave" hidden="false" targetId="1cc2-eaee-8bcf-96d3" type="rule"/>
+        <infoLink id="b66c-55a9-9b19-09eb" name="Graviton Pulse" hidden="false" targetId="5b9c-2738-616c-abdf" type="rule"/>
+        <infoLink id="e1d3-162f-73eb-5323" name="Haywire" hidden="false" targetId="1dd4-7a75-5c59-8425" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f227-a61a-3215-932b" name="Heavy Stubber" publicationId="bde1-6db1-163b-3b76" page="114" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="129d-1b6c-7ba2-29ec" name="Heavy Stubber" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">36&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">4</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">6</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="aa57-fc73-86fe-217c" name="Inferno Gun" publicationId="bde1-6db1-163b-3b76" page="116" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="b094-2f87-6a11-eca2" name="Inferno gun" publicationId="bde1-6db1-163b-3b76" page="116" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">Hellstorm</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">7</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">3</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Destroyer 1, Torrent (24&quot;)</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="90b5-d603-3559-936a" name="Destroyer" hidden="false" targetId="44d6-09b2-3bd3-b2d6" type="rule"/>
+        <infoLink id="c21b-7ff5-85f7-fe6d" name="Torrent (X)" hidden="false" targetId="5cfb-fc94-e6db-43b8" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Torrent (24&quot;)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b3c5-237f-e1d2-d9f8" name="Irad-Cleanser" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="484b-1446-7bac-46d9" name="Irad-Cleanser" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">Template</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">2</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">5</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Assault 1, Fleshbane, Rad-phage</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="356e-6348-0213-3dff" name="Fleshbane" hidden="false" targetId="40cd-9505-253c-e76f" type="rule"/>
+        <infoLink id="f1bf-681e-abf4-bb79" name="Rad-Phage" hidden="false" targetId="8189-e963-d2e5-5d3d" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1071-7d27-420c-07b9" name="Laser Blaster" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="09b8-b387-4c58-d09d" name="Laser Blaster" publicationId="bde1-6db1-163b-3b76" page="117" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">96&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">10</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">2</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Destroyer 1, Large Blast (5&quot;)</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="16ce-5549-b619-a651" name="Blast" hidden="false" targetId="1d9a-73ef-5f4f-8bd8" type="rule"/>
+        <infoLink id="96dd-fa04-b4c6-d7c6" name="Destroyer" hidden="false" targetId="44d6-09b2-3bd3-b2d6" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f65c-633a-5865-7f6b" name="Lightning Gun" publicationId="bde1-6db1-163b-3b76" page="113" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="7aca-056b-f2c7-e744" name="Lightning Gun (Arc)" publicationId="bde1-6db1-163b-3b76" page="113" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">18&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">4</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">-</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 3, Shred</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="530a-de1b-b3cd-989f" name="Lightning Gun (Strike)" publicationId="bde1-6db1-163b-3b76" page="113" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">18&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">7</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">5</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 1, Rending (4+), Shred</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="9621-1a87-9bbe-8c8e" name="Rending (X)" hidden="false" targetId="0ac9-fab7-aef3-de1d" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Rending (4+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="75d2-fa45-545b-b466" name="Shred" hidden="false" targetId="5e7e-1628-8174-6f2c" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7478-2c29-dfc4-f4cf" name="Mauler Bolt Cannon" publicationId="bde1-6db1-163b-3b76" page="114" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="0d73-2c3e-acc4-6043" name="Mauler Bolt Cannon" publicationId="bde1-6db1-163b-3b76" page="114" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">24&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">6</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">4</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 4, Pinning</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="c266-d515-6109-7c39" name="Pinning" hidden="false" targetId="1c96-205c-59a0-3cf2" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1d3e-1b60-d133-ea0d" name="Maxima Bolter" publicationId="bde1-6db1-163b-3b76" page="114" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="54b0-1838-c2c5-1191" name="Maxima Bolter" publicationId="bde1-6db1-163b-3b76" page="114" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">12&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">4</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">5</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Assault 3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7a16-0e23-c633-c668" name="Melta Cannon" publicationId="bde1-6db1-163b-3b76" page="117" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="ace6-d246-d221-6912" name="Melta Cannon" publicationId="bde1-6db1-163b-3b76" page="117" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">60&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">10</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">1</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 1, Massive Blast (7&quot;), Armourbane (Melta)</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="193d-4a08-ec01-d508" name="Blast" hidden="false" targetId="1d9a-73ef-5f4f-8bd8" type="rule"/>
+        <infoLink id="700f-46b5-5b7f-43e6" name="Armourbane (X)" hidden="false" targetId="cb59-f920-f071-7cd4" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Armourbane (Melta)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="eab1-7776-c8da-da00" name="Mori Quake Cannon" publicationId="bde1-6db1-163b-3b76" page="113" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="a101-d643-7adf-a419" name="Mori Quake Cannon" publicationId="bde1-6db1-163b-3b76" page="113" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">24&quot;-360&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">10/8/6</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">3</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Destroyer 1, Apocalyptic Mega-blast, Barrage, Seismic Shock, Concussive (1)</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="968b-72b9-94b1-2949" name="Destroyer" hidden="false" targetId="44d6-09b2-3bd3-b2d6" type="rule"/>
+        <infoLink id="47bf-488c-00ab-3694" name="Blast" hidden="false" targetId="1d9a-73ef-5f4f-8bd8" type="rule"/>
+        <infoLink id="e478-7a02-f953-f109" name="Barrage" hidden="false" targetId="7255-b5ee-c3f4-3037" type="rule"/>
+        <infoLink id="3e74-94bd-676c-20ea" name="Concussive (X)" hidden="false" targetId="7ce5-1bfb-64e6-f826" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Concussive (1)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="26b7-8408-49e0-48bb" name="Seismic Shock" hidden="false" targetId="5e0d-b2af-e7b4-a8cd" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="003b-af4b-0094-f5c3" name="Multi-Laser" publicationId="bde1-6db1-163b-3b76" page="117" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="39e5-062a-576b-91a9" name="Multi-Laser" publicationId="bde1-6db1-163b-3b76" page="117" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">36&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">6</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">6</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="cc2a-46fe-bbf3-6ba2" name="Paragon of Metal" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5a1f-7479-f67d-bcba" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7eb3-aecd-82f4-f2cb" type="max"/>
+      </constraints>
+      <rules>
+        <rule id="bd1e-ded3-8252-561d" name="Paragon of Metal" publicationId="bde1-6db1-163b-3b76" page="106" hidden="false">
+          <description>Only one model in an army may be upgraded to have the Paragon of Metal special rule. Models upgraded with the Paragon of Metal special rule must have the Automata (Cybernetica) Unit Type before the upgrade is applied. This rule confers the Paragon Sub-type, which replaces the Cybernetica Unit Sub-type, and confers the It Will Not Die (4+), Precision Strikes (4+), Precision Shots (4+) and Rampage (2) special rules. A model upgraded with the Paragon of Metal special rule also increases both their starting Wounds Characteristic and their Weapon Skill Characteristic by +1.
+In addition, a model with the Paragon of Metal special rule may not be targeted or affected by any Cybertheurgic Power or any Weapon with the Data-djinn special rule, either friendly or enemy.</description>
+        </rule>
+        <rule id="aa64-ebfc-e457-1e0d" name="Paragon Unit Sub-type" publicationId="bde1-6db1-163b-3b76" page="91" hidden="false">
+          <description>The following rules apply to all models with the Paragon Unit Sub-type:
+• Models with the Paragon Unit Sub-type are not affected by special rules that negatively modify their Characteristics (other than Wounds or Hull Points).
+• A model with the Paragon Unit Sub-type may fire all weapons they are equipped with in each Shooting Attack they make, including as part of a Reaction.
+• Models with the Paragon Unit Sub-type may fire Heavy and Ordnance weapons and count as Stationary even if they moved in the preceding Movement phase, and may declare Charges as normal regardless of any Shooting Attacks made in the same turn.
+• A unit that contains a model with the Paragon Unit Sub-type may never be joined by any other models, regardless of any other special rule.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="5635-6be8-9386-4eb3" name="It Will Not Die (X)" hidden="false" targetId="2784-d0be-a4e2-890f" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="It Will Not Die (4+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="c5eb-ba86-2739-2813" name="Precision Shots (X)" hidden="false" targetId="4b71-81ee-31f4-fa09" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Precision Shots (4+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="001d-d66b-e514-124a" name="Precision Strikes (X)" hidden="false" targetId="2206-8497-8fe1-e973" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Precision Strikes (4+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="0f59-348b-1eec-aec0" name="Rampage (X)" hidden="false" targetId="3efb-2a2c-2d0b-92fc" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Rampage (2)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="17c6-afe9-c5da-d9b6" name="Phased Plasma-Fusil" publicationId="bde1-6db1-163b-3b76" page="118" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="acdc-4f26-a91b-d291" name="Phased Plasma-Fusil" publicationId="bde1-6db1-163b-3b76" page="118" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">24&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">6</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">3</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 3, Breaching (4+), Gets Hot</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="71b8-7dad-0cd4-f886" name="Breaching (X)" hidden="false" targetId="a760-f736-1bf3-fa3c" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Breaching (4+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="1fbd-3c00-3e58-0615" name="Gets Hot" hidden="false" targetId="679f-9d97-5ace-a652" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="c666-29f6-42da-2e07" name="Plasma Blastgun" publicationId="bde1-6db1-163b-3b76" page="118" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="4dc5-1b5b-a916-9adb" name="Plasma Blastgun" publicationId="bde1-6db1-163b-3b76" page="118" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">72&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">9</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">3</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Ordnance 1, Massive Blast (7&quot;), Breaching (4+), Reactor Overload</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="8f70-d2ca-7e73-d50f" name="Ordnance" hidden="false" targetId="6c55-22c8-1b01-2105" type="rule"/>
+        <infoLink id="7355-35eb-d0ec-b453" name="Blast" hidden="false" targetId="1d9a-73ef-5f4f-8bd8" type="rule"/>
+        <infoLink id="458f-0eab-b419-0f7b" name="Breaching (X)" hidden="false" targetId="a760-f736-1bf3-fa3c" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Breaching (4+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="72f0-facd-626f-b9c5" name="Reactor Overload" hidden="false" targetId="a073-b86c-7bc1-d3f9" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="226a-8196-f0af-f8a8" name="Plasma Mortar" publicationId="bde1-6db1-163b-3b76" page="118" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="b024-fd99-74bd-a470" name="Plasma Mortar" publicationId="bde1-6db1-163b-3b76" page="118" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">36&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">8</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">4</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Ordnance 1, Large Blast (5&quot;), Breaching (4+), Ignores Cover, Reactor Overload</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="b1a0-5946-ac80-f88e" name="Blast" hidden="false" targetId="1d9a-73ef-5f4f-8bd8" type="rule"/>
+        <infoLink id="477b-d136-c36a-e2d5" name="Breaching (X)" hidden="false" targetId="a760-f736-1bf3-fa3c" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Breaching (4+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="9311-8b5a-f831-8f6c" name="Ignores Cover" hidden="false" targetId="fdb5-59e2-c446-1cbc" type="rule"/>
+        <infoLink id="3ce5-eddf-7453-a879" name="Reactor Overload" hidden="false" targetId="a073-b86c-7bc1-d3f9" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2121-ee7c-8ac9-5133" name="Power Blade Array" publicationId="bde1-6db1-163b-3b76" page="122" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="3a2b-2c15-46b8-f8f8" name="Power Blade Array" publicationId="bde1-6db1-163b-3b76" page="122" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">User</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">4</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Breaching (5+)</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="96da-8e2b-5b08-9145" name="Breaching (X)" hidden="false" targetId="a760-f736-1bf3-fa3c" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Breaching (5+)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3234-492f-9ebf-f23c" name="Shock Charger" publicationId="bde1-6db1-163b-3b76" page="123" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="6a03-3816-0065-83ff" name="Shock Charger" publicationId="bde1-6db1-163b-3b76" page="123" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">User</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">3</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="178d-8a3a-bfda-7443" name="Siege Wrecker" publicationId="bde1-6db1-163b-3b76" page="123" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="2ec5-4528-0a7c-0780" name="Siege Wrecker" publicationId="bde1-6db1-163b-3b76" page="123" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066"/>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458"/>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d"/>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Brutal (2), Sunder, Wrecker, Specialist Weapon</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="67f3-d6ef-7d2b-5b1d" name="Brutal (X)" hidden="false" targetId="5079-1fec-d32b-8b84" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Brutal (2)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="af67-1381-f757-4059" name="Sunder" hidden="false" targetId="20e2-75cf-bc16-cd8f" type="rule"/>
+        <infoLink id="ca1c-34bd-d31c-d32e" name="Wrecker" hidden="false" targetId="ba77-a802-55df-da67" type="rule"/>
+        <infoLink id="8894-4033-c69b-e5cd" name="Specialist Weapon" hidden="false" targetId="1a1f-3c9b-b097-5886" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="24d6-7dc1-0dde-9504" name="Sollex Heavy-Las" publicationId="bde1-6db1-163b-3b76" page="117" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="63ed-87d1-30f3-100d" name="Sollex Heavy-Las" publicationId="bde1-6db1-163b-3b76" page="117" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">48&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">10</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">2</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 3, Armourbane (Ranged), Shock Pulse</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="494e-b266-33dc-5871" name="Armourbane (X)" hidden="false" targetId="cb59-f920-f071-7cd4" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Armourbane (Ranged)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="e656-46c8-1175-7673" name="Shock Pulse" hidden="false" targetId="9222-f6c5-dc19-905a" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f4dc-88a0-0ad9-4c61" name="Sunfury Plasma Annihilator" publicationId="bde1-6db1-163b-3b76" page="118" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="bc66-cc98-7577-e716" name="Sunfury Plasma Annihilator" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">72&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">9</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">2</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Destroyer 2, Apocalyptic Barrage, Ignores Cover, Reactor Overload</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="e618-8358-4ee3-245c" name="Destroyer" hidden="false" targetId="44d6-09b2-3bd3-b2d6" type="rule"/>
+        <infoLink id="e712-a41d-76b9-dfde" name="Blast" hidden="false" targetId="1d9a-73ef-5f4f-8bd8" type="rule"/>
+        <infoLink id="1e2c-84c3-5b0e-0a40" name="Ignores Cover" hidden="false" targetId="fdb5-59e2-c446-1cbc" type="rule"/>
+        <infoLink id="c764-ef6c-259c-84bc" name="Reactor Overload" hidden="false" targetId="a073-b86c-7bc1-d3f9" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2903-fef6-e839-368b" name="Thanatar Siege-automata Maniple" publicationId="bde1-6db1-163b-3b76" page="46" hidden="false" collective="false" import="true" type="unit">
+      <rules>
+        <rule id="5b8f-4c94-7cc1-90f2" name="Thanatar Maniple" publicationId="bde1-6db1-163b-3b76" page="110" hidden="false">
+          <description>When deployed onto the battlefield (either at the start of the battle or when arriving from Reserves) all models in the unit must be placed within unit coherency, but afterwards operate independently and are not treated asa single unit.</description>
+        </rule>
+      </rules>
+      <categoryLinks>
+        <categoryLink id="ce97-d8a6-5bef-c2aa" name="Automata Unit-type:" hidden="false" targetId="d8ab-8e21-e193-63ba" primary="false"/>
+        <categoryLink id="12f3-e9d8-79be-f918" name="Cybernetica Sub-type:" hidden="false" targetId="2440-b64e-cb24-87f0" primary="false"/>
+        <categoryLink id="c841-2f37-df8e-f4f8" name="Light Sub-type:" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
+        <categoryLink id="c452-b818-fc00-c8d0" name="Heavy" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="c48e-f9ea-9d9d-46aa" name="Thanatar" publicationId="bde1-6db1-163b-3b76" page="46" hidden="false" collective="false" import="true" type="model">
+          <modifiers>
+            <modifier type="set" field="name" value="Thanatar Calix">
+              <conditions>
+                <condition field="selections" scope="c48e-f9ea-9d9d-46aa" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4c16-20c7-f928-2aa6" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="name" value="Thanatar Cavas">
+              <conditions>
+                <condition field="selections" scope="c48e-f9ea-9d9d-46aa" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5331-31f3-87ed-5ebe" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4f1c-057b-1a09-e4bb" type="min"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5056-7e9f-20b9-96eb" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="15b5-1ed0-a48c-a9b8" name="A single Thanatar-Cavas in the Maniple may be replaced with a Thanatar Calix" hidden="false" collective="false" import="true">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e0f0-a2f0-5ed0-84e4" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aefd-3258-c13f-7078" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="5331-31f3-87ed-5ebe" name="Thanatar Cavas" hidden="false" collective="false" import="true" type="upgrade">
+                  <profiles>
+                    <profile id="891f-90ee-c496-ce0d" name="Thanatar Cavas" publicationId="bde1-6db1-163b-3b76" page="46" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
+                      <characteristics>
+                        <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Automata (Cybernetica, Light)</characteristic>
+                        <characteristic name="Move" typeId="893e-2d76-8f04-44e5">8</characteristic>
+                        <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
+                        <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
+                        <characteristic name="S" typeId="e478-41d4-a092-48a8">6</characteristic>
+                        <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">5</characteristic>
+                        <characteristic name="W" typeId="57ee-1126-32a9-5672">4</characteristic>
+                        <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
+                        <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">3</characteristic>
+                        <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">7</characteristic>
+                        <characteristic name="Save" typeId="e593-6b3c-f169-04f0">3+</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <infoLinks>
+                    <infoLink id="cf31-6e0c-68b4-2bb4" name="Hammer of Wrath (X)" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
+                      <modifiers>
+                        <modifier type="set" field="name" value="Hammer of Wrath (1)"/>
+                      </modifiers>
+                    </infoLink>
+                  </infoLinks>
+                  <entryLinks>
+                    <entryLink id="f896-a67c-5732-74e6" name="Plasma Mortar" hidden="false" collective="false" import="true" targetId="226a-8196-f0af-f8a8" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f470-9498-1a5a-595d" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="62a2-4026-8135-684c" type="max"/>
+                      </constraints>
+                    </entryLink>
+                    <entryLink id="5504-f040-14db-6982" name="Shock Charger" hidden="false" collective="false" import="true" targetId="3234-492f-9ebf-f23c" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="09ba-e021-c071-a9c7" type="min"/>
+                        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6e3c-216c-30ac-0a04" type="max"/>
+                      </constraints>
+                    </entryLink>
+                    <entryLink id="6920-5af8-8152-d756" name="Atomantic Deflector" hidden="false" collective="false" import="true" targetId="38fb-9a0b-edef-a497" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8361-6260-e133-6fdb" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b414-b34e-2d24-b68b" type="max"/>
+                      </constraints>
+                    </entryLink>
+                    <entryLink id="7524-1194-0bcd-024e" name="Twin-linked Mauler Bolt Cannon" hidden="false" collective="false" import="true" targetId="ac88-bcf4-d7b4-5c56" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e16b-86f7-2db9-9778" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fdc8-c39c-127a-89b6" type="max"/>
+                      </constraints>
+                    </entryLink>
+                  </entryLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="4c16-20c7-f928-2aa6" name="Thanatar Calix" hidden="false" collective="false" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="2903-fef6-e839-368b" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="83fc-f27c-08a9-0907" type="max"/>
+                  </constraints>
+                  <profiles>
+                    <profile id="df17-9de2-31bf-f684" name="Thanatar Calix" publicationId="bde1-6db1-163b-3b76" page="46" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
+                      <characteristics>
+                        <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Automata (Cybernetica, Light)</characteristic>
+                        <characteristic name="Move" typeId="893e-2d76-8f04-44e5">8</characteristic>
+                        <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
+                        <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
+                        <characteristic name="S" typeId="e478-41d4-a092-48a8">6</characteristic>
+                        <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">5</characteristic>
+                        <characteristic name="W" typeId="57ee-1126-32a9-5672">4</characteristic>
+                        <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
+                        <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">3</characteristic>
+                        <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">7</characteristic>
+                        <characteristic name="Save" typeId="e593-6b3c-f169-04f0">3+</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <infoLinks>
+                    <infoLink id="5769-8876-abc8-6b62" name="Hammer of Wrath (X)" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
+                      <modifiers>
+                        <modifier type="set" field="name" value="Hammer of Wrath (1)"/>
+                      </modifiers>
+                    </infoLink>
+                  </infoLinks>
+                  <entryLinks>
+                    <entryLink id="0fc7-4df7-8728-f720" name="Graviton Ram" hidden="false" collective="false" import="true" targetId="f610-008f-5046-ea99" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b35e-74a6-848b-3971" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="869a-0615-e77d-8a4b" type="max"/>
+                      </constraints>
+                    </entryLink>
+                    <entryLink id="5528-2ffc-88ff-9c57" name="Sollex Heavy-Las" hidden="false" collective="false" import="true" targetId="24d6-7dc1-0dde-9504" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eac4-7aa1-ed74-2107" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ccf9-9967-b2f0-0e65" type="max"/>
+                      </constraints>
+                    </entryLink>
+                    <entryLink id="b455-6e04-25d8-2eb6" name="Atomantic Deflector" hidden="false" collective="false" import="true" targetId="38fb-9a0b-edef-a497" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f171-d842-4134-3bf0" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1bcb-8717-3150-e809" type="max"/>
+                      </constraints>
+                    </entryLink>
+                    <entryLink id="072c-045d-c5cc-c0e2" name="Twin-linked Mauler Bolt Cannon" hidden="false" collective="false" import="true" targetId="ac88-bcf4-d7b4-5c56" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="456b-366e-bb16-2a1a" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ee1-2b23-b60f-a203" type="max"/>
+                      </constraints>
+                    </entryLink>
+                  </entryLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="d184-0a35-7e08-07f1" name="Paragon of Metal" hidden="false" collective="false" import="true" targetId="cc2a-46fe-bbf3-6ba2" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="2903-fef6-e839-368b" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c48e-f9ea-9d9d-46aa" type="greaterThan"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="235.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2952-52d9-49e2-cbfd" name="Titan Power Fist" publicationId="bde1-6db1-163b-3b76" page="122" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="1198-69f8-54f2-7a5d" name="Titan Power Fist" publicationId="bde1-6db1-163b-3b76" page="122" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">14</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">1</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Sunder, Destructor</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="86c1-3c47-751e-9c64" name="Sunder" hidden="false" targetId="20e2-75cf-bc16-cd8f" type="rule"/>
+        <infoLink id="d31c-ac5b-aafc-3f5c" name="Destructor" hidden="false" targetId="1f93-c765-f7b2-a025" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ac88-bcf4-d7b4-5c56" name="Twin-linked Mauler Bolt Cannon" publicationId="bde1-6db1-163b-3b76" page="114" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="8398-d59e-6c60-9c3d" name="Twin-linked Mauler Bolt Cannon" publicationId="bde1-6db1-163b-3b76" page="114" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">24&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">6</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">4</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 4, Pinning, Twin-linked</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="7003-efbe-2388-6776" name="Pinning" hidden="false" targetId="1c96-205c-59a0-3cf2" type="rule"/>
+        <infoLink id="509e-4e52-b5d5-f867" name="Twin-linked" hidden="false" targetId="8542-ee9d-e2fa-52fe" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f947-d7f1-40bd-f425" name="Twin-linked Turbo Laser-Destructor**" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="7638-24f4-5d50-19a4" name="Twin-linked Turbo-Laser Destructor**" publicationId="a716-c1c4-7b26-8424" page="132" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">96&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">12</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">2</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Destroyer 1, Large Blast (5&quot;), Ignores Cover, Twin-linked</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="89df-a615-155d-b9e0" name="Destroyer" hidden="false" targetId="44d6-09b2-3bd3-b2d6" type="rule"/>
+        <infoLink id="7eb5-3a0c-7678-8195" name="Blast" hidden="false" targetId="1d9a-73ef-5f4f-8bd8" type="rule"/>
+        <infoLink id="c702-a2c4-ac1f-2d72" name="Twin-linked" hidden="false" targetId="8542-ee9d-e2fa-52fe" type="rule"/>
+        <infoLink id="45ab-52e4-d6d4-1bf3" name="**Turbo-Laser issue" hidden="false" targetId="2ac7-9784-9b0f-182b" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f144-1079-11ff-019d" name="Vorax Battle-automata Maniple" publicationId="bde1-6db1-163b-3b76" page="42" hidden="false" collective="false" import="true" type="unit">
+      <categoryLinks>
+        <categoryLink id="75eb-2b97-8b36-a501" name="Automata Unit-type:" hidden="false" targetId="d8ab-8e21-e193-63ba" primary="false"/>
+        <categoryLink id="4a9a-7fa9-75bb-1914" name="Cybernetica Sub-type:" hidden="false" targetId="2440-b64e-cb24-87f0" primary="false"/>
+        <categoryLink id="f6a5-5001-3a55-c7f9" name="Light Sub-type:" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="59fd-998f-8190-baec" name="Vorax" publicationId="bde1-6db1-163b-3b76" page="42" hidden="false" collective="false" import="true" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f64e-d371-c8bc-2142" type="min"/>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="263e-aaf5-8054-419e" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="244c-1e6b-3768-3c13" name="Vorax" publicationId="bde1-6db1-163b-3b76" page="42" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
+              <characteristics>
+                <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Automata (Cybernetica, Light)</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">8</characteristic>
+                <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
+                <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
+                <characteristic name="S" typeId="e478-41d4-a092-48a8">6</characteristic>
+                <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">5</characteristic>
+                <characteristic name="W" typeId="57ee-1126-32a9-5672">4</characteristic>
+                <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
+                <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">3</characteristic>
+                <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">7</characteristic>
+                <characteristic name="Save" typeId="e593-6b3c-f169-04f0">3+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="569f-ee61-f33a-e599" name="Fleet (X)" hidden="false" targetId="ddc9-0b4b-78da-bbd2" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Fleet (2)"/>
+              </modifiers>
+            </infoLink>
+            <infoLink id="3c21-bfee-eb7c-b5d2" name="Scout" hidden="false" targetId="aacf-9a7e-982d-b793" type="rule"/>
+            <infoLink id="e32e-91b4-6fa0-b57c" name="Hammer of Wrath (X)" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Hammer of Wrath (1)"/>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="65.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="ee45-7759-1541-af8c" name="Power Blade Array with In-Built Rotar Cannon" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="68f5-f681-5d6f-9474" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="13c8-0f3a-2331-f6db" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="b70c-2074-fc15-ed1c" name="Power Blade Array" hidden="false" collective="false" import="true" targetId="2121-ee7c-8ac9-5133" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b4ee-e1ee-76bf-98e5" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ee8-7743-087c-2c41" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="094e-d74f-b609-f0ab" name="Rotor Cannon" hidden="false" collective="false" import="true" targetId="5ce3-3aa5-3f5e-9ead" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="55d0-41a9-76c9-b974" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9c3a-e0d2-89d7-47f1" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="4d5d-73fe-9e1d-34f5" name="One in Three Vorax in the unit, may exchange its Lightning Gun" hidden="false" collective="false" import="true">
+          <modifiers>
+            <modifier type="increment" field="618c-0761-5152-1969" value="1.0">
+              <repeats>
+                <repeat field="selections" scope="f144-1079-11ff-019d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="59fd-998f-8190-baec" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+            <modifier type="increment" field="c07c-ccfe-108a-cbca" value="1.0">
+              <repeats>
+                <repeat field="selections" scope="f144-1079-11ff-019d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="59fd-998f-8190-baec" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c07c-ccfe-108a-cbca" type="min"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="618c-0761-5152-1969" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="c0fe-3ade-f089-a298" name="Irad-Cleanser" hidden="false" collective="false" import="true" targetId="b3c5-237f-e1d2-d9f8" type="selectionEntry">
+              <modifiers>
+                <modifier type="increment" field="0296-5f17-31bc-b1db" value="1.0">
+                  <repeats>
+                    <repeat field="selections" scope="f144-1079-11ff-019d" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="59fd-998f-8190-baec" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0296-5f17-31bc-b1db" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="c288-f2f9-d72d-e2b2" name="Lightning Gun" hidden="false" collective="false" import="true" targetId="f65c-633a-5865-7f6b" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="9503-d92e-8e8c-771a" name="Paragon of Metal" hidden="false" collective="false" import="true" targetId="cc2a-46fe-bbf3-6ba2" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="f144-1079-11ff-019d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="59fd-998f-8190-baec" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35.0"/>
+          </costs>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b953-83d7-6cc1-5695" name="Vulcan Mega-Bolter" publicationId="bde1-6db1-163b-3b76" page="114" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="5adb-5031-bfdf-fa27" name="Vulcan Mega-Bolter" publicationId="bde1-6db1-163b-3b76" page="114" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">72&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">6</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">3</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 15, Pinning, Shell Shock (1)</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="4e4f-59d7-cea8-fa2f" name="Pinning" hidden="false" targetId="1c96-205c-59a0-3cf2" type="rule"/>
+        <infoLink id="0619-3f5c-4161-0e0b" name="Shell Shock (X)" hidden="false" targetId="46b7-63a1-941c-96a5" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Shell Shock (1)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2c0d-36ba-7cfa-6915" name="Macro-Gatling Blaster " hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="a49a-38f5-511d-4a07" name="Macro-Gatling Blaster " hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">72&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">10</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">3</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Destroyer 3, Massive Blast (7&quot;), Pinning, Shell Shock (1)</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="1b45-c39e-76b3-0767" name="Destroyer" hidden="false" targetId="44d6-09b2-3bd3-b2d6" type="rule"/>
+        <infoLink id="ff62-e71c-7fcd-3611" name="Blast" hidden="false" targetId="1d9a-73ef-5f4f-8bd8" type="rule"/>
+        <infoLink id="b71a-abd4-2ade-bc85" name="Pinning" hidden="false" targetId="1c96-205c-59a0-3cf2" type="rule"/>
+        <infoLink id="5edf-cce3-29c3-0196" name="Shell Shock (X)" hidden="false" targetId="46b7-63a1-941c-96a5" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup id="4a48-4935-246d-0c2e" name="Legion" hidden="false" collective="false" import="true">
@@ -7323,6 +8729,54 @@ models with the Fortification Unit Type. Each model with
 the Fortification Unit Type is always considered a separate
 unit (excepting only Multi-part fortifications, see page 225 of
 Warhammer: The Horus Heresy – Age of Darkness Rulebook).</description>
+    </rule>
+    <rule id="2ac7-9784-9b0f-182b" name="**Turbo-Laser issue" hidden="false">
+      <description>The UK digital and Physcal versions of the Mech book had the wrong stats printed (lowering the S to 10 and AP to 3, as well as removing Ignores Cover). The correct value was in other versions of the book such as the German version which are the same as the stats presented in the Legion books.</description>
+    </rule>
+    <rule id="d242-cb71-bc7f-eadd" name="Ardex-Defensor" publicationId="bde1-6db1-163b-3b76" page="102" hidden="false">
+      <description>A model with the Knight or Titan Unit Sub-types that has weapons with this special rule may make the Overwatch Reaction when it is triggered by models that do not have the Knight, Titan, Super-heavy, or Lumbering Flyer Unit Sub-types, or that have fewer than 8 Wounds. When making Shooting Attacks as part of the Overwatch Reaction, the Reacting model may only make Shooting Attacks with weapons with this special rule.</description>
+    </rule>
+    <rule id="c41f-6ac9-6909-44c4" name="Catastrophic Destruction" publicationId="bde1-6db1-163b-3b76" page="103" hidden="false">
+      <description>When destroyed, a model with this special rule resolves Catastrophic Damage at AP 1.</description>
+    </rule>
+    <rule id="a13f-e697-6017-5a04" name="Catastrophic Explosion" publicationId="bde1-6db1-163b-3b76" page="103" hidden="false">
+      <description>When destroyed, a model with this special rule resolves Catastrophic Damage at AP 2</description>
+    </rule>
+    <rule id="1f93-c765-f7b2-a025" name="Destructor" publicationId="bde1-6db1-163b-3b76" page="103" hidden="false">
+      <description>Any model which suffers an unsaved Wound or Hull Point loss from a weapon with this special rule instead suffers D6 unsaved Wounds or Hull Points of damage. In addition, if the target of this attack is a model with the Knight, Titan, Super-heavy Vehicle, or Building or Fortification Unit Type, or the Monstrous Unit Sub-type, increase the number of Wounds suffered or Hull Points lost to 2D6.</description>
+    </rule>
+    <rule id="4eb9-9e5e-bb27-3644" name="Disruption (X)" publicationId="bde1-6db1-163b-3b76" page="103" hidden="false">
+      <description>To Hit rolls of the value X indicated made by a weapon with this rule cause an automatic Glancing Hit against models with the Vehicle Unit Type instead of rolling for Armour Penetration, and an automatic Wound against models with the Dreadnought or Automata Unit Types, instead of rolling To Wound.</description>
+    </rule>
+    <rule id="66b8-7232-1ed3-3f70" name="God-Engine" publicationId="bde1-6db1-163b-3b76" page="104" hidden="false">
+      <description>A model with this special rule ignores all Psychic Powers and Cybertheurgic Rites and Attacks made by Psychic and Cybertheurgic Weapons. In addition, a model with this special rule ignores the effects of the Haywire and Disruption (X) special rules. In all cases, weapons which benefit from these special rules must attempt to damage a model with this special rule normally using the attack’s Strength value. In addition, all friendly Mechanicum units with at least one model within 24&quot; of a model with this special rule gain the Fearless special rule.</description>
+    </rule>
+    <rule id="1cc2-eaee-8bcf-96d3" name="Grav Wave" publicationId="bde1-6db1-163b-3b76" page="104" hidden="false">
+      <description>Any successful Charge that targets a unit containing a model with a weapon with this special rule is always counted as a Disordered Charge.</description>
+    </rule>
+    <rule id="9247-462c-bcec-6fb8" name="Heavy Structure" publicationId="bde1-6db1-163b-3b76" page="105" hidden="false">
+      <description>A model with this special rule has an Invulnerable Save of 6+ against Shooting Attacks.</description>
+    </rule>
+    <rule id="5f22-e7a4-4141-ee2e" name="Overtaxed Reactor" publicationId="bde1-6db1-163b-3b76" page="105" hidden="false">
+      <description>When destroyed, a model with this special rule resolves Catastrophic Damage at AP 3.</description>
+    </rule>
+    <rule id="3b0e-4a45-9bdd-91dc" name="Reactor Meltdown (X)" publicationId="bde1-6db1-163b-3b76" page="108" hidden="false">
+      <description>When a model with this special rule is destroyed, the damage caused by its Catastrophic Damage is altered depending on the value of (X) in the version of this special rule as follows:
+Magna: When destroyed, a model with this special rule resolves Hits caused by Catastrophic Damage as Destroyer attacks.
+Major: When destroyed, a model with this special rule resolves Hits caused by Catastrophic Damage as Destroyer attacks at AP2.
+Maxima :When destroyed, a model with this special rule resolves Hits caused by Catastrophic Damage as Destroyer attacks at AP2, and doubles the range of the Catastrophic Damage effect.</description>
+    </rule>
+    <rule id="a073-b86c-7bc1-d3f9" name="Reactor Overload" publicationId="bde1-6db1-163b-3b76" page="106" hidden="false">
+      <description>A weapon with this special rule may double the number of shots it makes, but if it does so the firing model suffers D3 Wounds or Hull Points of damage with no Saves or Damage Mitigation rolls of any kind allowed.</description>
+    </rule>
+    <rule id="5b0d-5362-e961-f3b0" name="Reinforced Structure" publicationId="bde1-6db1-163b-3b76" page="108" hidden="false">
+      <description>A model with this special rule has an Invulnerable Save of 5+ against Shooting Attacks.</description>
+    </rule>
+    <rule id="5e0d-b2af-e7b4-a8cd" name="Seismic Shock" publicationId="bde1-6db1-163b-3b76" page="108" hidden="false">
+      <description>Units which suffer one or more Wounds or Hull Points lost from an attack from a weapon with this special rule halve their Movement Characteristic and may not Run or make Reactions until the end of the attacker’s next Shooting phase.</description>
+    </rule>
+    <rule id="ba77-a802-55df-da67" name="Wrecker" publicationId="bde1-6db1-163b-3b76" page="111" hidden="false">
+      <description>Penetrating Hits caused by attacks made with weapons or models with this special rule add +1 to the result of any rolls on the Vehicle or Building Damage tables.</description>
     </rule>
   </sharedRules>
   <sharedProfiles>

--- a/2022 - LA - Alpha Legion.cat
+++ b/2022 - LA - Alpha Legion.cat
@@ -702,14 +702,14 @@ The Instrument has two profiles. Pick which profile is used every time the weapo
   </sharedSelectionEntries>
   <catalogueLinks>
     <catalogueLink id="2f60-18fb-e6ed-8574" name="(HH V2) Legions Astartes" targetId="6393-649c-7213-a327" type="catalogue" importRootEntries="true"/>
-    <catalogueLink id="c2da-96e4-de72-6af5" name="Legiones Astartes: IX - Blood Angels" targetId="cd4d-8765-5387-8409" type="catalogue" importRootEntries="true"/>
-    <catalogueLink id="272b-fd4e-9675-94d1" name="LA -   I: Dark Angels" targetId="12ce-9c46-5335-827a" type="catalogue" importRootEntries="true"/>
+    <catalogueLink id="22ab-29e1-22f3-7cff" name="LA -   I: Dark Angels" targetId="ee5e-198e-1b19-4b9f" type="catalogue" importRootEntries="true"/>
     <catalogueLink id="a164-9b86-cdff-a77e" name="LA -   III: Emperor&apos;s Children" targetId="72ba-61c2-37ad-c785" type="catalogue" importRootEntries="true"/>
     <catalogueLink id="f3da-bf4c-5557-55ca" name="LA -   IV: Iron Warriors" targetId="2ee4-57ed-db44-8a63" type="catalogue" importRootEntries="true"/>
     <catalogueLink id="a765-0d93-a1aa-429d" name="LA -   V: White Scars" targetId="caa9-c50e-8eed-2259" type="catalogue" importRootEntries="true"/>
     <catalogueLink id="deaf-52e5-4b05-f2d6" name="LA -   VI: Space Wolves" targetId="ca15-13de-89cb-bbb2" type="catalogue" importRootEntries="true"/>
     <catalogueLink id="7d3f-8f37-29e5-3a1e" name="LA -   VII: Imperial Fists" targetId="8866-00ec-715f-f21a" type="catalogue" importRootEntries="true"/>
-    <catalogueLink id="31b5-a244-30e0-6609" name="LA -   VIII: Night Lords" targetId="9b01-77b9-2f38-6413" type="catalogue" importRootEntries="true"/>
+    <catalogueLink id="e854-80e6-908e-88db" name="LA -   VIII: Night Lords" targetId="36dc-14fc-8872-476b" type="catalogue" importRootEntries="true"/>
+    <catalogueLink id="d048-e6d9-e40e-8363" name="LA -  IX: Blood Angels" targetId="cd4d-8765-5387-8409" type="catalogue" importRootEntries="true"/>
     <catalogueLink id="7ea8-b20e-d38f-def3" name="LA -  X: Iron Hands" targetId="b73e-125f-db29-17f2" type="catalogue" importRootEntries="true"/>
     <catalogueLink id="1ab3-19e2-4e09-4cef" name="LA -  XII: World Eaters" targetId="d901-0eca-48b5-304a" type="catalogue" importRootEntries="true"/>
     <catalogueLink id="e1d9-0e0d-dd7c-564b" name="LA -  XIII: Ultramarines" targetId="68ae-9855-b56a-95e6" type="catalogue" importRootEntries="true"/>

--- a/2022 - LA - Blood Angels.cat
+++ b/2022 - LA - Blood Angels.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="cd4d-8765-5387-8409" name="LA-   IX - Blood Angels" revision="6" battleScribeVersion="2.03" authorName="Jon K &quot;Alphalas&quot;" authorContact="Twitter: Alphalas_ Discord: Alphalas#8789" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="10" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="cd4d-8765-5387-8409" name="LA -  IX: Blood Angels" revision="6" battleScribeVersion="2.03" authorName="Jon K &quot;Alphalas&quot;" authorContact="Twitter: Alphalas_ Discord: Alphalas#8789" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="11" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="1900-3f09-f47b-bed2" name="Praetor" hidden="false" collective="false" import="false" targetId="03be-5d55-d05a-771d" type="selectionEntry">
       <modifiers>

--- a/2022 - LA - Emperor's Children.cat
+++ b/2022 - LA - Emperor's Children.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="72ba-61c2-37ad-c785" name="LA -   III: Emperor&apos;s Children" revision="3" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="10" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="72ba-61c2-37ad-c785" name="LA -   III: Emperor&apos;s Children" revision="4" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="11" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="b36e-8c73-fe83-f087" name="   III: Emperor&apos;s Children" hidden="false" collective="false" import="false" targetId="3edc-a1b9-6dc6-b1ea" type="selectionEntry">
       <constraints>
@@ -1323,7 +1323,7 @@ then he gains +1 to his Attacks Characteristic.</description>
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <conditions>
-                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="51e5-c28f-d9dd-5e52" type="atLeast"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0de5-8b3c-74a0-858e" type="atLeast"/>
                   </conditions>
                 </modifier>
               </modifiers>

--- a/2022 - LA - Space Wolves.cat
+++ b/2022 - LA - Space Wolves.cat
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="ca15-13de-89cb-bbb2" name="LA -   VI: Space Wolves" revision="2" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="10" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="ca15-13de-89cb-bbb2" name="LA -   VI: Space Wolves" revision="2" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="11" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
-    <entryLink id="ff53-69d9-ec0b-9caa" name="   VI: Space Wolves" hidden="false" collective="false" import="true" targetId="4916-965e-8339-44f6" type="selectionEntry">
+    <entryLink id="ff53-69d9-ec0b-9caa" name="   VI: Space Wolves" hidden="false" collective="false" import="false" targetId="4916-965e-8339-44f6" type="selectionEntry">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4c8c-8356-e2e2-0b04" type="min"/>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d1d3-74cd-b6b9-0bf2" type="max"/>
@@ -124,6 +124,9 @@
               </constraints>
             </entryLink>
           </entryLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="3533-53d6-976c-05f1" name="The Armour Elavagar" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
@@ -137,6 +140,9 @@
               </characteristics>
             </profile>
           </profiles>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="d50f-2d25-e508-bcdd" name="The Axe of Helwinter" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
@@ -162,6 +168,9 @@
               </modifiers>
             </infoLink>
           </infoLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="8698-6c8a-f742-a3cd" name="The Sword of Balenight" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
@@ -196,6 +205,9 @@
               </modifiers>
             </infoLink>
           </infoLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="75d0-45ea-6f63-a352" name="Scornspitter" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
@@ -219,6 +231,9 @@
               </modifiers>
             </infoLink>
           </infoLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
@@ -1123,13 +1138,13 @@
           <modifiers>
             <modifier type="increment" field="5846-bbaa-e153-896f" value="1.0">
               <repeats>
-                <repeat field="selections" scope="4bbf-f3df-7b18-4a49" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ebc0-802a-8681-bab9" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="4bbf-f3df-7b18-4a49" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1f1f-8964-8920-6b19" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
             <modifier type="decrement" field="5846-bbaa-e153-896f" value="9.0"/>
             <modifier type="increment" field="0149-0a21-d344-d353" value="1.0">
               <repeats>
-                <repeat field="selections" scope="4bbf-f3df-7b18-4a49" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ebc0-802a-8681-bab9" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="4bbf-f3df-7b18-4a49" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1f1f-8964-8920-6b19" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
           </modifiers>
@@ -2104,6 +2119,9 @@
               </characteristics>
             </profile>
           </profiles>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
         </selectionEntry>
         <selectionEntry id="0a7d-31ab-699e-1377" name="Hunt-master" hidden="false" collective="false" import="true" type="model">
           <constraints>
@@ -2134,6 +2152,9 @@
               </characteristics>
             </profile>
           </profiles>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -2287,6 +2308,9 @@
           </constraints>
         </entryLink>
       </entryLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="f47e-c270-b62a-4205" name="Fenrisian Wolf Pack" publicationId="d0df-7166-5cd3-89fd" hidden="false" collective="false" import="true" type="upgrade">
       <modifiers>
@@ -2344,6 +2368,9 @@
               </characteristics>
             </profile>
           </profiles>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
       <costs>

--- a/2022 - LA - White Scars.cat
+++ b/2022 - LA - White Scars.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="caa9-c50e-8eed-2259" name="LA -   V: White Scars" revision="3" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="10" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="caa9-c50e-8eed-2259" name="LA -   V: White Scars" revision="3" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="11" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="a738-6a11-dfe7-286c" name="   V: White Scars" hidden="false" collective="false" import="false" targetId="e01e-5cdd-e512-8353" type="selectionEntry">
       <constraints>
@@ -826,12 +826,12 @@
       <modifiers>
         <modifier type="add" field="category" value="6d79-a3e4-381f-7b0f">
           <conditions>
-            <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fd19-4031-d763-437c" type="equalTo"/>
+            <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c7dc-206c-3e60-80fa" type="equalTo"/>
           </conditions>
         </modifier>
         <modifier type="add" field="category" value="8b4f-bfe2-ce7b-f1b1">
           <conditions>
-            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fd19-4031-d763-437c" type="equalTo"/>
+            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c7dc-206c-3e60-80fa" type="equalTo"/>
           </conditions>
         </modifier>
       </modifiers>

--- a/2022 - Legiones Astartes.cat
+++ b/2022 - Legiones Astartes.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="6393-649c-7213-a327" name="(HH V2) Legions Astartes" revision="32" battleScribeVersion="2.03" authorName="Various" authorUrl="https://github.com/BSData/horus-heresy" library="true" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="11" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="6393-649c-7213-a327" name="(HH V2) Legions Astartes" revision="32" battleScribeVersion="2.03" authorName="Various" authorUrl="https://github.com/BSData/horus-heresy" library="true" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="12" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profileTypes>
     <profileType id="7002-2f9a-59c4-2742" name="Minor Arcana">
       <characteristicTypes>
@@ -29775,4 +29775,8 @@ A unit that includes models with this special rule may only be joined by models 
       </characteristics>
     </profile>
   </sharedProfiles>
+  <catalogueLinks>
+    <catalogueLink id="f801-22ed-74ba-dade" name="2022 - Questoris Household" targetId="92b4-d476-8b4c-e7ef" type="catalogue" importRootEntries="true"/>
+    <catalogueLink id="476d-6f42-6871-cd81" name="2022 - Titan Legions" targetId="c01b-0224-f806-0d23" type="catalogue" importRootEntries="true"/>
+  </catalogueLinks>
 </catalogue>

--- a/2022 - Mech Library.cat
+++ b/2022 - Mech Library.cat
@@ -1,0 +1,547 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<catalogue id="3129-da35-55e0-642d" name="2022 - Mech Library" revision="1" battleScribeVersion="2.03" library="true" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="11" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+  <sharedSelectionEntries>
+    <selectionEntry id="e825-c60e-e6c3-60f0" name="Photon Gauntlet" publicationId="bde1-6db1-163b-3b76" page="117" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="b2b5-230a-997f-7f0c" name="Photon Gauntlet" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">12&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">5</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">2</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Assault 2, Blind, Gets Hot</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="9f64-3267-f0c8-fa85" name="Blind" hidden="false" targetId="d836-747d-07d6-2b63" type="rule"/>
+        <infoLink id="b121-8829-fddb-7b5c" name="Gets Hot" hidden="false" targetId="679f-9d97-5ace-a652" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="31eb-9c83-cc5e-ef2d" name="Lightning Cannon " publicationId="bde1-6db1-163b-3b76" page="113" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="119e-f108-83fe-d0e3" name="Lightning Cannon " hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">36&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">7</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">3</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 1, Large Blast (5&quot;), Rending (4+), Shred, Exoshock (4+)</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="484d-8eed-b58d-d65f" name="Blast" hidden="false" targetId="1d9a-73ef-5f4f-8bd8" type="rule"/>
+        <infoLink id="becd-4c4f-321a-9e24" name="Rending (X)" hidden="false" targetId="0ac9-fab7-aef3-de1d" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Rending (4+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="c294-96f3-123d-77ba" name="Shred" hidden="false" targetId="5e7e-1628-8174-6f2c" type="rule"/>
+        <infoLink id="ded2-d7aa-3527-4402" name="Exoshock (X)" hidden="false" targetId="69ca-318a-b47a-7a3c" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Exoshock (4+)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2b9f-41fb-a0a8-285e" name="Karacnos Mortar Battery" publicationId="bde1-6db1-163b-3b76" page="118" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="97fa-5adc-b1ff-7b4c" name="Karacnos Mortar Battery" publicationId="bde1-6db1-163b-3b76" page="118" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">60&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">6</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">4</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 1, Massive Blast (7&quot;), Barrage, Fleshbane, Rad-phage, Ignores Cover, Pinning, Shell Shock (3), Crawling Fire</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="571b-2655-5b71-24d9" name="Blast" hidden="false" targetId="1d9a-73ef-5f4f-8bd8" type="rule"/>
+        <infoLink id="763b-fcb9-2ba1-ff2d" name="Barrage" hidden="false" targetId="7255-b5ee-c3f4-3037" type="rule"/>
+        <infoLink id="e122-12ef-1058-de50" name="Fleshbane" hidden="false" targetId="40cd-9505-253c-e76f" type="rule"/>
+        <infoLink id="96d9-44ec-58e8-6c74" name="Rad-Phage" hidden="false" targetId="8189-e963-d2e5-5d3d" type="rule"/>
+        <infoLink id="b14a-aec2-111f-72f5" name="Ignores Cover" hidden="false" targetId="fdb5-59e2-c446-1cbc" type="rule"/>
+        <infoLink id="7cd3-182b-0eb0-4962" name="Pinning" hidden="false" targetId="1c96-205c-59a0-3cf2" type="rule"/>
+        <infoLink id="d4cc-9863-67e1-4538" name="Shell Shock (X)" hidden="false" targetId="46b7-63a1-941c-96a5" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Shell Shock (3)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="45c6-379d-0842-716a" name="Crawling Fire" hidden="false" targetId="8258-a7af-e4df-531d" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9ccc-276b-eb67-9a0f" name="Ion Gauntlet Shield" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="c622-aa22-5d98-69d2" name="Ion Gauntlet Shield" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
+          <characteristics>
+            <characteristic name="Description" typeId="347e-ee4a-764f-6be3">A model with an ion gauntlet shield gains a 5+ Invulnerable Save against Shooting Attacks which target its Front or Side Armour Values, and a 5+ Invulnerable Save against all Melee Attacks.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="dde9-961b-5765-21a2" name="Ion Shield" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="dcde-df05-1912-9a61" name="Ion Shield" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
+          <characteristics>
+            <characteristic name="Description" typeId="347e-ee4a-764f-6be3">A model with an ion shield gains a 4+ Invulnerable Save against Shooting Attacks which target its Front Armour Value, and a 5+ Invulnerable Save against Shooting Attacks which target its Side Armour Value.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="c587-8d02-aaba-ce19" name="Ionic Deflector" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="d6e7-9365-6336-6a51" name="Ionic Deflector" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
+          <characteristics>
+            <characteristic name="Description" typeId="347e-ee4a-764f-6be3">A model with an ionic deflector gains a 5+ Invulnerable Save, and any model with an ionic deflector and a Wounds Characteristic gains the Eternal Warrior special rule. In addition, when a model with an ionic deflector loses its last Wound or Hull Point, but before it is removed as a casualty or replaced with a Wreck, all models both friendly and enemy within D6+3&quot; suffer an automatic Hit atStr 8, AP -.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2164-1725-d032-ed49" name="Reaper Chainsword" publicationId="bde1-6db1-163b-3b76" page="120" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="bd92-cdfc-9ca6-ee9b" name="Reaper Chainsword" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">10</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">2</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Shred</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="9f27-5035-daec-7bff" name="Shred" hidden="false" targetId="5e7e-1628-8174-6f2c" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="13f4-be52-e1a7-4e51" name="Avenger Gatling Cannon" publicationId="bde1-6db1-163b-3b76" page="114" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="691d-aafb-9299-a873" name="Avenger Gatling Cannon" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">36&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">6</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">4</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 12, Rending (6+)</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="b776-a25d-562e-5923" name="Rending (X)" hidden="false" targetId="0ac9-fab7-aef3-de1d" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Rending (6+)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="82e0-160b-28f5-f01e" name="Ironstorm Missile Pod" publicationId="bde1-6db1-163b-3b76" page="118" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="c180-49e9-713a-0702" name="Ironstorm Missile Pod" publicationId="bde1-6db1-163b-3b76" page="118" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">48&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">5</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">4</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Ordnance 1, Large Blast (5&quot;)</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="86e5-71c5-6c49-7de3" name="Blast" hidden="false" targetId="1d9a-73ef-5f4f-8bd8" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="bd87-e395-1602-d73a" name="Twin-Linked Icarus Autocannon" publicationId="bde1-6db1-163b-3b76" page="114" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="29ff-cf22-701c-8812" name="Twin-Linked Icarus Autocannon" publicationId="bde1-6db1-163b-3b76" page="114" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">48&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">7</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">4</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 2, Rending (6+), Skyfire, Twin-linked</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="07c0-ae14-c6d2-0261" name="Rending (X)" hidden="false" targetId="0ac9-fab7-aef3-de1d" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Rending (6+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="44ed-c5d2-498e-7f91" name="Skyfire" hidden="false" targetId="f2bf-5daa-9f93-0b01" type="rule"/>
+        <infoLink id="7666-6d61-5307-454a" name="Twin-linked" hidden="false" targetId="8542-ee9d-e2fa-52fe" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1809-a6e7-c4a2-bc91" name="Stormspear Rocket Pod" publicationId="bde1-6db1-163b-3b76" page="118" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="9110-4a13-087c-24a3" name="Stormspear Rocket Pod" publicationId="bde1-6db1-163b-3b76" page="118" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">48&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">8</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">3</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="89d1-f5c7-7a80-3365" name="Radium Carbine" publicationId="bde1-6db1-163b-3b76" page="119" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="e48c-9cc5-f57f-9ed4" name="Radium Carbine" publicationId="bde1-6db1-163b-3b76" page="119" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">18&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">3</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">5</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Assault 3, Brutal (2)</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="4f5d-f307-af85-4f56" name="Brutal (X)" hidden="false" targetId="5079-1fec-d32b-8b84" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Brutal (2)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2484-a122-76a2-b142" name="Triaros Armoured Conveyor " publicationId="bde1-6db1-163b-3b76" page="38" hidden="false" collective="false" import="true" type="unit">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f5f4-5acb-8b82-a398" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="9c35-7828-ae5a-edd1" name="Triaros Armoured Conveyor " publicationId="bde1-6db1-163b-3b76" page="38" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName="Vehicle">
+          <characteristics>
+            <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">• Vehicle (Transport)</characteristic>
+            <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">12</characteristic>
+            <characteristic name="BS" typeId="51fb-b7d9-aa59-863d">4</characteristic>
+            <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">14</characteristic>
+            <characteristic name="Side" typeId="f150-c0dc-c192-9cb3">12</characteristic>
+            <characteristic name="Rear" typeId="8d4e-2aea-fffc-d556">12</characteristic>
+            <characteristic name="HP" typeId="a76c-83b1-602f-9e62">5</characteristic>
+            <characteristic name="Transport Capacity" typeId="0c90-79e2-f768-e547">22</characteristic>
+            <characteristic name="Access Points" typeId="e217-1b1e-9494-3e3e">A Triaros Armoured Conveyor has one Access Point on each side of the hull.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="4bd4-3a9e-5bf3-8e9d" name="Galvanic Traction Drive" hidden="false" targetId="e51e-cae1-d9e7-d317" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="fe7e-d7ac-b8ff-a623" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+      </categoryLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="0158-716f-8819-36c8" name="Centreline Mounted Volkite Calivers" hidden="false" collective="false" import="true" defaultSelectionEntryId="473a-89d7-e6ba-b3fa">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6abc-293c-3012-39a0" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5087-e127-5d50-22d0" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="473a-89d7-e6ba-b3fa" name="Volkite Caliver" hidden="false" collective="false" import="true" targetId="9250-490f-abeb-b901" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="7332-6e75-9ca7-1113" name="Pintle Mounted Twin-Linked Mauler Bolt Cannon" hidden="false" collective="false" import="true" defaultSelectionEntryId="8a3b-2033-fd0b-78ca">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="95d9-70a6-903d-8080" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7646-2d77-c613-2c28" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="8a3b-2033-fd0b-78ca" name="Twin-linked Mauler Bolt Cannon" hidden="false" collective="false" import="true" targetId="ac88-bcf4-d7b4-5c56" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="cab5-253f-bd6d-1b68" name="Up to two Hull (Front) Mounted Hunter-Killer Missiles" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0421-e81c-41c6-cca5" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="a180-22e5-6e87-1189" name="Hunter-Killer Missile" hidden="false" collective="false" import="true" targetId="1bf8-72f8-c331-6900" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="bdb6-0f3e-c8e0-76ad" name="Shock Ram" hidden="false" collective="false" import="true" targetId="e22e-df78-c49b-7b98" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="99dc-42d5-e907-65d8" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9292-8cd9-d375-9d8a" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="d0c6-98c2-9332-c626" name="Flare Shield" hidden="false" collective="false" import="true" targetId="0e77-6285-22bb-1534" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2856-a7c3-7b8f-cc0e" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f380-89be-2b65-a3ab" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="135.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e22e-df78-c49b-7b98" name="Shock Ram" publicationId="bde1-6db1-163b-3b76" page="123" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="8b5f-efb1-b545-2e1c" name="Shock Ram" publicationId="bde1-6db1-163b-3b76" page="123" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">10</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">4</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Concussive (3), Ram (D6)</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="1153-8a95-34f0-bf46" name="Concussive (X)" hidden="false" targetId="7ce5-1bfb-64e6-f826" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Concussive (3)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="fd0d-0e02-31f8-a1f4" name="Ram (X)" hidden="false" targetId="e993-bb10-e7fc-c959" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Ram (D6)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2deb-3354-c5cc-e6bd" name="Arc Lance" publicationId="bde1-6db1-163b-3b76" page="113" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="1637-f99e-92c3-6fc6" name="Arc Lance (Ranged)" publicationId="bde1-6db1-163b-3b76" page="113" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">12&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">6</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">5</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Assault 1, Disruption (6+)</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="a8bb-9064-436d-66f3" name="Arc Lance (Melee)" publicationId="bde1-6db1-163b-3b76" page="120" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">+1</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">5</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Disruption (5+)</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="7d8c-1416-cc8f-8cea" name="Disruption (X)" hidden="false" targetId="4eb9-9e5e-bb27-3644" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Disruption (5+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="bfab-a49f-fa6b-8553" name="Disruption (X)" hidden="false" targetId="4eb9-9e5e-bb27-3644" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Disruption (6+)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="837d-547d-f714-3ec6" name="Arc Maul" publicationId="bde1-6db1-163b-3b76" page="113" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="6eb0-c975-9c39-735b" name="Arc Maul" publicationId="bde1-6db1-163b-3b76" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">+2</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">5</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Disruption (5+)</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="cd64-e1e4-6366-7f96" name="Disruption (X)" hidden="false" targetId="4eb9-9e5e-bb27-3644" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Disruption (5+)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3b42-4abf-0b7b-85be" name="Arc Pistol" publicationId="bde1-6db1-163b-3b76" page="113" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="f008-ca76-d0a7-8cde" name="Arc Pistol" publicationId="bde1-6db1-163b-3b76" page="113" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">12&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">6</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">5</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Pistol, Disruption (6+)</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="33d1-6472-0ba1-2712" name="Disruption (X)" hidden="false" targetId="4eb9-9e5e-bb27-3644" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Disruption (6+)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1800-e29f-86a3-6abb" name="Arc Rifle" publicationId="bde1-6db1-163b-3b76" page="113" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="f40b-4c9e-fa2f-e8aa" name="Arc Rifle" publicationId="bde1-6db1-163b-3b76" page="113" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">30&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">6</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">5</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Rapid Fire, Disruption (6+)</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="6ce2-ab57-535e-6d5f" name="Disruption (X)" hidden="false" targetId="4eb9-9e5e-bb27-3644" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Disruption (6+)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="af1d-7611-f4e2-f09e" name="Galvanic Caster" publicationId="bde1-6db1-163b-3b76" page="116" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="b36d-6dd0-422c-0c87" name="Galvanic Caster - Flechette" publicationId="bde1-6db1-163b-3b76" page="116" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">24&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">3</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">6</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Rapid Fire, Shred</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="fd78-beb6-8780-5e0e" name="Galvanic Caster - Ignis" publicationId="bde1-6db1-163b-3b76" page="116" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">18&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">2</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">5</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Assault 2, Blind, Ignores Cover</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="4a34-9a80-79c3-9e31" name="Shred" hidden="false" targetId="5e7e-1628-8174-6f2c" type="rule"/>
+        <infoLink id="055f-0bf6-db8b-a2f0" name="Blind" hidden="false" targetId="d836-747d-07d6-2b63" type="rule"/>
+        <infoLink id="bb69-8878-0e87-29f9" name="Ignores Cover" hidden="false" targetId="fdb5-59e2-c446-1cbc" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="c3ab-36d1-f521-7ff1" name="Radium Pistol" publicationId="bde1-6db1-163b-3b76" page="119" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="edac-9f15-0cb5-710c" name="Radium Pistol" publicationId="bde1-6db1-163b-3b76" page="119" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">12&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">3</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">-</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Pistol 1, Brutal (2)</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="1723-a781-a15f-f541" name="Brutal (X)" hidden="false" targetId="5079-1fec-d32b-8b84" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Brutal (2)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+  </sharedSelectionEntries>
+  <sharedRules>
+    <rule id="41ab-227d-9d91-8001" name="Flank Speed" publicationId="bde1-6db1-163b-3b76" page="104" hidden="false">
+      <description>A model with this special rule may increase its Movement Distance by 4&quot; in any Movement phase, but if it does so it may not make any Shooting Attacks in the subsequent Shooting phase. Note this model may still Charge in the Assault phase. In addition, when declaring a Charge after making a Shooting Attack, a model with this special rule may Charge a unit that it did not target in that turn’s Shooting phase, provided that the target of the Charge meets all other criteria of a valid Charge target.</description>
+    </rule>
+    <rule id="53f7-6b93-cc7a-b976" name="Armiger Unit-Type" publicationId="bde1-6db1-163b-3b76" page="90" hidden="false">
+      <description>As with other Unit Types, the Armiger Type includes a number of Unit Sub-types which may be referenced in other Age of Darkness books. The following rules apply to all Armiger models and any Armiger Unit Sub-types:
+• Successful Wounds scored by attacks with the Poisoned (X) or Fleshbane special rules must be re-rolled against models of the Armiger Unit Type.
+• All Armiger models have the Stubborn special rule.
+• A model with the Armiger Unit Type may fire all weapons they are equipped with in each Shooting Attack they make, including as part of a Reaction.
+• A model of the Armiger Type may fire Heavy and Ordnance weapons and counts as Stationary even if it moved in the preceding Movement phase, and may declare Charges as normal regardless of any Shooting Attacks made in the same turn.
+• No model that is not also of the Armiger Unit Type may join a unit that includes an Armiger model.</description>
+    </rule>
+    <rule id="d840-fbd0-352e-b33e" name="Armiger and Moirax Talons" publicationId="bde1-6db1-163b-3b76" page="102" hidden="false">
+      <description>The Scout Knights of the Taghmata and Questoris Households often roamed the battlefield independently as the vanguard of their orders. While each war machine strode the battlefield distant from their companions, they shared fierce bonds of fealty and brotherhood.
+When deployed onto the battlefield (either at the start of the battle or when arriving from Reserves) all models in the unit must be placed within unit coherency, but afterwards operate independently and are not treated as a single unit.</description>
+    </rule>
+    <rule id="e993-bb10-e7fc-c959" name="Ram (X)" publicationId="bde1-6db1-163b-3b76" page="106" hidden="false">
+      <description>When a model with a weapon with this special rule performs a Ram Attack, it makes a number of additional attacks equal to the value of X. These attacks automatically hit the target of the Ram Attack and are resolved using the profile of the weapon with this special rule equal to the value of (X).</description>
+    </rule>
+    <rule id="e51e-cae1-d9e7-d317" name="Galvanic Traction Drive" publicationId="bde1-6db1-163b-3b76" page="104" hidden="false">
+      <description>A model with this special rule must re-roll failed Dangerous Terrain tests.</description>
+    </rule>
+  </sharedRules>
+  <sharedProfiles>
+    <profile id="f417-99e0-bb03-dfa7" name="Siege Claw" publicationId="bde1-6db1-163b-3b76" page="123" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
+        <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">x2</characteristic>
+        <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">2</characteristic>
+        <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Brutal (2), Sunder, Wrecker</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="2af9-d755-936d-0fa8" name="Twin-Linked Magna Lascannon" publicationId="bde1-6db1-163b-3b76" page="117" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="95ba-cda7-b831-6066">72&quot;</characteristic>
+        <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">10</characteristic>
+        <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">2</characteristic>
+        <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Ordnance 2, Large Blast (5&quot;)</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="fe4c-3b4d-5b20-0357" name="Reaper Chainfist" publicationId="bde1-6db1-163b-3b76" page="120" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
+        <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">10</characteristic>
+        <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">2</characteristic>
+        <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Armourbane (Melee)</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="4329-1f62-cf9b-2ff4" name="Galvanic Caster - Hammershot" publicationId="bde1-6db1-163b-3b76" page="116" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="95ba-cda7-b831-6066">30&quot;</characteristic>
+        <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">4</characteristic>
+        <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">3</characteristic>
+        <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Assault 1, Molecular Dissonance</characteristic>
+      </characteristics>
+    </profile>
+  </sharedProfiles>
+</catalogue>

--- a/2022 - Mechanicum.cat
+++ b/2022 - Mechanicum.cat
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <catalogue id="c247-da79-1654-d39e" name="2022 - Mechanicum" revision="1" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="11" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
-    <entryLink id="29c6-0ec7-0162-e817" name="Mechanicum" hidden="false" collective="false" import="true" targetId="ddf5-d792-3146-6e9a" type="selectionEntry">
+    <entryLink id="29c6-0ec7-0162-e817" name="Mechanicum" hidden="false" collective="false" import="false" targetId="ddf5-d792-3146-6e9a" type="selectionEntry">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c3e3-faec-34a7-3b4c" type="min"/>
       </constraints>
@@ -10,4 +10,16 @@
       </categoryLinks>
     </entryLink>
   </entryLinks>
+  <sharedSelectionEntries>
+    <selectionEntry id="7c8d-b21a-1f72-7e22" name="Upgrade Points (Placeholders)" hidden="false" collective="false" import="true" type="upgrade">
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="1.0"/>
+      </costs>
+    </selectionEntry>
+  </sharedSelectionEntries>
+  <catalogueLinks>
+    <catalogueLink id="8cf8-1625-654c-9bea" name="2022 - Titan Legions" targetId="c01b-0224-f806-0d23" type="catalogue" importRootEntries="true"/>
+    <catalogueLink id="4b43-4108-e5ce-dec3" name="2022 - Questoris Household" targetId="92b4-d476-8b4c-e7ef" type="catalogue" importRootEntries="true"/>
+    <catalogueLink id="5f24-4626-71c3-0547" name="2022 - Mech Library" targetId="3129-da35-55e0-642d" type="catalogue" importRootEntries="true"/>
+  </catalogueLinks>
 </catalogue>

--- a/2022 - Questoris Household.cat
+++ b/2022 - Questoris Household.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="92b4-d476-8b4c-e7ef" name="2022 - Questoris Household" revision="1" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="11" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="92b4-d476-8b4c-e7ef" name="2022 - Questoris Household" revision="1" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="12" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <forceEntries>
     <forceEntry id="28d3-4be2-608d-bf8a" name="Questoris Household Force Organisation Chart" hidden="false">
       <categoryLinks>
@@ -33,7 +33,7 @@
     </forceEntry>
   </forceEntries>
   <entryLinks>
-    <entryLink id="f32d-4f08-ccfa-21bb" name="Divisio Tactica: Questoris Household" hidden="false" collective="false" import="true" targetId="807e-0cf8-7f28-7b6d" type="selectionEntry">
+    <entryLink id="f32d-4f08-ccfa-21bb" name="Divisio Tactica: Questoris Household" hidden="false" collective="false" import="false" targetId="807e-0cf8-7f28-7b6d" type="selectionEntry">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7a16-b1cb-730d-f4b6" type="min"/>
       </constraints>
@@ -41,5 +41,2254 @@
         <categoryLink id="af54-5227-93ca-a151" name="New CategoryLink" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true"/>
       </categoryLinks>
     </entryLink>
+    <entryLink id="c64c-453a-329d-1662" name="Armiger Helverin Talon" hidden="false" collective="false" import="false" targetId="bd5d-61fa-d2f6-45a2" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="8834-b5ff-be64-696d" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="5985-7085-dad4-7e66" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="c8a9-bc4a-19a5-7e60" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="d584-89d3-0ba5-7faa" name="Knight Questoris" hidden="false" collective="false" import="true" targetId="3706-a84c-678d-b1c6" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="365e-b0a4-87b6-2f2a" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="e579-64c8-62ad-2e6f" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="94aa-a472-6134-9a69" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="cbd4-46bc-a375-5189" name="Armiger Warglaive Talon" hidden="false" collective="false" import="false" targetId="df92-71d6-bf1a-d62e" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="e55e-460f-c3d7-687c" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="8d75-6cf8-6121-ad9b" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="4af9-72f5-e618-a95f" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="09eb-0791-7539-e3fe" name="Knight Lancer" hidden="false" collective="false" import="true" targetId="8312-7457-e7b6-fd9f" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="3e12-5f5e-ac9c-4354" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="79bf-3d91-67d1-33fb" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="c291-9ee4-666e-9d10" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="4432-80ac-042a-591c" name="Knight Castigator" hidden="false" collective="false" import="true" targetId="0a65-543c-19b2-fd34" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="b47e-a501-6a7c-4580" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="83cc-eb2d-633f-e999" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="4788-cf09-0e2b-c067" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="16f1-41d4-e11d-7eea" name="Knight Acheron" hidden="false" collective="false" import="true" targetId="f971-ef52-5344-0b26" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="3d5a-ce72-e96a-7b84" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="7bef-0998-45bf-ea1c" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="33d6-a111-c3df-a379" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="ea1b-ebb0-a727-f6a1" name="Acastus Knight Porphyrion" hidden="false" collective="false" import="true" targetId="8cb2-7235-fc34-9983" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="2e28-e276-031d-c76e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="9ada-aa9b-2414-57c2" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="5f2e-d459-05ef-47cd" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="f6ab-b360-5a0c-ff16" name="Questoris Knight Styrix" hidden="false" collective="false" import="true" targetId="1944-033c-5b7e-a378" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="d0e2-884a-8ff6-1276" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="039b-e62e-649e-c494" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="81cf-e91f-c836-3d51" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="03a7-8a19-46fc-fb34" name="Questoris Knight Magaera" hidden="false" collective="false" import="true" targetId="6d0e-0d72-d9e2-01d1" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="f6c1-febb-5445-a61e" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="aaf6-7f9a-dc73-4735" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="0c31-ab40-c943-dce6" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="b701-ae0d-cf44-cd62" name="Questoris Knight Atrapos" hidden="false" collective="false" import="true" targetId="012b-109f-74d2-2c82" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="081a-4cc1-02c0-4470" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="f903-585f-a0ec-9d17" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="8a49-22f7-ef48-8294" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="1748-7d92-81f0-08be" name="Questoris Acastus Knight Asterius" hidden="false" collective="false" import="true" targetId="7b6b-49ab-d71d-e359" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="fe46-14a5-092c-1063" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="6233-a9df-929f-7b0c" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
+        <categoryLink id="9f63-749f-01c1-f860" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
   </entryLinks>
+  <sharedSelectionEntries>
+    <selectionEntry id="f971-ef52-5344-0b26" name="Knight Acheron" publicationId="bde1-6db1-163b-3b76" page="82" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="add" field="category" value="f75a-d5c1-59ba-5c5a">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e78c-787d-54ca-82c2" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f4a8-b2a3-1c3c-9761" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1682-2560-347c-e798" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b90-1389-3b29-3fca" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3dc3-9018-b7a3-8cf9" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63ce-0429-b209-c3e9" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <profiles>
+        <profile id="654a-e12d-e3f2-9078" name="Knight Acheron" publicationId="bde1-6db1-163b-3b76" page="82" hidden="false" typeId="75b5-9f7a-156e-6889" typeName="Knights and Titans">
+          <modifiers>
+            <modifier type="append" field="3c44-1e2a-23fe-c9e0" value="Character">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e78c-787d-54ca-82c2" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f4a8-b2a3-1c3c-9761" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1682-2560-347c-e798" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b90-1389-3b29-3fca" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3dc3-9018-b7a3-8cf9" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63ce-0429-b209-c3e9" type="greaterThan"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="decrement" field="7f12-0cc3-9dcd-25bc" value="2">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7496-3ece-e6d8-6d40" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="6c5a-df71-fefa-2ee3" value="1">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63ce-0429-b209-c3e9" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e78c-787d-54ca-82c2" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b90-1389-3b29-3fca" type="greaterThan"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="increment" field="4227-8eed-0c5c-a2d9" value="1">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63ce-0429-b209-c3e9" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3dc3-9018-b7a3-8cf9" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f4a8-b2a3-1c3c-9761" type="greaterThan"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="decrement" field="6c5a-df71-fefa-2ee3" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7496-3ece-e6d8-6d40" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="decrement" field="4227-8eed-0c5c-a2d9" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7496-3ece-e6d8-6d40" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="2490-aa2f-f5db-6070" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1682-2560-347c-e798" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="7f12-0cc3-9dcd-25bc" value="4">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="Unit Type" typeId="3c44-1e2a-23fe-c9e0">Vehicle (Knight)</characteristic>
+            <characteristic name="Move" typeId="7f12-0cc3-9dcd-25bc">14</characteristic>
+            <characteristic name="WS" typeId="4227-8eed-0c5c-a2d9">4</characteristic>
+            <characteristic name="BS" typeId="6c5a-df71-fefa-2ee3">4</characteristic>
+            <characteristic name="S" typeId="02ba-082e-e385-1ede">9</characteristic>
+            <characteristic name="Front" typeId="0d00-68d8-0535-e898">13</characteristic>
+            <characteristic name="Side" typeId="cb92-5809-d327-6981">12</characteristic>
+            <characteristic name="Rear" typeId="8fa4-6e34-29c4-d8c6">12</characteristic>
+            <characteristic name="I" typeId="91b3-4335-71bf-3fa9">4</characteristic>
+            <characteristic name="A" typeId="d54a-56a6-68c5-ae72">4</characteristic>
+            <characteristic name="HP" typeId="2490-aa2f-f5db-6070">7</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="9386-d32e-b5db-a2bc" name="Scout" hidden="false" targetId="aacf-9a7e-982d-b793" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="468f-1d89-c4c7-c30a" name="Outflank" hidden="false" targetId="bfbf-e75c-49a2-0285" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="ab43-72d7-1ff3-acd7" name="Flank Speed" hidden="false" targetId="41ab-227d-9d91-8001" type="rule"/>
+      </infoLinks>
+      <selectionEntries>
+        <selectionEntry id="23ea-5a4c-4701-65dd" name="Arm Mounted Reaper Chainfist with In-Built Twin-Linked Heavy Bolter" publicationId="bde1-6db1-163b-3b76" page="120" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0420-3735-e0aa-eb82" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="51a4-fd5a-5a5e-a037" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="89b3-cb2e-5135-028f" name="Twin-linked Heavy Bolter" hidden="false" targetId="9268-9301-e5ff-4c49" type="profile"/>
+            <infoLink id="9c78-4210-6db2-8d94" name="Twin-linked" hidden="false" targetId="8542-ee9d-e2fa-52fe" type="rule"/>
+            <infoLink id="0ad0-ddf1-71f1-bb5b" name="Armourbane (X)" hidden="false" targetId="cb59-f920-f071-7cd4" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Armourbane (Melee)"/>
+              </modifiers>
+            </infoLink>
+            <infoLink id="6081-b621-5a83-c703" name="Reaper Chainfist" hidden="false" targetId="fe4c-3b4d-5b20-0357" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="9ab3-b2a9-c302-6002" name="Arm Mounted Acheron Flamestorm Cannon" publicationId="bde1-6db1-163b-3b76" page="116" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0192-69b9-e6d9-d9ea" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d030-7dc9-9145-ba3c" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="df06-6278-11de-dc0b" name="Acheron Flamestorm Cannon" publicationId="bde1-6db1-163b-3b76" page="116" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="95ba-cda7-b831-6066">Hellstorm</characteristic>
+                <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">7</characteristic>
+                <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">4</characteristic>
+                <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Ordnance 1, Shred</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="6cf7-c9a2-db2d-7492" name="Template Weapons" hidden="false" targetId="5e0e-88e6-db81-5a70" type="rule"/>
+            <infoLink id="236c-3092-4fa1-f047" name="Ordnance" hidden="false" targetId="6c55-22c8-1b01-2105" type="rule"/>
+            <infoLink id="0f32-c621-bbc1-bfe5" name="Shred" hidden="false" targetId="5e7e-1628-8174-6f2c" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="04f4-da8f-d80b-0b6c" name="Household Ranks" hidden="false" collective="false" import="true" targetId="1b29-a58e-296c-3946" type="selectionEntryGroup"/>
+        <entryLink id="36d6-b5e6-647a-c536" name="Ion Shield" hidden="false" collective="false" import="true" targetId="dde9-961b-5765-21a2" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8647-e144-0829-d297" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3af0-f9eb-6ef8-d49f" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="415.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0a65-543c-19b2-fd34" name="Knight Castigator" publicationId="bde1-6db1-163b-3b76" page="81" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="add" field="category" value="f75a-d5c1-59ba-5c5a">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e78c-787d-54ca-82c2" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f4a8-b2a3-1c3c-9761" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1682-2560-347c-e798" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b90-1389-3b29-3fca" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3dc3-9018-b7a3-8cf9" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63ce-0429-b209-c3e9" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <profiles>
+        <profile id="8e25-8532-f01c-dae5" name="Knight Castigator" publicationId="bde1-6db1-163b-3b76" page="81" hidden="false" typeId="75b5-9f7a-156e-6889" typeName="Knights and Titans">
+          <modifiers>
+            <modifier type="append" field="3c44-1e2a-23fe-c9e0" value="Character">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e78c-787d-54ca-82c2" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f4a8-b2a3-1c3c-9761" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1682-2560-347c-e798" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b90-1389-3b29-3fca" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3dc3-9018-b7a3-8cf9" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63ce-0429-b209-c3e9" type="greaterThan"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="decrement" field="7f12-0cc3-9dcd-25bc" value="2">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7496-3ece-e6d8-6d40" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="decrement" field="6c5a-df71-fefa-2ee3" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7496-3ece-e6d8-6d40" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="decrement" field="4227-8eed-0c5c-a2d9" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7496-3ece-e6d8-6d40" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="4227-8eed-0c5c-a2d9" value="1">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63ce-0429-b209-c3e9" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3dc3-9018-b7a3-8cf9" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f4a8-b2a3-1c3c-9761" type="greaterThan"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="increment" field="2490-aa2f-f5db-6070" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1682-2560-347c-e798" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="6c5a-df71-fefa-2ee3" value="1">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63ce-0429-b209-c3e9" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e78c-787d-54ca-82c2" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b90-1389-3b29-3fca" type="greaterThan"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="increment" field="7f12-0cc3-9dcd-25bc" value="4">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="Unit Type" typeId="3c44-1e2a-23fe-c9e0">Vehicle (Knight)</characteristic>
+            <characteristic name="Move" typeId="7f12-0cc3-9dcd-25bc">14</characteristic>
+            <characteristic name="WS" typeId="4227-8eed-0c5c-a2d9">4</characteristic>
+            <characteristic name="BS" typeId="6c5a-df71-fefa-2ee3">4</characteristic>
+            <characteristic name="S" typeId="02ba-082e-e385-1ede">9</characteristic>
+            <characteristic name="Front" typeId="0d00-68d8-0535-e898">13</characteristic>
+            <characteristic name="Side" typeId="cb92-5809-d327-6981">12</characteristic>
+            <characteristic name="Rear" typeId="8fa4-6e34-29c4-d8c6">12</characteristic>
+            <characteristic name="I" typeId="91b3-4335-71bf-3fa9">4</characteristic>
+            <characteristic name="A" typeId="d54a-56a6-68c5-ae72">4</characteristic>
+            <characteristic name="HP" typeId="2490-aa2f-f5db-6070">7</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="b7e2-4bcc-e69f-b86a" name="Outflank" hidden="false" targetId="bfbf-e75c-49a2-0285" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="7837-d0e7-ac7d-6840" name="Scout" hidden="false" targetId="aacf-9a7e-982d-b793" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="7ee1-c3cb-13c2-ed75" name="Flank Speed" hidden="false" targetId="41ab-227d-9d91-8001" type="rule"/>
+      </infoLinks>
+      <selectionEntries>
+        <selectionEntry id="776d-1fb6-116b-e519" name="Arm Mounted Tempest Warblade" publicationId="bde1-6db1-163b-3b76" page="122" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8bf4-9e20-ecc9-aebb" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2df6-1c2c-8659-6539" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="4631-e659-37a2-8c5e" name="Tempest Warblade" publicationId="bde1-6db1-163b-3b76" page="122" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
+                <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">10</characteristic>
+                <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">2</characteristic>
+                <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Deflagrate, Tempest</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="f50c-88e7-1b1f-fe80" name="Tempest" publicationId="bde1-6db1-163b-3b76" page="110" hidden="false">
+              <description>Instead of making a Melee Attack, a model with a weapon with this special rule may make a special attack at Initiative step 2. This automatically inflicts a single Hit against each model (friendly or enemy) in contact with the attacking model’s base, using the profile of the weapon with this special rule.</description>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="e8eb-9b6b-0f43-292c" name="Deflagrate" hidden="false" targetId="60bc-f79a-67ae-be4f" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="edd6-6baf-3688-b3f9" name="Arm Mounted Twin-Linked Castigator Bolt Cannon" publicationId="bde1-6db1-163b-3b76" page="114" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af30-3e14-2384-868c" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5d6c-8bdb-de36-b51c" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="8bcc-e14d-7624-e81d" name="Twin-Linked Castigator Bolt Cannon" publicationId="bde1-6db1-163b-3b76" page="114" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="95ba-cda7-b831-6066">36&quot;</characteristic>
+                <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">6</characteristic>
+                <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">4</characteristic>
+                <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 18, Pinning, Shell Shock (1), Twin-linked</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="1a6b-9be5-6bc2-63f5" name="Pinning" hidden="false" targetId="1c96-205c-59a0-3cf2" type="rule"/>
+            <infoLink id="cbfa-295c-4c94-8b1a" name="Shell Shock (X)" hidden="false" targetId="46b7-63a1-941c-96a5" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Shell Shock (1)"/>
+              </modifiers>
+            </infoLink>
+            <infoLink id="6496-e622-7568-4b7a" name="Twin-linked" hidden="false" targetId="8542-ee9d-e2fa-52fe" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="f13e-417e-1d15-6b30" name="Household Ranks" hidden="false" collective="false" import="true" targetId="1b29-a58e-296c-3946" type="selectionEntryGroup"/>
+        <entryLink id="cb2f-983d-cac4-c147" name="Ion Shield" hidden="false" collective="false" import="true" targetId="dde9-961b-5765-21a2" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1619-8d61-1740-6a09" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b230-5f3f-9898-5421" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="380.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="8312-7457-e7b6-fd9f" name="Knight Lancer" publicationId="bde1-6db1-163b-3b76" page="80" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="add" field="category" value="f75a-d5c1-59ba-5c5a">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e78c-787d-54ca-82c2" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f4a8-b2a3-1c3c-9761" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1682-2560-347c-e798" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b90-1389-3b29-3fca" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3dc3-9018-b7a3-8cf9" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63ce-0429-b209-c3e9" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <profiles>
+        <profile id="8427-636e-af48-9641" name="Knight Lancer" publicationId="bde1-6db1-163b-3b76" page="80" hidden="false" typeId="75b5-9f7a-156e-6889" typeName="Knights and Titans">
+          <modifiers>
+            <modifier type="append" field="3c44-1e2a-23fe-c9e0" value="Character">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e78c-787d-54ca-82c2" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f4a8-b2a3-1c3c-9761" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1682-2560-347c-e798" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b90-1389-3b29-3fca" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3dc3-9018-b7a3-8cf9" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63ce-0429-b209-c3e9" type="greaterThan"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="decrement" field="7f12-0cc3-9dcd-25bc" value="2">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7496-3ece-e6d8-6d40" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="decrement" field="4227-8eed-0c5c-a2d9" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7496-3ece-e6d8-6d40" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="decrement" field="6c5a-df71-fefa-2ee3" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7496-3ece-e6d8-6d40" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="4227-8eed-0c5c-a2d9" value="1">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63ce-0429-b209-c3e9" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3dc3-9018-b7a3-8cf9" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f4a8-b2a3-1c3c-9761" type="greaterThan"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="increment" field="2490-aa2f-f5db-6070" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1682-2560-347c-e798" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="6c5a-df71-fefa-2ee3" value="1">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63ce-0429-b209-c3e9" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e78c-787d-54ca-82c2" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b90-1389-3b29-3fca" type="greaterThan"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="increment" field="7f12-0cc3-9dcd-25bc" value="4">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="Unit Type" typeId="3c44-1e2a-23fe-c9e0">Vehicle (Knight)</characteristic>
+            <characteristic name="Move" typeId="7f12-0cc3-9dcd-25bc">14</characteristic>
+            <characteristic name="WS" typeId="4227-8eed-0c5c-a2d9">4</characteristic>
+            <characteristic name="BS" typeId="6c5a-df71-fefa-2ee3">4</characteristic>
+            <characteristic name="S" typeId="02ba-082e-e385-1ede">9</characteristic>
+            <characteristic name="Front" typeId="0d00-68d8-0535-e898">13</characteristic>
+            <characteristic name="Side" typeId="cb92-5809-d327-6981">12</characteristic>
+            <characteristic name="Rear" typeId="8fa4-6e34-29c4-d8c6">12</characteristic>
+            <characteristic name="I" typeId="91b3-4335-71bf-3fa9">4</characteristic>
+            <characteristic name="A" typeId="d54a-56a6-68c5-ae72">4</characteristic>
+            <characteristic name="HP" typeId="2490-aa2f-f5db-6070">7</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="9586-700b-5614-546c" name="Outflank" hidden="false" targetId="bfbf-e75c-49a2-0285" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="e29c-de42-0431-82e3" name="Scout" hidden="false" targetId="aacf-9a7e-982d-b793" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="c43a-9453-0e12-d974" name="Flank Speed" hidden="false" targetId="41ab-227d-9d91-8001" type="rule"/>
+      </infoLinks>
+      <selectionEntries>
+        <selectionEntry id="9ab2-7ae8-6840-028a" name="Arm Mounted Shock Lance" publicationId="bde1-6db1-163b-3b76" page="119 &amp; 123" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="16ee-ad6a-630d-4c87" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a2e-ec50-4029-3b78" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="e0a8-b5d1-d174-5090" name="Shock Lance (Melee)" publicationId="bde1-6db1-163b-3b76" page="123" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
+                <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">10</characteristic>
+                <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">2</characteristic>
+                <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Reach (1), Exoshock (5+)</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="f430-bf47-d8a8-02ad" name="Shock Lance (Ranged)" publicationId="bde1-6db1-163b-3b76" page="119" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="95ba-cda7-b831-6066">18&quot;</characteristic>
+                <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">7</characteristic>
+                <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">3</characteristic>
+                <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 6, Concussive (2)</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="381b-1754-1c2c-6a73" name="Reach (X)" hidden="false" targetId="19bf-62a2-5737-890b" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Reach (1)"/>
+              </modifiers>
+            </infoLink>
+            <infoLink id="be59-fc4f-999e-ff96" name="Exoshock (X)" hidden="false" targetId="69ca-318a-b47a-7a3c" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Exoshock (5+)"/>
+              </modifiers>
+            </infoLink>
+            <infoLink id="33c6-81c1-9e83-8a83" name="Concussive (X)" hidden="false" targetId="7ce5-1bfb-64e6-f826" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Concussive (2)"/>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="77ba-d474-86a0-c60c" name="Household Ranks" hidden="false" collective="false" import="true" targetId="1b29-a58e-296c-3946" type="selectionEntryGroup"/>
+        <entryLink id="3ffb-d91c-5304-284b" name="Ion Gauntlet Shield" hidden="false" collective="false" import="true" targetId="9ccc-276b-eb67-9a0f" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b850-ff9d-ff94-da8b" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3b0d-281a-219a-5968" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="400.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3706-a84c-678d-b1c6" name="Knight Questoris" publicationId="bde1-6db1-163b-3b76" page="78" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="add" field="category" value="f75a-d5c1-59ba-5c5a">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e78c-787d-54ca-82c2" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f4a8-b2a3-1c3c-9761" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1682-2560-347c-e798" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b90-1389-3b29-3fca" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3dc3-9018-b7a3-8cf9" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63ce-0429-b209-c3e9" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <profiles>
+        <profile id="4e47-1b1d-3b5d-e6b6" name="Knight Questoris" publicationId="bde1-6db1-163b-3b76" page="78" hidden="false" typeId="75b5-9f7a-156e-6889" typeName="Knights and Titans">
+          <modifiers>
+            <modifier type="append" field="3c44-1e2a-23fe-c9e0" value="Character">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e78c-787d-54ca-82c2" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f4a8-b2a3-1c3c-9761" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1682-2560-347c-e798" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b90-1389-3b29-3fca" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3dc3-9018-b7a3-8cf9" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63ce-0429-b209-c3e9" type="greaterThan"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="decrement" field="7f12-0cc3-9dcd-25bc" value="2">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7496-3ece-e6d8-6d40" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="decrement" field="6c5a-df71-fefa-2ee3" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7496-3ece-e6d8-6d40" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="decrement" field="4227-8eed-0c5c-a2d9" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7496-3ece-e6d8-6d40" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="4227-8eed-0c5c-a2d9" value="1">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63ce-0429-b209-c3e9" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3dc3-9018-b7a3-8cf9" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f4a8-b2a3-1c3c-9761" type="greaterThan"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="increment" field="2490-aa2f-f5db-6070" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1682-2560-347c-e798" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="6c5a-df71-fefa-2ee3" value="1">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63ce-0429-b209-c3e9" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e78c-787d-54ca-82c2" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b90-1389-3b29-3fca" type="greaterThan"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="increment" field="7f12-0cc3-9dcd-25bc" value="4">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="Unit Type" typeId="3c44-1e2a-23fe-c9e0">Vehicle (Knight)</characteristic>
+            <characteristic name="Move" typeId="7f12-0cc3-9dcd-25bc">10</characteristic>
+            <characteristic name="WS" typeId="4227-8eed-0c5c-a2d9">4</characteristic>
+            <characteristic name="BS" typeId="6c5a-df71-fefa-2ee3">4</characteristic>
+            <characteristic name="S" typeId="02ba-082e-e385-1ede">8</characteristic>
+            <characteristic name="Front" typeId="0d00-68d8-0535-e898">13</characteristic>
+            <characteristic name="Side" typeId="cb92-5809-d327-6981">12</characteristic>
+            <characteristic name="Rear" typeId="8fa4-6e34-29c4-d8c6">12</characteristic>
+            <characteristic name="I" typeId="91b3-4335-71bf-3fa9">4</characteristic>
+            <characteristic name="A" typeId="d54a-56a6-68c5-ae72">3</characteristic>
+            <characteristic name="HP" typeId="2490-aa2f-f5db-6070">7</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="d6c2-a869-c334-77f0" name="Outflank" hidden="false" targetId="bfbf-e75c-49a2-0285" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="c6bb-6b03-6610-a0e3" name="Scout" hidden="false" targetId="aacf-9a7e-982d-b793" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="a933-83e5-a547-bc1e" name="May exchange its Arm Mounted Reaper Chainsword for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="1b2b-e5c6-7889-353a">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4d9c-c7b3-3db5-3f84" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e57e-2ea7-e6ed-1ac4" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="af82-0550-784c-c0d4" name="Avenger Gatling Cannon with In-Built Heavy Flamer" hidden="false" collective="false" import="true" type="upgrade">
+              <profiles>
+                <profile id="6bdb-5731-3d62-8777" name="Avenger Gatling Cannon" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="95ba-cda7-b831-6066">36&quot;</characteristic>
+                    <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">6</characteristic>
+                    <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">4</characteristic>
+                    <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 12, Rending (6+)</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink id="56cc-70cd-6767-1b78" name="Rending (X)" hidden="false" targetId="0ac9-fab7-aef3-de1d" type="rule">
+                  <modifiers>
+                    <modifier type="set" field="name" value="Rending (6+)"/>
+                  </modifiers>
+                </infoLink>
+                <infoLink id="9552-3cf8-6eb6-4aa5" name="Template Weapons" hidden="false" targetId="5e0e-88e6-db81-5a70" type="rule"/>
+                <infoLink id="e7f2-55ce-10c1-972a" name="Heavy Flamer" hidden="false" targetId="a6e9-e2e1-150f-b023" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="c4f8-e709-a77a-8919" name="Thunderstrike Gauntlet" publicationId="bde1-6db1-163b-3b76" page="122" hidden="false" collective="false" import="true" type="upgrade">
+              <profiles>
+                <profile id="e862-b785-a568-3f39" name="Thunderstrike Gauntlet" publicationId="bde1-6db1-163b-3b76" page="122" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
+                    <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">12</characteristic>
+                    <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">2</characteristic>
+                    <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Sunder</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink id="079a-e945-4510-a6cc" name="Sunder" hidden="false" targetId="20e2-75cf-bc16-cd8f" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <entryLinks>
+            <entryLink id="1b2b-e5c6-7889-353a" name="Reaper Chainsword" hidden="false" collective="false" import="true" targetId="2164-1725-d032-ed49" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="f296-e73b-2b07-5889" name="May exchange its Arm Mounted Rapid-Fire Battle Cannon with In-Built Heavy Stubber for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="c618-89b3-c1e3-77b8">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d934-1e97-98ca-f171" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cd6a-aab1-476b-826b" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="c618-89b3-c1e3-77b8" name="Rapid-Fire Battle Cannon with In-Built Heavy Stubber" publicationId="bde1-6db1-163b-3b76" page="113" hidden="false" collective="false" import="true" type="upgrade">
+              <profiles>
+                <profile id="75ac-285a-4d20-464a" name="Rapid-Fire Battle Cannon" publicationId="bde1-6db1-163b-3b76" page="113" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="95ba-cda7-b831-6066">48&quot;</characteristic>
+                    <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">8</characteristic>
+                    <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">4</characteristic>
+                    <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Ordnance 2, Large Blast (5&quot;)</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink id="403d-a0c0-b9ae-3a25" name="Heavy Stubber" hidden="false" targetId="129d-1b6c-7ba2-29ec" type="profile"/>
+                <infoLink id="1f72-e757-b485-2219" name="Blast" hidden="false" targetId="1d9a-73ef-5f4f-8bd8" type="rule"/>
+                <infoLink id="17fe-29b6-2474-103c" name="Ordnance" hidden="false" targetId="6c55-22c8-1b01-2105" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="dec9-b18c-c587-3cf5" name="Avenger Gatling Cannon with In-Built Heavy Flamer" hidden="false" collective="false" import="true" type="upgrade">
+              <infoLinks>
+                <infoLink id="bb79-fd97-d1ff-bb5c" name="Rending (X)" hidden="false" targetId="0ac9-fab7-aef3-de1d" type="rule">
+                  <modifiers>
+                    <modifier type="set" field="name" value="Rending (6+)"/>
+                  </modifiers>
+                </infoLink>
+                <infoLink id="6293-c366-3ebc-27d9" name="Template Weapons" hidden="false" targetId="5e0e-88e6-db81-5a70" type="rule"/>
+                <infoLink id="415c-35ea-18b2-bf44" name="Avenger Gatling Cannon" hidden="false" targetId="691d-aafb-9299-a873" type="profile"/>
+                <infoLink id="6064-89c9-1039-0081" name="Heavy Flamer" hidden="false" targetId="a6e9-e2e1-150f-b023" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="202c-9d61-4d63-51c1" name="Las-Impulsor" publicationId="bde1-6db1-163b-3b76" page="115 &amp; 121" hidden="false" collective="false" import="true" type="upgrade">
+              <profiles>
+                <profile id="ca99-0187-bfe4-ff22" name="Las-Impulsor (Ranged)" publicationId="bde1-6db1-163b-3b76" page="115" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="95ba-cda7-b831-6066">12&quot;</characteristic>
+                    <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">10</characteristic>
+                    <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">2</characteristic>
+                    <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 2, Sunder, Instant Death</characteristic>
+                  </characteristics>
+                </profile>
+                <profile id="87ca-5697-36b0-1abc" name="Las-Impulsor (Melee)" publicationId="bde1-6db1-163b-3b76" page="121" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
+                    <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">10</characteristic>
+                    <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">1</characteristic>
+                    <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Unwieldy, Cumbersome, Armourbane (Melee), Instant Death</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink id="a74e-f041-1c75-1ac0" name="Sunder" hidden="false" targetId="20e2-75cf-bc16-cd8f" type="rule"/>
+                <infoLink id="6328-0c8c-c14f-740f" name="Unwieldy" hidden="false" targetId="1570-c21a-881f-8b8a" type="rule"/>
+                <infoLink id="4f09-38e6-6786-04ae" name="Cumbersome" hidden="false" targetId="d89a-c10e-8a7a-92c3" type="rule"/>
+                <infoLink id="afdb-5218-4517-92f8" name="Armourbane (X)" hidden="false" targetId="cb59-f920-f071-7cd4" type="rule">
+                  <modifiers>
+                    <modifier type="set" field="name" value="Armourbane (Melee)"/>
+                  </modifiers>
+                </infoLink>
+                <infoLink id="10b4-0454-db83-e4d2" name="Instant Death" hidden="false" targetId="9e96-fff1-b916-d9a3" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="dce8-edfe-c778-2173" name="Thermal Cannon" publicationId="bde1-6db1-163b-3b76" page="117" hidden="false" collective="false" import="true" type="upgrade">
+              <profiles>
+                <profile id="750b-ff9a-7290-ae83" name="Thermal Cannon" publicationId="bde1-6db1-163b-3b76" page="117" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="95ba-cda7-b831-6066">36&quot;</characteristic>
+                    <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">8</characteristic>
+                    <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">1</characteristic>
+                    <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 1, Large Blast (5&quot;), Armourbane (Melta)</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink id="03de-53c2-b618-fc70" name="Blast" hidden="false" targetId="1d9a-73ef-5f4f-8bd8" type="rule"/>
+                <infoLink id="f5d3-a028-b662-d707" name="Armourbane (X)" hidden="false" targetId="cb59-f920-f071-7cd4" type="rule">
+                  <modifiers>
+                    <modifier type="set" field="name" value="Armourbane (Melta)"/>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <entryLinks>
+            <entryLink id="e37b-d0e9-1177-19a8" name="Reaper Chainsword" hidden="false" collective="false" import="true" targetId="2164-1725-d032-ed49" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="a0c2-701f-2e75-c019" name="May exchange its Hull (Front) Mounted Heavy Stubber with:" hidden="false" collective="false" import="true" defaultSelectionEntryId="fc40-d52a-2ed4-7ff3">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dea4-ba2b-0515-9311" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="97f8-72ab-3c94-2343" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="a3c8-3a8b-3fc8-7a59" name="Multi-Laser" hidden="false" collective="false" import="true" targetId="003b-af4b-0094-f5c3" type="selectionEntry"/>
+            <entryLink id="0c9a-aa21-9fa3-f82a" name="Meltagun" hidden="false" collective="false" import="true" targetId="4ebd-57e0-3560-e568" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="fc40-d52a-2ed4-7ff3" name="Heavy Stubber" hidden="false" collective="false" import="true" targetId="f227-a61a-3215-932b" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="d1ab-532a-bc69-aeae" name="May take one of the following Carapace Mounted Weapons:" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fc99-bc8e-f010-bb8d" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="47ff-a20f-4699-5bd7" name="Ironstorm Missile Pod" hidden="false" collective="false" import="true" targetId="82e0-160b-28f5-f01e" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="1fb7-cc60-ebc8-d6e6" name="Stormspear Rocket Pod" hidden="false" collective="false" import="true" targetId="1809-a6e7-c4a2-bc91" type="selectionEntry"/>
+            <entryLink id="24ef-fb02-2c82-8d23" name="Twin-Linked Icarus Autocannon" hidden="false" collective="false" import="true" targetId="bd87-e395-1602-d73a" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="d966-b5ab-7ee6-f73d" name="Household Ranks" hidden="false" collective="false" import="true" targetId="1b29-a58e-296c-3946" type="selectionEntryGroup"/>
+        <entryLink id="2cb2-f2ff-2ecd-db0d" name="Ion Shield" hidden="false" collective="false" import="true" targetId="dde9-961b-5765-21a2" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e06a-7cd5-0a92-8497" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a3b5-a04e-4bde-4c27" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="380.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="bd5d-61fa-d2f6-45a2" name="Armiger Helverin Talon" publicationId="bde1-6db1-163b-3b76" page="77" hidden="false" collective="false" import="true" type="unit">
+      <categoryLinks>
+        <categoryLink id="8f79-4ba0-8f89-2216" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
+        <categoryLink id="5e4a-62ee-832b-eb8a" name="Skirmish Sub-type:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="488a-c9e1-0b4f-5349" name="Armiger Helverin" publicationId="bde1-6db1-163b-3b76" page="77" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6876-c612-f7cb-eed6" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0e5e-91c5-f4ad-c2e2" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="92d5-f878-80c6-1f65" name="Armiger Helverin" publicationId="bde1-6db1-163b-3b76" page="77" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
+              <characteristics>
+                <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Armiger (Skirmish, Line)</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">8</characteristic>
+                <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
+                <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
+                <characteristic name="S" typeId="e478-41d4-a092-48a8">7</characteristic>
+                <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">7</characteristic>
+                <characteristic name="W" typeId="57ee-1126-32a9-5672">6</characteristic>
+                <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
+                <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">3</characteristic>
+                <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">7</characteristic>
+                <characteristic name="Save" typeId="e593-6b3c-f169-04f0">3+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="46be-5b08-b283-1586" name="Armiger Unit-Type" hidden="false" targetId="53f7-6b93-cc7a-b976" type="rule"/>
+            <infoLink id="a506-6939-099d-87f7" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
+            <infoLink id="80b0-1999-f091-7daf" name="Fleet (X)" hidden="false" targetId="ddc9-0b4b-78da-bbd2" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Fleet (2)"/>
+              </modifiers>
+            </infoLink>
+            <infoLink id="9c6f-5a54-cc55-722d" name="Move Through Cover" hidden="false" targetId="2b6f-bfec-759e-1746" type="rule"/>
+            <infoLink id="bd26-a7f9-ef54-36af" name="Armiger and Moirax Talons" hidden="false" targetId="d840-fbd0-352e-b33e" type="rule"/>
+          </infoLinks>
+          <selectionEntries>
+            <selectionEntry id="6c49-4990-c232-e94a" name="Phaeton Autocannon" publicationId="bde1-6db1-163b-3b76" page="114" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed9d-6128-3807-9b98" type="min"/>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b4df-62d6-e136-0aaf" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="5b79-445b-5319-4753" name="Phaeton Autocannon - AP rounds" publicationId="bde1-6db1-163b-3b76" page="114" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="95ba-cda7-b831-6066">64&quot;</characteristic>
+                    <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">7</characteristic>
+                    <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">3</characteristic>
+                    <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 2, Sunder, Rending (6+)</characteristic>
+                  </characteristics>
+                </profile>
+                <profile id="5f64-9724-2862-6c79" name="Phaeton Autocannon - Ignis rounds" publicationId="bde1-6db1-163b-3b76" page="114" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="95ba-cda7-b831-6066">64&quot;</characteristic>
+                    <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">7</characteristic>
+                    <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">3</characteristic>
+                    <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 2, Ignores Cover, Rending (6+)</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink id="2757-b9a0-5d10-3f64" name="Rending (X)" hidden="false" targetId="0ac9-fab7-aef3-de1d" type="rule">
+                  <modifiers>
+                    <modifier type="set" field="name" value="Rending (6+)"/>
+                  </modifiers>
+                </infoLink>
+                <infoLink id="89b5-b203-f418-1a0e" name="Ignores Cover" hidden="false" targetId="fdb5-59e2-c446-1cbc" type="rule"/>
+                <infoLink id="8381-ab0b-80ae-cd56" name="Sunder" hidden="false" targetId="20e2-75cf-bc16-cd8f" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="1c01-c6c9-9a54-d5ff" name="May Exchange its Heavy Stubber for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="ee45-de6e-10a9-4e8e">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9483-14cf-fef7-d227" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aef5-3285-a017-5482" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="ebf1-b7e7-cd7d-eb5e" name="Meltagun" hidden="false" collective="false" import="true" targetId="4ebd-57e0-3560-e568" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="ee45-de6e-10a9-4e8e" name="Heavy Stubber" hidden="false" collective="false" import="true" targetId="f227-a61a-3215-932b" type="selectionEntry"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="6fc2-2f92-f269-7b43" name="Ionic Deflector" hidden="false" collective="false" import="true" targetId="c587-8d02-aaba-ce19" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7f9e-a79d-2bfa-dea2" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="511d-07cf-fdff-bfbf" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="200.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="df92-71d6-bf1a-d62e" name="Armiger Warglaive Talon" publicationId="bde1-6db1-163b-3b76" page="76" hidden="false" collective="false" import="true" type="unit">
+      <categoryLinks>
+        <categoryLink id="d1d0-67ae-0057-406d" name="Line Sub-type:" hidden="false" targetId="6399-5c65-7833-1025" primary="false"/>
+        <categoryLink id="fe5c-b652-3117-40f5" name="Skirmish Sub-type:" hidden="false" targetId="59a4-7b61-600a-c457" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="0670-d7df-534f-4c84" name="Armiger Warglaive" publicationId="bde1-6db1-163b-3b76" page="76" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4bad-8b9c-e25b-2e4b" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ace6-bc17-b95a-fc61" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="9f68-af8c-a26b-529e" name="Armiger Warglaive" publicationId="bde1-6db1-163b-3b76" page="76" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
+              <characteristics>
+                <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Armiger (Skirmish, Line)</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">8</characteristic>
+                <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
+                <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
+                <characteristic name="S" typeId="e478-41d4-a092-48a8">7</characteristic>
+                <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">7</characteristic>
+                <characteristic name="W" typeId="57ee-1126-32a9-5672">6</characteristic>
+                <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
+                <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">3</characteristic>
+                <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">7</characteristic>
+                <characteristic name="Save" typeId="e593-6b3c-f169-04f0">3+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="077f-949d-0926-b7b0" name="Armiger Unit-Type" hidden="false" targetId="53f7-6b93-cc7a-b976" type="rule"/>
+            <infoLink id="7c5a-361d-35f5-9d3a" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
+            <infoLink id="10eb-ff83-a06e-92e5" name="Fleet (X)" hidden="false" targetId="ddc9-0b4b-78da-bbd2" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Fleet (2)"/>
+              </modifiers>
+            </infoLink>
+            <infoLink id="a85b-a5f0-cb95-75a0" name="Move Through Cover" hidden="false" targetId="2b6f-bfec-759e-1746" type="rule"/>
+            <infoLink id="1105-4d29-df97-2df0" name="Armiger and Moirax Talons" hidden="false" targetId="d840-fbd0-352e-b33e" type="rule"/>
+          </infoLinks>
+          <selectionEntries>
+            <selectionEntry id="e4e9-9456-1828-d57b" name="Reaper Chainblade" publicationId="bde1-6db1-163b-3b76" page="120" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed72-974e-1a59-9489" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4372-9594-d5d8-0653" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="74fb-33d3-4e56-97b0" name="Reaper Chainblade" publicationId="bde1-6db1-163b-3b76" page="120" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
+                    <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">9</characteristic>
+                    <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">2</characteristic>
+                    <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Shred</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink id="126f-af29-0280-7171" name="Shred" hidden="false" targetId="5e7e-1628-8174-6f2c" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="5a5d-1173-1210-73a8" name="Thermal Lance" publicationId="bde1-6db1-163b-3b76" page="117" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a218-e517-f139-9d75" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4d2a-9dcb-a4c4-31de" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="f220-4068-517b-9120" name="Thermal Lance" publicationId="bde1-6db1-163b-3b76" page="117" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="95ba-cda7-b831-6066">36&quot;</characteristic>
+                    <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">8</characteristic>
+                    <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">2</characteristic>
+                    <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 2, Armourbane (Melta), Twin-linked</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink id="181f-e337-79b8-e2fa" name="Armourbane (X)" hidden="false" targetId="cb59-f920-f071-7cd4" type="rule">
+                  <modifiers>
+                    <modifier type="set" field="name" value="Armourbane (Melta)"/>
+                  </modifiers>
+                </infoLink>
+                <infoLink id="38fd-0dc8-1001-eb91" name="Twin-linked" hidden="false" targetId="8542-ee9d-e2fa-52fe" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="930c-cb5c-c810-9ed6" name="May Exchange its Heavy Stubber for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="2a7e-ff48-084e-7c88">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7ecc-0c4c-42cc-b746" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="08b8-b922-5c2d-7727" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="91ea-18b9-7b64-4f2f" name="Meltagun" hidden="false" collective="false" import="true" targetId="4ebd-57e0-3560-e568" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="2a7e-ff48-084e-7c88" name="Heavy Stubber" hidden="false" collective="false" import="true" targetId="f227-a61a-3215-932b" type="selectionEntry"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="4a38-da75-5d39-a784" name="Ionic Deflector" hidden="false" collective="false" import="true" targetId="c587-8d02-aaba-ce19" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8502-cc85-a605-9122" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1727-54d7-771a-0625" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="200.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="8cb2-7235-fc34-9983" name="Acastus Knight Porphyrion" publicationId="bde1-6db1-163b-3b76" page="83" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="add" field="category" value="f75a-d5c1-59ba-5c5a">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e78c-787d-54ca-82c2" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f4a8-b2a3-1c3c-9761" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1682-2560-347c-e798" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b90-1389-3b29-3fca" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3dc3-9018-b7a3-8cf9" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="323e-5ecd-e961-7796" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="ec20-ea8c-3b05-c8e6" name="Acastus Knight Porphyrion" publicationId="bde1-6db1-163b-3b76" page="83" hidden="false" typeId="75b5-9f7a-156e-6889" typeName="Knights and Titans">
+          <modifiers>
+            <modifier type="append" field="3c44-1e2a-23fe-c9e0" value="Character">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e78c-787d-54ca-82c2" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f4a8-b2a3-1c3c-9761" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1682-2560-347c-e798" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b90-1389-3b29-3fca" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3dc3-9018-b7a3-8cf9" type="greaterThan"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="increment" field="6c5a-df71-fefa-2ee3" value="1">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b90-1389-3b29-3fca" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e78c-787d-54ca-82c2" type="greaterThan"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="decrement" field="7f12-0cc3-9dcd-25bc" value="2">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7496-3ece-e6d8-6d40" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="decrement" field="6c5a-df71-fefa-2ee3" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7496-3ece-e6d8-6d40" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="decrement" field="4227-8eed-0c5c-a2d9" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7496-3ece-e6d8-6d40" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="4227-8eed-0c5c-a2d9" value="1">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3dc3-9018-b7a3-8cf9" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f4a8-b2a3-1c3c-9761" type="greaterThan"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="increment" field="2490-aa2f-f5db-6070" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1682-2560-347c-e798" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="Unit Type" typeId="3c44-1e2a-23fe-c9e0">Vehicle (Knight)</characteristic>
+            <characteristic name="Move" typeId="7f12-0cc3-9dcd-25bc">12</characteristic>
+            <characteristic name="WS" typeId="4227-8eed-0c5c-a2d9">4</characteristic>
+            <characteristic name="BS" typeId="6c5a-df71-fefa-2ee3">4</characteristic>
+            <characteristic name="S" typeId="02ba-082e-e385-1ede">10</characteristic>
+            <characteristic name="Front" typeId="0d00-68d8-0535-e898">14</characteristic>
+            <characteristic name="Side" typeId="cb92-5809-d327-6981">13</characteristic>
+            <characteristic name="Rear" typeId="8fa4-6e34-29c4-d8c6">12</characteristic>
+            <characteristic name="I" typeId="91b3-4335-71bf-3fa9">3</characteristic>
+            <characteristic name="A" typeId="d54a-56a6-68c5-ae72">3</characteristic>
+            <characteristic name="HP" typeId="2490-aa2f-f5db-6070">9</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="2c24-59e1-1510-79e1" name="It Will Not Die (X)" hidden="false" targetId="2784-d0be-a4e2-890f" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="It Will Not Die (6+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="5502-b9e5-8118-d3b5" name="Catastrophic Explosion" hidden="false" targetId="a13f-e697-6017-5a04" type="rule"/>
+      </infoLinks>
+      <selectionEntries>
+        <selectionEntry id="8f56-23e7-36bc-47ca" name="Hull (Front) Mounted Twin-Linked Magna Lascannon" publicationId="bde1-6db1-163b-3b76" page="117" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5249-b203-b02f-d96d" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a312-91ee-a6cc-827a" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="70c6-6b16-2b8e-fd78" name="Blast" hidden="false" targetId="1d9a-73ef-5f4f-8bd8" type="rule"/>
+            <infoLink id="9e87-d58e-bde1-7cb3" name="Ordnance" hidden="false" targetId="6c55-22c8-1b01-2105" type="rule"/>
+            <infoLink id="5970-5f4a-3bd7-aea8" name="Twin-Linked Magna Lascannon" hidden="false" targetId="2af9-d755-936d-0fa8" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="bf3f-1515-4ef9-7132" name="May exchange its Hull (Front) Mounted Ironstorm missile pod for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="21cc-4800-39e9-62fc">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="80bd-4073-8e7b-5f92" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4c8b-9fcd-88bb-3426" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="f7f3-762b-e730-cb89" name="Whirlwind Launcher with Hyperios Warheads" publicationId="bde1-6db1-163b-3b76" page="118" hidden="false" collective="false" import="true" type="upgrade">
+              <profiles>
+                <profile id="e2e3-a239-1b99-8f96" name="Whirlwind Launcher with Hyperios Warheads" publicationId="bde1-6db1-163b-3b76" page="118" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="95ba-cda7-b831-6066">48&quot;</characteristic>
+                    <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">8</characteristic>
+                    <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">3</characteristic>
+                    <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 4, Skyfire, Twin-linked</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink id="5116-3bee-7cd1-17ff" name="Skyfire" hidden="false" targetId="f2bf-5daa-9f93-0b01" type="rule"/>
+                <infoLink id="1270-cddd-c287-544a" name="Twin-linked" hidden="false" targetId="8542-ee9d-e2fa-52fe" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <entryLinks>
+            <entryLink id="21cc-4800-39e9-62fc" name="Ironstorm Missile Pod" hidden="false" collective="false" import="true" targetId="82e0-160b-28f5-f01e" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="e5d0-fd09-329c-e0a0" name="May exchange either or both of its Hull (Front) Mounted Autocannon to one of the following:" hidden="false" collective="false" import="true" defaultSelectionEntryId="5b99-3364-aafa-33aa">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d710-7309-e4e1-79d1" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0ce7-5902-1cd6-86b0" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="5b99-3364-aafa-33aa" name="Autocannon" hidden="false" collective="false" import="true" targetId="56b3-de09-9fea-deb6" type="selectionEntry"/>
+            <entryLink id="ece5-a8db-dfb3-8f7f" name="Irad-Cleanser" hidden="false" collective="false" import="true" targetId="b3c5-237f-e1d2-d9f8" type="selectionEntry"/>
+            <entryLink id="c112-6a27-bb6c-f0aa" name="Lascannon" hidden="false" collective="false" import="true" targetId="b252-5a86-6e0f-218b" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="364e-0933-d4f8-8e6e" name="Household Ranks" hidden="false" collective="false" import="true" targetId="1b29-a58e-296c-3946" type="selectionEntryGroup"/>
+        <entryLink id="93d0-022b-1b85-d764" name="Ion Shield" hidden="false" collective="false" import="true" targetId="dde9-961b-5765-21a2" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4c4d-1bea-e8a1-075b" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f62a-3908-fb72-a2cd" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="625.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1944-033c-5b7e-a378" name="Questoris Knight Styrix" publicationId="bde1-6db1-163b-3b76" page="84" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="add" field="category" value="f75a-d5c1-59ba-5c5a">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e78c-787d-54ca-82c2" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f4a8-b2a3-1c3c-9761" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1682-2560-347c-e798" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b90-1389-3b29-3fca" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3dc3-9018-b7a3-8cf9" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63ce-0429-b209-c3e9" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <profiles>
+        <profile id="6137-513f-8fcf-677d" name="Questoris Knight Styrix" publicationId="bde1-6db1-163b-3b76" page="84" hidden="false" typeId="75b5-9f7a-156e-6889" typeName="Knights and Titans">
+          <modifiers>
+            <modifier type="append" field="3c44-1e2a-23fe-c9e0" value="Character">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e78c-787d-54ca-82c2" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f4a8-b2a3-1c3c-9761" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1682-2560-347c-e798" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b90-1389-3b29-3fca" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3dc3-9018-b7a3-8cf9" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63ce-0429-b209-c3e9" type="greaterThan"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="decrement" field="7f12-0cc3-9dcd-25bc" value="2">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7496-3ece-e6d8-6d40" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="decrement" field="6c5a-df71-fefa-2ee3" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7496-3ece-e6d8-6d40" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="decrement" field="4227-8eed-0c5c-a2d9" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7496-3ece-e6d8-6d40" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="4227-8eed-0c5c-a2d9" value="1">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63ce-0429-b209-c3e9" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3dc3-9018-b7a3-8cf9" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f4a8-b2a3-1c3c-9761" type="greaterThan"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="increment" field="2490-aa2f-f5db-6070" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1682-2560-347c-e798" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="6c5a-df71-fefa-2ee3" value="1">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63ce-0429-b209-c3e9" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e78c-787d-54ca-82c2" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b90-1389-3b29-3fca" type="greaterThan"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="increment" field="7f12-0cc3-9dcd-25bc" value="4">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="Unit Type" typeId="3c44-1e2a-23fe-c9e0">Vehicle (Knight)</characteristic>
+            <characteristic name="Move" typeId="7f12-0cc3-9dcd-25bc">10</characteristic>
+            <characteristic name="WS" typeId="4227-8eed-0c5c-a2d9">4</characteristic>
+            <characteristic name="BS" typeId="6c5a-df71-fefa-2ee3">4</characteristic>
+            <characteristic name="S" typeId="02ba-082e-e385-1ede">8</characteristic>
+            <characteristic name="Front" typeId="0d00-68d8-0535-e898">13</characteristic>
+            <characteristic name="Side" typeId="cb92-5809-d327-6981">12</characteristic>
+            <characteristic name="Rear" typeId="8fa4-6e34-29c4-d8c6">12</characteristic>
+            <characteristic name="I" typeId="91b3-4335-71bf-3fa9">2</characteristic>
+            <characteristic name="A" typeId="d54a-56a6-68c5-ae72">3</characteristic>
+            <characteristic name="HP" typeId="2490-aa2f-f5db-6070">7</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="bb06-6902-6ec8-b640" name="Outflank" hidden="false" targetId="bfbf-e75c-49a2-0285" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="51fb-2b6f-59c3-133c" name="Scout" hidden="false" targetId="aacf-9a7e-982d-b793" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="69af-dd04-16b0-3a0f" name="Night Vision" hidden="false" targetId="683e-b4f2-f032-d31b" type="rule"/>
+        <infoLink id="6880-a124-adca-871a" name="Overtaxed Reactor" hidden="false" targetId="5f22-e7a4-4141-ee2e" type="rule"/>
+      </infoLinks>
+      <selectionEntries>
+        <selectionEntry id="9601-8274-0377-7857" name="Arm Mounted Volkite Chieorovile" publicationId="bde1-6db1-163b-3b76" page="119" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="033f-70e8-7465-5745" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f681-cf98-6c0f-9190" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="2d67-0a61-b145-af2c" name="Volkite Chieorovile" publicationId="bde1-6db1-163b-3b76" page="119" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="95ba-cda7-b831-6066">45&quot;</characteristic>
+                <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">8</characteristic>
+                <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">4</characteristic>
+                <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 5, Deflagrate</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="101f-3b4e-75b7-d916" name="Deflagrate" hidden="false" targetId="60bc-f79a-67ae-be4f" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="c24a-4c0c-0239-3861" name="May exchange its Arm Mounted Reaper Chainsword for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="bbc6-0924-1229-cfed">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1437-2e1f-f0a1-cae3" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="040e-b35e-f4da-af9e" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="3470-29ee-7415-96c2" name="Siege Claw with In-Built Irad-Cleanser" hidden="false" collective="false" import="true" type="upgrade">
+              <infoLinks>
+                <infoLink id="5085-bc21-4999-38da" name="Irad-Cleanser" hidden="false" targetId="484b-1446-7bac-46d9" type="profile"/>
+                <infoLink id="e760-49ee-51db-5808" name="Fleshbane" hidden="false" targetId="40cd-9505-253c-e76f" type="rule"/>
+                <infoLink id="1972-0741-f23f-7a98" name="Rad-Phage" hidden="false" targetId="8189-e963-d2e5-5d3d" type="rule"/>
+                <infoLink id="e600-fbb9-1e63-a2dd" name="Brutal (X)" hidden="false" targetId="5079-1fec-d32b-8b84" type="rule">
+                  <modifiers>
+                    <modifier type="set" field="name" value="Brutal (2)"/>
+                  </modifiers>
+                </infoLink>
+                <infoLink id="5750-724b-05cf-a83d" name="Sunder" hidden="false" targetId="20e2-75cf-bc16-cd8f" type="rule"/>
+                <infoLink id="9446-ac4f-0c60-4793" name="Wrecker" hidden="false" targetId="ba77-a802-55df-da67" type="rule"/>
+                <infoLink id="b4ed-c3b4-ebf3-b1f3" name="Siege Claw" hidden="false" targetId="f417-99e0-bb03-dfa7" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <entryLinks>
+            <entryLink id="bbc6-0924-1229-cfed" name="Reaper Chainsword" hidden="false" collective="false" import="true" targetId="2164-1725-d032-ed49" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="59a9-e976-f824-787b" name="Hull (Front) Mounted Graviton Gun" hidden="false" collective="false" import="true" defaultSelectionEntryId="627c-d556-2c4a-dd4b">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0c55-8eac-06ec-91af" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5c5a-6889-c624-6456" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="627c-d556-2c4a-dd4b" name="Graviton Gun" hidden="false" collective="false" import="true" targetId="5303-5a3e-de51-1707" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="00a1-b153-0c3f-fe37" name="Household Ranks" hidden="false" collective="false" import="true" targetId="1b29-a58e-296c-3946" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="380.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6d0e-0d72-d9e2-01d1" name="Questoris Knight Magaera" publicationId="bde1-6db1-163b-3b76" page="85" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="add" field="category" value="f75a-d5c1-59ba-5c5a">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e78c-787d-54ca-82c2" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f4a8-b2a3-1c3c-9761" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1682-2560-347c-e798" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b90-1389-3b29-3fca" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3dc3-9018-b7a3-8cf9" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63ce-0429-b209-c3e9" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <profiles>
+        <profile id="46cc-7838-1ac7-9842" name="Questoris Knight Magaera" publicationId="bde1-6db1-163b-3b76" page="85" hidden="false" typeId="75b5-9f7a-156e-6889" typeName="Knights and Titans">
+          <modifiers>
+            <modifier type="append" field="3c44-1e2a-23fe-c9e0" value="Character">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e78c-787d-54ca-82c2" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f4a8-b2a3-1c3c-9761" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1682-2560-347c-e798" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b90-1389-3b29-3fca" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3dc3-9018-b7a3-8cf9" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63ce-0429-b209-c3e9" type="greaterThan"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="decrement" field="7f12-0cc3-9dcd-25bc" value="2">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7496-3ece-e6d8-6d40" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="decrement" field="6c5a-df71-fefa-2ee3" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7496-3ece-e6d8-6d40" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="decrement" field="4227-8eed-0c5c-a2d9" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7496-3ece-e6d8-6d40" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="4227-8eed-0c5c-a2d9" value="1">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63ce-0429-b209-c3e9" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3dc3-9018-b7a3-8cf9" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f4a8-b2a3-1c3c-9761" type="greaterThan"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="increment" field="2490-aa2f-f5db-6070" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1682-2560-347c-e798" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="6c5a-df71-fefa-2ee3" value="1">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63ce-0429-b209-c3e9" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e78c-787d-54ca-82c2" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b90-1389-3b29-3fca" type="greaterThan"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="increment" field="7f12-0cc3-9dcd-25bc" value="4">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="Unit Type" typeId="3c44-1e2a-23fe-c9e0">Vehicle (Knight)</characteristic>
+            <characteristic name="Move" typeId="7f12-0cc3-9dcd-25bc">10</characteristic>
+            <characteristic name="WS" typeId="4227-8eed-0c5c-a2d9">4</characteristic>
+            <characteristic name="BS" typeId="6c5a-df71-fefa-2ee3">4</characteristic>
+            <characteristic name="S" typeId="02ba-082e-e385-1ede">8</characteristic>
+            <characteristic name="Front" typeId="0d00-68d8-0535-e898">13</characteristic>
+            <characteristic name="Side" typeId="cb92-5809-d327-6981">12</characteristic>
+            <characteristic name="Rear" typeId="8fa4-6e34-29c4-d8c6">12</characteristic>
+            <characteristic name="I" typeId="91b3-4335-71bf-3fa9">2</characteristic>
+            <characteristic name="A" typeId="d54a-56a6-68c5-ae72">3</characteristic>
+            <characteristic name="HP" typeId="2490-aa2f-f5db-6070">7</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="a045-8677-765a-f9fb" name="Outflank" hidden="false" targetId="bfbf-e75c-49a2-0285" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="3ec1-564b-9510-35e5" name="Scout" hidden="false" targetId="aacf-9a7e-982d-b793" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="97ef-56b1-7977-7f80" name="Night Vision" hidden="false" targetId="683e-b4f2-f032-d31b" type="rule"/>
+        <infoLink id="737b-2cb1-2349-948e" name="Overtaxed Reactor" hidden="false" targetId="5f22-e7a4-4141-ee2e" type="rule"/>
+      </infoLinks>
+      <selectionEntries>
+        <selectionEntry id="3076-5d20-0d9b-42a6" name="Arm Mounted Lightning Cannon" publicationId="bde1-6db1-163b-3b76" page="113" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6542-cc94-1eed-281e" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="432d-97c7-9b24-6c1a" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="b4c5-352c-47e7-e1ef" name="Blast" hidden="false" targetId="1d9a-73ef-5f4f-8bd8" type="rule"/>
+            <infoLink id="daf2-54e8-793e-d299" name="Exoshock (X)" hidden="false" targetId="69ca-318a-b47a-7a3c" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Exoshock (4+)"/>
+              </modifiers>
+            </infoLink>
+            <infoLink id="92fd-96a0-29f2-cd1c" name="Rending (X)" hidden="false" targetId="0ac9-fab7-aef3-de1d" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Rending (4+)"/>
+              </modifiers>
+            </infoLink>
+            <infoLink id="7d8d-e406-9fde-3a13" name="Shred" hidden="false" targetId="5e7e-1628-8174-6f2c" type="rule"/>
+            <infoLink id="403c-4eeb-4934-1616" name="Lightning Cannon " publicationId="bde1-6db1-163b-3b76" page="113" hidden="false" targetId="119e-f108-83fe-d0e3" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="2dc0-8d80-1c37-d150" name="May exchange its Arm Mounted Reaper Chainsword for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="0b79-3184-edee-70cc">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="84d9-c18d-0733-d6c9" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="547b-c303-2a1b-d962" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="6fa6-da43-5460-36aa" name="Siege Claw with In-Built Irad-Cleanser" publicationId="bde1-6db1-163b-3b76" page="123" hidden="false" collective="false" import="true" type="upgrade">
+              <infoLinks>
+                <infoLink id="f930-5397-a911-040a" name="Irad-Cleanser" hidden="false" targetId="484b-1446-7bac-46d9" type="profile"/>
+                <infoLink id="6b8a-652b-dc9e-2a30" name="Fleshbane" hidden="false" targetId="40cd-9505-253c-e76f" type="rule"/>
+                <infoLink id="f245-44a6-d16e-bb26" name="Rad-Phage" hidden="false" targetId="8189-e963-d2e5-5d3d" type="rule"/>
+                <infoLink id="ed9f-a21c-d5f4-50f6" name="Brutal (X)" hidden="false" targetId="5079-1fec-d32b-8b84" type="rule">
+                  <modifiers>
+                    <modifier type="set" field="name" value="Brutal (2)"/>
+                  </modifiers>
+                </infoLink>
+                <infoLink id="fc68-38ed-f813-3bd0" name="Sunder" hidden="false" targetId="20e2-75cf-bc16-cd8f" type="rule"/>
+                <infoLink id="6d28-a833-d8f9-48b1" name="Wrecker" hidden="false" targetId="ba77-a802-55df-da67" type="rule"/>
+                <infoLink id="fa68-f793-874a-a7e2" name="Siege Claw" hidden="false" targetId="f417-99e0-bb03-dfa7" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <entryLinks>
+            <entryLink id="0b79-3184-edee-70cc" name="Reaper Chainsword" hidden="false" collective="false" import="true" targetId="2164-1725-d032-ed49" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="6908-7e12-3206-d066" name="Hull (Front) Mounted Phased Plasma-Fusil" hidden="false" collective="false" import="true" defaultSelectionEntryId="2bb8-7dbf-0039-9e5e">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f919-c714-3805-3ccf" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9d43-b9c5-2422-3a9e" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="2bb8-7dbf-0039-9e5e" name="Phased Plasma-Fusil" hidden="false" collective="false" import="true" targetId="17c6-afe9-c5da-d9b6" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="162e-1e2a-7367-c048" name="Household Ranks" hidden="false" collective="false" import="true" targetId="1b29-a58e-296c-3946" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="385.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="012b-109f-74d2-2c82" name="Questoris Knight Atrapos" publicationId="bde1-6db1-163b-3b76" page="86" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="add" field="category" value="f75a-d5c1-59ba-5c5a">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e78c-787d-54ca-82c2" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f4a8-b2a3-1c3c-9761" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1682-2560-347c-e798" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b90-1389-3b29-3fca" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3dc3-9018-b7a3-8cf9" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63ce-0429-b209-c3e9" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="40d3-44e0-a36b-28e3" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="0486-7afa-456d-953c" name="Questoris Knight Atrapos" publicationId="bde1-6db1-163b-3b76" page="86" hidden="false" typeId="75b5-9f7a-156e-6889" typeName="Knights and Titans">
+          <modifiers>
+            <modifier type="append" field="3c44-1e2a-23fe-c9e0" value="Character">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e78c-787d-54ca-82c2" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f4a8-b2a3-1c3c-9761" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1682-2560-347c-e798" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b90-1389-3b29-3fca" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3dc3-9018-b7a3-8cf9" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63ce-0429-b209-c3e9" type="greaterThan"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="decrement" field="7f12-0cc3-9dcd-25bc" value="2">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7496-3ece-e6d8-6d40" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="decrement" field="6c5a-df71-fefa-2ee3" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7496-3ece-e6d8-6d40" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="decrement" field="4227-8eed-0c5c-a2d9" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7496-3ece-e6d8-6d40" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="4227-8eed-0c5c-a2d9" value="1">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63ce-0429-b209-c3e9" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3dc3-9018-b7a3-8cf9" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f4a8-b2a3-1c3c-9761" type="greaterThan"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="increment" field="2490-aa2f-f5db-6070" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1682-2560-347c-e798" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="6c5a-df71-fefa-2ee3" value="1">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63ce-0429-b209-c3e9" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e78c-787d-54ca-82c2" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b90-1389-3b29-3fca" type="greaterThan"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="increment" field="7f12-0cc3-9dcd-25bc" value="4">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="Unit Type" typeId="3c44-1e2a-23fe-c9e0">Vehicle (Knight)</characteristic>
+            <characteristic name="Move" typeId="7f12-0cc3-9dcd-25bc">14</characteristic>
+            <characteristic name="WS" typeId="4227-8eed-0c5c-a2d9">4</characteristic>
+            <characteristic name="BS" typeId="6c5a-df71-fefa-2ee3">4</characteristic>
+            <characteristic name="S" typeId="02ba-082e-e385-1ede">9</characteristic>
+            <characteristic name="Front" typeId="0d00-68d8-0535-e898">13</characteristic>
+            <characteristic name="Side" typeId="cb92-5809-d327-6981">12</characteristic>
+            <characteristic name="Rear" typeId="8fa4-6e34-29c4-d8c6">12</characteristic>
+            <characteristic name="I" typeId="91b3-4335-71bf-3fa9">4</characteristic>
+            <characteristic name="A" typeId="d54a-56a6-68c5-ae72">4</characteristic>
+            <characteristic name="HP" typeId="2490-aa2f-f5db-6070">8</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="c8c4-ac90-1fd3-008b" name="Macro-extinction Targeting Protocols" publicationId="bde1-6db1-163b-3b76" hidden="false">
+          <description>When making Shooting Attacks against targets with the Super-heavy Vehicle, Knight or Titan Unit Types or the Monstrous Sub-type, a model with this special rule counts all of its ranged weapons as twin-linked.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="ea14-0b04-69d6-3e19" name="Outflank" hidden="false" targetId="bfbf-e75c-49a2-0285" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="c0ee-bf21-7f9c-20d5" name="Scout" hidden="false" targetId="aacf-9a7e-982d-b793" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="23ed-7300-b7c2-102b" name="Night Vision" hidden="false" targetId="683e-b4f2-f032-d31b" type="rule"/>
+        <infoLink id="4579-59fa-8a6d-ad32" name="Flank Speed" hidden="false" targetId="41ab-227d-9d91-8001" type="rule"/>
+        <infoLink id="16fb-879f-b25c-641d" name="Catastrophic Destruction" hidden="false" targetId="c41f-6ac9-6909-44c4" type="rule"/>
+      </infoLinks>
+      <selectionEntries>
+        <selectionEntry id="82ec-43f7-25ef-ebb7" name="Arm Mounted Atrapos Phasecutter" publicationId="bde1-6db1-163b-3b76" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="05ab-48b9-53ec-6bcc" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f5e0-6a4e-8bf7-3c19" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="ba87-6ceb-1c1c-6bf1" name="Atrapos Phasecutter (Ranged)" publicationId="bde1-6db1-163b-3b76" page="115" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="95ba-cda7-b831-6066">12&quot;</characteristic>
+                <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">10</characteristic>
+                <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">2</characteristic>
+                <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Ordnance 1</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="93f8-ea60-d968-53e1" name="Atrapos Phasecutter (Melee)" publicationId="bde1-6db1-163b-3b76" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
+                <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">10</characteristic>
+                <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">1</characteristic>
+                <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Cumbersome, Armourbane, Instant Death</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="cba3-3f5c-2afc-5a68" name="Ordnance" hidden="false" targetId="6c55-22c8-1b01-2105" type="rule"/>
+            <infoLink id="fde7-a195-69c9-0cba" name="Cumbersome" hidden="false" targetId="d89a-c10e-8a7a-92c3" type="rule"/>
+            <infoLink id="843d-d81b-8813-ceb8" name="Armourbane (X)" hidden="false" targetId="cb59-f920-f071-7cd4" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Armourbane (Melee)"/>
+              </modifiers>
+            </infoLink>
+            <infoLink id="91ae-b3d4-c3dc-91d7" name="Instant Death" hidden="false" targetId="9e96-fff1-b916-d9a3" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="6853-a562-8371-604b" name="Arm Mounted Singularity Cannon" publicationId="bde1-6db1-163b-3b76" page="116" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="809f-5791-e660-6c26" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7e6f-6e3c-a620-8645" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="bf38-57a9-62e8-e77c" name="Singularity Cannon" publicationId="bde1-6db1-163b-3b76" page="116" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="95ba-cda7-b831-6066">36&quot;</characteristic>
+                <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">8</characteristic>
+                <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">2</characteristic>
+                <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 1, Large Blast (5&quot;), Haywire, Concussive (1), Graviton Singularity</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="68b3-f712-fcf1-8839" name="Graviton Singularity" publicationId="bde1-6db1-163b-3b76" page="104" hidden="false">
+              <description>Before firing a weapon with this special rule, roll a D6. On a 1, the firing unit suffers a single Wound against which no Saves or Damage Mitigation rolls may be made. A model with the Vehicle Unit Type instead suffers 1 Hull Point against which no Saves or Damage Mitigation rolls may be made. On a 2-5, the weapon fires normally. On a result of a 6, the attack is carried out with the Vortex special rule.</description>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="4b05-1a65-dcbd-d469" name="Blast" hidden="false" targetId="1d9a-73ef-5f4f-8bd8" type="rule"/>
+            <infoLink id="8bca-0d42-e9f8-3676" name="Haywire" hidden="false" targetId="1dd4-7a75-5c59-8425" type="rule"/>
+            <infoLink id="08ca-cfad-5abe-d755" name="Concussive (X)" hidden="false" targetId="7ce5-1bfb-64e6-f826" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Concussive (1)"/>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="89d1-2153-c579-0886" name="Household Ranks" hidden="false" collective="false" import="true" targetId="1b29-a58e-296c-3946" type="selectionEntryGroup"/>
+        <entryLink id="6f33-26a9-4bf9-9b06" name="Ion Shield" hidden="false" collective="false" import="true" targetId="dde9-961b-5765-21a2" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0aa9-d1d5-5b68-e887" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f21a-2c63-7d68-d1c9" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="500.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7b6b-49ab-d71d-e359" name="Questoris Acastus Knight Asterius" publicationId="bde1-6db1-163b-3b76" page="87" hidden="false" collective="false" import="true" type="unit">
+      <modifiers>
+        <modifier type="add" field="category" value="f75a-d5c1-59ba-5c5a">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e78c-787d-54ca-82c2" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f4a8-b2a3-1c3c-9761" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1682-2560-347c-e798" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b90-1389-3b29-3fca" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3dc3-9018-b7a3-8cf9" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="44be-891e-7401-987d" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="c6fa-4ceb-1994-f329" name="Questoris Acastus Knight Asterius" publicationId="bde1-6db1-163b-3b76" page="87" hidden="false" typeId="75b5-9f7a-156e-6889" typeName="Knights and Titans">
+          <modifiers>
+            <modifier type="append" field="3c44-1e2a-23fe-c9e0" value="Character">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e78c-787d-54ca-82c2" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f4a8-b2a3-1c3c-9761" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1682-2560-347c-e798" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b90-1389-3b29-3fca" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3dc3-9018-b7a3-8cf9" type="greaterThan"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="decrement" field="7f12-0cc3-9dcd-25bc" value="2">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7496-3ece-e6d8-6d40" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="decrement" field="4227-8eed-0c5c-a2d9" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7496-3ece-e6d8-6d40" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="decrement" field="6c5a-df71-fefa-2ee3" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7496-3ece-e6d8-6d40" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="4227-8eed-0c5c-a2d9" value="1">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3dc3-9018-b7a3-8cf9" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f4a8-b2a3-1c3c-9761" type="greaterThan"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="increment" field="6c5a-df71-fefa-2ee3" value="1">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b90-1389-3b29-3fca" type="greaterThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e78c-787d-54ca-82c2" type="greaterThan"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="increment" field="2490-aa2f-f5db-6070" value="1">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1682-2560-347c-e798" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="7f12-0cc3-9dcd-25bc" value="4">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="Unit Type" typeId="3c44-1e2a-23fe-c9e0">Vehicle (Knight)</characteristic>
+            <characteristic name="Move" typeId="7f12-0cc3-9dcd-25bc">12</characteristic>
+            <characteristic name="WS" typeId="4227-8eed-0c5c-a2d9">4</characteristic>
+            <characteristic name="BS" typeId="6c5a-df71-fefa-2ee3">4</characteristic>
+            <characteristic name="S" typeId="02ba-082e-e385-1ede">10</characteristic>
+            <characteristic name="Front" typeId="0d00-68d8-0535-e898">14</characteristic>
+            <characteristic name="Side" typeId="cb92-5809-d327-6981">13</characteristic>
+            <characteristic name="Rear" typeId="8fa4-6e34-29c4-d8c6">12</characteristic>
+            <characteristic name="I" typeId="91b3-4335-71bf-3fa9">3</characteristic>
+            <characteristic name="A" typeId="d54a-56a6-68c5-ae72">3</characteristic>
+            <characteristic name="HP" typeId="2490-aa2f-f5db-6070">9</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="ac81-4903-d18c-3a66" name="Outflank" hidden="false" targetId="bfbf-e75c-49a2-0285" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="8e35-f276-1e25-3f6c" name="Scout" hidden="false" targetId="aacf-9a7e-982d-b793" type="rule">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="3c8b-42a2-8761-1774" name="Catastrophic Explosion" hidden="false" targetId="a13f-e697-6017-5a04" type="rule"/>
+        <infoLink id="307c-48a6-6f74-3597" name="It Will Not Die (X)" hidden="false" targetId="2784-d0be-a4e2-890f" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="It Will Not Die (6+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="823d-6bdf-65a7-5364" name="Night Vision" hidden="false" targetId="683e-b4f2-f032-d31b" type="rule"/>
+      </infoLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="e02c-7999-0d11-6d4b" name="Arm Mounted Twin-Linked Heavy Conversion Beam Cannon" hidden="false" collective="false" import="true" defaultSelectionEntryId="4533-c245-dae6-7822">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4808-2fe4-22b2-3119" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2b67-3968-341c-1176" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="4533-c245-dae6-7822" name="Heavy Conversion Beam Cannon" hidden="false" collective="false" import="true" targetId="7c47-e2e9-dc42-e838" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="a9bd-c3dc-0f37-ed99" name="Hull (Front) Mounted Karacnos Mortar Battery" hidden="false" collective="false" import="true" defaultSelectionEntryId="1e70-22fa-c60c-ef70">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="59fe-9eff-e552-f8b2" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="65c2-0b9c-a89c-060b" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="1e70-22fa-c60c-ef70" name="Karacnos Mortar Battery" hidden="false" collective="false" import="true" targetId="2b9f-41fb-a0a8-285e" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="37de-352d-6fd6-2ca6" name="Hull (Front) Mounted Volkite Culverin" hidden="false" collective="false" import="true" defaultSelectionEntryId="60cf-5543-d8fb-2a4b">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fa89-3d4b-6abe-62dc" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0afa-3f8e-3f28-5a0a" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="60cf-5543-d8fb-2a4b" name="Volkite Culverin" hidden="false" collective="false" import="true" targetId="170d-44e0-455c-8207" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="f6f3-55b4-08c3-8391" name="Household Ranks" hidden="false" collective="false" import="true" targetId="1b29-a58e-296c-3946" type="selectionEntryGroup"/>
+        <entryLink id="73a4-7fec-4bb7-f5e3" name="Ion Shield" hidden="false" collective="false" import="true" targetId="dde9-961b-5765-21a2" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4d11-757e-d04d-a768" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="93a7-a6ea-6e93-8f33" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="625.0"/>
+      </costs>
+    </selectionEntry>
+  </sharedSelectionEntries>
+  <sharedSelectionEntryGroups>
+    <selectionEntryGroup id="1b29-a58e-296c-3946" name="Household Ranks" hidden="true" collective="false" import="true">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="807e-0cf8-7f28-7b6d" type="greaterThan"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e178-5d4c-f6a5-28b0" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="f4a8-b2a3-1c3c-9761" name="Dolorous" publicationId="bde1-6db1-163b-3b76" page="89" hidden="false" collective="false" import="true" type="upgrade">
+          <rules>
+            <rule id="4e3f-1a1f-7f76-674a" name="Dolorous" publicationId="bde1-6db1-163b-3b76" page="89" hidden="false">
+              <description>A model with this upgrade increases its Weapon Skill Characteristic by +1, and gains the Character Unit Sub-type and the Dolorous special rule.
+Dolorous: A model with this special rule may attempt to make Sweeping Advances (as an exception to the normal rules for models with the Knight Unit Sub-type).</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="7496-3ece-e6d8-6d40" name="Aspirant" publicationId="bde1-6db1-163b-3b76" page="88" hidden="false" collective="false" import="true" type="upgrade">
+          <rules>
+            <rule id="54c7-f462-4d3d-c7c3" name="Aspirant" publicationId="bde1-6db1-163b-3b76" page="88" hidden="false">
+              <description>A model with this upgrade must reduce its Weapon Skill and Ballistic Skill Characteristics by -1 and its Movement Characteristics by -2.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="-30.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="e78c-787d-54ca-82c2" name="Arbalester" publicationId="bde1-6db1-163b-3b76" page="88" hidden="false" collective="false" import="true" type="upgrade">
+          <rules>
+            <rule id="4c36-c678-09a5-4f1c" name="Arbalester" publicationId="bde1-6db1-163b-3b76" page="88" hidden="false">
+              <description>A model with this upgrade increases its Ballistic Skill Characteristic by +1 and gains the Character Unit Sub-type and Arbalester special rule.
+Arbalester: When a model with this special rule is required to make a Scatter roll, roll an additional Scatter dice and the model’s controlling player chooses which is used to determine the results of the Scatter roll.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="55.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="63ce-0429-b209-c3e9" name="Seneschal (0-1)" publicationId="bde1-6db1-163b-3b76" page="88" hidden="false" collective="false" import="true" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8cb2-7235-fc34-9983" type="instanceOf"/>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7b6b-49ab-d71d-e359" type="instanceOf"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3e3f-1c62-250f-c9c7" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="6f73-0bfe-e2c7-895b" name="Seneschal (0-1)" hidden="false">
+              <description>Only a single unit in a Questoris Household Detachment may be upgraded to have the Seneschal rank, and an Acastus Knight Porphyrion or Acastus Knight Asterius may not be given this upgrade.
+A model with this upgrade gains the Character Unit Sub-type and increases its Weapon Skill and Ballistic Skill Characteristics by +1. In addition, if the Questoris Household Detachment is the Primary Detachment of the army, then a model with this upgrade must be chosen as the army’s Warlord. If selected as the army’s Warlord, a model with this upgrade automatically gains the following Warlord Trait:
+Master of the Household: Any friendly model with the Vehicle Unit Type and the Knight Unit Sub-type within 8&quot; of a Warlord with this Warlord Trait may make Reactions as per the standard rules, ignoring the usual restriction for Knights and Titans. In addition, an army whose Warlord has this Trait may make an additional Reaction during their opponent’s Shooting phase as long as the Warlord has not been removed as a casualty.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="80.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="3dc3-9018-b7a3-8cf9" name="Aucteller" publicationId="bde1-6db1-163b-3b76" page="89" hidden="false" collective="false" import="true" type="upgrade">
+          <rules>
+            <rule id="e8d1-dafa-ef1b-5dcb" name="Aucteller" publicationId="bde1-6db1-163b-3b76" page="89" hidden="false">
+              <description>A model with this upgrade increases its Weapon Skill Characteristic by +1 and gains the Character Unit Sub-type and the Aucteller special rule.
+Aucteller: When engaged in a Challenge against an enemy model with the Knight, Titan or Monstrous Unit Sub-type, the Primarch Unit Type or a model with a Wounds Characteristic of 8 or higher, a model with this special rule gains +1 Weapon Skill and +1 Attack. This bonus to Weapon Skill is in addition to the +1 Weapon Skill increase from the Aucteller upgrade detailed above.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="55.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="1682-2560-347c-e798" name="Implacable" publicationId="bde1-6db1-163b-3b76" page="89" hidden="false" collective="false" import="true" type="upgrade">
+          <rules>
+            <rule id="9494-9a41-5415-c9dd" name="Implacable" publicationId="bde1-6db1-163b-3b76" page="89" hidden="false">
+              <description>A model with this upgrade increases its Hull Points by +1, gains the Character Unit Sub-type and the Implacable special rule.
+Implacable: No attack targeting a model with this special rule may inflict more than a single Hull Point of damage, including those attacks with the Exoshock (X) special rule</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="65.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="4b90-1389-3b29-3fca" name="Preceptor" publicationId="bde1-6db1-163b-3b76" page="89" hidden="false" collective="false" import="true" type="upgrade">
+          <rules>
+            <rule id="f38a-9345-c968-6770" name="Preceptor" publicationId="bde1-6db1-163b-3b76" page="89" hidden="false">
+              <description>A model with this upgrade increases its Ballistic Skill Characteristic by +1 and gains the Character Unit Sub-type and Preceptor special rule.
+Preceptor: Any units of Armiger Warglaives or Armiger Helverins that have at least one model within 6&quot; of a friendly model with this special rule increase the Leadership of all models in the unit to 9.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="45.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="7f03-d8c0-0e83-1f6e" name="Uhlan" publicationId="bde1-6db1-163b-3b76" page="89" hidden="false" collective="false" import="true" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8cb2-7235-fc34-9983" type="instanceOf"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <rules>
+            <rule id="2960-d429-0759-09a6" name="Uhlan" publicationId="bde1-6db1-163b-3b76" page="89" hidden="false">
+              <description>A model with this upgrade increases its Movement Characteristic by +4 and gains the Character Unit Sub-type and the Scout and Outflank special rules. An Acastus Knight Porphyrion may not be given this upgrade.</description>
+            </rule>
+          </rules>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+  </sharedSelectionEntryGroups>
+  <catalogueLinks>
+    <catalogueLink id="f98f-e172-8ed2-4bef" name="2022 - Mech Library" targetId="3129-da35-55e0-642d" type="catalogue" importRootEntries="true"/>
+  </catalogueLinks>
 </catalogue>

--- a/2022 - Titan Legions.cat
+++ b/2022 - Titan Legions.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="c01b-0224-f806-0d23" name="2022 - Titan Legions" revision="1" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="11" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="c01b-0224-f806-0d23" name="2022 - Titan Legions" revision="1" battleScribeVersion="2.03" library="false" gameSystemId="28d4-bd2e-4858-ece6" gameSystemRevision="12" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <forceEntries>
     <forceEntry id="aebe-bed9-b32f-a8ea" name="Titan Maniple" hidden="false">
       <categoryLinks>
@@ -16,26 +16,12 @@
           </constraints>
         </categoryLink>
         <categoryLink id="dd8b-2d47-ad0f-f152" name="Troops:" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="false">
-          <modifiers>
-            <modifier type="increment" field="e4cd-8a9e-0f33-2138" value="1.0">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c658-dc6b-727b-c488" type="equalTo"/>
-              </conditions>
-            </modifier>
-          </modifiers>
           <constraints>
             <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e4cd-8a9e-0f33-2138" type="min"/>
             <constraint field="selections" scope="force" value="6.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a819-e905-205c-af5a" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="882a-092f-96da-a684" name="Lords of War:" hidden="false" targetId="c658-dc6b-727b-c488" primary="false">
-          <modifiers>
-            <modifier type="increment" field="d51d-0b0c-e7f2-da44" value="1.0">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9b5d-fac7-799b-d7e7" type="equalTo"/>
-              </conditions>
-            </modifier>
-          </modifiers>
           <constraints>
             <constraint field="selections" scope="force" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9657-b309-85f1-3a34" type="max"/>
             <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="d51d-0b0c-e7f2-da44" type="min"/>
@@ -45,7 +31,7 @@
     </forceEntry>
   </forceEntries>
   <entryLinks>
-    <entryLink id="6b36-d1b3-cba5-f217" name="Divisio Tactica: The Titan Legions" hidden="false" collective="false" import="true" targetId="47f0-bba9-6d89-9baa" type="selectionEntry">
+    <entryLink id="6b36-d1b3-cba5-f217" name="Divisio Tactica: The Titan Legions" hidden="false" collective="false" import="false" targetId="47f0-bba9-6d89-9baa" type="selectionEntry">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9b71-5246-c019-3c96" type="min"/>
       </constraints>
@@ -53,5 +39,1149 @@
         <categoryLink id="277b-dd85-3a29-3e6d" name="New CategoryLink" hidden="false" targetId="e90d-e5a8-f42d-da84" primary="true"/>
       </categoryLinks>
     </entryLink>
+    <entryLink id="0283-c466-47b4-de8f" name="Warlord Battle Titan" hidden="false" collective="false" import="true" targetId="d737-baca-32e7-8da6" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="53aa-f28d-38ab-c2fc" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="5e25-d5c2-8f6e-1e86" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="d6ad-baec-87f6-e839" name="Warbringer Nemesis Titan" hidden="false" collective="false" import="true" targetId="3dd1-77d8-4289-b745" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="fcdb-3e8d-a4f7-7665" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="203a-2c3d-872b-9cc1" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="61a7-4c8e-1ef8-84cc" name="Warhound Scout Titan" hidden="false" collective="false" import="true" targetId="841c-c2f5-9817-3061" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="eef0-bad3-f27a-6a02" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="acf1-ae9e-a4c0-91af" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="c8ee-7d52-39c1-17d4" name="Reaver Battle Titan" hidden="false" collective="false" import="true" targetId="2dbc-7655-bb05-ab89" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="e182-a612-dbd0-e0be" name="New CategoryLink" hidden="false" targetId="c658-dc6b-727b-c488" primary="true"/>
+        <categoryLink id="49e9-613a-ed0b-5efb" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="fc74-4887-4a56-b156" name="Secutarii Axiarch" hidden="false" collective="false" import="false" targetId="b08e-55fe-3e1d-913b" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="20c9-4414-e920-bb1d" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+        <categoryLink id="1bbb-eefa-3c7a-a644" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="08fe-a1c3-8026-bb5b" name="Secutarii Hoplite Phalanx" hidden="false" collective="false" import="false" targetId="f4cc-a854-5467-45cf" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="6a27-5000-b509-a7d7" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="032c-b742-5238-a7dc" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="d42f-542d-2cba-8d45" name="Secutarii Peltast Phalanx (Placeholder)" hidden="false" collective="false" import="false" targetId="4fc3-7259-f9b0-71cd" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="8940-f885-bcc9-b74f" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
+        <categoryLink id="a270-c7de-cbbf-fd44" name="New CategoryLink" hidden="false" targetId="9b5d-fac7-799b-d7e7" primary="true"/>
+      </categoryLinks>
+    </entryLink>
   </entryLinks>
+  <sharedSelectionEntries>
+    <selectionEntry id="d737-baca-32e7-8da6" name="Warlord Battle Titan" hidden="false" collective="false" import="true" type="unit">
+      <selectionEntries>
+        <selectionEntry id="eafb-9e64-17c6-f5f0" name="Warlord Battle Titan" hidden="false" collective="false" import="true" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8b8f-b910-f383-cbd8" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5c44-2b46-ba6d-4cdf" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="4a76-fd08-f62a-f77b" name="Warlord Battle Titan" hidden="false" typeId="75b5-9f7a-156e-6889" typeName="Knights and Titans">
+              <characteristics>
+                <characteristic name="Unit Type" typeId="3c44-1e2a-23fe-c9e0">Vehicle (Titan)</characteristic>
+                <characteristic name="Move" typeId="7f12-0cc3-9dcd-25bc">12</characteristic>
+                <characteristic name="WS" typeId="4227-8eed-0c5c-a2d9">9</characteristic>
+                <characteristic name="BS" typeId="6c5a-df71-fefa-2ee3">5</characteristic>
+                <characteristic name="S" typeId="02ba-082e-e385-1ede">10</characteristic>
+                <characteristic name="Front" typeId="0d00-68d8-0535-e898">15</characteristic>
+                <characteristic name="Side" typeId="cb92-5809-d327-6981">15</characteristic>
+                <characteristic name="Rear" typeId="8fa4-6e34-29c4-d8c6">14</characteristic>
+                <characteristic name="I" typeId="91b3-4335-71bf-3fa9">4</characteristic>
+                <characteristic name="A" typeId="d54a-56a6-68c5-ae72">4</characteristic>
+                <characteristic name="HP" typeId="2490-aa2f-f5db-6070">30</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="dd14-f899-4676-5e3b" name="Void Shields" hidden="false" targetId="c503-f5b8-3da0-16e6" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Void Shields (6)"/>
+              </modifiers>
+            </infoLink>
+            <infoLink id="6d93-3208-3375-36f7" name="Night Vision" hidden="false" targetId="683e-b4f2-f032-d31b" type="rule"/>
+            <infoLink id="4ef6-4193-f14d-073b" name="Reactor Meltdown (X)" hidden="false" targetId="3b0e-4a45-9bdd-91dc" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Reactor Meltdown (Maxima)"/>
+              </modifiers>
+            </infoLink>
+            <infoLink id="2cb5-37a8-da90-3679" name="God-Engine" hidden="false" targetId="66b8-7232-1ed3-3f70" type="rule"/>
+            <infoLink id="1ba1-3185-4e30-4a1a" name="Reinforced Structure" hidden="false" targetId="5b0d-5362-e961-f3b0" type="rule"/>
+          </infoLinks>
+          <categoryLinks>
+            <categoryLink id="a74e-73fa-b42a-10fe" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+          </categoryLinks>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="4eb8-020c-c441-cfe5" name="Left Arm Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="0294-f63e-a059-8730">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5f7d-ae7d-ba17-706a" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6fff-c4a2-0432-f5d3" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="22a0-25cb-adf4-4ee0" name="Arioch Power Claw with Vulkan Megabolter" hidden="false" collective="true" import="true" type="upgrade">
+                  <entryLinks>
+                    <entryLink id="a72b-6022-69d8-17ce" name="Arioch Power Claw" hidden="false" collective="false" import="true" targetId="c1d2-77e3-5d1c-5297" type="selectionEntry"/>
+                    <entryLink id="278d-0956-bf3c-2ca2" name="Vulcan Mega-Bolter" hidden="false" collective="false" import="true" targetId="b953-83d7-6cc1-5695" type="selectionEntry"/>
+                  </entryLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <entryLinks>
+                <entryLink id="0294-f63e-a059-8730" name="Mori Quake Cannon" hidden="false" collective="false" import="true" targetId="eab1-7776-c8da-da00" type="selectionEntry"/>
+                <entryLink id="3f01-9fba-1f9b-df1e" name="Belicosa Volcano Cannon" hidden="false" collective="false" import="true" targetId="454e-eb44-05fc-0471" type="selectionEntry"/>
+                <entryLink id="d25b-b7ff-51c6-c1f5" name="Macro-Gatling Blaster " hidden="false" collective="false" import="true" targetId="2c0d-36ba-7cfa-6915" type="selectionEntry"/>
+                <entryLink id="4edd-2969-ba88-56fe" name="Sunfury Plasma Annihilator" hidden="false" collective="false" import="true" targetId="f4dc-88a0-0ad9-4c61" type="selectionEntry"/>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="e9e0-2bc5-255b-0bd4" name="Right Arm Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="4462-3397-e3c9-a488">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f52d-fec9-2353-dc53" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="418e-0a69-d1ab-7ff1" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="1c33-7ffc-3341-493d" name="Arioch Power Claw with Vulkan Megabolter" hidden="false" collective="true" import="true" type="upgrade">
+                  <entryLinks>
+                    <entryLink id="e354-2478-926d-0f38" name="Arioch Power Claw" hidden="false" collective="false" import="true" targetId="c1d2-77e3-5d1c-5297" type="selectionEntry"/>
+                    <entryLink id="7cd5-2be5-bf64-bc99" name="Vulcan Mega-Bolter" hidden="false" collective="false" import="true" targetId="b953-83d7-6cc1-5695" type="selectionEntry"/>
+                  </entryLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <entryLinks>
+                <entryLink id="4462-3397-e3c9-a488" name="Mori Quake Cannon" hidden="false" collective="false" import="true" targetId="eab1-7776-c8da-da00" type="selectionEntry"/>
+                <entryLink id="8933-9b3f-443e-17ab" name="Belicosa Volcano Cannon" hidden="false" collective="false" import="true" targetId="454e-eb44-05fc-0471" type="selectionEntry"/>
+                <entryLink id="2eef-17a0-ff41-d52e" name="Macro-Gatling Blaster " hidden="false" collective="false" import="true" targetId="2c0d-36ba-7cfa-6915" type="selectionEntry"/>
+                <entryLink id="fd4e-2bb4-636d-5aba" name="Sunfury Plasma Annihilator" hidden="false" collective="false" import="true" targetId="f4dc-88a0-0ad9-4c61" type="selectionEntry"/>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="2728-c1f9-389d-196b" name="Two Carapace Mounted Weapons" hidden="false" collective="false" import="true" defaultSelectionEntryId="124e-4c1d-834f-f63b">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5ff0-de5c-95de-9e1f" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c696-fd31-0377-85ff" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="124e-4c1d-834f-f63b" name="Apocalypse Missile Launcher" hidden="false" collective="false" import="true" targetId="e127-4c28-1a5b-e372" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="name" value="Two Apocalypse Missile Launcher"/>
+                  </modifiers>
+                </entryLink>
+                <entryLink id="e183-51f7-1c56-64f3" name="Laser Blaster" hidden="false" collective="false" import="true" targetId="1071-7d27-420c-07b9" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="name" value="Two Laser Blasters"/>
+                  </modifiers>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="290c-99b7-0623-0a4e" name="Two Hull (Front) Weapons" hidden="false" collective="false" import="true" defaultSelectionEntryId="ee4e-93a3-f138-ecff">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6a3f-85e1-0a64-d918" type="min"/>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2da4-048b-00bd-8736" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="ee4e-93a3-f138-ecff" name="Defensor Bolt Cannon" hidden="false" collective="false" import="true" targetId="fee2-949c-6d55-2a2f" type="selectionEntry"/>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="1350-f866-cff7-e072" name="Two Hull (Rear) Weapons" hidden="false" collective="false" import="true" defaultSelectionEntryId="25c3-5f5c-3fdd-e3e2">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="39d1-87b1-7446-0b53" type="min"/>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1ef9-9dd6-5469-030f" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="25c3-5f5c-3fdd-e3e2" name="Defensor Lascannon" hidden="false" collective="false" import="true" targetId="2a03-11f0-739e-01a7" type="selectionEntry"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="3000.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="a207-e259-dadc-7e3d" name="Titan Legion Min Troop/LoW" hidden="false" collective="false" import="true" targetId="a4e4-d640-9fbf-4019" type="selectionEntry"/>
+      </entryLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3dd1-77d8-4289-b745" name="Warbringer Nemesis Titan" hidden="false" collective="false" import="true" type="unit">
+      <selectionEntries>
+        <selectionEntry id="d5d2-e3ef-a5d8-2dc7" name="Warbringer Nemesis Titan" hidden="false" collective="false" import="true" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4a92-f6e9-a7e0-6ef6" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b2ec-7e67-9e5b-8c64" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="0d93-deb9-59db-284f" name="Warbringer Nemesis Titan" hidden="false" typeId="75b5-9f7a-156e-6889" typeName="Knights and Titans">
+              <characteristics>
+                <characteristic name="Unit Type" typeId="3c44-1e2a-23fe-c9e0">Vehicle (Titan)</characteristic>
+                <characteristic name="Move" typeId="7f12-0cc3-9dcd-25bc">12</characteristic>
+                <characteristic name="WS" typeId="4227-8eed-0c5c-a2d9">8</characteristic>
+                <characteristic name="BS" typeId="6c5a-df71-fefa-2ee3">5</characteristic>
+                <characteristic name="S" typeId="02ba-082e-e385-1ede">10</characteristic>
+                <characteristic name="Front" typeId="0d00-68d8-0535-e898">15</characteristic>
+                <characteristic name="Side" typeId="cb92-5809-d327-6981">14</characteristic>
+                <characteristic name="Rear" typeId="8fa4-6e34-29c4-d8c6">12</characteristic>
+                <characteristic name="I" typeId="91b3-4335-71bf-3fa9">2</characteristic>
+                <characteristic name="A" typeId="d54a-56a6-68c5-ae72">2</characteristic>
+                <characteristic name="HP" typeId="2490-aa2f-f5db-6070">24</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="3fd4-2baa-674b-1a3c" name="Void Shields" hidden="false" targetId="c503-f5b8-3da0-16e6" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Void Shields (6)"/>
+              </modifiers>
+            </infoLink>
+            <infoLink id="581c-fb1f-50ff-dd3f" name="Night Vision" hidden="false" targetId="683e-b4f2-f032-d31b" type="rule"/>
+            <infoLink id="7d4c-0c7f-ef52-c1d6" name="Reactor Meltdown (X)" hidden="false" targetId="3b0e-4a45-9bdd-91dc" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Reactor Meltdown (Major)"/>
+              </modifiers>
+            </infoLink>
+            <infoLink id="77b8-e800-c96c-b189" name="God-Engine" hidden="false" targetId="66b8-7232-1ed3-3f70" type="rule"/>
+            <infoLink id="f3a8-8796-33a4-9a26" name="Heavy Structure" hidden="false" targetId="9247-462c-bcec-6fb8" type="rule"/>
+          </infoLinks>
+          <categoryLinks>
+            <categoryLink id="6271-9f49-6015-b293" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+          </categoryLinks>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="9fdb-9757-b9d8-f13f" name="Left Arm Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="f16c-7a72-31a3-cfec">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6925-1735-4a07-8555" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f255-a868-597d-8d3a" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="f16c-7a72-31a3-cfec" name="Gatling Blaster" hidden="false" collective="false" import="true" targetId="12c4-10db-40e2-04c4" type="selectionEntry"/>
+                <entryLink id="c63b-6109-9b4f-f099" name="Laser Blaster" hidden="false" collective="false" import="true" targetId="1071-7d27-420c-07b9" type="selectionEntry"/>
+                <entryLink id="b4bb-6aee-3bb7-85c7" name="Volcano Cannon" hidden="false" collective="false" import="true" targetId="c65f-0423-6564-a622" type="selectionEntry"/>
+                <entryLink id="b7d2-c4ab-0e29-1c95" name="Melta Cannon" hidden="false" collective="false" import="true" targetId="7a16-0e23-c633-c668" type="selectionEntry"/>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="46bd-4f52-34c2-7e6c" name="Right Arm Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="5486-e8fa-d43e-477a">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8933-6a87-141a-611f" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="310a-e27c-ece2-e846" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="5486-e8fa-d43e-477a" name="Gatling Blaster" hidden="false" collective="false" import="true" targetId="12c4-10db-40e2-04c4" type="selectionEntry"/>
+                <entryLink id="c6bc-1b78-572e-3a06" name="Laser Blaster" hidden="false" collective="false" import="true" targetId="1071-7d27-420c-07b9" type="selectionEntry"/>
+                <entryLink id="2374-2af3-3039-89bb" name="Volcano Cannon" hidden="false" collective="false" import="true" targetId="c65f-0423-6564-a622" type="selectionEntry"/>
+                <entryLink id="ee87-0bce-1782-3e7c" name="Melta Cannon" hidden="false" collective="false" import="true" targetId="7a16-0e23-c633-c668" type="selectionEntry"/>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="2388-1fbf-d680-56a0" name="Right Shoulder Carapace Mounted Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="af52-0e85-6585-e1a0">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="864b-8123-c7f4-b7fa" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="179b-18f4-ccc6-d676" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="af52-0e85-6585-e1a0" name="Defensor Autocannon Battery" hidden="false" collective="false" import="true" targetId="55e4-0853-3720-c068" type="selectionEntry"/>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="d6a6-3559-1836-0314" name="Left Shoulder Carapace Mounted Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="096d-e941-0d56-fd0e">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="46af-a0d7-01c2-c627" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a077-6af8-7b5c-6a0e" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="096d-e941-0d56-fd0e" name="Defensor Autocannon Battery" hidden="false" collective="false" import="true" targetId="55e4-0853-3720-c068" type="selectionEntry"/>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="9e6c-16f9-30c9-9771" name="Two Hull (Front) Weapons" hidden="false" collective="false" import="true" defaultSelectionEntryId="f185-30ab-5bef-70ec">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="262d-3df9-c915-121c" type="min"/>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0456-0b6b-1e6f-27e6" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="f185-30ab-5bef-70ec" name="Defensor Bolt Cannon" hidden="false" collective="false" import="true" targetId="fee2-949c-6d55-2a2f" type="selectionEntry"/>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="6965-4ba4-7168-2ad2" name="One Hull (Rear) Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="0952-9401-c337-719c">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e7f4-5287-86d8-5c98" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7038-4d83-9984-42d1" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="0952-9401-c337-719c" name="Defensor Bolt Cannon" hidden="false" collective="false" import="true" targetId="fee2-949c-6d55-2a2f" type="selectionEntry"/>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="f206-6212-23e8-07e6" name="Main Carapace Mounted Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="572b-c858-8765-1e15">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5fab-a8c8-18bb-c086" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5527-2a47-2321-05b5" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="572b-c858-8765-1e15" name="Nemesis Quake Cannon" publicationId="bde1-6db1-163b-3b76" page="113" hidden="false" collective="false" import="true" type="upgrade">
+                  <profiles>
+                    <profile id="202a-958a-57cc-acbb" name="Nemesis Quake Cannon" publicationId="bde1-6db1-163b-3b76" page="113" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+                      <characteristics>
+                        <characteristic name="Range" typeId="95ba-cda7-b831-6066">24&quot;-480&quot;</characteristic>
+                        <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">10/8/6</characteristic>
+                        <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">3</characteristic>
+                        <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Destroyer 1, Apocalyptic Mega-blast, Barrage, Seismic Shock, Concussive (1)</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <infoLinks>
+                    <infoLink id="daea-0a65-bdb5-7492" name="Destroyer" hidden="false" targetId="44d6-09b2-3bd3-b2d6" type="rule"/>
+                    <infoLink id="3e60-efba-314a-2050" name="Blast" hidden="false" targetId="1d9a-73ef-5f4f-8bd8" type="rule"/>
+                    <infoLink id="597c-ba27-561c-501c" name="Barrage" hidden="false" targetId="7255-b5ee-c3f4-3037" type="rule"/>
+                    <infoLink id="336a-ada3-443d-143e" name="Concussive (X)" hidden="false" targetId="7ce5-1bfb-64e6-f826" type="rule">
+                      <modifiers>
+                        <modifier type="set" field="name" value="Concussive (1)"/>
+                      </modifiers>
+                    </infoLink>
+                    <infoLink id="9c00-9d13-0651-9675" name="Seismic Shock" hidden="false" targetId="5e0d-b2af-e7b4-a8cd" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="5d92-649c-e928-caf6" name="Nemesis Volcano Cannon" publicationId="bde1-6db1-163b-3b76" page="117" hidden="false" collective="false" import="true" type="upgrade">
+                  <profiles>
+                    <profile id="2463-5e77-671a-d081" name="Nemesis Volcano Cannon" publicationId="bde1-6db1-163b-3b76" page="117" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+                      <characteristics>
+                        <characteristic name="Range" typeId="95ba-cda7-b831-6066">36-180&quot;</characteristic>
+                        <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">14</characteristic>
+                        <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">1</characteristic>
+                        <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Destroyer 1, Apocalyptic Blast (9&quot;), Sunder</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <infoLinks>
+                    <infoLink id="4824-ddef-0dd9-8110" name="Blast" hidden="false" targetId="1d9a-73ef-5f4f-8bd8" type="rule"/>
+                    <infoLink id="fd2d-a9e4-fed6-03e7" name="Sunder" hidden="false" targetId="20e2-75cf-bc16-cd8f" type="rule"/>
+                    <infoLink id="9e12-2b43-02af-b34e" name="Destroyer" hidden="false" targetId="44d6-09b2-3bd3-b2d6" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2000.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="67df-6953-0577-341a" name="Titan Legion Min Troop/LoW" hidden="false" collective="false" import="true" targetId="a4e4-d640-9fbf-4019" type="selectionEntry"/>
+      </entryLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2dbc-7655-bb05-ab89" name="Reaver Battle Titan" hidden="false" collective="false" import="true" type="unit">
+      <selectionEntries>
+        <selectionEntry id="8de7-e87d-272d-7752" name="Reaver Battle Titan" hidden="false" collective="false" import="true" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b70b-e6cd-ddc2-b9f9" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0711-2540-2b1b-ab31" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="ce86-3649-e746-35c7" name="Reaver Battle Titan" hidden="false" typeId="75b5-9f7a-156e-6889" typeName="Knights and Titans">
+              <characteristics>
+                <characteristic name="Unit Type" typeId="3c44-1e2a-23fe-c9e0">Vehicle (Titan)</characteristic>
+                <characteristic name="Move" typeId="7f12-0cc3-9dcd-25bc">12</characteristic>
+                <characteristic name="WS" typeId="4227-8eed-0c5c-a2d9">8</characteristic>
+                <characteristic name="BS" typeId="6c5a-df71-fefa-2ee3">5</characteristic>
+                <characteristic name="S" typeId="02ba-082e-e385-1ede">10</characteristic>
+                <characteristic name="Front" typeId="0d00-68d8-0535-e898">14</characteristic>
+                <characteristic name="Side" typeId="cb92-5809-d327-6981">14</characteristic>
+                <characteristic name="Rear" typeId="8fa4-6e34-29c4-d8c6">13</characteristic>
+                <characteristic name="I" typeId="91b3-4335-71bf-3fa9">2</characteristic>
+                <characteristic name="A" typeId="d54a-56a6-68c5-ae72">3</characteristic>
+                <characteristic name="HP" typeId="2490-aa2f-f5db-6070">18</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="9d15-5807-97c2-5022" name="Void Shields" hidden="false" targetId="c503-f5b8-3da0-16e6" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Void Shields (4)"/>
+              </modifiers>
+            </infoLink>
+            <infoLink id="ad60-adbd-e1d2-c80a" name="Night Vision" hidden="false" targetId="683e-b4f2-f032-d31b" type="rule"/>
+            <infoLink id="118b-a122-fbb9-8a1e" name="Reactor Meltdown (X)" hidden="false" targetId="3b0e-4a45-9bdd-91dc" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Reactor Meltdown (Major)"/>
+              </modifiers>
+            </infoLink>
+            <infoLink id="99a0-0c1a-38fb-7c1e" name="God-Engine" hidden="false" targetId="66b8-7232-1ed3-3f70" type="rule"/>
+          </infoLinks>
+          <categoryLinks>
+            <categoryLink id="555e-3568-0faf-2037" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+          </categoryLinks>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="4bd0-7503-e4af-d39d" name="Left Arm Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="1963-c6b1-951f-969b">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="908a-ce6f-c8df-95a9" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="492d-fbb6-fca0-b346" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="c974-39fc-4e72-5e33" name="Volcano Cannon" hidden="false" collective="false" import="true" targetId="c65f-0423-6564-a622" type="selectionEntry"/>
+                <entryLink id="79aa-d40b-28a8-5dc4" name="Laser Blaster" hidden="false" collective="false" import="true" targetId="1071-7d27-420c-07b9" type="selectionEntry"/>
+                <entryLink id="565e-873b-ae89-783f" name="Melta Cannon" hidden="false" collective="false" import="true" targetId="7a16-0e23-c633-c668" type="selectionEntry"/>
+                <entryLink id="1963-c6b1-951f-969b" name="Gatling Blaster" hidden="false" collective="false" import="true" targetId="12c4-10db-40e2-04c4" type="selectionEntry"/>
+                <entryLink id="5fa6-d782-45fd-b0c8" name="Titan Power Fist" hidden="false" collective="false" import="true" targetId="2952-52d9-49e2-cbfd" type="selectionEntry"/>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="c539-4121-4c2e-54a3" name="Right Arm Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="1406-44de-5865-5b91">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1db5-07b1-6c06-b606" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cacd-3cd7-1792-20dc" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="29e5-3e72-195c-e742" name="Laser Blaster" hidden="false" collective="false" import="true" targetId="1071-7d27-420c-07b9" type="selectionEntry"/>
+                <entryLink id="1406-44de-5865-5b91" name="Gatling Blaster" hidden="false" collective="false" import="true" targetId="12c4-10db-40e2-04c4" type="selectionEntry"/>
+                <entryLink id="2dbd-eae4-f088-816f" name="Titan Power Fist" hidden="false" collective="false" import="true" targetId="2952-52d9-49e2-cbfd" type="selectionEntry"/>
+                <entryLink id="fed3-13b2-94dd-26f7" name="Melta Cannon" hidden="false" collective="false" import="true" targetId="7a16-0e23-c633-c668" type="selectionEntry"/>
+                <entryLink id="7842-e685-4371-615d" name="Volcano Cannon" hidden="false" collective="false" import="true" targetId="c65f-0423-6564-a622" type="selectionEntry"/>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="31e7-9f08-d614-a3d6" name="Carapace Mounted Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="4ef3-8e78-36e3-637a">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8547-3c52-705b-159d" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0789-ea03-5241-81e8" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="4ef3-8e78-36e3-637a" name="Apocalypse Missile Launcher" hidden="false" collective="false" import="true" targetId="e127-4c28-1a5b-e372" type="selectionEntry"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="1500.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="25b4-f641-00a7-480f" name="Titan Legion Min Troop/LoW" hidden="false" collective="false" import="true" targetId="a4e4-d640-9fbf-4019" type="selectionEntry"/>
+      </entryLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="841c-c2f5-9817-3061" name="Warhound Scout Titan" hidden="false" collective="false" import="true" type="unit">
+      <selectionEntries>
+        <selectionEntry id="1f8a-929b-a949-7865" name="Warhound Scout Titan" hidden="false" collective="false" import="true" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2728-84a3-6a84-82e5" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aaae-3f1e-5b2b-a663" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="701a-1f85-a008-a8b9" name="Warhound Scout Titan" hidden="false" typeId="75b5-9f7a-156e-6889" typeName="Knights and Titans">
+              <characteristics>
+                <characteristic name="Unit Type" typeId="3c44-1e2a-23fe-c9e0">Vehicle (Fast, Titan)</characteristic>
+                <characteristic name="Move" typeId="7f12-0cc3-9dcd-25bc">15</characteristic>
+                <characteristic name="WS" typeId="4227-8eed-0c5c-a2d9">5</characteristic>
+                <characteristic name="BS" typeId="6c5a-df71-fefa-2ee3">5</characteristic>
+                <characteristic name="S" typeId="02ba-082e-e385-1ede">10</characteristic>
+                <characteristic name="Front" typeId="0d00-68d8-0535-e898">14</characteristic>
+                <characteristic name="Side" typeId="cb92-5809-d327-6981">13</characteristic>
+                <characteristic name="Rear" typeId="8fa4-6e34-29c4-d8c6">12</characteristic>
+                <characteristic name="I" typeId="91b3-4335-71bf-3fa9">4</characteristic>
+                <characteristic name="A" typeId="d54a-56a6-68c5-ae72">3</characteristic>
+                <characteristic name="HP" typeId="2490-aa2f-f5db-6070">12</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="bc55-f7e3-c837-8248" name="Void Shields" hidden="false" targetId="c503-f5b8-3da0-16e6" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Void Shields (2)"/>
+              </modifiers>
+            </infoLink>
+            <infoLink id="688f-3809-413c-43ca" name="Night Vision" hidden="false" targetId="683e-b4f2-f032-d31b" type="rule"/>
+            <infoLink id="2d52-38b8-7081-ee3c" name="Reactor Meltdown (X)" hidden="false" targetId="3b0e-4a45-9bdd-91dc" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Reactor Meltdown (Magna)"/>
+              </modifiers>
+            </infoLink>
+            <infoLink id="794b-9a05-a937-2563" name="God-Engine" hidden="false" targetId="66b8-7232-1ed3-3f70" type="rule"/>
+          </infoLinks>
+          <categoryLinks>
+            <categoryLink id="2018-06b6-05a8-082f" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
+            <categoryLink id="418d-d32f-d847-f923" name="Fast Vehicles" hidden="false" targetId="0ea2-efb5-b7af-226e" primary="false"/>
+          </categoryLinks>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="9421-2b5c-e5f4-6029" name="Left Arm Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="a622-054c-eba8-936c">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="996c-1e55-bda2-28e9" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="92dd-4c93-44c7-0179" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="722f-3c7b-5144-c6cc" name="Twin-linked Turbo Laser-Destructor**" hidden="false" collective="false" import="true" targetId="f947-d7f1-40bd-f425" type="selectionEntry"/>
+                <entryLink id="a622-054c-eba8-936c" name="Vulcan Mega-Bolter" hidden="false" collective="false" import="true" targetId="b953-83d7-6cc1-5695" type="selectionEntry"/>
+                <entryLink id="f3ce-b012-7d7e-137b" name="Plasma Blastgun" hidden="false" collective="false" import="true" targetId="c666-29f6-42da-2e07" type="selectionEntry"/>
+                <entryLink id="787a-2d9c-c9a5-f399" name="Inferno Gun" hidden="false" collective="false" import="true" targetId="aa57-fc73-86fe-217c" type="selectionEntry"/>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="2b18-4de0-85f9-e89b" name="Right Arm Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="70eb-59a0-afc5-d201">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="77e6-b47f-d8e0-30f2" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d81e-3e60-d038-e807" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="13d9-c8b4-3c68-bc0d" name="Twin-linked Turbo Laser-Destructor**" hidden="false" collective="false" import="true" targetId="f947-d7f1-40bd-f425" type="selectionEntry"/>
+                <entryLink id="70eb-59a0-afc5-d201" name="Vulcan Mega-Bolter" hidden="false" collective="false" import="true" targetId="b953-83d7-6cc1-5695" type="selectionEntry"/>
+                <entryLink id="b790-9155-dac8-f675" name="Plasma Blastgun" hidden="false" collective="false" import="true" targetId="c666-29f6-42da-2e07" type="selectionEntry"/>
+                <entryLink id="38a7-3eeb-1ea3-cdae" name="Inferno Gun" hidden="false" collective="false" import="true" targetId="aa57-fc73-86fe-217c" type="selectionEntry"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="750.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="9ea8-9512-3bf1-927f" name="Titan Legion Min Troop/LoW" hidden="false" collective="false" import="true" targetId="a4e4-d640-9fbf-4019" type="selectionEntry"/>
+      </entryLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b08e-55fe-3e1d-913b" name="Secutarii Axiarch" publicationId="bde1-6db1-163b-3b76" page="66" hidden="false" collective="false" import="true" type="unit">
+      <categoryLinks>
+        <categoryLink id="f5bd-8b5c-1e1e-4b5b" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+        <categoryLink id="bba2-2d6a-595b-788e" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+        <categoryLink id="4978-c880-3f1d-2466" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="fda8-8a94-6d14-d508" name="Secutarii Axiarch" publicationId="bde1-6db1-163b-3b76" page="66" hidden="false" collective="false" import="true" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="58a4-3983-e4c2-e01c" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f7d2-b0a3-53db-e41d" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="016f-94cf-53de-7370" name="Feel No Pain (X)" hidden="false" targetId="ec46-ff29-32e0-c2aa" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Feel No Pain (6+)"/>
+              </modifiers>
+            </infoLink>
+            <infoLink id="928b-eee4-a927-1e0c" name="Precision Shots (X)" hidden="false" targetId="4b71-81ee-31f4-fa09" type="rule">
+              <modifiers>
+                <modifier type="set" field="name" value="Precision Shots (6+)"/>
+              </modifiers>
+            </infoLink>
+            <infoLink id="130a-5526-3026-9f14" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
+          </infoLinks>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="3472-f680-33df-2d45" name="May be equipped with any of the following" hidden="false" collective="false" import="true">
+              <selectionEntries>
+                <selectionEntry id="66fd-9448-2a8e-32ec" name="Master-crafted a single weapon" hidden="false" collective="false" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7e61-d418-293b-4ab0" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="78fb-ce19-e380-1254" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <entryLinks>
+                <entryLink id="0eb5-0e49-c7e1-c803" name="Augury Scanner" hidden="false" collective="false" import="true" targetId="67ee-7338-3b74-04b4" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a7b1-2554-d3ac-857a" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="b2ba-7ba5-f514-cce0" name="Rad Grenades" hidden="false" collective="false" import="true" targetId="1b0b-3dfc-9521-b27e" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="57b6-d841-d224-195e" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="cb1e-18e8-3dab-fc58" name="Weapons" hidden="false" collective="false" import="true">
+              <modifiers>
+                <modifier type="set" field="5543-23e1-a3e8-6ea2" value="1.0">
+                  <conditions>
+                    <condition field="selections" scope="fda8-8a94-6d14-d508" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="def0-2a0a-e737-5e5a" type="greaterThan"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="d53f-31f9-e3c1-20af" value="1.0">
+                  <conditions>
+                    <condition field="selections" scope="fda8-8a94-6d14-d508" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="def0-2a0a-e737-5e5a" type="greaterThan"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d53f-31f9-e3c1-20af" type="min"/>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5543-23e1-a3e8-6ea2" type="max"/>
+              </constraints>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="4436-8bdd-45b2-c3d1" name="May exchange their Radium Pistol for one of the following weapons:" hidden="false" collective="false" import="true" defaultSelectionEntryId="5f6e-e664-e9e7-091a">
+                  <modifiers>
+                    <modifier type="set" field="eac4-d0dd-7876-11ef" value="0.0">
+                      <conditions>
+                        <condition field="selections" scope="fda8-8a94-6d14-d508" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="def0-2a0a-e737-5e5a" type="greaterThan"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="set" field="2e61-c631-0e8d-28e7" value="0.0">
+                      <conditions>
+                        <condition field="selections" scope="fda8-8a94-6d14-d508" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="def0-2a0a-e737-5e5a" type="greaterThan"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eac4-d0dd-7876-11ef" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2e61-c631-0e8d-28e7" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="5f6e-e664-e9e7-091a" name="Radium Pistol" hidden="false" collective="false" import="true" targetId="c3ab-36d1-f521-7ff1" type="selectionEntry"/>
+                    <entryLink id="1c00-b36b-41d8-86c6" name="Volkite Serpenta" hidden="false" collective="false" import="true" targetId="d535-1da8-290d-69a6" type="selectionEntry"/>
+                    <entryLink id="a273-d761-d53d-6b62" name="Archaeotech Pistol" hidden="false" collective="false" import="true" targetId="c22a-ed4d-af68-bf00" type="selectionEntry">
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="2acf-8441-cd62-a19e" name="Arc Pistol" hidden="false" collective="false" import="true" targetId="3b42-4abf-0b7b-85be" type="selectionEntry">
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="3d7b-093c-2112-636e" name="Photon Gauntlet" hidden="false" collective="false" import="true" targetId="e825-c60e-e6c3-60f0" type="selectionEntry">
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="3882-9e52-c344-4e5e" name="May exchange their Arc Maul for one of the following weapons:" hidden="false" collective="false" import="true" defaultSelectionEntryId="5ba4-54e2-1e27-5ae6">
+                  <modifiers>
+                    <modifier type="set" field="5600-9613-bfb4-85cb" value="0.0">
+                      <conditions>
+                        <condition field="selections" scope="fda8-8a94-6d14-d508" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="def0-2a0a-e737-5e5a" type="greaterThan"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="set" field="e368-459a-108d-eb0a" value="0.0">
+                      <conditions>
+                        <condition field="selections" scope="fda8-8a94-6d14-d508" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="def0-2a0a-e737-5e5a" type="greaterThan"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5600-9613-bfb4-85cb" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e368-459a-108d-eb0a" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="5ba4-54e2-1e27-5ae6" name="Arc Maul" hidden="false" collective="false" import="true" targetId="837d-547d-f714-3ec6" type="selectionEntry"/>
+                    <entryLink id="7a80-e113-9c5b-9ce2" name="Corposant Stave" hidden="false" collective="false" import="true" targetId="cfc3-0ca2-ebdc-e6b0" type="selectionEntry">
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="7806-002d-ab1e-b4ff" name="Power Fist" hidden="false" collective="false" import="true" targetId="768d-b89b-7328-d749" type="selectionEntry">
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="8b5f-2542-8915-eb57" name="Power Sword" hidden="false" collective="false" import="true" targetId="a3cd-aa97-a148-2309" type="selectionEntry">
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="d7e3-7f09-c22a-974e" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry">
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="893f-539c-00ec-6d0f" name="Power Lance" hidden="false" collective="false" import="true" targetId="a4c8-c8ff-87f2-1ac9" type="selectionEntry">
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="46b1-3c90-aaf1-35a8" name="Power Maul" hidden="false" collective="false" import="true" targetId="0df4-c67e-cf64-82e0" type="selectionEntry">
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="3e08-e9fa-4dd9-e27a" name="May exchange both their Radium Pistol and Arc Maul for an: " hidden="false" collective="false" import="true">
+                  <selectionEntries>
+                    <selectionEntry id="def0-2a0a-e737-5e5a" name="Arc Lance and Mag-Inverter Shield" publicationId="bde1-6db1-163b-3b76" hidden="false" collective="false" import="true" type="upgrade">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5346-9188-fca1-47c3" type="max"/>
+                      </constraints>
+                      <entryLinks>
+                        <entryLink id="c2ee-8072-bdfb-7208" name="Arc Lance" hidden="false" collective="false" import="true" targetId="2deb-3354-c5cc-e6bd" type="selectionEntry">
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4641-d8e3-71bf-1e10" type="min"/>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eabb-960d-cd00-e7c1" type="max"/>
+                          </constraints>
+                        </entryLink>
+                        <entryLink id="87b9-495f-a621-6a5a" name="Mag-Inverter Shield" hidden="false" collective="false" import="true" targetId="cc57-5eda-5dfe-792a" type="selectionEntry">
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1573-2545-6d7b-3da2" type="min"/>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5cf9-b39c-b913-ae69" type="max"/>
+                          </constraints>
+                        </entryLink>
+                      </entryLinks>
+                      <costs>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+                      </costs>
+                    </selectionEntry>
+                  </selectionEntries>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="d8c0-72d2-d714-6b45" name="Binaric Stratagems" hidden="false" collective="false" import="true" targetId="3ca1-6daa-7f73-22f4" type="selectionEntry"/>
+            <entryLink id="7f54-44c9-956e-71d9" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="cf9c-327b-3449-00d7" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7e93-52ed-a52f-88c0" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fb96-4c52-d7d7-257b" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="5534-0d44-8848-69b9" name="Titanshard Armour" hidden="false" collective="false" import="true" targetId="c497-145b-70df-9558" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7ca0-8524-7aa6-7fa6" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a082-4f11-3cbd-ea55" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="2e9b-ec83-7601-3475" name="Kyropatris Field Generator" hidden="false" collective="false" import="true" targetId="0edc-de4d-cea8-5fb0" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cbc4-caf3-a313-adb6" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2def-d730-e954-4ce9" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="60.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f4cc-a854-5467-45cf" name="Secutarii Hoplite Phalanx" hidden="false" collective="false" import="true" type="unit">
+      <infoLinks>
+        <infoLink id="4824-7ba3-0cbd-a131" name="Feel No Pain (X)" hidden="false" targetId="ec46-ff29-32e0-c2aa" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Feel No Pain (6+)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="99ff-110c-e9cb-7051" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="d566-e52a-2fd0-0b97" name="Secutarii Hoplite" hidden="false" collective="false" import="true" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eed1-2bcf-a77b-f35b" type="min"/>
+            <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2216-a1f0-f489-91b4" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="12.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="7e53-3d8b-5f85-993e" name="Hoplite Alpha" hidden="false" collective="false" import="true" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1d85-d96c-fee1-ee15" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="36b4-11e6-f7d5-16d6" type="max"/>
+          </constraints>
+          <categoryLinks>
+            <categoryLink id="55af-f53a-1ef0-c792" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+          </categoryLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="62f7-74de-2034-9c97" name="Hoplite Alpha may be equipped with any of the following:" hidden="false" collective="false" import="true">
+          <entryLinks>
+            <entryLink id="25f9-c985-4aa0-b4db" name="Augury Scanner" hidden="false" collective="false" import="true" targetId="67ee-7338-3b74-04b4" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4c77-41c4-0b91-d48a" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="a1bf-14f9-2cf6-cf19" name="Rad Grenades" hidden="false" collective="false" import="true" targetId="1b0b-3dfc-9521-b27e" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7e78-472e-b26f-a610" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="69e3-1e25-3e8b-14b4" name="Hoplite Alpha may exchange their Arc Lance for a:" hidden="false" collective="false" import="true" defaultSelectionEntryId="d9f0-08be-4f61-274e">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8e73-0dfe-8e93-84ee" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0140-c785-947b-28fd" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="9613-2c77-1412-bd16" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry"/>
+            <entryLink id="d9d3-d011-b331-6335" name="Power Maul" hidden="false" collective="false" import="true" targetId="0df4-c67e-cf64-82e0" type="selectionEntry"/>
+            <entryLink id="f466-3b54-dccd-8793" name="Power Sword" hidden="false" collective="false" import="true" targetId="a3cd-aa97-a148-2309" type="selectionEntry"/>
+            <entryLink id="bd79-55b8-1274-f208" name="Power Lance" hidden="false" collective="false" import="true" targetId="a4c8-c8ff-87f2-1ac9" type="selectionEntry"/>
+            <entryLink id="8da4-0ff3-f062-7db7" name="Arc Maul" hidden="false" collective="false" import="true" targetId="837d-547d-f714-3ec6" type="selectionEntry"/>
+            <entryLink id="d9f0-08be-4f61-274e" name="Arc Lance" hidden="false" collective="false" import="true" targetId="2deb-3354-c5cc-e6bd" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="2362-3834-65db-741a" name="Hoplite Alpha may take one of the following additional weapons options:" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6c4e-ffa6-b628-8f54" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="5992-191a-1ad6-1685" name="Radium Pistol" hidden="false" collective="false" import="true" targetId="c3ab-36d1-f521-7ff1" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="16f4-9ef9-9d40-6fbd" name="Volkite Serpenta" hidden="false" collective="false" import="true" targetId="d535-1da8-290d-69a6" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="4fea-ec4b-3410-9857" name="Arc Pistol" hidden="false" collective="false" import="true" targetId="3b42-4abf-0b7b-85be" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="47c8-d123-5c72-29c3" name="Dedicated Transport" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0565-8aa6-670a-ef99" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="cbfb-ae08-e5bb-2e5c" name="Triaros Armoured Conveyor " hidden="false" collective="false" import="true" targetId="2484-a122-76a2-b142" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="e479-c030-93dd-28a8" name="Titan Legion Min Troop/LoW" hidden="false" collective="false" import="true" targetId="a4e4-d640-9fbf-4019" type="selectionEntry"/>
+        <entryLink id="9419-bd79-9cff-a58f" name="The Corpus Skitarii" hidden="false" collective="false" import="true" targetId="77d7-c7c1-7028-8030" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e6a9-4e3e-551e-9202" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3459-69d7-2727-c905" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="0006-9a7a-d61e-477d" name="Mag-Inverter Shield" hidden="false" collective="false" import="true" targetId="cc57-5eda-5dfe-792a" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2f25-c167-1402-d2d1" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bae3-f993-ff9a-9650" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="38ee-8ef7-fa22-557e" name="Kyropatris Field Generator" hidden="false" collective="false" import="true" targetId="0edc-de4d-cea8-5fb0" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="41d3-a06b-90a5-c087" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="993d-d00f-5077-d5f4" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="570b-a531-55cc-929b" name="Arc Lance" hidden="false" collective="false" import="true" targetId="2deb-3354-c5cc-e6bd" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ab8f-5533-9c31-4279" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="76a5-4cab-b3b3-b848" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="22.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4fc3-7259-f9b0-71cd" name="Secutarii Peltast Phalanx" hidden="false" collective="false" import="true" type="unit">
+      <rules>
+        <rule id="56e7-b54b-877c-5f0c" name="Blind Barrage" publicationId="bde1-6db1-163b-3b76" page="102" hidden="false">
+          <description>So long as a unit with this special rule contains at least five models with galvanic casters, once per battle during the controlling player’s Shooting phase, the unit may make a Blind Barrage instead of making a Shooting Attack. Select a friendly unit with a model within 18&quot; and within line of sight of the unit making the Blind Barrage. That friendly unit gains the Shrouded (4+) special rule until the beginning of the controlling player’s next player turn. Models with the Vehicle Unit Type, the Knight Unit Sub-type, the Titan Unit Sub-type, or the Monstrous Unit Sub-type may not be the target of a Blind Barrage</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="e29e-7f44-837c-7465" name="Feel No Pain (X)" hidden="false" targetId="ec46-ff29-32e0-c2aa" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Feel No Pain (6+)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="0bb4-9db7-e8b6-b2a5" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="b0f8-c05c-0920-4076" name="Secutarii Peltast" hidden="false" collective="false" import="true" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0e55-0967-7406-b644" type="min"/>
+            <constraint field="selections" scope="parent" value="19.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f46f-b687-b5da-88c1" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="59a0-bcc7-8dce-8ab0" name="Peltast Alpha" hidden="false" collective="false" import="true" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3340-4bdb-c7c6-bc93" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="82d2-cada-d7fc-ff7a" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="aeed-1c2a-2b6d-8def" name="Additionally Hammershot ammunition for Galvanic Casters" hidden="false" collective="false" import="true" type="upgrade">
+          <modifiers>
+            <modifier type="increment" field="d2ee-04cb-5f8a-2642" value="5.0">
+              <repeats>
+                <repeat field="selections" scope="4fc3-7259-f9b0-71cd" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="af1d-7611-f4e2-f09e" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9b87-26c1-63df-a51d" type="max"/>
+          </constraints>
+          <rules>
+            <rule id="b2c8-7374-7621-1e31" name="Molecular Dissonance" publicationId="bde1-6db1-163b-3b76" page="105" hidden="false">
+              <description>Any To Hit roll of a 6 made by a weapon with this special rule Wounds automatically. This special rule has no effect on models with the Primarch or Vehicle Unit Types.</description>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="6a1d-3889-c353-49ca" name="Galvanic Caster - Hammershot" hidden="false" targetId="4329-1f62-cf9b-2ff4" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="e02f-5460-2872-ebc6" name="Peltast Alpha may be equipped with any of the following:" hidden="false" collective="false" import="true">
+          <entryLinks>
+            <entryLink id="438d-ed3b-8ac3-6c77" name="Augury Scanner" hidden="false" collective="false" import="true" targetId="67ee-7338-3b74-04b4" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d368-274b-a9c7-450d" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="7c91-7163-d8e7-6f6e" name="Rad Grenades" hidden="false" collective="false" import="true" targetId="1b0b-3dfc-9521-b27e" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e233-4ac6-3df1-c889" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="0584-de6a-68f7-fddc" name="Refractor Field" hidden="false" collective="false" import="true" targetId="a06a-55a5-070b-1d0e" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7c6e-3a8e-0357-731b" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="fdf1-ec7a-4f34-fe56" name="Peltast Alpha may exchange their Galvanic Caster for a:" hidden="false" collective="false" import="true" defaultSelectionEntryId="f2a2-7d6e-8d04-7b6f">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="03eb-33dc-92d2-1122" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="58d4-c7b1-64ea-1b99" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="dcdb-b707-d94b-5ebd" name="Power Axe" hidden="false" collective="false" import="true" targetId="c066-2ace-f68c-e440" type="selectionEntry"/>
+            <entryLink id="4eda-a6c0-7475-2d8c" name="Power Maul" hidden="false" collective="false" import="true" targetId="0df4-c67e-cf64-82e0" type="selectionEntry"/>
+            <entryLink id="7115-71af-7e12-1721" name="Power Sword" hidden="false" collective="false" import="true" targetId="a3cd-aa97-a148-2309" type="selectionEntry"/>
+            <entryLink id="048a-c8b8-c788-f02f" name="Power Lance" hidden="false" collective="false" import="true" targetId="a4c8-c8ff-87f2-1ac9" type="selectionEntry"/>
+            <entryLink id="490f-980f-ee2f-2ad7" name="Arc Maul" hidden="false" collective="false" import="true" targetId="837d-547d-f714-3ec6" type="selectionEntry"/>
+            <entryLink id="f2a2-7d6e-8d04-7b6f" name="Galvanic Caster" hidden="false" collective="false" import="true" targetId="af1d-7611-f4e2-f09e" type="selectionEntry"/>
+            <entryLink id="43d3-09ae-e0ab-861d" name="Arc Rifle" hidden="false" collective="false" import="true" targetId="1800-e29f-86a3-6abb" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="59ba-0b6e-19fe-829c" name="Radium Carbine" hidden="false" collective="false" import="true" targetId="89d1-f5c7-7a80-3365" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="5aa9-2400-8d15-048a" name="Any model in the squad may exchange their Galvanic Caster for a:" hidden="false" collective="false" import="true" defaultSelectionEntryId="7a78-3fd7-831c-bbfd">
+          <modifiers>
+            <modifier type="increment" field="186f-5ac9-089e-480d" value="1.0">
+              <repeats>
+                <repeat field="selections" scope="4fc3-7259-f9b0-71cd" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b0f8-c05c-0920-4076" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+            <modifier type="decrement" field="9192-122a-bf3f-08e8" value="9.0"/>
+            <modifier type="increment" field="9192-122a-bf3f-08e8" value="1.0">
+              <repeats>
+                <repeat field="selections" scope="4fc3-7259-f9b0-71cd" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b0f8-c05c-0920-4076" repeats="1" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9192-122a-bf3f-08e8" type="min"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="186f-5ac9-089e-480d" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="7a78-3fd7-831c-bbfd" name="Galvanic Caster" hidden="false" collective="false" import="true" targetId="af1d-7611-f4e2-f09e" type="selectionEntry"/>
+            <entryLink id="b9a6-406d-069f-ae3a" name="Arc Rifle" hidden="false" collective="false" import="true" targetId="1800-e29f-86a3-6abb" type="selectionEntry">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="6064-681c-56e8-79ff" name="Radium Carbine" hidden="false" collective="false" import="true" targetId="89d1-f5c7-7a80-3365" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="c90e-0b5b-01a9-f164" name="Dedicated Transport" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c544-7385-c12b-7b10" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="f33f-098b-3007-20c5" name="Triaros Armoured Conveyor " hidden="false" collective="false" import="true" targetId="2484-a122-76a2-b142" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="d096-27b4-5bc6-6250" name="Titan Legion Min Troop/LoW" hidden="false" collective="false" import="true" targetId="a4e4-d640-9fbf-4019" type="selectionEntry"/>
+      </entryLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="493e-6c57-ba53-4d19" name="Upgrade Points (Placeholders)" hidden="false" collective="false" import="true" type="upgrade">
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="1.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a4e4-d640-9fbf-4019" name="Titan Legion Min Troop/LoW" hidden="false" collective="false" import="true" type="upgrade">
+      <modifiers>
+        <modifier type="increment" field="6010-fde7-14d7-d394" value="1.0">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="aebe-bed9-b32f-a8ea" type="instanceOf"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="149a-9d3d-877a-7068" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5863-bb3e-e3d0-eee7" type="max"/>
+        <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6010-fde7-14d7-d394" type="min"/>
+      </constraints>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="cc57-5eda-5dfe-792a" name="Mag-Inverter Shield" publicationId="bde1-6db1-163b-3b76" page="127" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="2b81-d2a9-b098-eaa0" name="Mag-Inverter Shield" publicationId="bde1-6db1-163b-3b76" page="127" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
+          <characteristics>
+            <characteristic name="Description" typeId="347e-ee4a-764f-6be3">Mag-inverter shields confer a 5+ Invulnerable Save. A model with a mag-inverter shield cannot claim bonus attacks for having more than one melee weapon, or make attacks during the Assault phase using a weapon with the Two-handed special rule.
+Invulnerable Saves granted by a mag-inverter shield do not stack with other Invulnerable Saves, but can benefit from rules (such as cyber-familiar) that specifically increase existing Saves. If a model has another Invulnerable Save then the controlling player must choose one to use.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0edc-de4d-cea8-5fb0" name="Kyropatris Field Generator" publicationId="bde1-6db1-163b-3b76" page="126" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="7b79-49d9-110a-a173" name="Kyropatris Field Generator" publicationId="bde1-6db1-163b-3b76" page="126" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
+          <characteristics>
+            <characteristic name="Description" typeId="347e-ee4a-764f-6be3">So long as a unit contains at least five models with a Kyropatris field generator, all models in the unit may re-roll failed Armour Saves of 1. In addition, if the unit contains at least 10 models with Kyropatris field generators then all Shooting Attacks made against the unit suffer a modifier of -1 to the Strength of the attack (to a minimum of Strength 1).</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="c497-145b-70df-9558" name="Titanshard Armour" publicationId="bde1-6db1-163b-3b76" page="125" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="fb0b-d16f-5099-6792" name="Titanshard Armour" publicationId="bde1-6db1-163b-3b76" page="125" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
+          <characteristics>
+            <characteristic name="Description" typeId="347e-ee4a-764f-6be3">Titanshard Armour confers a 3+ Armour Save and a 5+ Invulnerable Save. In addition, a model with Titanshard Armour may re-roll Feel No Pain Damage Mitigation rolls which are the result of attacks made by weapons with the Poisoned (X) or Rad-phage special rules.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="77d7-c7c1-7028-8030" name="The Corpus Skitarii" publicationId="bde1-6db1-163b-3b76" page="124" hidden="false" collective="false" import="true" type="upgrade">
+      <profiles>
+        <profile id="a0e2-f24a-31e1-2ce3" name="The Corpus Skitarii" publicationId="bde1-6db1-163b-3b76" page="124" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
+          <characteristics>
+            <characteristic name="Description" typeId="347e-ee4a-764f-6be3">The Corpus Skitarii confers a 4+ Armour Save. In addition, a model with Corpus Skitarii may re-roll Feel No Pain Damage Mitigation rolls which are the result of attacks made by weapons with the Poisoned (X) or Rad-phage special rules</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3ca1-6daa-7f73-22f4" name="Binaric Stratagems" publicationId="bde1-6db1-163b-3b76" page="102" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c79b-ea08-5716-0a7b" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c388-f5cf-087a-06d7" type="max"/>
+      </constraints>
+      <rules>
+        <rule id="84d6-404e-e083-d165" name="Binaric Stratagems*" publicationId="bde1-6db1-163b-3b76" page="102" hidden="false">
+          <description>At the start of the battle, once both armies have set up all their models, including any units with the Infiltrator special rule, a player that controls any models with this special rule may select one of the effects listed below as part of this special rule. All units with the Kyropatris field generator item of Wargear in the Detachment that includes the model with this special rule gain the chosen effect for the duration of the battle. Note that only a single bonus may be given to the units, regardless of how many models with this special rule are present in the Detachment. If an army includes multiple Detachments that include any models with this special rule, the controlling player must select an effect for each such Detachment and may select the same or different effects for each Detachment:
+
+• Pain Suppression Override: Affected models gain the Feel No Pain (5+) special rule.
+• Explorator Synaesthesis: Models in affected units gain the Move Through Cover special rule.
+• Deconstructive Confluence: Models in affected units gain the Wrecker special rule.
+• Extinction Interlock: Models in the affected units gain the Preferred Enemy (Infantry) special rule.</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="a607-aeba-79a3-5c40" name="Feel No Pain (X)" hidden="false" targetId="ec46-ff29-32e0-c2aa" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="*Feel No Pain (5+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="9359-9184-414d-873f" name="Move Through Cover" hidden="false" targetId="2b6f-bfec-759e-1746" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="*Move Through Cover"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="0fcb-c933-b5f1-3af4" name="Wrecker" hidden="false" targetId="ba77-a802-55df-da67" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="*Wrecker"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="9f57-1d93-cc91-7f83" name="Preferred Enemy (X)" hidden="false" targetId="37ab-d4db-891a-de8c" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="*Preferred Enemy (Infantry)"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0.0"/>
+      </costs>
+    </selectionEntry>
+  </sharedSelectionEntries>
+  <catalogueLinks>
+    <catalogueLink id="de74-d2a5-d0be-55c8" name="2022 - Mech Library" targetId="3129-da35-55e0-642d" type="catalogue" importRootEntries="true"/>
+  </catalogueLinks>
 </catalogue>


### PR DESCRIPTION
Fixed a couple of catalogue link issues in SW, BA and WS that had been caused by copy.
Added a bunch of Mech stuff to GST as per description below.
Made a Mech Library to hold some information.
Linked LA to Questoris and Titans.


Added
Added a Knights and Titans Profile type
Added Fast Vehicle Catagory with sub rule of Flat Out

Warhound, Reaver, Nemisis and Warlord Titans to Titans all selectable in all lists.
All appropriate stuff also added for them as well.
Decompiled the Missile launcher into a single entry, rather than entry with sub entries within it.

Reasons for adding
Photon Gauntlet - to GST ADDED as Shared Selection Entry as it is shared with Mech and Titans
Castellax Battle-automata Maniples - to GST for Praevian & Brethren of Iron (ROW) [gains 5+ It Will not Die] & Head of the Gorgon (IH ROW)
Vorax Battle-automata Maniples - to GST for Brethren of Iron & Praevian
Domitar Battle-automata Maniples - to GST for Brethren of Iron
Thanatar Siege-automata Maniple - to GST for Brethren of Iron (Max 1)

Cybernetica type ADDED as Category with Rule
Paragon of Metal ADDED as Shared Selection Entry

Castellax STUFF - ADDED as Shared Selection Entry
Shock Chargers ADDED as Shared Selection Entry
Mauler Bolt Cannon ADDED as Shared Selection Entry
Darkfire Cannon ADDED as Shared Selection Entry
Siege Wrecker ADDED as Shared Selection Entry
Power Blade Array ADDED as Shared Selection Entry
Maxima Bolter ADDED as Shared Selection Entry

Vorax STUFF - ADDED as Shared Selection Entry
Power Blade Array ADDED as Shared Selection Entry
Lightning Gun ADDED as Shared Selection Entry
Irad Cleanser ADDED as Shared Selection Entry

Domitar STUFF - ADDED as Shared Selection Entry
Graviton Hammers ADDED as Shared Selection Entry

Thanatar STUFF - ADDED as Shared Selection Entry
Shock Chargers ADDED as Shared Selection Entry
Graviton Ram ADDED as Shared Selection Entry
Plasma Mortar ADDED as Shared Selection Entry
Sollex Heavy-Las ADDED as Shared Selection Entry
Twin-linked Mauler Bolt Cannon ADDED as Shared Selection Entry
Thanatar Maniple ADDED in Thanatar

STAGE 2
Disruption ADDED TO GST (used mainly in Titans but also somewhere else for Arc Blaster)
Placeholder Knights ADDED to Knight Catalogue along with Household Ranks and a way to hide them when shared.
Heavy Stubber ADDED to GST
Ion Gauntlet Shield ADDED to GST (used in Questoris and Mech)
Ion Shield ADDED to GST (used in Questoris and Mech)
Ionic Deflector ADDED to GST (used in Questoris and Mech)
Flank Speed rule ADDED to GST (used in Questoris and Mech)
Karacnos Mortar Battery ADDED to GST (used in Questoris and Mech)
Multi-laser (used in Questoris and Mech and likely in others)
Catastrophic Explosion ADDED to GST
Catastrophic Destuction ADDED to GST
Overtaxed Reactor ADDED to GST
Phased Plasma-Fusil ADDED to GST
Lightning Cannon ADDED to GST

Added Knights
Acastus Knight Porphyrion
Armiger Helverin Talon
Armiger Warglaive Talon
Knight Acheron
Knight Castigator
Knight Lancer
Knight Questoris
Questoris Acastus Knight Asterius
Questoris Knight Atrapos
Questoris Knight Magaera
Questoris Knight Styrix

All of these once catalogue is linked should show up on LA, & Mech as LoW. with the exception of the Armigers that aren't meant to.

Moved a bunch of the things I'd put in GST into Mech Library.
Added Triaros Dedicated transport to Mech library and linked to be dedicated transport for Secutarii units

Titans and Questoris should now been 100% active and working.

Please set a title for the PR describing your changes,
fill out the information below, and delete this heading.

## Added Units

## Fixed Units

### Related Issues

* closes # [insert issue name here](insert link here)

## Not done yet

_Any issues related to your new changes, or known missing options_

## Test Case

Please upload a roster do demonstrate your changes. 
